### PR TITLE
fix: log resolved model IDs in PostHog events

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2150,16 +2150,17 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         setTranslationCount(0);
   
         const currentSettings = getCurrentProviderSettings();
+        const sessionConfig = getSessionConfig();
         trackEvent('translation_session_start', {
           source_language: currentSettings.sourceLanguage,
           target_language: currentSettings.targetLanguage,
           session_id: newSessionId,
           provider: provider,
-          model: (currentSettings as any).model,
+          model: (sessionConfig as any).model,
           ...(provider === Provider.LOCAL_INFERENCE && {
-            asr_model: localInferenceSettings.asrModel,
-            translation_model: localInferenceSettings.translationModel || 'auto',
-            tts_model: localInferenceSettings.ttsModel || 'auto',
+            asr_model: (sessionConfig as any).asrModelId,
+            translation_model: (sessionConfig as any).translationModelId || 'unknown',
+            tts_model: (sessionConfig as any).ttsModelId || 'none',
           }),
           noise_suppression_enabled: isNoiseSuppressEnabled,
           real_voice_passthrough_enabled: isRealVoicePassthroughEnabled,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -13,7 +13,7 @@ import {
   VolcengineAST2SessionConfig,
   LocalInferenceSessionConfig
 } from '../services/interfaces/IClient';
-import { getTtsModelsForLanguage, getManifestEntry } from '../lib/local-inference/modelManifest';
+import { getTtsModelsForLanguage, getManifestEntry, getTranslationModel } from '../lib/local-inference/modelManifest';
 import {ApiKeyValidationResult} from '../services/interfaces/ISettingsService';
 import {Provider, ProviderType} from '../types/Provider';
 import {ClientOperations} from '../services/ClientOperations';
@@ -474,7 +474,7 @@ function createLocalInferenceSessionConfig(
     sourceLanguage: settings.sourceLanguage,
     targetLanguage: settings.targetLanguage,
     asrModelId: settings.asrModel,
-    translationModelId: settings.translationModel || undefined,
+    translationModelId: settings.translationModel || getTranslationModel(settings.sourceLanguage, settings.targetLanguage)?.id,
     ttsModelId,
     ttsSpeakerId: settings.ttsSpeakerId,
     ttsSpeed: settings.ttsSpeed,


### PR DESCRIPTION
## Summary
- When `translationModel` or `ttsModel` is set to auto (empty string), PostHog `translation_session_start` events logged `'auto'` instead of the actual model being used
- Resolve translation model ID in `createLocalInferenceSessionConfig` (matching the existing TTS resolution pattern) so the session config always contains concrete model IDs
- Read from session config in MainPanel analytics instead of raw settings values

## Test plan
- [ ] Start a LOCAL_INFERENCE session with auto translation/TTS model selection
- [ ] Check PostHog event for `translation_session_start` — should show actual model IDs (e.g. `opus-mt-ja-en`, `piper-en`) instead of `auto`
- [ ] Start a session with manually selected models — should still log the correct model IDs
- [ ] Verify translation and TTS engines still initialize correctly (no behavioral change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics now report model fields based on the active session configuration to reflect actual runtime choices.
  * Local inference model selection improved: translation and TTS model choices fall back to manifest-based selections when not explicitly set.
  * For local inference, missing model IDs now use clearer defaults (e.g., "unknown"/"none") instead of ambiguous placeholders.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->