### PR TITLE
feat(analytics): move PostHog key to environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # Sokuji Frontend Environment Variables
-# Copy this file to .env.local and fill in your values
+# Copy this file to .env and fill in your values
 
 # Backend Base URL (without /api suffix)
 # This is the base URL for your Cloudflare Workers backend
@@ -9,10 +9,11 @@
 # For production: https://sokuji.kizuna.ai
 VITE_BACKEND_URL=http://localhost:8787
 
-# PostHog Analytics (Optional)
-# VITE_POSTHOG_KEY=your_posthog_key
-# VITE_POSTHOG_HOST=https://app.posthog.com
+# Enable Kizuna AI provider (true/false)
+VITE_ENABLE_KIZUNA_AI=true
 
-# Feature Flags (Optional)
-# VITE_ENABLE_AUTH=true
-# VITE_ENABLE_QUOTA_TRACKING=true
+# PostHog Analytics Configuration
+# Set VITE_POSTHOG_KEY to enable analytics tracking
+# Leave empty or unset to disable analytics (recommended for forks)
+VITE_POSTHOG_KEY=
+VITE_POSTHOG_HOST=https://us.i.posthog.com

--- a/docs/app/app-analytics-integration.md
+++ b/docs/app/app-analytics-integration.md
@@ -10,16 +10,31 @@ The application uses PostHog for comprehensive analytics tracking, including use
 
 ### Configuration
 
-PostHog credentials are now hardcoded in the source code for both Electron and extension environments. The configuration is located in `src/config/analytics.ts`:
+PostHog credentials are configured via environment variables in `src/config/analytics.ts`:
 
 ```typescript
 export const ANALYTICS_CONFIG = {
-  POSTHOG_KEY: 'phc_EMOuUDTntTI5SuzKQATy11qHgxVrlhJsgNFbBaWEhet',
-  POSTHOG_HOST: 'https://us.i.posthog.com',
+  POSTHOG_KEY: import.meta.env.VITE_POSTHOG_KEY || '',
+  POSTHOG_HOST: import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
 } as const;
+
+// Helper to check if analytics is configured
+export const isAnalyticsEnabled = (): boolean => {
+  return Boolean(ANALYTICS_CONFIG.POSTHOG_KEY);
+};
 ```
 
-This approach ensures compatibility across all environments (Electron app, browser extension, and web) without requiring environment variable configuration.
+**Environment Variables:**
+- `VITE_POSTHOG_KEY`: Your PostHog project API key (leave empty to disable analytics)
+- `VITE_POSTHOG_HOST`: PostHog host URL (defaults to `https://us.i.posthog.com`)
+
+**For Fork Projects:**
+Fork projects can simply not set `VITE_POSTHOG_KEY` to disable analytics entirely. No code changes required.
+
+**Setup:**
+1. Copy `.env.example` to `.env`
+2. Set `VITE_POSTHOG_KEY` to your PostHog project API key
+3. Run the application
 
 ### Development vs Production Behavior
 

--- a/docs/extension/extension-popup-analytics.md
+++ b/docs/extension/extension-popup-analytics.md
@@ -14,19 +14,28 @@ The extension popup now tracks user interactions and page context to provide ins
 
 ### PostHog Installation and Initialization
 
-The popup uses the locally installed `posthog-js` package (not CDN) for better security and offline support:
+The popup uses the locally installed `posthog-js-lite` package for better security and offline support:
 
 ```javascript
 // Import PostHog from installed package
-import posthog from 'posthog-js';
+import PostHog from 'posthog-js-lite';
 
+// Analytics configuration - set via environment or leave empty to disable
 const ANALYTICS_CONFIG = {
-  POSTHOG_KEY: 'phc_EMOuUDTntTI5SuzKQATy11qHgxVrlhJsgNFbBaWEhet',
-  POSTHOG_HOST: 'https://us.i.posthog.com'
+  POSTHOG_KEY: process.env.POSTHOG_KEY || '',
+  POSTHOG_HOST: process.env.POSTHOG_HOST || 'https://us.i.posthog.com'
 };
+
+// Helper to check if analytics is enabled
+function isAnalyticsEnabled() {
+  return Boolean(ANALYTICS_CONFIG.POSTHOG_KEY);
+}
 ```
 
