### PR TITLE
ci: add Windows code signing via SignPath

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,10 +185,60 @@ jobs:
           name: ${{ matrix.artifact_name }}-artifacts
           path: out/make/*.pkg
 
+  sign-windows:
+    name: Sign Windows artifacts
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download unsigned artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-unsigned
+          path: unsigned/
+
+      # SignPath requires a github-artifact-id from upload-artifact.
+      # We must re-upload because the original upload happened in a different job
+      # and artifact IDs cannot be passed across jobs without explicit output wiring.
+      - name: Upload for SignPath
+        id: upload-for-signing
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-to-sign
+          path: unsigned/
+          overwrite: true
+
+      - name: Submit signing request
+        id: sign
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: default
+          github-artifact-id: ${{ steps.upload-for-signing.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed/
+          wait-for-completion-timeout-in-seconds: 1200
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-signed
+          path: signed/
+
   release:
     # Only run for tag pushes
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: build
+    needs: [build, sign-windows]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -254,11 +254,17 @@ jobs:
           name: linux-arm64-artifacts
           path: linux-arm64-artifacts
 
-      - name: Download Windows artifacts
+      - name: Download signed Windows installer
         uses: actions/download-artifact@v4
         with:
-          name: windows-artifacts
-          path: windows-artifacts
+          name: windows-signed
+          path: windows-signed
+
+      - name: Download Windows nupkg
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-nupkg
+          path: windows-nupkg
 
       - name: Download macOS ARM64 artifacts
         uses: actions/download-artifact@v4
@@ -278,8 +284,10 @@ jobs:
           find linux-x64-artifacts -type f || true
           echo "=== Linux ARM64 ==="
           find linux-arm64-artifacts -type f || true
-          echo "=== Windows ==="
-          find windows-artifacts -type f || true
+          echo "=== Windows (signed) ==="
+          find windows-signed -type f || true
+          echo "=== Windows (nupkg) ==="
+          find windows-nupkg -type f || true
           echo "=== macOS ARM64 ==="
           find macos-arm64-artifacts -type f || true
           echo "=== macOS x64 ==="
@@ -293,8 +301,8 @@ jobs:
           find linux-x64-artifacts -name "sokuji-extension.zip" -exec cp {} release-assets/ \;
           find linux-arm64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
           find linux-arm64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
-          find windows-artifacts -name "*.exe" -exec cp {} release-assets/ \;
-          find windows-artifacts -name "*.nupkg" -exec cp {} release-assets/ \;
+          find windows-signed -name "*.exe" -exec cp {} release-assets/ \;
+          find windows-nupkg -name "*.nupkg" -exec cp {} release-assets/ \;
           find macos-arm64-artifacts -name "*.pkg" -exec cp {} release-assets/ \;
           find macos-x64-artifacts -name "*.pkg" -exec cp {} release-assets/ \;
           echo "=== Release assets ==="

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -164,12 +164,19 @@ jobs:
             out/make/**/*.deb
             out/make/**/*.zip
 
