### PR TITLE
fix: downgrade posthog-js to v1.167.0 to resolve Chrome Web Store review issues

### DIFF
--- a/extension/package.json
+++ b/extension/package.json
@@ -10,7 +10,7 @@
   },
   "dependencies": {
     "@openai/realtime-api-beta": "github:openai/openai-realtime-api-beta",
-    "posthog-js": "^1.250.1"
+    "posthog-js": "^1.167.0"
   },
   "devDependencies": {
     "@babel/core": "^7.23.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "i18next": "^25.2.1",
     "i18next-browser-languagedetector": "^8.1.0",
     "lucide-react": "^0.515.0",
-    "posthog-js": "^1.250.1",
+    "posthog-js": "^1.167.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^15.5.2",


### PR DESCRIPTION
## Problem

The Chrome Web Store rejected our extension submission because the newer version of `posthog-js` (v1.250.1) includes a `config.js` string literal in the minified bundle, which the reviewer flagged as "remotely-hosted code" violating Manifest V3 policies.

## Solution

This PR downgrades `posthog-js` from v1.250.1 to v1.167.0 to resolve the Chrome Web Store review issue. The downgrade removes the problematic `config.js` string from the bundle while maintaining analytics functionality.

## Changes

- ⬇️ Downgrade `posthog-js` from `^1.250.1` to `^1.167.0` in root `package.json`
- ⬇️ Downgrade `posthog-js` from `^1.250.1` to `^1.167.0` in `extension/package.json`

## Impact

- ✅ Resolves Chrome Web Store rejection issue
- ✅ Maintains analytics functionality with PostHog
- ✅ Allows extension updates to be published successfully
- ⚠️ Uses slightly older version of PostHog library (temporary workaround)

## Related Issues

- Upstream issue filed: [PostHog/posthog-js#2034](https://github.com/PostHog/posthog-js/issues/2034)

## Testing

- [ ] Extension builds successfully
- [ ] PostHog analytics continue to work as expected
- [ ] Chrome Web Store submission should pass review

This is a temporary workaround until the upstream issue is resolved in PostHog.