-The extension has `posthog-js` as a dependency and bundles it via webpack for production use.
+**For Fork Projects:**
+Fork projects can disable analytics by not setting `POSTHOG_KEY` in their build environment. The extension will work normally without analytics.
+
+The extension has `posthog-js-lite` as a dependency and bundles it via webpack for production use.
 
 ### Benefits of Local Installation
 

--- a/docs/uninstall_feedback.html
+++ b/docs/uninstall_feedback.html
@@ -209,7 +209,18 @@
     </div>
 
     <!-- PostHog Script -->
+    <!--
+        FORK NOTE: This is a static HTML page for uninstall feedback.
+        Fork projects should either:
+        1. Replace the PostHog key below with your own PostHog project key
+        2. Remove the entire PostHog script section to disable analytics
+        3. Host your own version of this page
+    -->
     <script>
+        // PostHog configuration - replace with your own key or remove to disable
+        const POSTHOG_KEY = ''; // Set your PostHog key here, or leave empty to disable
+        const POSTHOG_HOST = 'https://us.i.posthog.com';
+
         // Get distinct_id from URL parameters before initializing PostHog
         function getDistinctIdFromURL() {
             const urlParams = new URLSearchParams(window.location.search);
@@ -219,21 +230,32 @@
         // Get distinct_id from URL if available
         const distinctIdFromURL = getDistinctIdFromURL();
 
-        !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        
-        // Initialize PostHog with configuration
-        const posthogConfig = {
-            api_host: 'https://us.i.posthog.com',
-            loaded: function(posthog) {
-                // If distinct_id is provided in URL, identify the user immediately
-                if (distinctIdFromURL) {
-                    console.debug('[Sokuji] [Uninstall Feedback] Using distinct_id from URL');
-                    posthog.identify(distinctIdFromURL);
-                }
-            }
-        };
+        // Only initialize PostHog if key is configured
+        if (POSTHOG_KEY) {
+            !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]);t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.async=!0,p.src=s.api_host+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="capture identify alias people.set people.set_once set_config register register_once unregister opt_out_capturing has_opted_out_capturing opt_in_capturing reset isFeatureEnabled onFeatureFlags getFeatureFlag getFeatureFlagPayload reloadFeatureFlags group updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures getActiveMatchingSurveys getSurveys onSessionId".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
 
-        posthog.init('phc_EMOuUDTntTI5SuzKQATy11qHgxVrlhJsgNFbBaWEhet', posthogConfig);
+            // Initialize PostHog with configuration
+            const posthogConfig = {
+                api_host: POSTHOG_HOST,
+                loaded: function(posthog) {
+                    // If distinct_id is provided in URL, identify the user immediately
+                    if (distinctIdFromURL) {
+                        console.debug('[Sokuji] [Uninstall Feedback] Using distinct_id from URL');
+                        posthog.identify(distinctIdFromURL);
+                    }
+                }
+            };
+
+            posthog.init(POSTHOG_KEY, posthogConfig);
+        } else {
+            console.info('[Sokuji] [Uninstall Feedback] PostHog analytics disabled (no key configured)');
+            // Create a stub posthog object for the rest of the page
+            window.posthog = {
+                capture: function() {},
+                identify: function() {},
+                getSurveys: function(callback) { callback([]); }
+            };
+        }
     </script>
 
     <script>

--- a/extension/.env.example
+++ b/extension/.env.example
@@ -1,0 +1,14 @@
+# Extension Build Environment Variables
+# Copy this file to .env and fill in your values before building
+
+# Backend Base URL
+VITE_BACKEND_URL=https://sokuji.kizuna.ai
+
+# Enable Kizuna AI provider (true/false)
+VITE_ENABLE_KIZUNA_AI=true
+
+# PostHog Analytics Configuration
+# Set POSTHOG_KEY to enable analytics tracking
+# Leave empty or unset to disable analytics (recommended for forks)
+POSTHOG_KEY=
+POSTHOG_HOST=https://us.i.posthog.com

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -3,11 +3,21 @@
 // Import PostHog from installed package
 import PostHog from 'posthog-js-lite';
 
