### PR TITLE
fix: validate localStorage parse result for dismissed tutorials

### DIFF
--- a/src/components/Settings/sections/ProviderSection.tsx
+++ b/src/components/Settings/sections/ProviderSection.tsx
@@ -96,7 +96,9 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
   const [dismissedTutorials, setDismissedTutorials] = useState<Set<string>>(() => {
     try {
       const stored = localStorage.getItem(DISMISSED_KEY);
-      return stored ? new Set(JSON.parse(stored)) : new Set();
+      if (!stored) return new Set();
+      const parsed = JSON.parse(stored);
+      return Array.isArray(parsed) ? new Set(parsed as string[]) : new Set();
     } catch { return new Set(); }
   });
 


### PR DESCRIPTION
## Summary
`JSON.parse(stored)` in the dismissed tutorials initializer passes the result directly to `new Set()` without type validation. If localStorage contains non-array JSON (e.g., an object or number), `new Set()` may produce unexpected results.

Added `Array.isArray()` check to ensure only valid arrays are used to initialize the Set.

## Test plan
- [ ] Dismissing tutorials still persists correctly
- [ ] Corrupted localStorage doesn't break the settings page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of settings persistence handling to prevent potential issues with corrupted or missing stored data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->