### PR TITLE
feat(ui): Display OpenAI server error messages in conversation list w…

### DIFF
--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -109,6 +109,27 @@
           max-width: 90%;
         }
         
+        &.error {
+          background-color: #5a1a1a;
+          border: 1px solid #cc4444;
+          align-self: center;
+          
+          &.playing {
+            background-color: #6a2a2a;
+            box-shadow: 0 0 10px rgba(204, 68, 68, 0.3);
+          }
+          max-width: 90%;
+          
+          .conversation-item-role {
+            color: #ff6b6b;
+            font-weight: 600;
+            
+            svg {
+              margin-right: 4px;
+            }
+          }
+        }
+        
         .conversation-item-role {
           font-size: 10px;
           color: rgba(255, 255, 255, 0.6);
@@ -201,6 +222,42 @@
               .karaoke-unplayed {
                 color: rgba(255, 255, 255, 0.8);
                 transition: all 0.2s ease;
+              }
+            }
+            
+            &.error-message {
+              color: #ff6b6b;
+              
+              .error-header {
+                display: flex;
+                flex-direction: column;
+                gap: 4px;
+                margin-bottom: 8px;
+                font-size: 0.85em;
+                
+                .error-type {
+                  font-weight: 600;
+                  text-transform: uppercase;
+                  color: #ff9999;
+                }
+                
+                .error-param {
+                  color: #ffaaaa;
+                  font-size: 0.9em;
+                }
+              }
+              
+              .error-content {
+                font-size: 0.95em;
+                line-height: 1.5;
+                margin-bottom: 6px;
+                word-wrap: break-word;
+              }
+              
+              .error-timestamp {
+                font-size: 0.75em;
+                color: rgba(255, 107, 107, 0.6);
+                margin-top: 4px;
               }
             }
             

--- a/src/components/SimpleMainPanel/SimpleMainPanel.scss
+++ b/src/components/SimpleMainPanel/SimpleMainPanel.scss
@@ -74,6 +74,38 @@
           border-bottom-left-radius: 4px;
         }
 
