### PR TITLE
fix(analytics): eliminate PostHog provider initialization warning

### DIFF
--- a/shared/index.tsx
+++ b/shared/index.tsx
@@ -19,9 +19,8 @@ export const PostHogProvider: React.FC<{ client: PostHog; children: React.ReactN
 // Hook to use PostHog in components
 export const usePostHog = () => {
   const posthog = useContext(PostHogContext);
-  if (!posthog) {
-    console.warn('[Sokuji] usePostHog called outside of PostHogProvider');
-  }
+  // PostHog context now always exists, but client may be null during initialization
+  // No warning needed as this is expected behavior during startup
   return posthog;
 };
 
@@ -165,17 +164,12 @@ const UnifiedApp = () => {
     );
   }
 
-  // Render app immediately, PostHog will be injected when ready
+  // Render app immediately with PostHogProvider (client can be null initially)
   return (
     <React.StrictMode>
-      {posthogClient ? (
-        <PostHogProvider client={posthogClient}>
-          <App />
-        </PostHogProvider>
-      ) : (
-        // Render without PostHog initially
+      <PostHogProvider client={posthogClient as PostHog}>
         <App />
-      )}
+      </PostHogProvider>
     </React.StrictMode>
   );
 };


### PR DESCRIPTION
## Summary
- Fixed console warnings about `usePostHog called outside of PostHogProvider` that appeared during app startup
- Ensured PostHog context is always available, even during async initialization

## Problem
The app was showing multiple warnings during startup because:
1. PostHog was initialized asynchronously using `requestIdleCallback`
2. The app would render without the PostHogProvider wrapper initially
3. Components calling `useAnalytics()` would trigger warnings when PostHog context was not available

## Solution
- **Always wrap with PostHogProvider**: Modified `UnifiedApp` to always wrap the app with `PostHogProvider`, even when the client is null initially
- **Remove unnecessary warning**: Updated `usePostHog` hook to not warn, since null client during initialization is now expected behavior
- **Existing null checks**: The `useAnalytics` hook already had proper null checks for the PostHog instance

## Test Plan
- [x] App builds successfully without errors
- [x] App runs without the PostHog warning in console
- [x] PostHog still initializes asynchronously as intended
- [x] No impact on app performance or functionality
- [x] Analytics tracking still works after PostHog initializes

## Before
```
[Sokuji] usePostHog called outside of PostHogProvider
```
Multiple warnings appeared in console during startup.

## After
No warnings during startup, clean console output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PostHog analytics initialization to ensure the provider is consistently available during app startup.
  * Eliminated unnecessary runtime warning messages from the console.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->