-      - name: Upload Windows artifacts
+      - name: Upload unsigned Windows installer for signing
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: windows-artifacts
-          path: out/make/
+          name: windows-unsigned
+          path: out/make/squirrel.windows/x64/*Setup*.exe
+
+      - name: Upload Windows nupkg for release
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-nupkg
+          path: out/make/squirrel.windows/x64/*.nupkg
 
       - name: Upload macOS artifacts
         if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'macOS'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,7 +187,7 @@ jobs:
 
   sign-windows:
     name: Sign Windows artifacts
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'kizuna-ai-lab/sokuji'
     needs: build
     runs-on: ubuntu-latest
     permissions:

--- a/.signpath/artifact-configurations/default.xml
+++ b/.signpath/artifact-configurations/default.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <!-- Sign the Squirrel installer exe (contains embedded nupkg) -->
+    <pe-file path="*Setup*.exe">
+      <authenticode-sign />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>

--- a/docs/superpowers/plans/2026-03-13-signpath-windows-signing.md
+++ b/docs/superpowers/plans/2026-03-13-signpath-windows-signing.md
@@ -1,0 +1,387 @@
+# SignPath Windows Code Signing Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Windows code signing via SignPath to the GitHub Actions CI pipeline so that Setup.exe is Authenticode-signed before release.
+
+**Architecture:** SignPath signs artifacts externally via API. A new `sign-windows` job sits between the existing `build` and `release` jobs. Only `Setup.exe` is signed — Squirrel embeds the nupkg inside it, and SmartScreen only checks the outer executable.
+
+**Tech Stack:** GitHub Actions, SignPath OSS (submit-signing-request@v2), Electron Forge maker-squirrel
+
+**Spec:** `docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `.signpath/artifact-configurations/default.xml` | Create | Tells SignPath what to sign inside the uploaded ZIP |
+| `.github/workflows/build.yml` | Modify | Add sign job, split Windows artifact uploads, update release job |
+
+No other files are created or modified. `forge.config.js` is unchanged.
+
+---
+
+## Chunk 1: Implementation
+
+### Task 1: Create SignPath artifact configuration
+
+**Files:**
+- Create: `.signpath/artifact-configurations/default.xml`
+
+- [ ] **Step 1: Create the artifact configuration file**
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <!-- Sign the Squirrel installer exe (contains embedded nupkg) -->
+    <pe-file path="*Setup*.exe">
+      <authenticode-sign />
+    </pe-file>
+  </zip-file>
+</artifact-configuration>
+```
+
+This tells SignPath: "The uploaded artifact is a ZIP containing a PE file matching `*Setup*.exe`. Sign it with Authenticode."
+
+The `<zip-file>` root is required because GitHub's `upload-artifact` wraps files in a ZIP.
+
+- [ ] **Step 2: Verify the file is valid XML**
+
+Run: `xmllint --noout .signpath/artifact-configurations/default.xml`
+Expected: No output (valid XML)
+
+If `xmllint` is not available, visual inspection is sufficient — the file is 8 lines.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .signpath/artifact-configurations/default.xml
+git commit -m "ci: add SignPath artifact configuration for Windows signing"
+```
+
+---
+
+### Task 2: Modify build job — split Windows artifact uploads
+
+**Files:**
+- Modify: `.github/workflows/build.yml:167-172`
+
+**Context:** The current build job has a single Windows upload step (lines 167-172):
+
+```yaml
+      - name: Upload Windows artifacts
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifacts
+          path: out/make/
+```
+
+This uploads the entire `out/make/` directory as `windows-artifacts`. We need to split this into two artifacts:
+1. `windows-unsigned` — only `*Setup*.exe` (sent to SignPath for signing)
+2. `windows-nupkg` — only `*.nupkg` (passed directly to release job for Squirrel auto-updates)
+
+The old `windows-artifacts` artifact name is removed entirely.
+
+- [ ] **Step 1: Replace the existing Windows upload step**
+
+Replace lines 167-172 of `.github/workflows/build.yml`:
+
+```yaml
+      - name: Upload Windows artifacts
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-artifacts
+          path: out/make/
+```
+
+With these two steps:
+
+```yaml
+      - name: Upload unsigned Windows installer for signing
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-unsigned
+          path: out/make/squirrel.windows/x64/*Setup*.exe
+
+      - name: Upload Windows nupkg for release
+        if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-nupkg
+          path: out/make/squirrel.windows/x64/*.nupkg
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: split Windows artifact upload into unsigned exe + nupkg"
+```
+
+---
+
+### Task 3: Add sign-windows job
+
+**Files:**
+- Modify: `.github/workflows/build.yml` (insert new job between `build` and `release`)
+
+**Context:** Insert the `sign-windows` job after the `build` job definition (after line 179) and before the `release` job (line 181). The job:
+1. Downloads the unsigned Setup.exe
+2. Re-uploads it so SignPath gets a fresh artifact ID from this job's context
+3. Submits the signing request to SignPath
+4. Waits for completion and uploads the signed result
+
+- [ ] **Step 1: Add the sign-windows job**
+
+Insert this job between the `build` job's closing and the `release` job:
+
+```yaml
+  sign-windows:
+    name: Sign Windows artifacts
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download unsigned artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-unsigned
+          path: unsigned/
+
+      # SignPath requires a github-artifact-id from upload-artifact.
+      # We must re-upload because the original upload happened in a different job
+      # and artifact IDs cannot be passed across jobs without explicit output wiring.
+      - name: Upload for SignPath
+        id: upload-for-signing
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-to-sign
+          path: unsigned/
+          overwrite: true
+
+      - name: Submit signing request
+        id: sign
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: sokuji
+          signing-policy-slug: test-signing
+          artifact-configuration-slug: default
+          github-artifact-id: ${{ steps.upload-for-signing.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: signed/
+          wait-for-completion-timeout-in-seconds: 1200
+
+      - name: Upload signed artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-signed
+          path: signed/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: add sign-windows job for SignPath code signing"
+```
+
+---
+
+### Task 4: Modify release job to use signed artifacts
+
+**Files:**
+- Modify: `.github/workflows/build.yml` (release job, lines 181-255)
+
+**Context:** The release job needs three changes:
+1. Add `sign-windows` to `needs` array
+2. Replace `windows-artifacts` download with `windows-signed` + `windows-nupkg` downloads
+3. Update "Collect release assets" to find exe in `windows-signed/` and nupkg in `windows-nupkg/`
+
+- [ ] **Step 1: Update release job `needs`**
+
+Change line 184:
+```yaml
+    needs: build
+```
+To:
+```yaml
+    needs: [build, sign-windows]
+```
+
+- [ ] **Step 2: Replace Windows artifact download**
+
+Replace lines 200-204:
+```yaml
+      - name: Download Windows artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-artifacts
+          path: windows-artifacts
+```
+
+With:
+```yaml
+      - name: Download signed Windows installer
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-signed
+          path: windows-signed
+
+      - name: Download Windows nupkg
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-nupkg
+          path: windows-nupkg
+```
+
+- [ ] **Step 3: Update Debug artifacts step**
+
+In the "Debug artifacts structure" step, replace:
+```bash
+          echo "=== Windows ==="
+          find windows-artifacts -type f || true
+```
+With:
+```bash
+          echo "=== Windows (signed) ==="
+          find windows-signed -type f || true
+          echo "=== Windows (nupkg) ==="
+          find windows-nupkg -type f || true
+```
+
+- [ ] **Step 4: Update Collect release assets step**
+
+In the "Collect release assets" step, replace:
+```bash
+          find windows-artifacts -name "*.exe" -exec cp {} release-assets/ \;
+          find windows-artifacts -name "*.nupkg" -exec cp {} release-assets/ \;
+```
+With:
+```bash
+          find windows-signed -name "*.exe" -exec cp {} release-assets/ \;
+          find windows-nupkg -name "*.nupkg" -exec cp {} release-assets/ \;
+```
+
+- [ ] **Step 5: Validate YAML syntax**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`
+Expected: No error output (valid YAML)
+
+Alternatively: `npx yaml-lint .github/workflows/build.yml` or `actionlint .github/workflows/build.yml`
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: update release job to use signed Windows artifacts"
+```
+
+---
+
+### Task 5: Final review and squash commit
+
+- [ ] **Step 1: Review the full diff**
+
+Run: `git diff main -- .github/workflows/build.yml .signpath/`
+
+Verify:
+- `.signpath/artifact-configurations/default.xml` exists with correct XML
+- Build job has two Windows upload steps (`windows-unsigned` + `windows-nupkg`)
+- `sign-windows` job exists between `build` and `release`
+- Release job `needs: [build, sign-windows]`
+- Release job downloads `windows-signed` and `windows-nupkg`
+- Release job collects exe from `windows-signed/` and nupkg from `windows-nupkg/`
+- No references to old `windows-artifacts` remain
+
+- [ ] **Step 2: Verify no remaining references to `windows-artifacts`**
+
+Run: `grep -n "windows-artifacts" .github/workflows/build.yml`
+Expected: No output (no matches)
+
+---
+
+## Chunk 2: Manual Setup & Validation
+
+These steps require human action in external systems. They cannot be automated.
+
+### Task 6: SignPath Dashboard Setup (manual — done by project owner)
+
+- [ ] **Step 1: Create project in SignPath**
+  - Go to https://app.signpath.io
+  - Create new project with slug: `sokuji`
+  - Repository URL: `https://github.com/kizuna-ai-lab/sokuji`
+
+- [ ] **Step 2: Link trusted build system**
+  - In project settings, link the predefined "GitHub.com" trusted build system
+
+- [ ] **Step 3: Create artifact configuration**
+  - Name/slug: `default`
+  - Paste the contents of `.signpath/artifact-configurations/default.xml`
+
+- [ ] **Step 4: Verify test-signing policy exists**
+  - Confirm `test-signing` policy with self-signed certificate is available
+
+### Task 7: GitHub Repository Setup (manual — done by project owner)
+
+- [ ] **Step 1: Add SignPath API token as repository secret**
+  - Name: `SIGNPATH_API_TOKEN`
+  - Value: Generate from SignPath dashboard → User menu → API Tokens
+  - The token must have **submitter** role on the `sokuji` project
+
+- [ ] **Step 2: Add SignPath organization ID as repository variable**
+  - Name: `SIGNPATH_ORGANIZATION_ID`
+  - Value: Copy from SignPath dashboard → Organization settings → Organization ID
+  - This is a **variable** (not a secret) — it's not sensitive
+
+### Task 8: Pipeline Validation (after manual setup is complete)
+
+- [ ] **Step 1: Push the branch and create a test tag**
+
+```bash
+git push origin worktree-signpath-windows-signing
+git tag -a v0.0.0-signing-test -m "Test SignPath signing pipeline"
+git push origin v0.0.0-signing-test
+```
+
+- [ ] **Step 2: Monitor the GitHub Actions run**
+  - Verify `build` job completes and uploads `windows-unsigned` + `windows-nupkg`
+  - Verify `sign-windows` job starts, submits to SignPath, and receives signed artifact
+  - Verify `release` job collects signed exe and nupkg in release assets
+
+- [ ] **Step 3: Verify the signed artifact**
+  - Download `SokujiSetup.exe` from the GitHub release
+  - On Windows, run: `Get-AuthenticodeSignature .\SokujiSetup.exe`
+  - Expected: `Status: Valid` with the test-signing certificate subject
+
+- [ ] **Step 4: Clean up test tag**
+
+```bash
+git push origin --delete v0.0.0-signing-test
+git tag -d v0.0.0-signing-test
+```
+
+---
+
+## Phase 2 Reference (future — when release-signing is available)
+
+Not part of this implementation. When SignPath assigns the EV certificate:
+
+1. In SignPath dashboard: assign EV cert to `release-signing` policy, enable origin verification
+2. In workflow: change `signing-policy-slug: test-signing` to `signing-policy-slug: release-signing`
+3. Push a real release tag and verify SmartScreen does not warn on a clean Windows machine
+4. Close issue #105

--- a/docs/superpowers/plans/2026-03-13-signpath-windows-signing.md
+++ b/docs/superpowers/plans/2026-03-13-signpath-windows-signing.md
@@ -178,8 +178,8 @@ Insert this job between the `build` job's closing and the `release` job:
         with:
           api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
           organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-          project-slug: sokuji
-          signing-policy-slug: test-signing
+          project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
           artifact-configuration-slug: default
           github-artifact-id: ${{ steps.upload-for-signing.outputs.artifact-id }}
           wait-for-completion: true
@@ -339,14 +339,22 @@ These steps require human action in external systems. They cannot be automated.
 ### Task 7: GitHub Repository Setup (manual — done by project owner)
 
 - [ ] **Step 1: Add SignPath API token as repository secret**
+  - Go to: Settings → Secrets and variables → Actions → Secrets tab
   - Name: `SIGNPATH_API_TOKEN`
   - Value: Generate from SignPath dashboard → User menu → API Tokens
   - The token must have **submitter** role on the `sokuji` project
 
-- [ ] **Step 2: Add SignPath organization ID as repository variable**
-  - Name: `SIGNPATH_ORGANIZATION_ID`
-  - Value: Copy from SignPath dashboard → Organization settings → Organization ID
-  - This is a **variable** (not a secret) — it's not sensitive
+- [ ] **Step 2: Add SignPath repository variables**
+  - Go to: Settings → Secrets and variables → Actions → Variables tab
+  - Add these three variables:
+
+  | Variable | Value |
+  |----------|-------|
+  | `SIGNPATH_ORGANIZATION_ID` | *(from SignPath dashboard → Organization settings)* |
+  | `SIGNPATH_PROJECT_SLUG` | `sokuji` |
+  | `SIGNPATH_SIGNING_POLICY_SLUG` | `test-signing` |
+
+  These are non-sensitive identifiers. Using variables (not secrets) so they're visible and easy to change. Phase 2 only requires changing `SIGNPATH_SIGNING_POLICY_SLUG` to `release-signing`.
 
 ### Task 8: Pipeline Validation (after manual setup is complete)
 
@@ -382,6 +390,6 @@ git tag -d v0.0.0-signing-test
 Not part of this implementation. When SignPath assigns the EV certificate:
 
 1. In SignPath dashboard: assign EV cert to `release-signing` policy, enable origin verification
-2. In workflow: change `signing-policy-slug: test-signing` to `signing-policy-slug: release-signing`
+2. In GitHub repo variables: change `SIGNPATH_SIGNING_POLICY_SLUG` from `test-signing` to `release-signing`
 3. Push a real release tag and verify SmartScreen does not warn on a clean Windows machine
 4. Close issue #105

--- a/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
+++ b/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
@@ -127,19 +127,26 @@ SignPath policies are configured **in the SignPath dashboard**, not via reposito
 
 #### Build job changes
 
-Replace the existing `Upload Windows artifacts` step. Only upload `Setup.exe` for signing:
+Replace the existing `Upload Windows artifacts` step with two separate uploads:
 
 ```yaml
-# Replace the existing "Upload Windows artifacts" step with this:
-- name: Upload unsigned Windows artifacts for signing
+# Replace the existing "Upload Windows artifacts" step with these two:
+- name: Upload unsigned Windows installer for signing
   if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
   uses: actions/upload-artifact@v4
   with:
     name: windows-unsigned
     path: out/make/squirrel.windows/x64/*Setup*.exe
+
+- name: Upload Windows nupkg for release
+  if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+  uses: actions/upload-artifact@v4
+  with:
+    name: windows-nupkg
+    path: out/make/squirrel.windows/x64/*.nupkg
 ```
 
-Note: Only the Setup.exe is uploaded (not the nupkg or RELEASES file). The release job will collect the signed Setup.exe from `windows-signed`.
+The Setup.exe goes through signing. The nupkg is passed directly to the release job (needed for Squirrel auto-updates). The RELEASES file is not uploaded — it was never included in GitHub Releases.
 
 #### New sign job
 
@@ -172,6 +179,7 @@ sign-windows:
       with:
         name: windows-to-sign
         path: unsigned/
+        overwrite: true
 
     - name: Submit signing request
       id: sign
@@ -206,13 +214,21 @@ release:
   steps:
     # ... existing download steps for linux, macos ...
 
-    - name: Download Windows artifacts
+    - name: Download signed Windows installer
       uses: actions/download-artifact@v4
       with:
         name: windows-signed
-        path: windows-artifacts
+        path: windows-signed
 
-    # Rest of release job unchanged — it already collects *.exe from windows-artifacts/
+    - name: Download Windows nupkg
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-nupkg
+        path: windows-nupkg
+
+    # Update "Collect release assets" to use new paths:
+    #   find windows-signed -name "*.exe" -exec cp {} release-assets/ \;
+    #   find windows-nupkg -name "*.nupkg" -exec cp {} release-assets/ \;
 ```
 
 ## Files Changed

--- a/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
+++ b/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
@@ -12,7 +12,7 @@ Windows SmartScreen blocks unsigned executables with "Unknown Publisher" warning
 
 Use [SignPath](https://signpath.io) (approved OSS plan) for Windows code signing. SignPath provides EV-level Authenticode signing through their HSM infrastructure, integrated as a post-build step in GitHub Actions.
 
-**Scope**: Windows code signing only (`.exe` installer + `.nupkg` app package). No macOS signing, no Microsoft Store distribution.
+**Scope**: Windows code signing only (Setup.exe installer). No macOS signing, no Microsoft Store distribution.
 
 ## Architecture
 
@@ -20,13 +20,13 @@ Use [SignPath](https://signpath.io) (approved OSS plan) for Windows code signing
 
 ```
 Build job (existing, windows-latest)
-  → electron-forge make → unsigned SokujiSetup.exe + .nupkg
-  → upload-artifact (windows-unsigned)
+  → electron-forge make → unsigned SokujiSetup.exe
+  → upload-artifact (windows-unsigned) — Setup.exe only
         ↓
 Sign job (new, ubuntu-latest) — tag pushes only
   → submit-signing-request to SignPath
-  → SignPath deep-signs: PE files inside .nupkg → nuget-sign .nupkg → authenticode-sign Setup.exe
-  → download signed artifacts
+  → SignPath Authenticode-signs Setup.exe
+  → download signed Setup.exe
   → upload-artifact (windows-signed)
         ↓
 Release job (existing, modified)
@@ -35,11 +35,21 @@ Release job (existing, modified)
 ```
 
 Key architectural decisions:
+- **Sign only Setup.exe** — Squirrel's Setup.exe embeds the full `.nupkg` inside itself. SmartScreen checks the signature of the executable the user runs. Signing Setup.exe is sufficient and is the established pattern used by other Electron + SignPath OSS projects (TurboWarp, VSCodium, Spicetify). No deep signing of nupkg internals needed.
 - Signing happens **externally** via SignPath API, not inside `electron-forge make`
 - No changes to `forge.config.js` — signing is a CI-only concern
 - `<zip-file>` must be root element because GitHub's `upload-artifact` wraps everything in ZIP
 - All jobs must run on **GitHub-hosted runners** (OSS requirement)
 - Sign job runs **only on tag pushes** — avoids secret unavailability on fork PRs and unnecessary SignPath API calls on every push
+
+### Why not deep-sign the nupkg?
+
+Research into existing Electron + SignPath integrations shows:
+- **TurboWarp**: Signs only `TurboWarp-Setup*x64.exe`
+- **VSCodium**: Signs only `*.exe` and `*.msi`
+- **Spicetify**: Signs only `spicetify.exe`
+
+None of these projects deep-sign nupkg internals. Setup.exe contains the Squirrel bootstrapper with the nupkg embedded — the OS only checks the outer executable's signature. Deep signing would add complexity and potential failure points for no user-facing benefit.
 
 ### Phased Rollout
 
@@ -54,65 +64,28 @@ If signing breaks a release, the sign job can be bypassed by:
 
 This restores the pre-signing behavior (unsigned releases).
 
-## Pre-Implementation: Verify Nupkg Structure
-
-**This step is mandatory before creating the artifact configuration.**
-
-Squirrel.Windows uses the NuGet package format but may not follow the standard `lib/net*` layout. The exact internal path must be verified:
-
-```bash
-# Build locally on Windows (or from CI artifacts)
-npx electron-forge make --platform win32
-
-# Inspect the nupkg (it's a ZIP file)
-unzip -l out/make/squirrel.windows/x64/*.nupkg
-```
-
-Common Squirrel layouts:
-- `lib/net45/` — most common, Squirrel's historical convention
-- `lib/` — flat layout in some versions
-
-The artifact configuration XML below assumes `lib/net45/`. **Adjust paths based on actual inspection results.**
-
 ## Artifact Configuration
 
 **File**: `.signpath/artifact-configurations/default.xml`
 
-Electron Forge Squirrel output structure:
+Electron Forge Squirrel output:
 ```
 out/make/squirrel.windows/x64/
-  ├── SokujiSetup.exe           # Squirrel installer
-  ├── Sokuji-x.y.z-full.nupkg   # NuGet update package (contains app .exe + .dll)
-  └── RELEASES                   # Squirrel update manifest (plain text, no signing needed)
+  ├── SokujiSetup.exe           # Squirrel installer (embeds nupkg inside)
+  ├── Sokuji-x.y.z-full.nupkg   # NuGet update package (not uploaded for signing)
+  └── RELEASES                   # Squirrel update manifest (not uploaded for signing)
 ```
 
-SignPath artifact configuration (deep signing):
+Only `SokujiSetup.exe` is uploaded for signing. The artifact configuration:
+
 ```xml
 <?xml version="1.0" encoding="utf-8"?>
 <artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
   <zip-file>
-    <!-- Deep sign: sign PE files inside nupkg, then sign the nupkg itself -->
-    <nupkg-file path="*.nupkg" max-matches="unbounded">
-      <!-- VERIFY THIS PATH: run `unzip -l *.nupkg` and adjust if needed -->
-      <directory path="lib">
-        <directory path="net*" max-matches="unbounded">
-          <pe-file-set>
-            <include path="*.exe" max-matches="unbounded" />
-            <include path="*.dll" min-matches="0" max-matches="unbounded" />
-            <for-each>
-              <authenticode-sign />
-            </for-each>
-          </pe-file-set>
-        </directory>
-      </directory>
-      <nuget-sign />
-    </nupkg-file>
-    <!-- Sign the Squirrel installer exe -->
+    <!-- Sign the Squirrel installer exe (contains embedded nupkg) -->
     <pe-file path="*Setup*.exe">
       <authenticode-sign />
     </pe-file>
-    <!-- RELEASES file: plain text, no signing needed. -->
-    <!-- If SignPath rejects unmatched files, add: <file path="RELEASES" /> -->
   </zip-file>
 </artifact-configuration>
 ```
@@ -154,20 +127,19 @@ SignPath policies are configured **in the SignPath dashboard**, not via reposito
 
 #### Build job changes
 
-Add upload of unsigned Windows artifacts (runs on all tag pushes, alongside existing artifact uploads):
+Replace the existing `Upload Windows artifacts` step. Only upload `Setup.exe` for signing:
 
 ```yaml
-# After existing "Build Electron app with Forge" step (windows-latest)
 # Replace the existing "Upload Windows artifacts" step with this:
 - name: Upload unsigned Windows artifacts for signing
   if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
   uses: actions/upload-artifact@v4
   with:
     name: windows-unsigned
-    path: out/make/squirrel.windows/x64/
+    path: out/make/squirrel.windows/x64/*Setup*.exe
 ```
 
-This **replaces** the existing `Upload Windows artifacts` step (which uploaded to `windows-artifacts`). The unsigned artifacts are now named `windows-unsigned`, and the release job will consume `windows-signed` after the sign job processes them.
+Note: Only the Setup.exe is uploaded (not the nupkg or RELEASES file). The release job will collect the signed Setup.exe from `windows-signed`.
 
 #### New sign job
 
@@ -203,7 +175,7 @@ sign-windows:
 
     - name: Submit signing request
       id: sign
-      uses: signpath/github-action-submit-signing-request@v1
+      uses: signpath/github-action-submit-signing-request@v2
       with:
         api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
         organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
@@ -247,7 +219,7 @@ release:
 
 | File | Action | Description |
 |------|--------|-------------|
-| `.signpath/artifact-configurations/default.xml` | Create | Artifact config for deep signing |
+| `.signpath/artifact-configurations/default.xml` | Create | Artifact config for Authenticode signing of Setup.exe |
 | `.github/workflows/build.yml` | Modify | Add sign job, replace Windows artifact upload, update release job |
 
 ## Manual Setup Required
@@ -267,8 +239,7 @@ These steps must be completed in external systems before the CI pipeline will wo
 3. **Create artifact configuration**
    - Name/slug: `default`
    - Paste the XML from the "Artifact Configuration" section above
-   - Alternatively: upload a sample unsigned ZIP for SignPath to analyze, then adjust
-   - **Important**: Verify the nupkg internal paths first (see "Pre-Implementation" section)
+   - Alternatively: upload a sample unsigned Setup.exe ZIP for SignPath to analyze
 
 4. **Verify signing policies**
    - `test-signing`: Should already exist with self-signed certificate
@@ -297,14 +268,12 @@ The `.cer` file from SignPath's test-signing certificate can be installed on a W
 
 ## Testing Plan
 
-1. **Nupkg structure verification**: Build locally, inspect `.nupkg` contents, adjust artifact config XML if needed
-2. **Pipeline validation**: Push a test tag (e.g., `v0.0.0-signing-test`), confirm sign job runs and completes with `test-signing`
-3. **Artifact inspection**: Download signed artifacts, verify Authenticode signatures:
+1. **Pipeline validation**: Push a test tag (e.g., `v0.0.0-signing-test`), confirm sign job runs and completes with `test-signing`
+2. **Artifact inspection**: Download signed artifacts, verify Authenticode signatures:
    - PowerShell: `Get-AuthenticodeSignature .\SokujiSetup.exe`
    - Or: `signtool verify /pa SokujiSetup.exe`
-4. **Nupkg deep signing**: Extract signed `.nupkg`, verify inner `.exe` and `.dll` files are also signed
-5. **Clean install test**: Run signed installer on a Windows test machine (with test cert installed)
-6. **Full release test**: Create a test tag, verify the complete build → sign → release flow
+3. **Clean install test**: Run signed installer on a Windows test machine (with test cert installed)
+4. **Full release test**: Create a test tag, verify the complete build → sign → release flow
 
 ## Phase 2 Checklist (when release-signing becomes available)
 

--- a/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
+++ b/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
@@ -94,16 +94,12 @@ Only `SokujiSetup.exe` is uploaded for signing. The artifact configuration:
 
 ### Policy selection
 
-During Phase 1, use `test-signing` only. During Phase 2, switch to `release-signing` for tag pushes:
+The signing policy slug is configured as a GitHub repository variable (`SIGNPATH_SIGNING_POLICY_SLUG`), not hardcoded in the workflow. To switch policies, change the variable value — no workflow file changes needed.
 
-```yaml
-# Phase 1 (immediate)
-signing-policy-slug: test-signing
+- **Phase 1**: Set `SIGNPATH_SIGNING_POLICY_SLUG` = `test-signing`
+- **Phase 2**: Set `SIGNPATH_SIGNING_POLICY_SLUG` = `release-signing`
 
-# Phase 2 (after EV cert is available)
-signing-policy-slug: release-signing
-```
-
+Policy details:
 - **`test-signing`**: Self-signed cert. Validates pipeline correctness. Available now.
 - **`release-signing`**: EV cert from SignPath Foundation. Solves SmartScreen. Available after SignPath configures it.
 
@@ -187,8 +183,8 @@ sign-windows:
       with:
         api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
         organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-        project-slug: sokuji
-        signing-policy-slug: test-signing
+        project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+        signing-policy-slug: ${{ vars.SIGNPATH_SIGNING_POLICY_SLUG }}
         artifact-configuration-slug: default
         github-artifact-id: ${{ steps.upload-for-signing.outputs.artifact-id }}
         wait-for-completion: true
@@ -271,8 +267,13 @@ These steps must be completed in external systems before the CI pipeline will wo
    - Generate in SignPath dashboard: User menu → API Tokens
    - Token must have **submitter** role on the `sokuji` project
 
-2. **Add variable**: `SIGNPATH_ORGANIZATION_ID`
-   - Found in SignPath dashboard: Organization settings → Organization ID
+2. **Add variables** (Settings → Secrets and variables → Actions → Variables tab):
+
+   | Variable | Value | Notes |
+   |----------|-------|-------|
+   | `SIGNPATH_ORGANIZATION_ID` | *(from SignPath dashboard → Organization settings)* | Organization identifier |
+   | `SIGNPATH_PROJECT_SLUG` | `sokuji` | Project slug in SignPath |
+   | `SIGNPATH_SIGNING_POLICY_SLUG` | `test-signing` | Change to `release-signing` for Phase 2 |
 
 ### Test Certificate (Phase 1 validation)
 
@@ -295,7 +296,7 @@ The `.cer` file from SignPath's test-signing certificate can be installed on a W
 
 - [ ] SignPath assigns EV certificate to `release-signing` policy
 - [ ] Configure origin verification on `release-signing` policy (main branch + v* tags)
-- [ ] Update workflow: change `signing-policy-slug` from `test-signing` to `release-signing`
+- [ ] Update GitHub variable: change `SIGNPATH_SIGNING_POLICY_SLUG` from `test-signing` to `release-signing`
 - [ ] Push a test release tag to validate EV signing end-to-end
 - [ ] Verify SmartScreen does NOT warn on a clean Windows machine (no test cert installed)
 - [ ] Update issue #105 as complete

--- a/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
+++ b/docs/superpowers/specs/2026-03-13-signpath-windows-signing-design.md
@@ -1,0 +1,316 @@
+# SignPath Windows Code Signing Design
+
+**Issue**: [#105 — Add Windows code signing for SmartScreen trust](https://github.com/kizuna-ai-lab/sokuji/issues/105)
+**Date**: 2026-03-13
+**Status**: Approved
+
+## Problem
+
+Windows SmartScreen blocks unsigned executables with "Unknown Publisher" warnings. The current CI pipeline (`build.yml`) produces unsigned Windows installers via Electron Forge's `maker-squirrel`.
+
+## Decision
+
+Use [SignPath](https://signpath.io) (approved OSS plan) for Windows code signing. SignPath provides EV-level Authenticode signing through their HSM infrastructure, integrated as a post-build step in GitHub Actions.
+
+**Scope**: Windows code signing only (`.exe` installer + `.nupkg` app package). No macOS signing, no Microsoft Store distribution.
+
+## Architecture
+
+### Signing Flow
+
+```
+Build job (existing, windows-latest)
+  → electron-forge make → unsigned SokujiSetup.exe + .nupkg
+  → upload-artifact (windows-unsigned)
+        ↓
+Sign job (new, ubuntu-latest) — tag pushes only
+  → submit-signing-request to SignPath
+  → SignPath deep-signs: PE files inside .nupkg → nuget-sign .nupkg → authenticode-sign Setup.exe
+  → download signed artifacts
+  → upload-artifact (windows-signed)
+        ↓
+Release job (existing, modified)
+  → download windows-signed (instead of windows-artifacts)
+  → attach to GitHub Release
+```
+
+Key architectural decisions:
+- Signing happens **externally** via SignPath API, not inside `electron-forge make`
+- No changes to `forge.config.js` — signing is a CI-only concern
+- `<zip-file>` must be root element because GitHub's `upload-artifact` wraps everything in ZIP
+- All jobs must run on **GitHub-hosted runners** (OSS requirement)
+- Sign job runs **only on tag pushes** — avoids secret unavailability on fork PRs and unnecessary SignPath API calls on every push
+
+### Phased Rollout
+
+- **Phase 1 (immediate)**: Implement CI pipeline with `test-signing` policy. Validate end-to-end by pushing a test tag (e.g., `v0.0.0-signing-test`).
+- **Phase 2 (after SignPath approval)**: Switch to `release-signing` (EV cert) for real release tags. This is a config-only change — update the `signing-policy-slug` value in the workflow.
+
+### Rollback
+
+If signing breaks a release, the sign job can be bypassed by:
+1. Removing `sign-windows` from the release job's `needs` array
+2. Changing the release job to download `windows-unsigned` instead of `windows-signed`
+
+This restores the pre-signing behavior (unsigned releases).
+
+## Pre-Implementation: Verify Nupkg Structure
+
+**This step is mandatory before creating the artifact configuration.**
+
+Squirrel.Windows uses the NuGet package format but may not follow the standard `lib/net*` layout. The exact internal path must be verified:
+
+```bash
+# Build locally on Windows (or from CI artifacts)
+npx electron-forge make --platform win32
+
+# Inspect the nupkg (it's a ZIP file)
+unzip -l out/make/squirrel.windows/x64/*.nupkg
+```
+
+Common Squirrel layouts:
+- `lib/net45/` — most common, Squirrel's historical convention
+- `lib/` — flat layout in some versions
+
+The artifact configuration XML below assumes `lib/net45/`. **Adjust paths based on actual inspection results.**
+
+## Artifact Configuration
+
+**File**: `.signpath/artifact-configurations/default.xml`
+
+Electron Forge Squirrel output structure:
+```
+out/make/squirrel.windows/x64/
+  ├── SokujiSetup.exe           # Squirrel installer
+  ├── Sokuji-x.y.z-full.nupkg   # NuGet update package (contains app .exe + .dll)
+  └── RELEASES                   # Squirrel update manifest (plain text, no signing needed)
+```
+
+SignPath artifact configuration (deep signing):
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<artifact-configuration xmlns="http://signpath.io/artifact-configuration/v1">
+  <zip-file>
+    <!-- Deep sign: sign PE files inside nupkg, then sign the nupkg itself -->
+    <nupkg-file path="*.nupkg" max-matches="unbounded">
+      <!-- VERIFY THIS PATH: run `unzip -l *.nupkg` and adjust if needed -->
+      <directory path="lib">
+        <directory path="net*" max-matches="unbounded">
+          <pe-file-set>
+            <include path="*.exe" max-matches="unbounded" />
+            <include path="*.dll" min-matches="0" max-matches="unbounded" />
+            <for-each>
+              <authenticode-sign />
+            </for-each>
+          </pe-file-set>
+        </directory>
+      </directory>
+      <nuget-sign />
+    </nupkg-file>
+    <!-- Sign the Squirrel installer exe -->
+    <pe-file path="*Setup*.exe">
+      <authenticode-sign />
+    </pe-file>
+    <!-- RELEASES file: plain text, no signing needed. -->
+    <!-- If SignPath rejects unmatched files, add: <file path="RELEASES" /> -->
+  </zip-file>
+</artifact-configuration>
+```
+
+## Signing Policies
+
+### Policy selection
+
+During Phase 1, use `test-signing` only. During Phase 2, switch to `release-signing` for tag pushes:
+
+```yaml
+# Phase 1 (immediate)
+signing-policy-slug: test-signing
+
+# Phase 2 (after EV cert is available)
+signing-policy-slug: release-signing
+```
+
+- **`test-signing`**: Self-signed cert. Validates pipeline correctness. Available now.
+- **`release-signing`**: EV cert from SignPath Foundation. Solves SmartScreen. Available after SignPath configures it.
+
+### Policy enforcement
+
+SignPath policies are configured **in the SignPath dashboard**, not via repository files. The policy settings to configure:
+
+| Setting | `test-signing` | `release-signing` |
+|---------|---------------|-------------------|
+| Certificate | Self-signed (auto-assigned) | EV cert (assigned by SignPath) |
+| Submitters | CI user | CI user |
+| Approval required | No | No (or optional manual approval) |
+| Trusted build system | GitHub.com | GitHub.com |
+| Origin verification | Off | On — restrict to `main` branch + `v*` tags |
+| GitHub-hosted runners | Required (OSS) | Required (OSS) |
+| Disallow reruns | Off | On |
+
+## Workflow Changes
+
+### Modified: `.github/workflows/build.yml`
+
+#### Build job changes
+
+Add upload of unsigned Windows artifacts (runs on all tag pushes, alongside existing artifact uploads):
+
+```yaml
+# After existing "Build Electron app with Forge" step (windows-latest)
+# Replace the existing "Upload Windows artifacts" step with this:
+- name: Upload unsigned Windows artifacts for signing
+  if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
+  uses: actions/upload-artifact@v4
+  with:
+    name: windows-unsigned
+    path: out/make/squirrel.windows/x64/
+```
+
+This **replaces** the existing `Upload Windows artifacts` step (which uploaded to `windows-artifacts`). The unsigned artifacts are now named `windows-unsigned`, and the release job will consume `windows-signed` after the sign job processes them.
+
+#### New sign job
+
+```yaml
+sign-windows:
+  name: Sign Windows artifacts
+  if: startsWith(github.ref, 'refs/tags/v')
+  needs: build
+  runs-on: ubuntu-latest
+  permissions:
+    contents: read
+    id-token: write
+    actions: read
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Download unsigned artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-unsigned
+        path: unsigned/
+
+    # SignPath requires a github-artifact-id from upload-artifact.
+    # We must re-upload because the original upload happened in a different job
+    # and artifact IDs cannot be passed across jobs without explicit output wiring.
+    - name: Upload for SignPath
+      id: upload-for-signing
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-to-sign
+        path: unsigned/
+
+    - name: Submit signing request
+      id: sign
+      uses: signpath/github-action-submit-signing-request@v1
+      with:
+        api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+        organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+        project-slug: sokuji
+        signing-policy-slug: test-signing
+        artifact-configuration-slug: default
+        github-artifact-id: ${{ steps.upload-for-signing.outputs.artifact-id }}
+        wait-for-completion: true
+        output-artifact-directory: signed/
+        wait-for-completion-timeout-in-seconds: 1200
+
+    - name: Upload signed artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: windows-signed
+        path: signed/
+```
+
+#### Release job changes
+
+Update `needs` and download signed artifacts:
+
+```yaml
+release:
+  if: startsWith(github.ref, 'refs/tags/v')
+  needs: [build, sign-windows]
+  runs-on: ubuntu-latest
+  steps:
+    # ... existing download steps for linux, macos ...
+
+    - name: Download Windows artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: windows-signed
+        path: windows-artifacts
+
+    # Rest of release job unchanged — it already collects *.exe from windows-artifacts/
+```
+
+## Files Changed
+
+| File | Action | Description |
+|------|--------|-------------|
+| `.signpath/artifact-configurations/default.xml` | Create | Artifact config for deep signing |
+| `.github/workflows/build.yml` | Modify | Add sign job, replace Windows artifact upload, update release job |
+
+## Manual Setup Required
+
+These steps must be completed in external systems before the CI pipeline will work.
+
+### SignPath Dashboard (https://app.signpath.io)
+
+1. **Create project**
+   - Project slug: `sokuji`
+   - Repository URL: `https://github.com/kizuna-ai-lab/sokuji`
+
+2. **Link trusted build system**
+   - Select the predefined "GitHub.com" trusted build system
+   - Link it to the `sokuji` project
+
+3. **Create artifact configuration**
+   - Name/slug: `default`
+   - Paste the XML from the "Artifact Configuration" section above
+   - Alternatively: upload a sample unsigned ZIP for SignPath to analyze, then adjust
+   - **Important**: Verify the nupkg internal paths first (see "Pre-Implementation" section)
+
+4. **Verify signing policies**
+   - `test-signing`: Should already exist with self-signed certificate
+   - `release-signing`: Will be available after SignPath configures it — see Phase 2 checklist
+
+5. **Set origin verification** (on `release-signing` policy, when available)
+   - Repository URL: `https://github.com/kizuna-ai-lab/sokuji`
+   - Allowed branches: `main` and tags matching `v*`
+
+### GitHub Repository Settings
+
+1. **Add secret**: `SIGNPATH_API_TOKEN`
+   - Generate in SignPath dashboard: User menu → API Tokens
+   - Token must have **submitter** role on the `sokuji` project
+
+2. **Add variable**: `SIGNPATH_ORGANIZATION_ID`
+   - Found in SignPath dashboard: Organization settings → Organization ID
+
+### Test Certificate (Phase 1 validation)
+
+The `.cer` file from SignPath's test-signing certificate can be installed on a Windows test machine:
+1. Double-click the `.cer` file
+2. Install to "Trusted Root Certification Authorities" store
+3. Run the test-signed installer — it should not show SmartScreen warning on that machine
+4. This confirms signing is working correctly before EV cert is available
+
+## Testing Plan
+
+1. **Nupkg structure verification**: Build locally, inspect `.nupkg` contents, adjust artifact config XML if needed
+2. **Pipeline validation**: Push a test tag (e.g., `v0.0.0-signing-test`), confirm sign job runs and completes with `test-signing`
+3. **Artifact inspection**: Download signed artifacts, verify Authenticode signatures:
+   - PowerShell: `Get-AuthenticodeSignature .\SokujiSetup.exe`
+   - Or: `signtool verify /pa SokujiSetup.exe`
+4. **Nupkg deep signing**: Extract signed `.nupkg`, verify inner `.exe` and `.dll` files are also signed
+5. **Clean install test**: Run signed installer on a Windows test machine (with test cert installed)
+6. **Full release test**: Create a test tag, verify the complete build → sign → release flow
+
+## Phase 2 Checklist (when release-signing becomes available)
+
+- [ ] SignPath assigns EV certificate to `release-signing` policy
+- [ ] Configure origin verification on `release-signing` policy (main branch + v* tags)
+- [ ] Update workflow: change `signing-policy-slug` from `test-signing` to `release-signing`
+- [ ] Push a test release tag to validate EV signing end-to-end
+- [ ] Verify SmartScreen does NOT warn on a clean Windows machine (no test cert installed)
+- [ ] Update issue #105 as complete


### PR DESCRIPTION
## Summary

- Add SignPath integration for Authenticode signing of Windows Setup.exe installer
- New `sign-windows` job in CI pipeline between build and release
- Only signs Setup.exe (Squirrel embeds nupkg inside; SmartScreen checks outer executable)
- All SignPath config externalized as GitHub variables for easy Phase 2 switch

Closes #105

## Changes

- **`.signpath/artifact-configurations/default.xml`** — SignPath artifact config (PE file Authenticode signing)
- **`.github/workflows/build.yml`** — Split Windows artifact uploads, add sign-windows job, update release job
- **`docs/superpowers/specs/`** — Design spec with manual setup instructions
- **`docs/superpowers/plans/`** — Implementation plan

## Manual Setup Required (before pipeline works)

### SignPath Dashboard
1. Create project with slug `sokuji`, link GitHub.com trusted build system
2. Create artifact configuration `default` with the XML from `.signpath/artifact-configurations/default.xml`
3. Verify `test-signing` policy exists

### GitHub Repository
1. Secret: `SIGNPATH_API_TOKEN`
2. Variables: `SIGNPATH_ORGANIZATION_ID`, `SIGNPATH_PROJECT_SLUG` (`sokuji`), `SIGNPATH_SIGNING_POLICY_SLUG` (`test-signing`)

## Phase 2 (after EV cert)
Change `SIGNPATH_SIGNING_POLICY_SLUG` variable to `release-signing` — no code changes needed.

## Test plan
- [ ] Complete SignPath dashboard setup (project, artifact config, trusted build system)
- [ ] Add GitHub secret and variables
- [ ] Push test tag `v0.0.0-signing-test` and verify sign-windows job completes
- [ ] Download signed Setup.exe and verify Authenticode signature
- [ ] Clean install test on Windows machine

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Windows code-signing to CI: signs installer artifacts via SignPath, separates unsigned installer and package artifacts, uploads signed outputs, and makes release depend on signing.

* **Documentation**
  * Added implementation plan, rollout/design notes, and an artifact signing configuration describing Authenticode signing for Windows installers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->