### PR TITLE
fix(macos): request microphone permission on startup

### DIFF
--- a/build-pkg.sh
+++ b/build-pkg.sh
@@ -42,6 +42,11 @@ if [ ! -w "out/Sokuji-darwin-arm64/Sokuji.app" ]; then
     sudo chown -R $(whoami):staff out/Sokuji-darwin-arm64/Sokuji.app
 fi
 
+# Step 2.6: Ad-hoc sign the app (required for macOS to show permission dialogs)
+echo "Step 2.6: Ad-hoc signing the app..."
+codesign --force --deep --sign - out/Sokuji-darwin-arm64/Sokuji.app
+echo "✅ App signed successfully"
+
 # Step 3: Create output directory if it doesn't exist
 echo "Step 3: Preparing output directory..."
 mkdir -p out/make

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow, ipcMain, Menu, dialog, shell, session } = require('electron');
+const { app, BrowserWindow, ipcMain, Menu, dialog, shell, session, systemPreferences } = require('electron');
 const path = require('path');
 const { betterAuthAdapter } = require('./better-auth-adapter');
 
@@ -384,6 +384,19 @@ app.whenReady().then(async () => {
 
   // Create the application menu
   createApplicationMenu();
+
+  // Request microphone permission on macOS before creating window
+  if (process.platform === 'darwin') {
+    const micStatus = systemPreferences.getMediaAccessStatus('microphone');
+    console.log('[Sokuji] [Main] Microphone permission status:', micStatus);
+
+    if (micStatus === 'not-determined') {
+      const granted = await systemPreferences.askForMediaAccess('microphone');
+      console.log('[Sokuji] [Main] Microphone permission granted:', granted);
+    } else if (micStatus === 'denied') {
+      console.warn('[Sokuji] [Main] Microphone permission denied - please enable in System Preferences > Privacy & Security > Microphone');
+    }
+  }
 
   createWindow();
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12860,9 +12860,6 @@
         "string-width": "^1.0.2 || 2 || 3 || 4"
       }
     },
-    "node_modules/win-core-audio": {
-      "optional": true
-    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",


### PR DESCRIPTION
## Summary
- Add `systemPreferences.askForMediaAccess('microphone')` call before creating window on macOS
- Add ad-hoc code signing step to `build-pkg.sh` (required for macOS to show permission dialogs)

## Problem
On macOS, the packaged app could get the microphone device list and create audio streams, but the audio data was always silent. This was because:

1. macOS TCC (Transparency, Consent, and Control) requires apps to explicitly request microphone permission
2. **Unsigned apps cannot trigger the system permission dialog** - `askForMediaAccess()` returns `false` without showing any prompt
3. macOS silently returns empty audio data instead of throwing an error

## Solution
1. Call `systemPreferences.askForMediaAccess('microphone')` in `app.whenReady()` before creating the window
2. Add ad-hoc code signing (`codesign --force --deep --sign -`) to the build script

## Test plan
- [ ] Build pkg with `./build-pkg.sh`
- [ ] Install on a fresh macOS system (or reset permissions with `tccutil reset Microphone com.electron.sokuji`)
- [ ] Launch app - should see macOS microphone permission dialog
- [ ] Grant permission - audio recording should work (not silent)

## Thanks
Thanks to [@nickcheng](https://github.com/nickcheng) for reporting this issue! 🙏
@nickcheng

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS users are now prompted to grant microphone access permissions on app launch.

* **Improvements**
  * Enhanced security and compatibility for macOS app distribution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->