### PR TITLE
feat: migrate OpenAI Realtime API from beta to GA protocol

### DIFF
--- a/docs/superpowers/plans/2026-03-14-openai-ga-migration.md
+++ b/docs/superpowers/plans/2026-03-14-openai-ga-migration.md
@@ -1,0 +1,1063 @@
+# OpenAI Realtime API GA Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the OpenAI direct provider from the deprecated beta Realtime API protocol to the GA protocol using the official `openai` SDK, while keeping `openai-realtime-api` for OpenAI Compatible and Kizuna AI providers.
+
+**Architecture:** New `OpenAIGAClient` using `OpenAIRealtimeWebSocket` from official `openai` SDK for `Provider.OPENAI` WebSocket transport. Existing `OpenAIClient` stays for beta-protocol providers. `OpenAIWebRTCClient` gets defensive dual event name handling.
+
+**Tech Stack:** `openai` SDK v6.27.0+, TypeScript, WebSocket, Zustand
+
+**Spec:** `docs/superpowers/specs/2026-03-14-openai-ga-migration-design.md`
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|------|---------------|--------|
+| `package.json` | Root dependencies | Modify: add `openai` |
+| `extension/package.json` | Extension dependencies | Modify: add `openai` |
+| `src/services/interfaces/IClient.ts` | Client interface contract | Modify: fix import |
+| `src/services/clients/OpenAIClient.ts` | Beta WebSocket client (Compatible/KizunaAI) | Modify: fix import |
+| `src/services/clients/OpenAIGAClient.ts` | GA WebSocket client (OpenAI direct) | **Create** |
+| `src/services/clients/OpenAIWebRTCClient.ts` | WebRTC client | Modify: add GA event names |
+| `src/services/clients/ClientFactory.ts` | Client routing | Modify: route to GA client |
+| `src/stores/logStore.ts` | Event type definitions | Modify: decouple from library |
+| `evals/runner/clients/NodeOpenAIClient.ts` | Eval runner client | Modify: add TODO |
+
+---
+
+## Chunk 1: Dependencies and Import Fixes
+
+### Task 1: Add `openai` SDK dependency
+
+**Files:**
+- Modify: `package.json`
+- Modify: `extension/package.json`
+
+- [ ] **Step 1: Add openai to root package.json**
+
+In `package.json`, add to `"dependencies"`:
+```json
+"openai": "^6.27.0"
+```
+
+- [ ] **Step 2: Add openai to extension package.json**
+
+In `extension/package.json`, add to `"dependencies"`:
+```json
+"openai": "^6.27.0"
+```
+
+- [ ] **Step 3: Install dependencies**
+
+Run: `npm install`
+Expected: Clean install, no errors. Both `openai` and `openai-realtime-api` coexist.
+
+- [ ] **Step 4: Verify SDK exports**
+
+Run: `node -e "const { OpenAIRealtimeWebSocket } = require('openai/beta/realtime/websocket'); console.log(typeof OpenAIRealtimeWebSocket)"`
+
+If that path fails, try: `node -e "const openai = require('openai'); console.log(Object.keys(openai))"`
+
+Document the correct import path. The issue mentions `openai/realtime/websocket` but the actual path may differ in v6.27.0+. Check `node_modules/openai/` for the exact export structure.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add package.json extension/package.json package-lock.json
+git commit -m "chore: add official openai SDK dependency for GA Realtime API migration"
+```
+
+---
+
+### Task 2: Fix stale LogContext imports
+
+**Files:**
+- Modify: `src/services/interfaces/IClient.ts:6`
+- Modify: `src/services/clients/OpenAIClient.ts:8`
+
+- [ ] **Step 1: Fix IClient.ts import**
+
+In `src/services/interfaces/IClient.ts`, line 6, change:
+```typescript
+// FROM:
+import { RealtimeEvent } from '../../contexts/LogContext';
+// TO:
+import { RealtimeEvent } from '../../stores/logStore';
+```
+
+- [ ] **Step 2: Fix OpenAIClient.ts import**
+
+In `src/services/clients/OpenAIClient.ts`, line 8, change:
+```typescript
+// FROM:
+import { RealtimeEvent } from '../../contexts/LogContext';
+// TO:
+import { RealtimeEvent } from '../../stores/logStore';
+```
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: No TypeScript errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/interfaces/IClient.ts src/services/clients/OpenAIClient.ts
+git commit -m "fix: correct stale LogContext imports to use logStore"
+```
+
+---
+
+### Task 3: Decouple logStore.ts from openai-realtime-api types
+
+**Files:**
+- Modify: `src/stores/logStore.ts`
+
+- [ ] **Step 1: Remove the openai-realtime-api type imports**
+
+In `src/stores/logStore.ts`, remove lines 5-9:
+```typescript
+import type {
+  RealtimeServerEvents,
+  RealtimeClientEvents,
+  RealtimeCustomEvents
+} from 'openai-realtime-api';
+```
+
+- [ ] **Step 2: Replace type references in EventData**
+
+In `src/stores/logStore.ts`, replace the three type references (lines 36-38):
+```typescript
+// FROM:
+    | RealtimeServerEvents.EventType
+    | RealtimeClientEvents.EventType
+    | RealtimeCustomEvents.EventType
+```
+
+With explicit string literals:
+```typescript
+    // OpenAI server events (shared between beta and GA)
+    | 'session.created' | 'session.updated'
+    | 'conversation.created'
+    | 'conversation.item.created' | 'conversation.item.deleted' | 'conversation.item.truncated'
+    | 'conversation.item.input_audio_transcription.completed'
+    | 'conversation.item.input_audio_transcription.failed'
+    | 'input_audio_buffer.committed' | 'input_audio_buffer.cleared'
+    | 'input_audio_buffer.speech_started' | 'input_audio_buffer.speech_stopped'
+    | 'response.created' | 'response.done'
+    | 'response.output_item.added' | 'response.output_item.done'
+    | 'response.function_call_arguments.delta' | 'response.function_call_arguments.done'
+    | 'rate_limits.updated'
+    | 'error'
+    // Beta-only event names (OpenAI Compatible, Kizuna AI)
+    | 'response.text.delta' | 'response.text.done'
+    | 'response.audio.delta' | 'response.audio.done'
+    | 'response.audio_transcript.delta' | 'response.audio_transcript.done'
+    // GA-only event names (OpenAI direct)
+    | 'response.output_text.delta' | 'response.output_text.done'
+    | 'response.output_audio.delta' | 'response.output_audio.done'
+    | 'response.output_audio_transcript.delta' | 'response.output_audio_transcript.done'
+    | 'response.output_text.annotation.added'
+    | 'conversation.item.added' | 'conversation.item.done'
+    | 'response.content_part.added' | 'response.content_part.done'
+    // OpenAI client events
+    | 'session.update'
+    | 'input_audio_buffer.append' | 'input_audio_buffer.commit' | 'input_audio_buffer.clear'
+    | 'conversation.item.create' | 'conversation.item.truncate' | 'conversation.item.delete'
+    | 'response.create' | 'response.cancel'
+    // openai-realtime-api custom events (for beta clients)
+    | 'conversation.item.appended' | 'conversation.item.completed'
+    | 'conversation.updated' | 'conversation.interrupted'
+    | 'realtime.event'
+```
+
+- [ ] **Step 3: Verify grouping logic handles GA events**
+
+Check the grouping logic around line 242 in `logStore.ts`. The existing code uses `eventType.includes('delta')` which catches GA delta events like `response.output_audio.delta`. Also verify `eventType === 'input_audio_buffer.append'` has no issue. No changes needed — just verify.
+
+- [ ] **Step 4: Verify build**
+
+Run: `npm run build`
+Expected: No TypeScript errors. The `EventData.type` union now covers all event names inline.
+
+- [ ] **Step 5: Run tests**
+
+Run: `npm run test`
+Expected: All existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/stores/logStore.ts
+git commit -m "refactor: decouple logStore event types from openai-realtime-api package"
+```
+
+---
+
+## Chunk 2: Create OpenAIGAClient
+
+### Task 4: Create OpenAIGAClient.ts — Connection & Session Management
+
+**Files:**
+- Create: `src/services/clients/OpenAIGAClient.ts`
+
+**Reference:** `src/services/clients/OpenAIWebRTCClient.ts` for conversation tracking patterns, `src/services/clients/OpenAIClient.ts` for session config mapping and static methods.
+
+- [ ] **Step 1: Create the file with imports and class skeleton**
+
+Create `src/services/clients/OpenAIGAClient.ts`:
+
+```typescript
+/**
+ * OpenAIGAClient
+ *
+ * OpenAI Realtime API client using the official openai SDK's GA protocol.
+ * Uses OpenAIRealtimeWebSocket for WebSocket transport to api.openai.com.
+ *
+ * This client is used ONLY for Provider.OPENAI with WebSocket transport.
+ * OpenAI Compatible and Kizuna AI providers use OpenAIClient (beta protocol).
+ *
+ * Key differences from OpenAIClient (beta):
+ * - Uses official openai SDK instead of third-party openai-realtime-api
+ * - GA event names (response.output_text.delta vs response.text.delta)
+ * - Manual conversation item tracking (no library helper)
+ * - Manual base64 audio encoding/decoding
+ */
+
+// NOTE: The exact import path may vary by openai SDK version.
+// Check node_modules/openai/ for the correct export.
+// Possible paths: 'openai/beta/realtime/websocket', 'openai/realtime/websocket'
+import { OpenAIRealtimeWebSocket } from 'openai/beta/realtime/websocket';
+import {
+  IClient,
+  ConversationItem,
+  SessionConfig,
+  ClientEventHandlers,
+  ApiKeyValidationResult,
+  FilteredModel,
+  ResponseConfig,
+  isOpenAISessionConfig,
+  OpenAISessionConfig
+} from '../interfaces/IClient';
+import { RealtimeEvent } from '../../stores/logStore';
+import { Provider, ProviderType } from '../../types/Provider';
+import { unwrapTranslationText } from '../../utils/textUtils';
+import i18n from '../../locales';
+
+/**
+ * OpenAI Realtime API client using official SDK (GA protocol)
+ */
+export class OpenAIGAClient implements IClient {
+  private static readonly DEFAULT_API_HOST = 'https://api.openai.com';
+
+  private rt: OpenAIRealtimeWebSocket | null = null;
+  private eventHandlers: ClientEventHandlers = {};
+  private apiKey: string;
+  private connected: boolean = false;
+  private deltaSequenceNumber: number = 0;
+  private turnDetectionDisabled: boolean = false;
+
+  // Conversation tracking (manual, no library helper)
+  private conversationItems: ConversationItem[] = [];
+  private itemLookup: Map<string, ConversationItem> = new Map();
+  private itemCreatedAtMap: Map<string, number> = new Map();
+  private currentResponseItemId: string | null = null;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  // --- Connection lifecycle ---
+
+  async connect(config: SessionConfig): Promise<void> {
+    // Reset state for new session
+    this.deltaSequenceNumber = 0;
+    this.conversationItems = [];
+    this.itemLookup.clear();
+    this.itemCreatedAtMap.clear();
+    this.currentResponseItemId = null;
+    this.connected = false;
+
+    // Create OpenAIRealtimeWebSocket instance
+    // The SDK connects automatically on construction
+    this.rt = new OpenAIRealtimeWebSocket({
+      model: config.model,
+      apiKey: this.apiKey,
+      dangerouslyAllowAPIKeyInBrowser: true,
+    });
+
+    // Set up event handlers before waiting for session
+    this.setupEventListeners();
+
+    // Wait for session.created with timeout
+    await this.waitForSessionCreated();
+
+    // Send session configuration
+    if (isOpenAISessionConfig(config)) {
+      this.sendSessionUpdate(config);
+    }
+
+    this.connected = true;
+
+    // Emit connection events
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'session.opened',
+        data: {
+          status: 'connected',
+          provider: 'openai',
+          model: config.model,
+          timestamp: Date.now(),
+          voice: config.voice,
+          temperature: config.temperature,
+        }
+      }
+    });
+
+    this.eventHandlers.onOpen?.();
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.rt) {
+      this.rt.close();
+      this.rt = null;
+    }
+    this.connected = false;
+
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'session.closed',
+        data: {
+          status: 'disconnected',
+          provider: 'openai',
+          timestamp: Date.now(),
+          reason: 'client_disconnect'
+        }
+      }
+    });
+    this.eventHandlers.onClose?.({});
+  }
+
+  isConnected(): boolean {
+    return this.connected;
+  }
+
+  reset(): void {
+    this.conversationItems = [];
+    this.itemLookup.clear();
+    this.itemCreatedAtMap.clear();
+    this.currentResponseItemId = null;
+  }
+
+  // --- Session management ---
+
+  private waitForSessionCreated(): Promise<void> {
+    const SESSION_TIMEOUT = 30000;
+
+    return new Promise<void>((resolve, reject) => {
+      let isSettled = false;
+
+      const timeout = setTimeout(() => {
+        if (!isSettled) {
+          isSettled = true;
+          reject(new Error('Session creation timeout - server did not respond in time'));
+        }
+      }, SESSION_TIMEOUT);
+
+      // The SDK emits typed events via .on()
+      this.rt!.on('session.created', () => {
+        if (!isSettled) {
+          isSettled = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      this.rt!.on('error', (event: any) => {
+        if (!isSettled) {
+          isSettled = true;
+          clearTimeout(timeout);
+          const errorMessage = event.error?.message || event.message || 'Session creation failed';
+          reject(new Error(errorMessage));
+        }
+      });
+    });
+  }
+
+  private sendSessionUpdate(config: OpenAISessionConfig): void {
+    if (!this.rt) return;
+
+    const session: any = {
+      modalities: config.textOnly ? ['text'] : ['text', 'audio'],
+      voice: config.voice || 'alloy',
+      instructions: config.instructions,
+      input_audio_format: 'pcm16',
+      output_audio_format: 'pcm16',
+      temperature: config.temperature ?? 0.8,
+      max_response_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
+      tool_choice: 'none',
+      tools: []
+    };
+
+    // Turn detection
+    if (config.turnDetection) {
+      if (config.turnDetection.type === 'none') {
+        session.turn_detection = null;
+        this.turnDetectionDisabled = true;
+      } else {
+        this.turnDetectionDisabled = false;
+        session.turn_detection = {
+          type: config.turnDetection.type,
+          threshold: config.turnDetection.threshold,
+          prefix_padding_ms: config.turnDetection.prefixPadding
+            ? Math.round(config.turnDetection.prefixPadding * 1000)
+            : undefined,
+          silence_duration_ms: config.turnDetection.silenceDuration
+            ? Math.round(config.turnDetection.silenceDuration * 1000)
+            : undefined,
+          create_response: config.turnDetection.createResponse ?? true,
+          interrupt_response: config.turnDetection.interruptResponse ?? false
+        };
+
+        if (config.turnDetection.type === 'semantic_vad' && config.turnDetection.eagerness) {
+          session.turn_detection.eagerness = config.turnDetection.eagerness.toLowerCase();
+        }
+
+        // Remove undefined fields
+        Object.keys(session.turn_detection).forEach(key =>
+          session.turn_detection[key] === undefined && delete session.turn_detection[key]
+        );
+      }
+    }
+
+    // Input audio transcription
+    if (config.inputAudioTranscription?.model) {
+      session.input_audio_transcription = {
+        model: config.inputAudioTranscription.model
+      };
+    }
+
+    // Noise reduction
+    if (config.inputAudioNoiseReduction?.type) {
+      session.input_audio_noise_reduction = {
+        type: config.inputAudioNoiseReduction.type
+      };
+    }
+
+    this.sendEvent({ type: 'session.update', session });
+  }
+
+  updateSession(config: Partial<SessionConfig>): void {
+    if (isOpenAISessionConfig(config as SessionConfig)) {
+      this.sendSessionUpdate(config as OpenAISessionConfig);
+    }
+  }
+
+  // --- Event handling ---
+
+  private setupEventListeners(): void {
+    const rt = this.rt!;
+
+    // Session events
+    rt.on('session.created', (event: any) => this.forwardEvent('server', event));
+    rt.on('session.updated', (event: any) => this.forwardEvent('server', event));
+
+    // Conversation item lifecycle
+    rt.on('conversation.item.created', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleItemCreated(event);
+    });
+
+    // GA text output events
+    rt.on('response.output_text.delta', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleTextDelta(event);
+    });
+
+    rt.on('response.output_text.done', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleTextDone(event);
+    });
+
+    // GA audio output events
+    rt.on('response.output_audio.delta', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleAudioDelta(event);
+    });
+
+    rt.on('response.output_audio.done', (event: any) => {
+      this.forwardEvent('server', event);
+    });
+
+    // GA audio transcript events
+    rt.on('response.output_audio_transcript.delta', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleTranscriptDelta(event);
+    });
+
+    rt.on('response.output_audio_transcript.done', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleTranscriptDone(event);
+    });
+
+    // Input transcription
+    rt.on('conversation.item.input_audio_transcription.completed', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleInputTranscriptionCompleted(event);
+    });
+
+    // Response lifecycle
+    rt.on('response.created', (event: any) => this.forwardEvent('server', event));
+    rt.on('response.done', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleResponseDone(event);
+    });
+
+    // Audio buffer events
+    rt.on('input_audio_buffer.speech_started', (event: any) => {
+      this.forwardEvent('server', event);
+      this.eventHandlers.onConversationInterrupted?.();
+    });
+
+    rt.on('input_audio_buffer.speech_stopped', (event: any) => {
+      this.forwardEvent('server', event);
+    });
+
+    rt.on('input_audio_buffer.committed', (event: any) => {
+      this.forwardEvent('server', event);
+    });
+
+    // Rate limits
+    rt.on('rate_limits.updated', (event: any) => this.forwardEvent('server', event));
+
+    // Error handling
+    rt.on('error', (event: any) => {
+      this.forwardEvent('server', event);
+      this.handleErrorEvent(event);
+    });
+  }
+
+  private forwardEvent(source: 'server' | 'client', event: any): void {
+    const realtimeEvent: RealtimeEvent = {
+      source,
+      event: {
+        type: event.type || 'unknown',
+        data: event
+      }
+    };
+    this.eventHandlers.onRealtimeEvent?.(realtimeEvent);
+  }
+
+  // --- Conversation item tracking ---
+
+  private handleItemCreated(event: any): void {
+    const item = event.item;
+    if (!item) return;
+
+    const createdAt = Date.now();
+    this.itemCreatedAtMap.set(item.id, createdAt);
+
+    const conversationItem: ConversationItem = {
+      id: item.id,
+      role: item.role || 'assistant',
+      type: item.type || 'message',
+      status: item.status || 'in_progress',
+      createdAt,
+      formatted: {
+        text: '',
+        transcript: ''
+      },
+      content: item.content || []
+    };
+
+    // Track current assistant response item for audio association
+    if (conversationItem.role === 'assistant') {
+      this.currentResponseItemId = item.id;
+    }
+
+    this.conversationItems.push(conversationItem);
+    this.itemLookup.set(item.id, conversationItem);
+    this.eventHandlers.onConversationUpdated?.({ item: conversationItem });
+  }
+
+  private findItem(itemId: string | undefined): ConversationItem | undefined {
+    if (!itemId) return undefined;
+    return this.itemLookup.get(itemId);
+  }
+
+  private handleTextDelta(event: any): void {
+    const itemId = event.item_id;
+    const delta = event.delta;
+    if (!itemId || !delta) return;
+
+    const item = this.findItem(itemId);
+    if (!item) return;
+
+    if (item.formatted) {
+      item.formatted.text = (item.formatted.text || '') + delta;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({
+      item,
+      delta: { text: delta }
+    });
+  }
+
+  private handleTextDone(event: any): void {
+    const itemId = event.item_id;
+    const text = event.text;
+    if (!itemId) return;
+
+    const item = this.findItem(itemId);
+    if (!item) return;
+
+    if (item.formatted && text) {
+      const cleaned = unwrapTranslationText(text);
+      item.formatted.text = cleaned;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({ item });
+  }
+
+  private handleTranscriptDelta(event: any): void {
+    const itemId = event.item_id;
+    const delta = event.delta;
+    if (!itemId || !delta) return;
+
+    const item = this.findItem(itemId);
+    if (!item) return;
+
+    if (item.formatted) {
+      item.formatted.transcript = (item.formatted.transcript || '') + delta;
+      item.formatted.text = item.formatted.transcript;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({
+      item,
+      delta: { transcript: delta }
+    });
+  }
+
+  private handleTranscriptDone(event: any): void {
+    const itemId = event.item_id;
+    const transcript = event.transcript;
+    if (!itemId) return;
+
+    const item = this.findItem(itemId);
+    if (!item) return;
+
+    if (item.formatted && transcript) {
+      const cleaned = unwrapTranslationText(transcript);
+      item.formatted.transcript = cleaned;
+      item.formatted.text = cleaned;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({ item });
+  }
+
+  // --- Audio I/O ---
+
+  private handleAudioDelta(event: any): void {
+    const itemId = event.item_id;
+    if (!itemId || !event.delta) return;
+
+    const item = this.findItem(itemId);
+    if (!item) return;
+
+    // Decode base64 audio to Int16Array
+    const audioData = this.base64ToInt16Array(event.delta);
+    const sequenceNumber = ++this.deltaSequenceNumber;
+
+    this.eventHandlers.onConversationUpdated?.({
+      item,
+      delta: {
+        audio: audioData,
+        sequenceNumber,
+        timestamp: Date.now()
+      }
+    });
+  }
+
+  appendInputAudio(audioData: Int16Array): void {
+    if (!this.rt) return;
+
+    const base64 = this.int16ArrayToBase64(audioData);
+    this.sendEvent({
+      type: 'input_audio_buffer.append',
+      audio: base64
+    });
+  }
+
+  private int16ArrayToBase64(data: Int16Array): string {
+    const uint8 = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+    let binary = '';
+    for (let i = 0; i < uint8.length; i++) {
+      binary += String.fromCharCode(uint8[i]);
+    }
+    return btoa(binary);
+  }
+
+  private base64ToInt16Array(base64: string): Int16Array {
+    const binary = atob(base64);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return new Int16Array(bytes.buffer);
+  }
+
+  // --- Text input ---
+
+  appendInputText(text: string): void {
+    if (!this.rt || !text.trim()) return;
+
+    this.sendEvent({
+      type: 'conversation.item.create',
+      item: {
+        type: 'message',
+        role: 'user',
+        content: [{
+          type: 'input_text',
+          text: text.trim()
+        }]
+      }
+    });
+
+    // Auto-trigger response after text input (matches WebRTC client pattern)
+    this.sendEvent({ type: 'response.create' });
+  }
+
+  // --- Response management ---
+
+  createResponse(config?: ResponseConfig): void {
+    if (!this.rt) return;
+
+    // Commit audio buffer in PTT mode (skip for out-of-band responses)
+    if (this.turnDetectionDisabled && config?.conversation !== 'none') {
+      this.sendEvent({ type: 'input_audio_buffer.commit' });
+    }
+
+    if (config) {
+      const responseEvent: any = {
+        type: 'response.create',
+        response: {}
+      };
+
+      if (config.instructions) {
+        responseEvent.response.instructions = config.instructions;
+      }
+      if (config.conversation) {
+        responseEvent.response.conversation = config.conversation;
+      }
+      if (config.modalities) {
+        responseEvent.response.modalities = config.modalities;
+      }
+      if (config.metadata) {
+        responseEvent.response.metadata = config.metadata;
+      }
+
+      if (config.conversation === 'none') {
+        console.debug('[OpenAIGAClient] Sending out-of-band response:', {
+          conversation: config.conversation,
+          modalities: config.modalities,
+          hasInstructions: !!config.instructions,
+          metadata: config.metadata
+        });
+      }
+
+      this.sendEvent(responseEvent);
+    } else {
+      this.sendEvent({ type: 'response.create' });
+    }
+  }
+
+  cancelResponse(_trackId?: string, _offset?: number): void {
+    if (!this.rt) return;
+    this.sendEvent({ type: 'response.cancel' });
+  }
+
+  // --- Other handlers ---
+
+  private handleInputTranscriptionCompleted(event: any): void {
+    const itemId = event.item_id;
+    const transcript = event.transcript;
+    if (!itemId) return;
+
+    const item = this.findItem(itemId);
+    if (item && item.formatted) {
+      item.formatted.transcript = transcript;
+      item.formatted.text = transcript;
+      this.eventHandlers.onConversationUpdated?.({ item });
+    }
+  }
+
+  private handleResponseDone(event: any): void {
+    const response = event.response;
+    if (!response?.output) return;
+
+    for (const outputItem of response.output) {
+      const item = this.findItem(outputItem.id);
+      if (item) {
+        item.status = 'completed';
+        this.eventHandlers.onConversationUpdated?.({ item });
+      }
+    }
+
+    this.currentResponseItemId = null;
+  }
+
+  private handleErrorEvent(event: any): void {
+    const error = event.error || event;
+    const errorItem: ConversationItem = {
+      id: `error_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
+      role: 'system',
+      type: 'error',
+      status: 'completed',
+      formatted: {
+        text: `[${error.type || 'error'}] ${error.message || 'Unknown error'}`
+      },
+      content: [{
+        type: 'text',
+        text: error.message || 'Unknown error'
+      }]
+    };
+
+    this.eventHandlers.onConversationUpdated?.({ item: errorItem });
+    this.eventHandlers.onError?.(error);
+  }
+
+  // --- Event sending ---
+
+  private sendEvent(event: any): void {
+    if (!this.rt) {
+      console.warn('[OpenAIGAClient] Cannot send event, not connected');
+      return;
+    }
+
+    this.rt.send(event);
+
+    // Emit client event for logging
+    this.forwardEvent('client', event);
+  }
+
+  // --- Conversation state ---
+
+  getConversationItems(): ConversationItem[] {
+    return [...this.conversationItems];
+  }
+
+  setEventHandlers(handlers: ClientEventHandlers): void {
+    this.eventHandlers = { ...handlers };
+  }
+
+  getProvider(): ProviderType {
+    return Provider.OPENAI;
+  }
+
+  // --- Static methods (reused from OpenAIClient, REST-based) ---
+
+  static async validateApiKeyAndFetchModels(apiKey: string, apiHost?: string): Promise<{
+    validation: ApiKeyValidationResult;
+    models: FilteredModel[];
+  }> {
+    // Delegate to OpenAIClient's static method — it's REST-based, not WebSocket
+    const { OpenAIClient } = await import('./OpenAIClient');
+    return OpenAIClient.validateApiKeyAndFetchModels(apiKey, apiHost);
+  }
+
+  static getLatestRealtimeModel(filteredModels: FilteredModel[]): string {
+    const realtimeModels = filteredModels.filter(model => model.type === 'realtime');
+    if (realtimeModels.length > 0) {
+      return realtimeModels[0].id;
+    }
+    return 'gpt-realtime-mini';
+  }
+}
+```
+
+- [ ] **Step 2: Verify the import path for OpenAIRealtimeWebSocket**
+
+Check the actual export path in the installed `openai` package:
+
+Run: `ls node_modules/openai/realtime/ 2>/dev/null || ls node_modules/openai/beta/realtime/ 2>/dev/null || echo "Check node_modules/openai/ manually"`
+
+Update the import statement in `OpenAIGAClient.ts` if the path differs from `'openai/beta/realtime/websocket'`.
+
+- [ ] **Step 3: Verify build compiles**
+
+Run: `npm run build`
+Expected: No TypeScript errors. The new client compiles cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/services/clients/OpenAIGAClient.ts
+git commit -m "feat: add OpenAIGAClient using official openai SDK for GA Realtime API"
+```
+
+---
+
+## Chunk 3: Integration and WebRTC Fix
+
+### Task 5: Update WebRTC client event names
+
+**Files:**
+- Modify: `src/services/clients/OpenAIWebRTCClient.ts:337-344`
+
+- [ ] **Step 1: Add GA event name fallthrough cases**
+
+In `src/services/clients/OpenAIWebRTCClient.ts`, in the `handleServerEvent` switch statement (around lines 337-345), add GA event names as fallthrough cases:
+
+```typescript
+// FROM:
+      case 'response.audio_transcript.delta':
+      case 'response.text.delta':
+        this.handleTranscriptDelta(event);
+        break;
+
+      case 'response.audio_transcript.done':
+      case 'response.text.done':
+        this.handleTranscriptDone(event);
+        break;
+```
+
+```typescript
+// TO:
+      case 'response.audio_transcript.delta':
+      case 'response.output_audio_transcript.delta':  // GA
+      case 'response.text.delta':
+      case 'response.output_text.delta':              // GA
+        this.handleTranscriptDelta(event);
+        break;
+
+      case 'response.audio_transcript.done':
+      case 'response.output_audio_transcript.done':    // GA
+      case 'response.text.done':
+      case 'response.output_text.done':                // GA
+        this.handleTranscriptDone(event);
+        break;
+```
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+Expected: No TypeScript errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/clients/OpenAIWebRTCClient.ts
+git commit -m "fix: add GA event name fallthrough in WebRTC client for forward compatibility"
+```
+
+---
+
+### Task 6: Update ClientFactory routing
+
+**Files:**
+- Modify: `src/services/clients/ClientFactory.ts`
+
+- [ ] **Step 1: Add OpenAIGAClient import**
+
+At the top of `src/services/clients/ClientFactory.ts`, add:
+```typescript
+import { OpenAIGAClient } from './OpenAIGAClient';
+```
+
+- [ ] **Step 2: Route Provider.OPENAI WebSocket to OpenAIGAClient**
+
+In `ClientFactory.ts`, in the `switch (provider)` statement, change the `case Provider.OPENAI` block. Replace:
+```typescript
+        return new OpenAIClient(apiKey);
+```
+With:
+```typescript
+        return new OpenAIGAClient(apiKey);
+```
+
+Keep the WebRTC path (`return new OpenAIWebRTCClient(...)`) unchanged.
+
+Keep `Provider.OPENAI_COMPATIBLE` and `Provider.KIZUNA_AI` using `OpenAIClient` unchanged.
+
+- [ ] **Step 3: Verify build**
+
+Run: `npm run build`
+Expected: No TypeScript errors.
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test`
+Expected: All existing tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/clients/ClientFactory.ts
+git commit -m "feat: route OpenAI WebSocket transport to GA client"
+```
+
+---
+
+### Task 7: Add TODO to eval runner
+
+**Files:**
+- Modify: `evals/runner/clients/NodeOpenAIClient.ts`
+
+- [ ] **Step 1: Add TODO comment**
+
+At the top of `evals/runner/clients/NodeOpenAIClient.ts`, after the existing imports, add:
+```typescript
+// TODO: Migrate to official openai SDK's GA Realtime API before May 7, 2026
+// when the beta protocol (OpenAI-Beta: realtime=v1) is shut down.
+// See: https://github.com/kizuna-ai-lab/sokuji/issues/115
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add evals/runner/clients/NodeOpenAIClient.ts
+git commit -m "chore: add migration TODO to eval runner client"
+```
+
+---
+
+## Chunk 4: Verification
+
+### Task 8: Static verification
+
+- [ ] **Step 1: Full build check**
+
+Run: `npm run build`
+Expected: TypeScript compilation succeeds, no errors.
+
+- [ ] **Step 2: Test suite**
+
+Run: `npm run test`
+Expected: All existing tests pass.
+
+- [ ] **Step 3: Verify import separation**
+
+Run: `grep -rn "from 'openai-realtime-api'" src/`
+Expected: Only `src/services/clients/OpenAIClient.ts` should appear. No imports in `OpenAIGAClient.ts`, `logStore.ts`, or `IClient.ts`.
+
+- [ ] **Step 4: Verify GA client has no beta dependency**
+
+Run: `grep -n "openai-realtime-api" src/services/clients/OpenAIGAClient.ts`
+Expected: No matches.
+
+### Task 9: Manual E2E testing (user-performed)
+
+Refer to the **Verification Plan** in `docs/superpowers/specs/2026-03-14-openai-ga-migration-design.md` for the complete 6-phase test checklist covering:
+
+- Phase 1: Static checks (automated, done in Task 8)
+- Phase 2: OpenAI GA provider E2E (connection, voice, text, PTT, errors, transcription)
+- Phase 3: OpenAI Compatible beta regression
+- Phase 4: Kizuna AI (BLOCKED — external dependency)
+- Phase 5: WebRTC smoke test
+- Phase 6: Cross-cutting concerns (logs, state, extension)

--- a/docs/superpowers/specs/2026-03-14-openai-ga-migration-design.md
+++ b/docs/superpowers/specs/2026-03-14-openai-ga-migration-design.md
@@ -211,7 +211,7 @@ case 'response.output_text.done':                // GA
 
 This is a minimal, safe change — adding fallthrough cases costs nothing and prevents silent event drops.
 
-### Step 7: Update `ClientFactory.ts`
+### Step 6: Update `ClientFactory.ts`
 
 **File**: `src/services/clients/ClientFactory.ts`
 
@@ -231,11 +231,11 @@ import { OpenAIGAClient } from './OpenAIGAClient';
 | OPENAI_COMPATIBLE | webrtc | OpenAIWebRTCClient (event names updated) |
 | KIZUNA_AI | any | OpenAIClient (beta, unchanged) |
 
-### Step 8: EphemeralTokenService (deferred)
+### Step 7: EphemeralTokenService (deferred)
 
 `EphemeralTokenService.ts` is only used by `OpenAIWebRTCClient`. WebRTC is not affected by this migration. If the GA API requires `"type": "realtime"` in the session creation body, that can be done separately.
 
-### Step 9: Eval runner (deferred)
+### Step 8: Eval runner (deferred)
 
 `evals/runner/clients/NodeOpenAIClient.ts` — Keep on `openai-realtime-api` for now. Add TODO comment noting future migration need before May 7, 2026.
 

--- a/docs/superpowers/specs/2026-03-14-openai-ga-migration-design.md
+++ b/docs/superpowers/specs/2026-03-14-openai-ga-migration-design.md
@@ -1,0 +1,366 @@
+# Design: Migrate OpenAI Realtime API from Beta to GA
+
+**Issue**: [#115](https://github.com/kizuna-ai-lab/sokuji/issues/115)
+**Date**: 2026-03-14
+**Deadline**: 2026-05-07 (beta API shutdown)
+**Status**: Design Complete
+
+## Problem
+
+The project uses `openai-realtime-api` v1.0.8 (third-party) which sends the beta header `OpenAI-Beta: realtime=v1` and uses beta event names (`response.text.delta`, `response.audio.delta`, etc.). OpenAI is shutting down the beta Realtime API protocol on May 7, 2026.
+
+Two separate concerns:
+- **Model migration**: Beta preview models (`gpt-4o-realtime-preview`) → GA models (`gpt-realtime-mini`, `gpt-realtime-1.5`). Already completed in commit 04c7161.
+- **Protocol migration** (this spec): Beta protocol (beta header, beta event names) → GA protocol (no beta header, GA event names like `response.output_text.delta`).
+
+## Decision: Split Client Strategy
+
+**Migrate only the OpenAI direct provider** to the official `openai` SDK's `OpenAIRealtimeWebSocket`. Keep `openai-realtime-api` for OpenAI Compatible and Kizuna AI providers — third-party services and backend proxy may not support GA yet.
+
+### Rationale
+
+- OpenAI Compatible endpoints (CometAPI, etc.) may still use the beta protocol
+- Kizuna AI routes through a backend proxy that currently uses beta — migration requires backend coordination
+- The `openai-realtime-api` library will continue to work with beta-compatible services indefinitely
+- Clean separation: GA client for OpenAI, beta client for everything else
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  ClientFactory                   │
+├─────────────────────────────────────────────────┤
+│ Provider.OPENAI (ws)       → OpenAIGAClient     │ ← NEW (official openai SDK)
+│ Provider.OPENAI (webrtc)   → OpenAIWebRTCClient │   (event names updated)
+│ Provider.OPENAI_COMPATIBLE → OpenAIClient       │   (beta, unchanged)
+│ Provider.KIZUNA_AI         → OpenAIClient       │   (beta, unchanged)
+└─────────────────────────────────────────────────┘
+
+OpenAIGAClient data flow:
+  OpenAIRealtimeWebSocket (official SDK)
+    ↓ GA events (response.output_text.delta, etc.)
+  OpenAIGAClient (manual conversation tracking)
+    ↓ maps to ConversationItem + delta
+  IClient interface (unchanged)
+    ↓
+  MainPanel (unchanged)
+```
+
+## Pre-existing Bug Fix
+
+`src/services/clients/OpenAIClient.ts:8` and `src/services/interfaces/IClient.ts:6` import `RealtimeEvent` from `../../contexts/LogContext` which does not exist. Should be `../../stores/logStore`. Fix as part of this migration.
+
+---
+
+## Implementation Steps
+
+### Step 1: Add `openai` SDK dependency
+
+- `package.json`: Add `"openai": "^6.27.0"` to dependencies
+- `extension/package.json`: Add `"openai": "^6.27.0"` to dependencies
+- Keep `openai-realtime-api` in both (still needed for Compatible/KizunaAI)
+- Run `npm install`
+
+### Step 2: Fix stale `LogContext` imports
+
+| File | Change |
+|------|--------|
+| `src/services/clients/OpenAIClient.ts:8` | `../../contexts/LogContext` → `../../stores/logStore` |
+| `src/services/interfaces/IClient.ts:6` | `../../contexts/LogContext` → `../../stores/logStore` |
+
+### Step 3: Decouple `logStore.ts` from `openai-realtime-api` types
+
+**File**: `src/stores/logStore.ts`
+
+Remove type imports:
+```typescript
+// REMOVE:
+import type { RealtimeServerEvents, RealtimeClientEvents, RealtimeCustomEvents } from 'openai-realtime-api';
+```
+
+Replace `RealtimeServerEvents.EventType | RealtimeClientEvents.EventType | RealtimeCustomEvents.EventType` with explicit string literals covering both beta and GA event names:
+
+```typescript
+// OpenAI server events (shared between beta and GA)
+| 'session.created' | 'session.updated'
+| 'conversation.created'
+| 'conversation.item.created' | 'conversation.item.deleted' | 'conversation.item.truncated'
+| 'conversation.item.input_audio_transcription.completed'
+| 'conversation.item.input_audio_transcription.failed'
+| 'input_audio_buffer.committed' | 'input_audio_buffer.cleared'
+| 'input_audio_buffer.speech_started' | 'input_audio_buffer.speech_stopped'
+| 'response.created' | 'response.done'
+| 'response.output_item.added' | 'response.output_item.done'
+| 'response.function_call_arguments.delta' | 'response.function_call_arguments.done'
+| 'rate_limits.updated'
+| 'error'
+// Beta-only event names (OpenAI Compatible, Kizuna AI)
+| 'response.text.delta' | 'response.text.done'
+| 'response.audio.delta' | 'response.audio.done'
+| 'response.audio_transcript.delta' | 'response.audio_transcript.done'
+// GA-only event names (OpenAI direct)
+| 'response.output_text.delta' | 'response.output_text.done'
+| 'response.output_audio.delta' | 'response.output_audio.done'
+| 'response.output_audio_transcript.delta' | 'response.output_audio_transcript.done'
+| 'conversation.item.added' | 'conversation.item.done'
+| 'response.content_part.added' | 'response.content_part.done'
+// OpenAI client events
+| 'session.update'
+| 'input_audio_buffer.append' | 'input_audio_buffer.commit' | 'input_audio_buffer.clear'
+| 'conversation.item.create' | 'conversation.item.truncate' | 'conversation.item.delete'
+| 'response.create' | 'response.cancel'
+// openai-realtime-api custom events (for beta clients)
+| 'conversation.item.appended' | 'conversation.item.completed'
+| 'conversation.updated' | 'conversation.interrupted'
+| 'realtime.event'
+```
+
+Also add `'response.output_text.annotation.added'` to the GA event type list.
+
+**`getEventGroup()` update**: The existing grouping logic uses `eventType.includes('delta')` which already catches GA delta events generically. The `input_audio_buffer.append` special case and item-ID-based grouping should work unchanged. Verify during implementation that GA audio delta events (`response.output_audio.delta`) are grouped correctly — if the logic checks for `response.audio.delta` specifically, add the GA variant.
+
+### Step 4: Create `OpenAIGAClient.ts`
+
+**File**: `src/services/clients/OpenAIGAClient.ts` (~500 lines)
+
+New client implementing `IClient` using `OpenAIRealtimeWebSocket` from the official `openai` SDK.
+
+**Reference implementation**: `OpenAIWebRTCClient.ts` — already does manual conversation tracking and event handling without `openai-realtime-api`.
+
+#### a) Connection lifecycle
+- Constructor takes `apiKey` only (no custom host — GA client is OpenAI-only)
+- `connect(config)`: Create `OpenAIRealtimeWebSocket({model, apiKey, dangerouslyAllowAPIKeyInBrowser})`, register event handlers, wait for `session.created` with 30s timeout, send `session.update`
+- `disconnect()`: Call `rt.close()`, emit `session.closed`
+
+#### b) Manual conversation item tracking (no library helper)
+- Internal `conversationItems: ConversationItem[]` array
+- `itemLookup: Map<string, ConversationItem>` for fast access
+- Create items on `conversation.item.created`
+- Update text/transcript/audio on delta events
+- Mark completed on `response.done`
+
+#### c) GA event → internal event mapping
+
+| GA Event | Internal Handler |
+|----------|-----------------|
+| `response.output_text.delta` | Update item.formatted.text, emit onConversationUpdated with text delta |
+| `response.output_audio.delta` | Decode base64 → Int16Array, emit onConversationUpdated with audio delta + sequenceNumber |
+| `response.output_audio_transcript.delta` | Update item.formatted.transcript, emit onConversationUpdated |
+| `conversation.item.created` | Create new ConversationItem, add to tracking. Note: GA also emits `conversation.item.added` — handle both defensively (fallthrough), prefer `conversation.item.created` as primary trigger since it contains the full item payload. |
+| `conversation.item.input_audio_transcription.completed` | Update user item transcript |
+| `input_audio_buffer.speech_started` | Emit onConversationInterrupted |
+| `response.done` | Mark items completed |
+| `error` | Create error ConversationItem, emit |
+
+#### d) Audio I/O
+- `appendInputAudio(Int16Array)`: Convert to base64 → `rt.send({type: 'input_audio_buffer.append', audio})`
+- Audio output: Receive base64 in `response.output_audio.delta` → decode to Int16Array → emit as delta
+- Utility methods: `int16ArrayToBase64()`, `base64ToInt16Array()`
+
+#### e) Text input
+- `appendInputText(text)`: Send `conversation.item.create` with `{type: 'message', role: 'user', content: [{type: 'input_text', text}]}` via `rt.send()`. Does NOT auto-trigger response — caller handles that separately (same as WebRTC client pattern).
+
+#### f) Session/response management
+- `updateSession(config)`: Same field mapping logic as current `OpenAIClient.ts` but sends via `rt.send({type: 'session.update', session: {...}})`
+- `createResponse(config?)`: Send `input_audio_buffer.commit` + `response.create` via `rt.send()`
+- `cancelResponse()`: Send `response.cancel` via `rt.send()`
+
+#### g) Connection state
+- `isConnected()`: Track via internal `connected: boolean` flag, set `true` after `session.created`, set `false` on close/error. Same pattern as `OpenAIWebRTCClient`.
+
+#### h) Reset
+- `reset()`: Clear `conversationItems`, `itemLookup`, `itemCreatedAtMap`, `currentResponseItemId`, reset `deltaSequenceNumber` to 0. Return `[...this.conversationItems]` (defensive shallow copy) from `getConversationItems()`.
+
+#### i) Event forwarding for logging
+- No generic `realtime.event` in official SDK — must register individual handlers for each event type
+- Each handler calls `forwardEvent(source, event)` to emit `onRealtimeEvent`
+
+#### j) Static methods — Reuse from existing `OpenAIClient.ts`
+- `validateApiKeyAndFetchModels()` — REST-based, not WebSocket, so unchanged
+- `filterRelevantModels()`, `checkRealtimeModelAvailability()`, etc.
+
+### Step 5: Update `OpenAIWebRTCClient.ts` event names
+
+**File**: `src/services/clients/OpenAIWebRTCClient.ts`
+
+The WebRTC client connects directly to OpenAI's API (not through `openai-realtime-api`) and currently uses beta event names in its `handleServerEvent` switch statement (lines 337-345):
+
+```typescript
+// Current (beta):
+case 'response.audio_transcript.delta':
+case 'response.text.delta':
+// ...
+case 'response.audio_transcript.done':
+case 'response.text.done':
+```
+
+**Change**: Handle both beta AND GA event names defensively. This ensures the WebRTC client works regardless of when OpenAI switches the WebRTC endpoint to GA events:
+
+```typescript
+// Updated (both beta and GA):
+case 'response.audio_transcript.delta':
+case 'response.output_audio_transcript.delta':  // GA
+case 'response.text.delta':
+case 'response.output_text.delta':              // GA
+// ...
+case 'response.audio_transcript.done':
+case 'response.output_audio_transcript.done':    // GA
+case 'response.text.done':
+case 'response.output_text.done':                // GA
+```
+
+This is a minimal, safe change — adding fallthrough cases costs nothing and prevents silent event drops.
+
+### Step 7: Update `ClientFactory.ts`
+
+**File**: `src/services/clients/ClientFactory.ts`
+
+```typescript
+import { OpenAIGAClient } from './OpenAIGAClient';
+
+// Route Provider.OPENAI WebSocket → OpenAIGAClient (GA)
+// Keep Provider.OPENAI_COMPATIBLE → OpenAIClient (beta)
+// Keep Provider.KIZUNA_AI → OpenAIClient (beta)
+```
+
+| Provider | Transport | Client |
+|----------|-----------|--------|
+| OPENAI | websocket | **OpenAIGAClient** (new) |
+| OPENAI | webrtc | OpenAIWebRTCClient (event names updated) |
+| OPENAI_COMPATIBLE | websocket | OpenAIClient (beta, unchanged) |
+| OPENAI_COMPATIBLE | webrtc | OpenAIWebRTCClient (event names updated) |
+| KIZUNA_AI | any | OpenAIClient (beta, unchanged) |
+
+### Step 8: EphemeralTokenService (deferred)
+
+`EphemeralTokenService.ts` is only used by `OpenAIWebRTCClient`. WebRTC is not affected by this migration. If the GA API requires `"type": "realtime"` in the session creation body, that can be done separately.
+
+### Step 9: Eval runner (deferred)
+
+`evals/runner/clients/NodeOpenAIClient.ts` — Keep on `openai-realtime-api` for now. Add TODO comment noting future migration need before May 7, 2026.
+
+---
+
+## Files Modified
+
+| File | Action |
+|------|--------|
+| `package.json` | Add `openai` dependency |
+| `extension/package.json` | Add `openai` dependency |
+| `src/services/clients/OpenAIGAClient.ts` | **CREATE** — New GA client |
+| `src/services/clients/OpenAIWebRTCClient.ts` | Add GA event name fallthrough cases in handleServerEvent |
+| `src/services/clients/ClientFactory.ts` | Route OPENAI → OpenAIGAClient |
+| `src/services/clients/OpenAIClient.ts` | Fix stale LogContext import |
+| `src/services/interfaces/IClient.ts` | Fix stale LogContext import |
+| `src/stores/logStore.ts` | Remove `openai-realtime-api` type imports, add explicit event type strings |
+| `evals/runner/clients/NodeOpenAIClient.ts` | Add TODO comment |
+
+## Key Reference Files (read-only)
+
+| File | Purpose |
+|------|---------|
+| `src/services/clients/OpenAIWebRTCClient.ts` | Reference for manual conversation tracking, event handling, session update patterns |
+| `src/services/clients/OpenAIClient.ts` | Reference for session config mapping, static validation methods, translation text unwrapping |
+| `src/components/MainPanel/MainPanel.tsx` | Understanding how events are consumed by UI |
+
+---
+
+## Verification Plan
+
+### Phase 1: Static Checks (Automated)
+
+- [ ] `npm run build` — TypeScript compilation succeeds, no type errors
+- [ ] `npm run test` — All existing unit tests pass
+- [ ] Verify no remaining imports from `openai-realtime-api` in GA client code
+- [ ] Verify `openai-realtime-api` imports only exist in: `OpenAIClient.ts` (beta), `NodeOpenAIClient.ts` (eval)
+
+### Phase 2: OpenAI GA Provider — End-to-End (Real API Key Required)
+
+**Prerequisites**: OpenAI API key with Realtime API access, microphone + speaker
+
+#### 2a. Connection & Session
+- [ ] Select OpenAI provider, choose `gpt-realtime-mini` model
+- [ ] Click connect → verify session creation succeeds (no timeout)
+- [ ] Check Logs panel → confirm `session.created` and `session.updated` events appear
+- [ ] Verify GA event names in logs (e.g., `response.output_text.delta` NOT `response.text.delta`)
+- [ ] Disconnect → verify clean disconnection, `session.closed` event logged
+
+#### 2b. Voice Translation (Core Flow)
+- [ ] Connect with server VAD → speak → verify:
+  - Speech detection triggers (`input_audio_buffer.speech_started` in logs)
+  - Translation text appears in conversation bubbles
+  - Audio playback works (assistant speaks back)
+  - Audio ordering is correct (no garbled/out-of-order audio)
+- [ ] Test with semantic VAD → verify similar behavior with different eagerness
+- [ ] Test interruption: speak while assistant is responding → verify response is cut off
+
+#### 2c. Text Input
+- [ ] Switch to text-only mode or type text input
+- [ ] Verify text message appears in conversation
+- [ ] Verify translation response received
+
+#### 2d. PTT (Push-to-Talk) Mode
+- [ ] Set turn detection to "none" (manual/PTT)
+- [ ] Hold PTT → speak → release → verify `input_audio_buffer.commit` sent
+- [ ] Verify response generated after commit
+
+#### 2e. Error Handling
+- [ ] Connect with invalid API key → verify meaningful error displayed
+- [ ] Test network interruption (disconnect WiFi briefly) → verify error state
+- [ ] Verify error items appear in conversation with error styling
+
+#### 2f. Input Transcription
+- [ ] Enable input audio transcription in settings
+- [ ] Speak → verify user's speech transcript appears in conversation
+
+### Phase 3: OpenAI Compatible Provider — Beta Regression (Real Compatible Endpoint Required)
+
+**Prerequisites**: Access to a compatible API service (CometAPI, etc.)
+
+- [ ] Select OpenAI Compatible provider, enter endpoint URL + API key
+- [ ] Connect → verify session creation succeeds via beta protocol
+- [ ] Check Logs panel → confirm beta event names (`response.text.delta`, `response.audio.delta`)
+- [ ] Speak → verify translation works (audio + text)
+- [ ] Verify no GA event names appear (confirms beta protocol active)
+
+### Phase 4: Kizuna AI Provider — External Dependency
+
+**Status**: Depends on backend team — mark as **BLOCKED** until backend confirms beta protocol compatibility.
+
+- [ ] 🔒 Verify Kizuna AI provider still connects through backend proxy
+- [ ] 🔒 Verify authentication flow works (Better Auth → API key fetch → connect)
+- [ ] 🔒 Verify translation output received
+
+> **Note**: If backend team migrates to GA protocol, Kizuna AI routing in `ClientFactory.ts` should be updated to use `OpenAIGAClient` in a follow-up PR.
+
+### Phase 5: WebRTC Transport — Smoke Test
+
+**Prerequisites**: OpenAI API key
+
+- [ ] Select OpenAI provider, switch transport to WebRTC
+- [ ] Connect → verify WebRTC connection establishes (ICE + DataChannel)
+- [ ] Speak → verify audio flows via MediaStreamTrack (not appendInputAudio)
+- [ ] Verify translation output received
+- [ ] Disconnect → verify clean cleanup
+
+### Phase 6: Cross-Cutting Concerns
+
+- [ ] **Logs Panel**: Events from all providers display correctly, no crashes
+- [ ] **Event grouping**: GA event names grouped properly (audio deltas grouped, etc.)
+- [ ] **Conversation state**: `getConversationItems()` returns correct items after multiple exchanges
+- [ ] **Multiple sessions**: Connect → translate → disconnect → reconnect → translate again → verify state resets properly
+- [ ] **Browser extension**: Build extension (`npm run build`), load in Chrome, verify OpenAI provider works in side panel
+
+---
+
+## Risks & Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `OpenAIRealtimeWebSocket` browser incompatibility | Medium | High | Fall back to raw WebSocket with manual GA protocol (similar to WebRTC client approach) |
+| No generic event listener in official SDK | High | Low | Register individual handlers for each event type |
+| Audio base64 encode/decode performance | Low | Medium | Profile in browser; consider Web Workers if needed |
+| `cancelResponse` lacks sample count support in GA | Medium | Low | Send basic `response.cancel`; precise truncation is nice-to-have |
+| Kizuna AI backend not compatible after migration | Low | Medium | Keep beta client; coordinate with backend team separately |
+| WebRTC endpoint switches to GA event names | High | High | Add both beta + GA event name fallthrough in WebRTC client (Step 5) |
+| `dangerouslyAllowAPIKeyInBrowser` security concern | Low | Low | Consistent with current beta client; ephemeral tokens for WebSocket is a future improvement |

--- a/evals/runner/clients/NodeOpenAIClient.ts
+++ b/evals/runner/clients/NodeOpenAIClient.ts
@@ -5,6 +5,9 @@
  * for consistent behavior and proper handling of cancelled responses.
  */
 
+// TODO: Migrate to official openai SDK's GA Realtime API before May 7, 2026
+// when the beta protocol (OpenAI-Beta: realtime=v1) is shut down.
+// See: https://github.com/kizuna-ai-lab/sokuji/issues/115
 import { RealtimeClient } from 'openai-realtime-api';
 import type { TestCaseConfig, ConversationItem } from '../types.js';
 

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -1,13 +1,14 @@
 {
   "name": "sokuji-extension",
-  "version": "0.15.4",
+  "version": "0.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sokuji-extension",
-      "version": "0.15.4",
+      "version": "0.15.7",
       "dependencies": {
+        "openai": "^6.27.0",
         "openai-realtime-api": "1.0.8",
         "posthog-js-lite": "^4.1.0"
       },
@@ -3539,6 +3540,27 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.29.0.tgz",
+      "integrity": "sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openai-realtime-api": {

--- a/extension/package-lock.json
+++ b/extension/package-lock.json
@@ -8,7 +8,7 @@
       "name": "sokuji-extension",
       "version": "0.15.7",
       "dependencies": {
-        "openai": "^6.27.0",
+        "openai": "^6.29.0",
         "openai-realtime-api": "1.0.8",
         "posthog-js-lite": "^4.1.0"
       },

--- a/extension/package.json
+++ b/extension/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "openai": "^6.27.0",
     "openai-realtime-api": "1.0.8",
     "posthog-js-lite": "^4.1.0"
   },

--- a/extension/package.json
+++ b/extension/package.json
@@ -9,7 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "openai": "^6.27.0",
+    "openai": "^6.29.0",
     "openai-realtime-api": "1.0.8",
     "posthog-js-lite": "^4.1.0"
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "idb": "^8.0.3",
         "livekit-client": "^2.15.2",
         "lucide-react": "^0.515.0",
-        "openai": "^6.27.0",
+        "openai": "^6.29.0",
         "openai-realtime-api": "1.0.8",
         "posthog-js-lite": "^4.1.0",
         "protobufjs": "^8.0.0",
@@ -11774,9 +11774,9 @@
       }
     },
     "node_modules/openai": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/openai/-/openai-6.27.0.tgz",
-      "integrity": "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.29.0.tgz",
+      "integrity": "sha512-YxoArl2BItucdO89/sN6edksV0x47WUTgkgVfCgX7EuEMhbirENsgYe5oO4LTjBL9PtdKtk2WqND1gSLcTd2yw==",
       "license": "Apache-2.0",
       "bin": {
         "openai": "bin/cli"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sokuji",
-  "version": "0.15.5",
+  "version": "0.15.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sokuji",
-      "version": "0.15.5",
+      "version": "0.15.7",
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.15",
@@ -31,6 +31,7 @@
         "idb": "^8.0.3",
         "livekit-client": "^2.15.2",
         "lucide-react": "^0.515.0",
+        "openai": "^6.27.0",
         "openai-realtime-api": "1.0.8",
         "posthog-js-lite": "^4.1.0",
         "protobufjs": "^8.0.0",
@@ -11770,6 +11771,27 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/openai": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.27.0.tgz",
+      "integrity": "sha512-osTKySlrdYrLYTt0zjhY8yp0JUBmWDCN+Q+QxsV4xMQnnoVFpylgKGgxwN8sSdTNw0G4y+WUXs4eCMWpyDNWZQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "openai": "bin/cli"
+      },
+      "peerDependencies": {
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/openai-realtime-api": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "idb": "^8.0.3",
     "livekit-client": "^2.15.2",
     "lucide-react": "^0.515.0",
-    "openai": "^6.27.0",
+    "openai": "^6.29.0",
     "openai-realtime-api": "1.0.8",
     "posthog-js-lite": "^4.1.0",
     "protobufjs": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "idb": "^8.0.3",
     "livekit-client": "^2.15.2",
     "lucide-react": "^0.515.0",
+    "openai": "^6.27.0",
     "openai-realtime-api": "1.0.8",
     "posthog-js-lite": "^4.1.0",
     "protobufjs": "^8.0.0",

--- a/src/components/LogsPanel/LogsPanel.scss
+++ b/src/components/LogsPanel/LogsPanel.scss
@@ -58,6 +58,28 @@
       }
     }
     
+    .copy-logs-button {
+      display: flex;
+      align-items: center;
+      background: none;
+      border: none;
+      color: #aaa;
+      cursor: pointer;
+      padding: 5px 10px;
+      border-radius: 4px;
+      transition: all 0.2s;
+
+      span {
+        margin-left: 5px;
+        font-size: 13px;
+      }
+
+      &:hover {
+        background-color: rgba(255, 255, 255, 0.1);
+        color: white;
+      }
+    }
+
     .clear-logs-button {
       display: flex;
       align-items: center;

--- a/src/components/LogsPanel/LogsPanel.tsx
+++ b/src/components/LogsPanel/LogsPanel.tsx
@@ -189,14 +189,17 @@ const LogsPanel: React.FC<LogsPanelProps> = ({ toggleLogs }) => {
     setAutoScroll(prev => !prev);
   }, []);
 
-  // Copy filtered logs to clipboard
+  // Copy filtered logs to clipboard as NDJSON
   const handleCopyLogs = useCallback(() => {
-    const text = filteredLogs.map(log => {
-      if (log.events && log.events.length > 0 && log.source) {
-        return `[${log.timestamp}] ${log.source}: ${log.eventType || 'unknown'}`;
+    const lines: string[] = [];
+    for (const log of filteredLogs) {
+      if (log.events && log.events.length > 0) {
+        for (const event of log.events) {
+          lines.push(JSON.stringify(event));
+        }
       }
-      return `[${log.timestamp}] ${log.message || ''}`;
-    }).join('\n');
+    }
+    const text = lines.join('\n');
     navigator.clipboard.writeText(text).then(() => {
       setCopyLabel(t('logsPanel.logsCopied'));
       setTimeout(() => setCopyLabel(null), 1500);

--- a/src/components/LogsPanel/LogsPanel.tsx
+++ b/src/components/LogsPanel/LogsPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
-import { ArrowRight, Terminal, Trash2, ArrowUp, ArrowDown, FastForward, Mic, Users } from 'lucide-react';
+import { ArrowRight, Terminal, Trash2, ArrowUp, ArrowDown, FastForward, Mic, Users, ClipboardCopy } from 'lucide-react';
 import './LogsPanel.scss';
 import { useLogData, useLogActions } from '../../stores/logStore';
 import type { LogEntry, ClientId } from '../../stores/logStore';
@@ -111,6 +111,7 @@ const LogsPanel: React.FC<LogsPanelProps> = ({ toggleLogs }) => {
   const logsContentRef = useRef<HTMLDivElement>(null);
   const scrollTimeoutRef = useRef<NodeJS.Timeout>();
   const [activeTab, setActiveTab] = useState<ClientId>('speaker');
+  const [copyLabel, setCopyLabel] = useState<string | null>(null);
 
   // Filter logs based on active tab
   const filteredLogs = useMemo(() => {
@@ -188,6 +189,20 @@ const LogsPanel: React.FC<LogsPanelProps> = ({ toggleLogs }) => {
     setAutoScroll(prev => !prev);
   }, []);
 
+  // Copy filtered logs to clipboard
+  const handleCopyLogs = useCallback(() => {
+    const text = filteredLogs.map(log => {
+      if (log.events && log.events.length > 0 && log.source) {
+        return `[${log.timestamp}] ${log.source}: ${log.eventType || 'unknown'}`;
+      }
+      return `[${log.timestamp}] ${log.message || ''}`;
+    }).join('\n');
+    navigator.clipboard.writeText(text).then(() => {
+      setCopyLabel(t('logsPanel.logsCopied'));
+      setTimeout(() => setCopyLabel(null), 1500);
+    });
+  }, [filteredLogs, t]);
+
   // Memoized function to render regular log entry
   const renderLogEntry = useCallback((log: LogEntry, index: number) => {
     const elements: React.ReactNode[] = [];
@@ -250,6 +265,12 @@ const LogsPanel: React.FC<LogsPanelProps> = ({ toggleLogs }) => {
             <FastForward size={16} />
             <span>{autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}</span>
           </button>
+          {filteredLogs.length > 0 && (
+            <button className="copy-logs-button" onClick={handleCopyLogs}>
+              <ClipboardCopy size={16} />
+              <span>{copyLabel || t('logsPanel.copyLogs')}</span>
+            </button>
+          )}
           {logs.length > 0 && (
             <button className="clear-logs-button" onClick={clearLogs}>
               <Trash2 size={16} />

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -442,7 +442,9 @@
     "unknown": "unknown",
     "sessionEnded": "Session Ended",
     "speakerClient": "Speaker",
-    "participantClient": "Participant"
+    "participantClient": "Participant",
+    "copyLogs": "Copy Logs",
+    "logsCopied": "Copied!"
   },
   "mainPanel": {
     "conversationPlaceholder": "Conversation will appear here",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -268,7 +268,9 @@
     "unknown": "不明",
     "sessionEnded": "セッション終了",
     "speakerClient": "話者",
-    "participantClient": "参加者"
+    "participantClient": "参加者",
+    "copyLogs": "ログをコピー",
+    "logsCopied": "コピー完了！"
   },
   "mainPanel": {
     "conversationPlaceholder": "会話がここに表示されます",

--- a/src/services/clients/ClientFactory.ts
+++ b/src/services/clients/ClientFactory.ts
@@ -1,5 +1,6 @@
 import { IClient } from '../interfaces/IClient';
 import { OpenAIClient } from './OpenAIClient';
+import { OpenAIGAClient } from './OpenAIGAClient';
 import { OpenAIWebRTCClient } from './OpenAIWebRTCClient';
 import { GeminiClient } from './GeminiClient';
 import { PalabraAIClient } from './PalabraAIClient';
@@ -62,7 +63,9 @@ export class ClientFactory {
             outputDeviceId: webrtcOptions?.outputDeviceId
           });
         }
-        return new OpenAIClient(apiKey);
+        // Use GA client for direct OpenAI WebSocket connections
+        // (official SDK, no beta header)
+        return new OpenAIGAClient(apiKey);
 
       case Provider.OPENAI_COMPATIBLE:
         // OpenAI Compatible uses OpenAIClient with custom endpoint

--- a/src/services/clients/OpenAIClient.ts
+++ b/src/services/clients/OpenAIClient.ts
@@ -5,7 +5,7 @@ import type {
   FormattedItem
 } from 'openai-realtime-api';
 import { IClient, ConversationItem, SessionConfig, ClientEventHandlers, ApiKeyValidationResult, FilteredModel, ResponseConfig } from '../interfaces/IClient';
-import { RealtimeEvent } from '../../contexts/LogContext';
+import { RealtimeEvent } from '../../stores/logStore';
 import { Provider, ProviderType } from '../../types/Provider';
 import { unwrapTranslationText } from '../../utils/textUtils';
 import i18n from '../../locales';

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -560,49 +560,54 @@ export class OpenAIGAClient implements IClient {
       tools: []
     };
 
-    // Turn detection
+    // GA API nests turn_detection, transcription, noise_reduction under audio.input
+    const audioInput: any = {};
+    let hasAudioInput = false;
+
+    // Turn detection → audio.input.turn_detection
     if (config.turnDetection) {
       if (config.turnDetection.type === 'none') {
-        session.turn_detection = null;
+        audioInput.turn_detection = null;
         this.turnDetectionDisabled = true;
       } else {
         this.turnDetectionDisabled = false;
-        session.turn_detection = {
+        const td: any = {
           type: config.turnDetection.type,
-          threshold: config.turnDetection.threshold,
-          prefix_padding_ms: config.turnDetection.prefixPadding
-            ? Math.round(config.turnDetection.prefixPadding * 1000)
-            : undefined,
-          silence_duration_ms: config.turnDetection.silenceDuration
-            ? Math.round(config.turnDetection.silenceDuration * 1000)
-            : undefined,
           create_response: config.turnDetection.createResponse ?? true,
           interrupt_response: config.turnDetection.interruptResponse ?? false
         };
 
-        if (config.turnDetection.type === 'semantic_vad' && config.turnDetection.eagerness) {
-          session.turn_detection.eagerness = config.turnDetection.eagerness.toLowerCase();
+        if (config.turnDetection.type === 'server_vad') {
+          if (config.turnDetection.threshold !== undefined) td.threshold = config.turnDetection.threshold;
+          if (config.turnDetection.prefixPadding !== undefined) td.prefix_padding_ms = Math.round(config.turnDetection.prefixPadding * 1000);
+          if (config.turnDetection.silenceDuration !== undefined) td.silence_duration_ms = Math.round(config.turnDetection.silenceDuration * 1000);
+        } else if (config.turnDetection.type === 'semantic_vad' && config.turnDetection.eagerness) {
+          td.eagerness = config.turnDetection.eagerness.toLowerCase();
         }
 
-        // Remove undefined fields
-        Object.keys(session.turn_detection).forEach(key =>
-          session.turn_detection[key] === undefined && delete session.turn_detection[key]
-        );
+        audioInput.turn_detection = td;
       }
+      hasAudioInput = true;
     }
 
-    // Input audio transcription
+    // Input audio transcription → audio.input.transcription
     if (config.inputAudioTranscription?.model) {
-      session.input_audio_transcription = {
+      audioInput.transcription = {
         model: config.inputAudioTranscription.model
       };
+      hasAudioInput = true;
     }
 
-    // Noise reduction — GA uses nested 'audio.input_audio_noise_reduction'
+    // Noise reduction → audio.input.noise_reduction
     if (config.inputAudioNoiseReduction?.type) {
-      session.input_audio_noise_reduction = {
+      audioInput.noise_reduction = {
         type: config.inputAudioNoiseReduction.type
       };
+      hasAudioInput = true;
+    }
+
+    if (hasAudioInput) {
+      session.audio = { input: audioInput };
     }
 
     this.rt.send({

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -202,7 +202,9 @@ export class OpenAIGAClient implements IClient {
     });
 
     // Input audio buffer events
+    // When audio buffer is committed, create a user conversation item
     this.rt.on('input_audio_buffer.committed', (event) => {
+      this.handleUserItemCreated(event);
       this.forwardServerEvent('input_audio_buffer.committed', event);
     });
 
@@ -262,7 +264,10 @@ export class OpenAIGAClient implements IClient {
     });
 
     // Response content structure events
+    // GA API uses response.output_item.added instead of conversation.item.created
+    // for assistant response items
     this.rt.on('response.output_item.added', (event) => {
+      this.handleItemCreated(event);
       this.forwardServerEvent('response.output_item.added', event);
     });
 
@@ -386,6 +391,36 @@ export class OpenAIGAClient implements IClient {
 
     this.conversationItems.push(conversationItem);
     this.itemLookup.set(item.id, conversationItem);
+    this.eventHandlers.onConversationUpdated?.({ item: conversationItem });
+  }
+
+  /**
+   * Handle user item creation from input_audio_buffer.committed
+   * GA API doesn't emit conversation.item.created for user audio items,
+   * so we create a user ConversationItem when the audio buffer is committed.
+   */
+  private handleUserItemCreated(event: any): void {
+    const itemId = event.item_id;
+    if (!itemId || this.itemLookup.has(itemId)) return;
+
+    const createdAt = Date.now();
+    this.itemCreatedAtMap.set(itemId, createdAt);
+
+    const conversationItem: ConversationItem = {
+      id: itemId,
+      role: 'user',
+      type: 'message',
+      status: 'in_progress',
+      createdAt,
+      formatted: {
+        text: '',
+        transcript: ''
+      },
+      content: []
+    };
+
+    this.conversationItems.push(conversationItem);
+    this.itemLookup.set(itemId, conversationItem);
     this.eventHandlers.onConversationUpdated?.({ item: conversationItem });
   }
 

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -778,8 +778,10 @@ export class OpenAIGAClient implements IClient {
       if (config.conversation) {
         responseEvent.response.conversation = config.conversation;
       }
-      // Note: GA API does not support 'modalities' in response.create
-      // Modalities are set at the session level via session.update
+      // GA API uses 'output_modalities' instead of 'modalities' in response.create
+      if (config.modalities) {
+        responseEvent.response.output_modalities = config.modalities;
+      }
       if (config.metadata) {
         responseEvent.response.metadata = config.metadata;
       }

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -41,6 +41,8 @@ export class OpenAIGAClient implements IClient {
   private itemLookup: Map<string, ConversationItem> = new Map();
   private connected: boolean = false;
   private turnDetectionDisabled: boolean = false;
+  // Track out-of-band response IDs (conversation_id === null) to filter from UI
+  private outOfBandResponseIds: Set<string> = new Set();
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
@@ -74,6 +76,7 @@ export class OpenAIGAClient implements IClient {
     this.conversationItems = [];
     this.itemLookup.clear();
     this.turnDetectionDisabled = false;
+    this.outOfBandResponseIds.clear();
 
     // Create the official SDK WebSocket client
     this.rt = new OpenAIRealtimeWebSocket({
@@ -255,6 +258,12 @@ export class OpenAIGAClient implements IClient {
 
     // Response lifecycle events
     this.rt.on('response.created', (event) => {
+      // Track out-of-band responses (conversation_id === null) — these are anchor
+      // messages that should not appear in the conversation UI
+      const response = (event as any).response;
+      if (response?.id && response?.conversation_id === null) {
+        this.outOfBandResponseIds.add(response.id);
+      }
       this.forwardServerEvent('response.created', event);
     });
 
@@ -265,9 +274,12 @@ export class OpenAIGAClient implements IClient {
 
     // Response content structure events
     // GA API uses response.output_item.added instead of conversation.item.created
-    // for assistant response items
+    // for assistant response items — skip out-of-band (anchor) responses
     this.rt.on('response.output_item.added', (event) => {
-      this.handleItemCreated(event);
+      const responseId = (event as any).response_id;
+      if (!this.outOfBandResponseIds.has(responseId)) {
+        this.handleItemCreated(event);
+      }
       this.forwardServerEvent('response.output_item.added', event);
     });
 

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -545,6 +545,7 @@ export class OpenAIGAClient implements IClient {
     if (!this.rt) return;
 
     const session: any = {
+      type: 'realtime',
       modalities: config.textOnly ? ['text'] : ['text', 'audio'],
       voice: config.voice || 'alloy',
       instructions: config.instructions,
@@ -723,9 +724,8 @@ export class OpenAIGAClient implements IClient {
       if (config.conversation) {
         responseEvent.response.conversation = config.conversation;
       }
-      if (config.modalities) {
-        responseEvent.response.modalities = config.modalities;
-      }
+      // Note: GA API does not support 'modalities' in response.create
+      // Modalities are set at the session level via session.update
       if (config.metadata) {
         responseEvent.response.metadata = config.metadata;
       }

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -553,7 +553,6 @@ export class OpenAIGAClient implements IClient {
     const session: any = {
       type: 'realtime',
       output_modalities: config.textOnly ? ['text'] : ['audio'],
-      voice: config.voice || 'alloy',
       instructions: config.instructions,
       max_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
       // Explicitly disable tools to prevent model drift from translator role

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -743,17 +743,40 @@ export class OpenAIGAClient implements IClient {
   appendInputText(text: string): void {
     if (!this.rt || !text.trim()) return;
 
+    const trimmedText = text.trim();
+    const localItemId = `text_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`;
+
     this.rt.send({
       type: 'conversation.item.create',
       item: {
+        id: localItemId,
         type: 'message',
         role: 'user',
         content: [{
           type: 'input_text',
-          text: text.trim()
+          text: trimmedText
         }]
       }
     } as any);
+
+    // Create local user conversation item immediately (GA API may not
+    // emit conversation.item.created for client-created items)
+    const createdAt = Date.now();
+    const conversationItem: ConversationItem = {
+      id: localItemId,
+      role: 'user',
+      type: 'message',
+      status: 'completed',
+      createdAt,
+      formatted: {
+        text: trimmedText,
+        transcript: trimmedText
+      },
+      content: [{ type: 'input_text', text: trimmedText }]
+    };
+    this.conversationItems.push(conversationItem);
+    this.itemLookup.set(localItemId, conversationItem);
+    this.eventHandlers.onConversationUpdated?.({ item: conversationItem });
 
     // Forward as client event for logging
     this.eventHandlers.onRealtimeEvent?.({

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -544,15 +544,18 @@ export class OpenAIGAClient implements IClient {
   private sendSessionUpdate(config: OpenAISessionConfig): void {
     if (!this.rt) return;
 
+    // GA API session parameters differ from beta:
+    // - 'modalities' → 'output_modalities' (only ['text'] or ['audio'], not both)
+    // - 'max_response_output_tokens' → 'max_output_tokens'
+    // - 'input_audio_format'/'output_audio_format' → nested 'audio' config
+    // - 'temperature' → removed (not a GA session param)
+    // - 'voice' → set at connection time, can only be updated if no audio output yet
     const session: any = {
       type: 'realtime',
-      modalities: config.textOnly ? ['text'] : ['text', 'audio'],
+      output_modalities: config.textOnly ? ['text'] : ['audio'],
       voice: config.voice || 'alloy',
       instructions: config.instructions,
-      input_audio_format: 'pcm16',
-      output_audio_format: 'pcm16',
-      temperature: config.temperature ?? 0.8,
-      max_response_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
+      max_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
       // Explicitly disable tools to prevent model drift from translator role
       tool_choice: 'none',
       tools: []
@@ -589,17 +592,17 @@ export class OpenAIGAClient implements IClient {
       }
     }
 
-    // Noise reduction
-    if (config.inputAudioNoiseReduction?.type) {
-      session.input_audio_noise_reduction = {
-        type: config.inputAudioNoiseReduction.type
-      };
-    }
-
     // Input audio transcription
     if (config.inputAudioTranscription?.model) {
       session.input_audio_transcription = {
         model: config.inputAudioTranscription.model
+      };
+    }
+
+    // Noise reduction — GA uses nested 'audio.input_audio_noise_reduction'
+    if (config.inputAudioNoiseReduction?.type) {
+      session.input_audio_noise_reduction = {
+        type: config.inputAudioNoiseReduction.type
       };
     }
 

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -43,6 +43,8 @@ export class OpenAIGAClient implements IClient {
   private turnDetectionDisabled: boolean = false;
   // Track out-of-band response IDs (conversation_id === null) to filter from UI
   private outOfBandResponseIds: Set<string> = new Set();
+  // Audio chunk list per item — merged into formatted.audio on response.done
+  private audioChunks: Map<string, Int16Array[]> = new Map();
 
   constructor(apiKey: string) {
     this.apiKey = apiKey;
@@ -77,6 +79,7 @@ export class OpenAIGAClient implements IClient {
     this.itemLookup.clear();
     this.turnDetectionDisabled = false;
     this.outOfBandResponseIds.clear();
+    this.audioChunks.clear();
 
     // Create the official SDK WebSocket client
     this.rt = new OpenAIRealtimeWebSocket({
@@ -453,7 +456,7 @@ export class OpenAIGAClient implements IClient {
 
     this.eventHandlers.onConversationUpdated?.({
       item,
-      delta: { transcript: delta }
+      delta: { text: delta }
     });
   }
 
@@ -491,14 +494,15 @@ export class OpenAIGAClient implements IClient {
     const audioData = base64ToInt16Array(audioBase64);
     const sequenceNumber = ++this.deltaSequenceNumber;
 
+    // Store audio chunks — merged into item.formatted.audio on response.done
+    // This avoids O(n²) array merging on every delta event
+    if (!this.audioChunks.has(itemId)) {
+      this.audioChunks.set(itemId, []);
+    }
+    this.audioChunks.get(itemId)!.push(audioData);
+
     this.eventHandlers.onConversationUpdated?.({
-      item: {
-        ...item,
-        formatted: {
-          ...item.formatted,
-          audio: audioData
-        }
-      },
+      item,
       delta: {
         audio: audioData,
         sequenceNumber,
@@ -578,11 +582,24 @@ export class OpenAIGAClient implements IClient {
     for (const outputItem of response.output) {
       const item = this.itemLookup.get(outputItem.id);
       if (item) {
+        // Merge accumulated audio chunks into item.formatted.audio for manual playback
+        const chunks = this.audioChunks.get(outputItem.id);
+        if (chunks && chunks.length > 0 && item.formatted) {
+          const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+          const merged = new Int16Array(totalLength);
+          let offset = 0;
+          for (const chunk of chunks) {
+            merged.set(chunk, offset);
+            offset += chunk.length;
+          }
+          item.formatted.audio = merged;
+          this.audioChunks.delete(outputItem.id);
+        }
+
         item.status = 'completed';
         this.eventHandlers.onConversationUpdated?.({ item });
       }
     }
-
   }
 
   /**
@@ -710,6 +727,7 @@ export class OpenAIGAClient implements IClient {
     this.conversationItems = [];
     this.itemLookup.clear();
     this.itemCreatedAtMap.clear();
+    this.audioChunks.clear();
   }
 
   appendInputAudio(audioData: Int16Array): void {

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -1,0 +1,812 @@
+/**
+ * OpenAIGAClient
+ *
+ * OpenAI Realtime API client using the official 'openai' SDK (GA).
+ * Uses OpenAIRealtimeWebSocket which does NOT send the beta header.
+ *
+ * This client is used for direct OpenAI connections only.
+ * OpenAI Compatible and Kizuna AI providers continue to use OpenAIClient (beta).
+ */
+
+import { OpenAIRealtimeWebSocket } from 'openai/realtime/websocket';
+import {
+  IClient,
+  ConversationItem,
+  SessionConfig,
+  ClientEventHandlers,
+  OpenAISessionConfig,
+  isOpenAISessionConfig,
+  ApiKeyValidationResult,
+  FilteredModel,
+  ResponseConfig
+} from '../interfaces/IClient';
+import type { EventData } from '../../stores/logStore';
+import { Provider, ProviderType } from '../../types/Provider';
+import { unwrapTranslationText } from '../../utils/textUtils';
+import { OpenAIClient } from './OpenAIClient';
+
+/**
+ * OpenAI Realtime API client using the official SDK (GA protocol)
+ * Implements the IClient interface for OpenAI's GA Realtime API
+ */
+export class OpenAIGAClient implements IClient {
+  private rt: OpenAIRealtimeWebSocket | null = null;
+  private eventHandlers: ClientEventHandlers = {};
+  private apiKey: string;
+  private deltaSequenceNumber: number = 0;
+  private itemCreatedAtMap: Map<string, number> = new Map();
+
+  // Manual conversation tracking (same pattern as OpenAIWebRTCClient)
+  private conversationItems: ConversationItem[] = [];
+  private itemLookup: Map<string, ConversationItem> = new Map();
+  private connected: boolean = false;
+  private turnDetectionDisabled: boolean = false;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+  }
+
+  /**
+   * Validate API key and fetch available models (delegates to OpenAIClient static methods)
+   */
+  static async validateApiKeyAndFetchModels(apiKey: string): Promise<{
+    validation: ApiKeyValidationResult;
+    models: FilteredModel[];
+  }> {
+    return OpenAIClient.validateApiKeyAndFetchModels(apiKey);
+  }
+
+  /**
+   * Get the latest realtime model from the filtered models
+   */
+  static getLatestRealtimeModel(filteredModels: FilteredModel[]): string {
+    return OpenAIClient.getLatestRealtimeModel(filteredModels);
+  }
+
+  async connect(config: SessionConfig): Promise<void> {
+    if (!isOpenAISessionConfig(config)) {
+      throw new Error('OpenAIGAClient requires OpenAI session config');
+    }
+
+    // Reset state for new session
+    this.deltaSequenceNumber = 0;
+    this.itemCreatedAtMap.clear();
+    this.conversationItems = [];
+    this.itemLookup.clear();
+    this.turnDetectionDisabled = false;
+
+    // Create the official SDK WebSocket client
+    this.rt = new OpenAIRealtimeWebSocket({
+      model: config.model,
+      dangerouslyAllowBrowser: true
+    }, {
+      apiKey: this.apiKey,
+      baseURL: 'https://api.openai.com/v1'
+    });
+
+    // Set up event listeners
+    this.setupEventListeners();
+
+    // Wait for session creation with timeout
+    await this.waitForSessionCreated();
+
+    // Send session configuration
+    this.sendSessionUpdate(config);
+
+    // Emit session opened event
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'session.opened',
+        data: {
+          status: 'connected',
+          provider: 'openai',
+          model: config.model,
+          timestamp: Date.now(),
+          voice: config.voice,
+          temperature: config.temperature,
+          protocol: 'ga'
+        }
+      }
+    });
+
+    this.connected = true;
+    this.eventHandlers.onOpen?.();
+  }
+
+  /**
+   * Wait for session.created event with timeout and error handling
+   */
+  private waitForSessionCreated(): Promise<void> {
+    const SESSION_TIMEOUT = 30000;
+
+    return new Promise<void>((resolve, reject) => {
+      if (!this.rt) {
+        reject(new Error('WebSocket client not initialized'));
+        return;
+      }
+
+      let isSettled = false;
+
+      const timeout = setTimeout(() => {
+        if (!isSettled) {
+          isSettled = true;
+          reject(new Error('Session creation timeout - server did not respond in time'));
+        }
+      }, SESSION_TIMEOUT);
+
+      this.rt.on('session.created', () => {
+        if (!isSettled) {
+          isSettled = true;
+          clearTimeout(timeout);
+          resolve();
+        }
+      });
+
+      this.rt.on('error', (err: any) => {
+        if (!isSettled) {
+          isSettled = true;
+          clearTimeout(timeout);
+          reject(new Error(err?.message || 'Connection failed'));
+        }
+      });
+
+      // Handle WebSocket close before session is created
+      this.rt!.socket.addEventListener('close', (event) => {
+        if (!isSettled) {
+          isSettled = true;
+          clearTimeout(timeout);
+          reject(new Error(`WebSocket closed before session created: ${event.code} ${event.reason}`));
+        }
+      });
+    });
+  }
+
+  /**
+   * Set up all event listeners on the GA WebSocket client
+   */
+  private setupEventListeners(): void {
+    if (!this.rt) return;
+
+    // Session events
+    this.rt.on('session.created', (event) => {
+      this.forwardServerEvent('session.created', event);
+    });
+
+    this.rt.on('session.updated', (event) => {
+      this.forwardServerEvent('session.updated', event);
+    });
+
+    // Conversation item events
+    this.rt.on('conversation.item.created', (event) => {
+      this.handleItemCreated(event);
+      this.forwardServerEvent('conversation.item.created', event);
+    });
+
+    this.rt.on('conversation.item.deleted', (event) => {
+      this.forwardServerEvent('conversation.item.deleted', event);
+    });
+
+    this.rt.on('conversation.item.truncated', (event) => {
+      this.forwardServerEvent('conversation.item.truncated', event);
+    });
+
+    // Input audio transcription
+    this.rt.on('conversation.item.input_audio_transcription.completed', (event) => {
+      this.handleInputTranscriptionCompleted(event);
+      this.forwardServerEvent('conversation.item.input_audio_transcription.completed', event);
+    });
+
+    this.rt.on('conversation.item.input_audio_transcription.failed', (event) => {
+      this.forwardServerEvent('conversation.item.input_audio_transcription.failed', event);
+    });
+
+    // Input audio buffer events
+    this.rt.on('input_audio_buffer.committed', (event) => {
+      this.forwardServerEvent('input_audio_buffer.committed', event);
+    });
+
+    this.rt.on('input_audio_buffer.cleared', (event) => {
+      this.forwardServerEvent('input_audio_buffer.cleared', event);
+    });
+
+    this.rt.on('input_audio_buffer.speech_started', (event) => {
+      this.eventHandlers.onConversationInterrupted?.();
+      this.forwardServerEvent('input_audio_buffer.speech_started', event);
+    });
+
+    this.rt.on('input_audio_buffer.speech_stopped', (event) => {
+      this.forwardServerEvent('input_audio_buffer.speech_stopped', event);
+    });
+
+    // GA text output events
+    this.rt.on('response.output_text.delta', (event) => {
+      this.handleTextDelta(event);
+      this.forwardServerEvent('response.output_text.delta', event);
+    });
+
+    this.rt.on('response.output_text.done', (event) => {
+      this.handleTextDone(event);
+      this.forwardServerEvent('response.output_text.done', event);
+    });
+
+    // GA audio output events
+    this.rt.on('response.output_audio.delta', (event) => {
+      this.handleAudioDelta(event);
+      this.forwardServerEvent('response.output_audio.delta', event);
+    });
+
+    this.rt.on('response.output_audio.done', (event) => {
+      this.forwardServerEvent('response.output_audio.done', event);
+    });
+
+    // GA audio transcript events
+    this.rt.on('response.output_audio_transcript.delta', (event) => {
+      this.handleTranscriptDelta(event);
+      this.forwardServerEvent('response.output_audio_transcript.delta', event);
+    });
+
+    this.rt.on('response.output_audio_transcript.done', (event) => {
+      this.handleTranscriptDone(event);
+      this.forwardServerEvent('response.output_audio_transcript.done', event);
+    });
+
+    // Response lifecycle events
+    this.rt.on('response.created', (event) => {
+      this.forwardServerEvent('response.created', event);
+    });
+
+    this.rt.on('response.done', (event) => {
+      this.handleResponseDone(event);
+      this.forwardServerEvent('response.done', event);
+    });
+
+    // Response content structure events
+    this.rt.on('response.output_item.added', (event) => {
+      this.forwardServerEvent('response.output_item.added', event);
+    });
+
+    this.rt.on('response.output_item.done', (event) => {
+      this.forwardServerEvent('response.output_item.done', event);
+    });
+
+    this.rt.on('response.content_part.added', (event) => {
+      this.forwardServerEvent('response.content_part.added', event);
+    });
+
+    this.rt.on('response.content_part.done', (event) => {
+      this.forwardServerEvent('response.content_part.done', event);
+    });
+
+    // Function calling events
+    this.rt.on('response.function_call_arguments.delta', (event) => {
+      this.forwardServerEvent('response.function_call_arguments.delta', event);
+    });
+
+    this.rt.on('response.function_call_arguments.done', (event) => {
+      this.forwardServerEvent('response.function_call_arguments.done', event);
+    });
+
+    // Rate limits
+    this.rt.on('rate_limits.updated', (event) => {
+      this.forwardServerEvent('rate_limits.updated', event);
+    });
+
+    // Error handling
+    this.rt.on('error', (err: any) => {
+      this.eventHandlers.onRealtimeEvent?.({
+        source: 'server',
+        event: {
+          type: 'error',
+          data: err
+        }
+      });
+
+      // Create error ConversationItem for display in UI
+      const errorType = err?.error?.type || err?.type || 'error';
+      const errorMessage = err?.error?.message || err?.message || 'Unknown error';
+      const errorItem: ConversationItem = {
+        id: `error_${Date.now()}_${Math.random().toString(36).substring(2, 11)}`,
+        role: 'system',
+        type: 'error',
+        status: 'completed',
+        formatted: {
+          text: `[${errorType}] ${errorMessage}`,
+        },
+        content: [{
+          type: 'text',
+          text: errorMessage
+        }]
+      };
+
+      this.eventHandlers.onConversationUpdated?.({ item: errorItem });
+      this.eventHandlers.onError?.(err);
+    });
+
+    // WebSocket close
+    this.rt.socket.addEventListener('close', () => {
+      if (this.connected) {
+        this.connected = false;
+        this.eventHandlers.onRealtimeEvent?.({
+          source: 'client',
+          event: {
+            type: 'session.closed',
+            data: {
+              status: 'disconnected',
+              provider: 'openai',
+              timestamp: Date.now(),
+              reason: 'websocket_closed'
+            }
+          }
+        });
+        this.eventHandlers.onClose?.({});
+      }
+    });
+  }
+
+  /**
+   * Forward a server event to the logging system
+   */
+  private forwardServerEvent(type: EventData['type'], event: any): void {
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'server',
+      event: {
+        type,
+        data: event
+      }
+    });
+  }
+
+  /**
+   * Handle conversation.item.created event
+   */
+  private handleItemCreated(event: any): void {
+    const item = event.item;
+    if (!item) return;
+
+    const createdAt = Date.now();
+    this.itemCreatedAtMap.set(item.id, createdAt);
+
+    const conversationItem: ConversationItem = {
+      id: item.id,
+      role: item.role || 'assistant',
+      type: item.type || 'message',
+      status: item.status || 'in_progress',
+      createdAt,
+      formatted: {
+        text: '',
+        transcript: ''
+      },
+      content: item.content || []
+    };
+
+    // Track current assistant response item
+    // (Not currently needed since audio uses item_id, but kept for consistency
+    // with WebRTC client pattern)
+
+    this.conversationItems.push(conversationItem);
+    this.itemLookup.set(item.id, conversationItem);
+    this.eventHandlers.onConversationUpdated?.({ item: conversationItem });
+  }
+
+  /**
+   * Handle response.output_text.delta (GA event)
+   */
+  private handleTextDelta(event: any): void {
+    const itemId = event.item_id;
+    const delta = event.delta;
+    if (!itemId || !delta) return;
+
+    const item = this.itemLookup.get(itemId);
+    if (!item) return;
+
+    if (item.formatted) {
+      item.formatted.text = (item.formatted.text || '') + delta;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({
+      item,
+      delta: { transcript: delta }
+    });
+  }
+
+  /**
+   * Handle response.output_text.done (GA event)
+   */
+  private handleTextDone(event: any): void {
+    const itemId = event.item_id;
+    const text = event.text;
+    if (!itemId) return;
+
+    const item = this.itemLookup.get(itemId);
+    if (!item) return;
+
+    if (item.formatted && text) {
+      const cleaned = unwrapTranslationText(text);
+      item.formatted.text = cleaned;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({ item });
+  }
+
+  /**
+   * Handle response.output_audio.delta (GA event)
+   * Decode base64 audio to Int16Array and emit as delta
+   */
+  private handleAudioDelta(event: any): void {
+    const itemId = event.item_id;
+    const audioBase64 = event.delta;
+    if (!itemId || !audioBase64) return;
+
+    const item = this.itemLookup.get(itemId);
+    if (!item) return;
+
+    const audioData = base64ToInt16Array(audioBase64);
+    const sequenceNumber = ++this.deltaSequenceNumber;
+
+    this.eventHandlers.onConversationUpdated?.({
+      item: {
+        ...item,
+        formatted: {
+          ...item.formatted,
+          audio: audioData
+        }
+      },
+      delta: {
+        audio: audioData,
+        sequenceNumber,
+        timestamp: Date.now()
+      }
+    });
+  }
+
+  /**
+   * Handle response.output_audio_transcript.delta (GA event)
+   */
+  private handleTranscriptDelta(event: any): void {
+    const itemId = event.item_id;
+    const delta = event.delta;
+    if (!itemId || !delta) return;
+
+    const item = this.itemLookup.get(itemId);
+    if (!item) return;
+
+    if (item.formatted) {
+      item.formatted.transcript = (item.formatted.transcript || '') + delta;
+      // Also update text to show transcript when text output isn't available
+      if (!item.formatted.text) {
+        item.formatted.text = item.formatted.transcript;
+      }
+    }
+
+    this.eventHandlers.onConversationUpdated?.({
+      item,
+      delta: { transcript: delta }
+    });
+  }
+
+  /**
+   * Handle response.output_audio_transcript.done (GA event)
+   */
+  private handleTranscriptDone(event: any): void {
+    const itemId = event.item_id;
+    const transcript = event.transcript;
+    if (!itemId) return;
+
+    const item = this.itemLookup.get(itemId);
+    if (!item) return;
+
+    if (item.formatted && transcript) {
+      const cleaned = unwrapTranslationText(transcript);
+      item.formatted.transcript = cleaned;
+      item.formatted.text = cleaned;
+    }
+
+    this.eventHandlers.onConversationUpdated?.({ item });
+  }
+
+  /**
+   * Handle input audio transcription completed
+   */
+  private handleInputTranscriptionCompleted(event: any): void {
+    const itemId = event.item_id;
+    const transcript = event.transcript;
+    if (!itemId) return;
+
+    const item = this.itemLookup.get(itemId);
+    if (item && item.formatted) {
+      item.formatted.transcript = transcript;
+      item.formatted.text = transcript;
+      this.eventHandlers.onConversationUpdated?.({ item });
+    }
+  }
+
+  /**
+   * Handle response.done event - mark items as completed
+   */
+  private handleResponseDone(event: any): void {
+    const response = event.response;
+    if (!response?.output) return;
+
+    for (const outputItem of response.output) {
+      const item = this.itemLookup.get(outputItem.id);
+      if (item) {
+        item.status = 'completed';
+        this.eventHandlers.onConversationUpdated?.({ item });
+      }
+    }
+
+  }
+
+  /**
+   * Send session.update event with configuration
+   */
+  private sendSessionUpdate(config: OpenAISessionConfig): void {
+    if (!this.rt) return;
+
+    const session: any = {
+      modalities: config.textOnly ? ['text'] : ['text', 'audio'],
+      voice: config.voice || 'alloy',
+      instructions: config.instructions,
+      input_audio_format: 'pcm16',
+      output_audio_format: 'pcm16',
+      temperature: config.temperature ?? 0.8,
+      max_response_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
+      // Explicitly disable tools to prevent model drift from translator role
+      tool_choice: 'none',
+      tools: []
+    };
+
+    // Turn detection
+    if (config.turnDetection) {
+      if (config.turnDetection.type === 'none') {
+        session.turn_detection = null;
+        this.turnDetectionDisabled = true;
+      } else {
+        this.turnDetectionDisabled = false;
+        session.turn_detection = {
+          type: config.turnDetection.type,
+          threshold: config.turnDetection.threshold,
+          prefix_padding_ms: config.turnDetection.prefixPadding
+            ? Math.round(config.turnDetection.prefixPadding * 1000)
+            : undefined,
+          silence_duration_ms: config.turnDetection.silenceDuration
+            ? Math.round(config.turnDetection.silenceDuration * 1000)
+            : undefined,
+          create_response: config.turnDetection.createResponse ?? true,
+          interrupt_response: config.turnDetection.interruptResponse ?? false
+        };
+
+        if (config.turnDetection.type === 'semantic_vad' && config.turnDetection.eagerness) {
+          session.turn_detection.eagerness = config.turnDetection.eagerness.toLowerCase();
+        }
+
+        // Remove undefined fields
+        Object.keys(session.turn_detection).forEach(key =>
+          session.turn_detection[key] === undefined && delete session.turn_detection[key]
+        );
+      }
+    }
+
+    // Noise reduction
+    if (config.inputAudioNoiseReduction?.type) {
+      session.input_audio_noise_reduction = {
+        type: config.inputAudioNoiseReduction.type
+      };
+    }
+
+    // Input audio transcription
+    if (config.inputAudioTranscription?.model) {
+      session.input_audio_transcription = {
+        model: config.inputAudioTranscription.model
+      };
+    }
+
+    this.rt.send({
+      type: 'session.update',
+      session
+    } as any);
+
+    // Forward as client event for logging
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'session.update',
+        data: { session }
+      }
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    if (this.rt) {
+      this.rt.close();
+      this.rt = null;
+    }
+
+    if (this.connected) {
+      this.connected = false;
+      this.eventHandlers.onRealtimeEvent?.({
+        source: 'client',
+        event: {
+          type: 'session.closed',
+          data: {
+            status: 'disconnected',
+            provider: 'openai',
+            timestamp: Date.now(),
+            reason: 'client_disconnect'
+          }
+        }
+      });
+      this.eventHandlers.onClose?.({});
+    }
+  }
+
+  isConnected(): boolean {
+    return this.connected && this.rt !== null;
+  }
+
+  updateSession(config: Partial<SessionConfig>): void {
+    if (isOpenAISessionConfig(config as SessionConfig)) {
+      this.sendSessionUpdate(config as OpenAISessionConfig);
+    }
+  }
+
+  reset(): void {
+    this.conversationItems = [];
+    this.itemLookup.clear();
+    this.itemCreatedAtMap.clear();
+  }
+
+  appendInputAudio(audioData: Int16Array): void {
+    if (!this.rt) return;
+
+    const base64 = int16ArrayToBase64(audioData);
+    this.rt.send({
+      type: 'input_audio_buffer.append',
+      audio: base64
+    } as any);
+  }
+
+  appendInputText(text: string): void {
+    if (!this.rt || !text.trim()) return;
+
+    this.rt.send({
+      type: 'conversation.item.create',
+      item: {
+        type: 'message',
+        role: 'user',
+        content: [{
+          type: 'input_text',
+          text: text.trim()
+        }]
+      }
+    } as any);
+
+    // Forward as client event for logging
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'conversation.item.create',
+        data: { text: text.trim() }
+      }
+    });
+
+    this.rt.send({ type: 'response.create' } as any);
+  }
+
+  createResponse(config?: ResponseConfig): void {
+    if (!this.rt) return;
+
+    // When turn detection is disabled, commit audio buffer first (PTT mode)
+    // Skip for out-of-band anchor messages (conversation: 'none')
+    if (this.turnDetectionDisabled && config?.conversation !== 'none') {
+      this.rt.send({ type: 'input_audio_buffer.commit' } as any);
+
+      this.eventHandlers.onRealtimeEvent?.({
+        source: 'client',
+        event: {
+          type: 'input_audio_buffer.commit',
+          data: {}
+        }
+      });
+    }
+
+    if (config) {
+      const responseEvent: any = {
+        type: 'response.create',
+        response: {}
+      };
+
+      if (config.instructions) {
+        responseEvent.response.instructions = config.instructions;
+      }
+      if (config.conversation) {
+        responseEvent.response.conversation = config.conversation;
+      }
+      if (config.modalities) {
+        responseEvent.response.modalities = config.modalities;
+      }
+      if (config.metadata) {
+        responseEvent.response.metadata = config.metadata;
+      }
+
+      if (config.conversation === 'none') {
+        console.debug('[OpenAIGAClient] Sending out-of-band response:', {
+          conversation: config.conversation,
+          modalities: config.modalities,
+          hasInstructions: !!config.instructions,
+          metadata: config.metadata
+        });
+      }
+
+      this.rt.send(responseEvent);
+
+      this.eventHandlers.onRealtimeEvent?.({
+        source: 'client',
+        event: {
+          type: 'response.create',
+          data: responseEvent
+        }
+      });
+    } else {
+      this.rt.send({ type: 'response.create' } as any);
+
+      this.eventHandlers.onRealtimeEvent?.({
+        source: 'client',
+        event: {
+          type: 'response.create',
+          data: {}
+        }
+      });
+    }
+  }
+
+  cancelResponse(_trackId?: string, _offset?: number): void {
+    if (!this.rt) return;
+    this.rt.send({ type: 'response.cancel' } as any);
+
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'response.cancel',
+        data: {}
+      }
+    });
+  }
+
+  getConversationItems(): ConversationItem[] {
+    return [...this.conversationItems];
+  }
+
+  setEventHandlers(handlers: ClientEventHandlers): void {
+    this.eventHandlers = { ...handlers };
+  }
+
+  getProvider(): ProviderType {
+    return Provider.OPENAI;
+  }
+}
+
+/**
+ * Convert Int16Array to base64-encoded string
+ */
+function int16ArrayToBase64(data: Int16Array): string {
+  const bytes = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Convert base64-encoded string to Int16Array
+ */
+function base64ToInt16Array(base64: string): Int16Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new Int16Array(bytes.buffer);
+}

--- a/src/services/clients/OpenAIWebRTCClient.ts
+++ b/src/services/clients/OpenAIWebRTCClient.ts
@@ -335,12 +335,16 @@ export class OpenAIWebRTCClient implements IClient {
         break;
 
       case 'response.audio_transcript.delta':
+      case 'response.output_audio_transcript.delta':  // GA
       case 'response.text.delta':
+      case 'response.output_text.delta':              // GA
         this.handleTranscriptDelta(event);
         break;
 
       case 'response.audio_transcript.done':
+      case 'response.output_audio_transcript.done':    // GA
       case 'response.text.done':
+      case 'response.output_text.done':                // GA
         this.handleTranscriptDone(event);
         break;
 

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -3,7 +3,7 @@
  * This interface provides a unified API for different AI providers
  */
 
-import { RealtimeEvent } from '../../contexts/LogContext';
+import { RealtimeEvent } from '../../stores/logStore';
 import { ProviderType } from '../../types/Provider';
 
 export interface ConversationItem {

--- a/src/stores/logStore.ts
+++ b/src/stores/logStore.ts
@@ -2,11 +2,6 @@ import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { shallow } from 'zustand/shallow';
 import { useMemo } from 'react';
-import type {
-  RealtimeServerEvents,
-  RealtimeClientEvents,
-  RealtimeCustomEvents
-} from 'openai-realtime-api';
 
 // Define the core event data structure
 export interface EventData {
@@ -32,10 +27,39 @@ export interface EventData {
     | 'serverContent.modelTurn'
     | 'serverContent.outputTranscription'
     | 'serverContent.inputTranscription'
-    // OpenAI event types from the openai-realtime-api package
-    | RealtimeServerEvents.EventType
-    | RealtimeClientEvents.EventType
-    | RealtimeCustomEvents.EventType
+    // OpenAI server events (shared between beta and GA)
+    | 'session.created' | 'session.updated'
+    | 'conversation.created'
+    | 'conversation.item.created' | 'conversation.item.deleted' | 'conversation.item.truncated'
+    | 'conversation.item.input_audio_transcription.completed'
+    | 'conversation.item.input_audio_transcription.failed'
+    | 'conversation.item.input_audio_transcription.delta'
+    | 'input_audio_buffer.committed' | 'input_audio_buffer.cleared'
+    | 'input_audio_buffer.speech_started' | 'input_audio_buffer.speech_stopped'
+    | 'response.created' | 'response.done'
+    | 'response.output_item.added' | 'response.output_item.done'
+    | 'response.function_call_arguments.delta' | 'response.function_call_arguments.done'
+    | 'rate_limits.updated'
+    | 'error'
+    // Beta-only event names (OpenAI Compatible, Kizuna AI)
+    | 'response.text.delta' | 'response.text.done'
+    | 'response.audio.delta' | 'response.audio.done'
+    | 'response.audio_transcript.delta' | 'response.audio_transcript.done'
+    // GA-only event names (OpenAI direct)
+    | 'response.output_text.delta' | 'response.output_text.done'
+    | 'response.output_audio.delta' | 'response.output_audio.done'
+    | 'response.output_audio_transcript.delta' | 'response.output_audio_transcript.done'
+    | 'conversation.item.added' | 'conversation.item.done'
+    | 'response.content_part.added' | 'response.content_part.done'
+    // OpenAI client events
+    | 'session.update'
+    | 'input_audio_buffer.append' | 'input_audio_buffer.commit' | 'input_audio_buffer.clear'
+    | 'conversation.item.create' | 'conversation.item.truncate' | 'conversation.item.delete'
+    | 'response.create' | 'response.cancel'
+    // openai-realtime-api custom events (for beta clients)
+    | 'conversation.item.appended' | 'conversation.item.completed'
+    | 'conversation.updated' | 'conversation.interrupted'
+    | 'realtime.event'
     // PalabraAI-specific request types (client → server)
     | 'set_task'
     | 'end_task'

--- a/src/stores/logStore.ts
+++ b/src/stores/logStore.ts
@@ -49,6 +49,7 @@ export interface EventData {
     | 'response.output_text.delta' | 'response.output_text.done'
     | 'response.output_audio.delta' | 'response.output_audio.done'
     | 'response.output_audio_transcript.delta' | 'response.output_audio_transcript.done'
+    | 'response.output_text.annotation.added'
     | 'conversation.item.added' | 'conversation.item.done'
     | 'response.content_part.added' | 'response.content_part.done'
     // OpenAI client events


### PR DESCRIPTION
## Summary

Closes #115

- **New `OpenAIGAClient`** using official `openai` SDK's `OpenAIRealtimeWebSocket` (GA protocol, no beta header)
- **Split client strategy**: OpenAI direct → GA client; OpenAI Compatible & Kizuna AI → existing beta client
- **WebRTC forward compatibility**: Added GA event name fallthrough cases
- **Decoupled `logStore`** from `openai-realtime-api` type imports

## Key Changes

| File | Change |
|------|--------|
| `src/services/clients/OpenAIGAClient.ts` | **New** — GA client with manual conversation tracking, base64 audio I/O |
| `src/services/clients/ClientFactory.ts` | Route `Provider.OPENAI` WebSocket → `OpenAIGAClient` |
| `src/services/clients/OpenAIWebRTCClient.ts` | Add GA event name fallthrough (`response.output_text.delta`, etc.) |
| `src/stores/logStore.ts` | Replace `openai-realtime-api` type imports with explicit string literals |
| `src/services/clients/OpenAIClient.ts` | Fix stale `LogContext` import |
| `src/services/interfaces/IClient.ts` | Fix stale `LogContext` import |

## Architecture

```
Provider.OPENAI (ws)       → OpenAIGAClient      (NEW, official openai SDK)
Provider.OPENAI (webrtc)   → OpenAIWebRTCClient   (event names updated)
Provider.OPENAI_COMPATIBLE → OpenAIClient          (beta, unchanged)
Provider.KIZUNA_AI         → OpenAIClient          (beta, unchanged)
```

## GA API Event Name Changes

| Beta (current) | GA (new) |
|---|---|
| `response.text.delta` | `response.output_text.delta` |
| `response.audio.delta` | `response.output_audio.delta` |
| `response.audio_transcript.delta` | `response.output_audio_transcript.delta` |

## Test plan

- [ ] `npm run build` — TypeScript compilation succeeds
- [ ] `npm run test` — No regressions (3 pre-existing failures unrelated)
- [ ] OpenAI provider: connect with `gpt-realtime-mini`, verify voice translation works
- [ ] OpenAI provider: verify GA event names in Logs panel
- [ ] OpenAI Compatible provider: verify beta protocol still works
- [ ] WebRTC transport: smoke test (connect, speak, verify output)
- [ ] Kizuna AI: blocked on backend team confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for OpenAI GA realtime protocol: improved realtime text/audio responses, transcripts, conversation tracking, and session lifecycle.
  * "Copy Logs" button in the Logs panel with localized labels and temporary copy feedback.

* **Chores**
  * Switched routing to GA realtime transport and adjusted client selection.
  * Hardened logging/event typing and fixed related imports.
  * Added official OpenAI SDK dependency.

* **Documentation**
  * Added migration design, rollout plan, and operational notes for the GA realtime migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->