+        &.error {
+          align-self: center;
+          background: #5a1a1a;
+          border: 1px solid #cc4444;
+          margin-left: auto;
+          margin-right: auto;
+          
+          .message-header {
+            color: #ff6b6b;
+            font-weight: 600;
+            
+            svg {
+              margin-right: 4px;
+            }
+          }
+          
+          .message-content.error-content {
+            color: #ff6b6b;
+            
+            .error-message-text {
+              font-size: 14px;
+              margin-bottom: 4px;
+            }
+            
+            .error-param {
+              font-size: 12px;
+              color: #ffaaaa;
+              opacity: 0.8;
+            }
+          }
+        }
+
         .message-header {
           font-size: 11px;
           text-transform: uppercase;

--- a/src/components/SimpleMainPanel/SimpleMainPanel.tsx
+++ b/src/components/SimpleMainPanel/SimpleMainPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useMemo, useCallback } from 'react';
-import { Mic, MicOff, Volume2, VolumeX, Loader, MessageSquare, Send } from 'lucide-react';
+import { Mic, MicOff, Volume2, VolumeX, Loader, MessageSquare, Send, AlertCircle } from 'lucide-react';
 import './SimpleMainPanel.scss';
 import {
   useProvider,
@@ -243,6 +243,27 @@ const SimpleMainPanel: React.FC<SimpleMainPanelProps> = React.memo(({
               
               // Calculate highlighted characters for karaoke effect
               const highlightedChars = isPlaying ? Math.floor(text.length * progressRatio) : 0;
+              
+              // Handle error messages
+              if (item.error) {
+                const errorMessage = item.error.message || item.error.code || t('mainPanel.unknownError', 'Unknown error');
+                return (
+                  <div key={index} className={`message-bubble ${item.role} error`}>
+                    <div className="message-header">
+                      <span className="role">
+                        <AlertCircle size={12} style={{ marginRight: '4px' }} />
+                        {t('mainPanel.error', 'Error')}
+                      </span>
+                    </div>
+                    <div className="message-content error-content">
+                      <div className="error-message-text">{errorMessage}</div>
+                      {item.error.param && (
+                        <div className="error-param">{t('mainPanel.errorParam', 'Parameter')}: {item.error.param}</div>
+                      )}
+                    </div>
+                  </div>
+                );
+              }
               
               return (
                 <div key={index} className={`message-bubble ${item.role} ${isPlaying ? 'playing' : ''}`}>

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -198,7 +198,10 @@
     "basicMode": "Basis",
     "advancedMode": "Erweitert",
     "typeMessage": "Text zum Übersetzen...",
-    "send": "Senden"
+    "send": "Senden",
+    "error": "Fehler",
+    "unknownError": "Unbekannter Fehler",
+    "errorParam": "Parameter"
   },
   "errors": {
     "microphoneAccess": "Mikrofonzugriff verweigert",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -402,7 +402,10 @@
     "switchToAdvanced": "Switch to advanced mode",
     "switchToBasic": "Switch to basic mode",
     "typeMessage": "Text to translate...",
-    "send": "Send"
+    "send": "Send",
+    "error": "Error",
+    "unknownError": "Unknown error",
+    "errorParam": "Parameter"
   },
   "simplePanel": {
     "clickToConfigLanguages": "Click to configure languages",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -198,7 +198,10 @@
     "basicMode": "Básico",
     "advancedMode": "Avanzado",
     "typeMessage": "Texto a traducir...",
-    "send": "Enviar"
+    "send": "Enviar",
+    "error": "Error",
+    "unknownError": "Error desconocido",
+    "errorParam": "Parámetro"
   },
   "errors": {
     "microphoneAccess": "Acceso al micrófono denegado",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -198,7 +198,10 @@
     "basicMode": "Basique",
     "advancedMode": "Avancé",
     "typeMessage": "Texte à traduire...",
-    "send": "Envoyer"
+    "send": "Envoyer",
+    "error": "Erreur",
+    "unknownError": "Erreur inconnue",
+    "errorParam": "Paramètre"
   },
   "errors": {
     "microphoneAccess": "Accès au microphone refusé",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -198,7 +198,10 @@
     "basicMode": "ベーシック",
     "advancedMode": "アドバンスト",
     "typeMessage": "翻訳するテキスト...",
-    "send": "送信"
+    "send": "送信",
+    "error": "エラー",
+    "unknownError": "不明なエラー",
+    "errorParam": "パラメータ"
   },
   "errors": {
     "microphoneAccess": "マイクへのアクセスが拒否されました",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -306,7 +306,10 @@
     "basicMode": "基础",
     "advancedMode": "高级",
     "typeMessage": "输入要翻译的文字...",
-    "send": "发送"
+    "send": "发送",
+    "error": "错误",
+    "unknownError": "未知错误",
+    "errorParam": "参数"
   },
   "errors": {
     "microphoneAccess": "麦克风访问被拒绝",

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -28,6 +28,15 @@ export interface ConversationItem {
     audio?: any;
     transcript?: string | null;
   }>;
+  // Error metadata for server error messages
+  error?: {
+    type?: string;
+    code?: string;
+    message?: string;
+    param?: string;
+    eventId?: string;
+  };
+  createdAt?: string | number; // Timestamp for error messages
 }
 
 /**


### PR DESCRIPTION
…indow

- Detect and handle OpenAI server error events in MainPanel
- Add error metadata support to ConversationItem interface
- Render error messages with visual distinction (red styling, error icon)
- Display error type, message, parameter, and timestamp
- Add error message support to SimpleMainPanel
- Add error message translations for 6 languages (en, ja, es, de, fr, zh_CN)

Fixes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual error state handling in the chat interface with error indicators, detailed error information display (type, message, optional parameters), and timestamps.
  * Added multilingual support for error messages in German, Spanish, French, Japanese, and Simplified Chinese.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->