-// Analytics configuration - matches main app config
+// Analytics configuration - uses environment variables
+// Fork projects can disable analytics by not setting POSTHOG_KEY in webpack config
 const ANALYTICS_CONFIG = {
-  POSTHOG_KEY: 'phc_EMOuUDTntTI5SuzKQATy11qHgxVrlhJsgNFbBaWEhet',
-  POSTHOG_HOST: 'https://us.i.posthog.com'
+  POSTHOG_KEY: typeof process !== 'undefined' && process.env && process.env.POSTHOG_KEY
+    ? process.env.POSTHOG_KEY
+    : '',
+  POSTHOG_HOST: typeof process !== 'undefined' && process.env && process.env.POSTHOG_HOST
+    ? process.env.POSTHOG_HOST
+    : 'https://us.i.posthog.com'
 };
+
+// Helper to check if analytics is enabled
+function isAnalyticsEnabled() {
+  return Boolean(ANALYTICS_CONFIG.POSTHOG_KEY);
+}
 
 // PostHog instance
 let posthogInstance = null;
@@ -15,7 +25,13 @@ let posthogInstance = null;
 // Initialize PostHog
 function initializePostHog() {
   if (posthogInstance || typeof window === 'undefined') return;
-  
+
+  // Skip initialization if no key configured (fork projects without PostHog)
+  if (!isAnalyticsEnabled()) {
+    console.debug('[Sokuji] [Popup] PostHog analytics disabled (POSTHOG_KEY not set)');
+    return;
+  }
+
   try {
     // Initialize PostHog with posthog-js-lite
     posthogInstance = new PostHog(ANALYTICS_CONFIG.POSTHOG_KEY, {

--- a/extension/webpack.config.js
+++ b/extension/webpack.config.js
@@ -70,6 +70,9 @@ module.exports = (env, argv) => {
     plugins: [
       new webpack.DefinePlugin({
         'process.env.NODE_ENV': JSON.stringify(argv.mode || 'development'),
+        // PostHog analytics configuration - set via environment or leave empty to disable
+        'process.env.POSTHOG_KEY': JSON.stringify(process.env.POSTHOG_KEY || ''),
+        'process.env.POSTHOG_HOST': JSON.stringify(process.env.POSTHOG_HOST || 'https://us.i.posthog.com'),
         // Define import.meta for Extension builds to prevent runtime errors
         'import.meta.env.MODE': JSON.stringify(argv.mode || 'development'),
         'import.meta.env.VITE_BACKEND_URL': JSON.stringify(
@@ -83,6 +86,9 @@ module.exports = (env, argv) => {
         'import.meta.env.VITE_ENABLE_PALABRA_AI': JSON.stringify(
           process.env.VITE_ENABLE_PALABRA_AI || 'false'  // Disabled by default, can be enabled via env var
         ),
+        // PostHog analytics configuration for shared/index.tsx (fullpage entry)
+        'import.meta.env.VITE_POSTHOG_KEY': JSON.stringify(process.env.POSTHOG_KEY || ''),
+        'import.meta.env.VITE_POSTHOG_HOST': JSON.stringify(process.env.POSTHOG_HOST || 'https://us.i.posthog.com'),
         'import.meta.env.DEV': JSON.stringify(isDevMode),
         // Define import.meta.url as empty string to prevent parse errors
         'import.meta.url': JSON.stringify('')

--- a/shared/index.tsx
+++ b/shared/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, createContext, useContext } from 'react';
 import ReactDOM from 'react-dom/client';
 import App from '../src/App';
 import PostHog from 'posthog-js-lite';
-import { ANALYTICS_CONFIG, isDevelopment, getPlatform, getEnvironment } from '../src/config/analytics';
+import { ANALYTICS_CONFIG, isDevelopment, getPlatform, getEnvironment, isAnalyticsEnabled } from '../src/config/analytics';
 
 // Create PostHog context for React
 const PostHogContext = createContext<PostHog | null>(null);
@@ -57,7 +57,13 @@ const getPackageInfo = async () => {
   }
 };
 
-const initializePostHog = async () => {
+const initializePostHog = async (): Promise<PostHog | null> => {
+  // Skip initialization if no key configured (fork projects without PostHog)
+  if (!isAnalyticsEnabled()) {
+    console.info('[Sokuji] PostHog analytics disabled (VITE_POSTHOG_KEY not set)');
+    return null;
+  }
+
   const packageInfo = await getPackageInfo();
 
   const options = {

--- a/src/config/analytics.ts
+++ b/src/config/analytics.ts
@@ -1,12 +1,17 @@
-// Analytics configuration that works in both Electron and extension environments
-// This replaces the need for environment variables
+// Analytics configuration using environment variables
+// Fork projects can disable analytics by not setting VITE_POSTHOG_KEY
 
 import { isElectron, isExtension, isWeb } from '../utils/environment';
 
 export const ANALYTICS_CONFIG = {
-  POSTHOG_KEY: 'phc_EMOuUDTntTI5SuzKQATy11qHgxVrlhJsgNFbBaWEhet',
-  POSTHOG_HOST: 'https://us.i.posthog.com',
+  POSTHOG_KEY: import.meta.env.VITE_POSTHOG_KEY || '',
+  POSTHOG_HOST: import.meta.env.VITE_POSTHOG_HOST || 'https://us.i.posthog.com',
 } as const;
+
+// Helper to check if analytics is configured
+export const isAnalyticsEnabled = (): boolean => {
+  return Boolean(ANALYTICS_CONFIG.POSTHOG_KEY);
+};
 
 // Environment detection that works in both Electron and extension
 export const getEnvironment = (): 'development' | 'production' => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,12 @@
-/// <reference types="vite/client" /> 
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BACKEND_URL?: string;
+  readonly VITE_POSTHOG_KEY?: string;
+  readonly VITE_POSTHOG_HOST?: string;
+  readonly VITE_ENABLE_KIZUNA_AI?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+} 


### PR DESCRIPTION
## Summary

- Remove hardcoded PostHog API key from all source files
- Add environment variable configuration for PostHog credentials
- Add `isAnalyticsEnabled()` helper for conditional initialization
- Skip PostHog initialization when key not configured (fork-friendly)

## Motivation

The PostHog API key was hardcoded in multiple files, causing any fork of this project to inadvertently use Kizuna AI's PostHog account if not modified.

## Changes

| File | Change |
|------|--------|
| `src/config/analytics.ts` | Read from `VITE_POSTHOG_KEY` env var, add `isAnalyticsEnabled()` |
| `shared/index.tsx` | Conditional PostHog init when no key |
| `src/vite-env.d.ts` | TypeScript type declarations for env vars |
| `extension/popup.js` | Use `process.env.POSTHOG_KEY` instead of hardcoded |
| `extension/webpack.config.js` | Inject PostHog env vars at build time |
| `docs/uninstall_feedback.html` | Remove hardcoded key, add fork instructions |
| `docs/app/app-analytics-integration.md` | Update documentation |
| `docs/extension/extension-popup-analytics.md` | Update documentation |
| `.env.example` | Document env vars |
| `extension/.env.example` | Extension-specific env example |

## For Fork Projects

Fork projects can simply not set `VITE_POSTHOG_KEY` / `POSTHOG_KEY` to disable analytics entirely. No code changes required.

## Test Plan

- [ ] Verify app runs without `VITE_POSTHOG_KEY` (should see "PostHog analytics disabled" in console)
- [ ] Verify analytics work when `VITE_POSTHOG_KEY` is set
- [ ] Test Electron app
- [ ] Test browser extension (popup and side panel)
- [ ] Test uninstall feedback page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kizuna AI provider can be toggled via configuration.

* **Configuration**
  * Analytics now configurable via environment variables (key and host) and can be fully disabled.
  * Default analytics host set to the US endpoint.

* **Documentation**
  * Updated docs explaining environment-based analytics setup and how to disable or replace analytics.

* **Chores**
  * Updated environment templates and build/runtime defaults for analytics and backend URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->