### PR TITLE
feat: remember model selections per language pair

### DIFF
--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1407,6 +1407,14 @@
     text-transform: uppercase;
     letter-spacing: 0.5px;
   }
+
+  .participant-hint {
+    display: block;
+    margin-top: 4px;
+    font-size: 10px;
+    color: vars.$text-muted;
+    font-style: italic;
+  }
 }
 
 // Help section buttons (shared between SimpleSettings and AdvancedSettings)

--- a/src/components/Settings/sections/ModelManagementSection.tsx
+++ b/src/components/Settings/sections/ModelManagementSection.tsx
@@ -390,6 +390,14 @@ export function ModelManagementSection({
     if (Object.keys(updates).length > 0) {
       onUpdateSettings(updates);
     }
+
+    // Remember the final model selection for this language pair
+    const finalAsr = updates.asrModel ?? asrModel;
+    const finalTranslation = updates.translationModel ?? translationModel;
+    const finalTts = updates.ttsModel ?? ttsModel;
+    if (finalAsr) {
+      useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, finalAsr, finalTranslation, finalTts);
+    }
   }, [initialized, statuses, sourceLanguage, targetLanguage, asrModel, translationModel, ttsModel, webgpuAvailable, onUpdateSettings]);
 
   // ── Memoized model lists ──────────────────────────────────────────────
@@ -550,7 +558,10 @@ export function ModelManagementSection({
           renderSubGroups(
             compatibleAsrModels,
             asrModel,
-            (id) => onUpdateSettings({ asrModel: id }),
+            (id) => {
+              onUpdateSettings({ asrModel: id });
+              useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, id, translationModel, ttsModel);
+            },
           )
         ) : (
           <div className="model-card__no-model-warning">
@@ -584,7 +595,10 @@ export function ModelManagementSection({
                 isCompatible={false}
                 showRadio={true}
                 compatibilityHint={t('settings.langMismatch', 'language mismatch')}
-                onSelect={() => onUpdateSettings({ asrModel: entry.id })}
+                onSelect={() => {
+                  onUpdateSettings({ asrModel: entry.id });
+                  useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, entry.id, translationModel, ttsModel);
+                }}
                 onDownload={() => handleDownload(entry.id)}
                 onCancel={() => cancelDownload(entry.id)}
                 onDelete={() => deleteModel(entry.id)}
@@ -605,7 +619,10 @@ export function ModelManagementSection({
           renderSubGroups(
             compatibleTranslationModels,
             translationModel,
-            (id) => onUpdateSettings({ translationModel: id }),
+            (id) => {
+              onUpdateSettings({ translationModel: id });
+              useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, asrModel, id, ttsModel);
+            },
           )
         ) : (
           <div className="model-card__no-model-warning">
@@ -646,7 +663,10 @@ export function ModelManagementSection({
                     ? t('settings.webgpuNotSupported', 'Not available in current environment')
                     : t('settings.langMismatch', 'language mismatch')
                 }
-                onSelect={() => onUpdateSettings({ translationModel: entry.id })}
+                onSelect={() => {
+                  onUpdateSettings({ translationModel: entry.id });
+                  useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, asrModel, entry.id, ttsModel);
+                }}
                 onDownload={() => handleDownload(entry.id)}
                 onCancel={() => cancelDownload(entry.id)}
                 onDelete={() => deleteModel(entry.id)}
@@ -670,7 +690,10 @@ export function ModelManagementSection({
           renderSubGroups(
             compatibleTtsModels,
             ttsModel,
-            (id) => onUpdateSettings({ ttsModel: id }),
+            (id) => {
+              onUpdateSettings({ ttsModel: id });
+              useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, asrModel, translationModel, id);
+            },
           )
         ) : (
           <div className="model-card__no-model-warning">
@@ -704,7 +727,10 @@ export function ModelManagementSection({
                 isCompatible={false}
                 showRadio={true}
                 compatibilityHint={t('settings.langMismatch', 'language mismatch')}
-                onSelect={() => onUpdateSettings({ ttsModel: entry.id })}
+                onSelect={() => {
+                  onUpdateSettings({ ttsModel: entry.id });
+                  useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, asrModel, translationModel, entry.id);
+                }}
                 onDownload={() => handleDownload(entry.id)}
                 onCancel={() => cancelDownload(entry.id)}
                 onDelete={() => deleteModel(entry.id)}

--- a/src/components/Settings/sections/ProviderSection.tsx
+++ b/src/components/Settings/sections/ProviderSection.tsx
@@ -474,6 +474,12 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
                     <span className="model-chip-value model-warn">✗</span>
                   )}
                 </button>
+                <span className="participant-hint">
+                  {t('settings.participantModelHint', 'Switch to {{source}} → {{target}} to change participant models', {
+                    source: localInferenceSettings.targetLanguage,
+                    target: localInferenceSettings.sourceLanguage,
+                  })}
+                </span>
               </div>
             )}
           </div>

--- a/src/components/SettingsInitializer/SettingsInitializer.tsx
+++ b/src/components/SettingsInitializer/SettingsInitializer.tsx
@@ -103,10 +103,24 @@ export function SettingsInitializer() {
   // ── LOCAL_INFERENCE: validate when model statuses or language settings change ──
   // validateApiKey() handles everything: model store init, auto-select, readiness check.
   useEffect(() => {
-    if (!settingsLoaded) return;
+    if (!settingsLoaded) {
+      console.debug('[SettingsInitializer] LOCAL_INFERENCE effect: skipped (settings not loaded)');
+      return;
+    }
     if (provider !== Provider.LOCAL_INFERENCE) return;
-    // Wait until model store has scanned IndexedDB
-    if (!modelInitialized) return;
+    if (!modelInitialized) {
+      console.debug('[SettingsInitializer] LOCAL_INFERENCE effect: skipped (model store not initialized)');
+      return;
+    }
+
+    console.log('[SettingsInitializer] LOCAL_INFERENCE effect triggered:', {
+      sourceLanguage: localInferenceSettings.sourceLanguage,
+      targetLanguage: localInferenceSettings.targetLanguage,
+      asrModel: localInferenceSettings.asrModel,
+      translationModel: localInferenceSettings.translationModel,
+      ttsModel: localInferenceSettings.ttsModel,
+      isValidating: isValidatingRef.current,
+    });
 
     // Track provider ref so the API-provider effect above doesn't re-fire
     prevProviderRef.current = provider;
@@ -115,13 +129,20 @@ export function SettingsInitializer() {
     // so no flickering despite being async. It handles autoSelectModels + isProviderReady.
     if (!isValidatingRef.current) {
       isValidatingRef.current = true;
+      console.log('[SettingsInitializer] LOCAL_INFERENCE: starting validateApiKey');
       validateApiKey()
+        .then((result) => {
+          console.log('[SettingsInitializer] LOCAL_INFERENCE: validateApiKey result:', result);
+        })
         .catch((error) => {
           console.error('[SettingsInitializer] Failed to validate LOCAL_INFERENCE provider:', error);
         })
         .finally(() => {
           isValidatingRef.current = false;
+          console.debug('[SettingsInitializer] LOCAL_INFERENCE: isValidatingRef reset to false');
         });
+    } else {
+      console.warn('[SettingsInitializer] LOCAL_INFERENCE effect: SKIPPED — already validating');
     }
   }, [settingsLoaded, provider, modelInitialized, modelStatuses, localInferenceSettings,
       validateApiKey]);

--- a/src/components/SettingsInitializer/SettingsInitializer.tsx
+++ b/src/components/SettingsInitializer/SettingsInitializer.tsx
@@ -103,24 +103,10 @@ export function SettingsInitializer() {
   // ── LOCAL_INFERENCE: validate when model statuses or language settings change ──
   // validateApiKey() handles everything: model store init, auto-select, readiness check.
   useEffect(() => {
-    if (!settingsLoaded) {
-      console.debug('[SettingsInitializer] LOCAL_INFERENCE effect: skipped (settings not loaded)');
-      return;
-    }
+    if (!settingsLoaded) return;
     if (provider !== Provider.LOCAL_INFERENCE) return;
-    if (!modelInitialized) {
-      console.debug('[SettingsInitializer] LOCAL_INFERENCE effect: skipped (model store not initialized)');
-      return;
-    }
-
-    console.log('[SettingsInitializer] LOCAL_INFERENCE effect triggered:', {
-      sourceLanguage: localInferenceSettings.sourceLanguage,
-      targetLanguage: localInferenceSettings.targetLanguage,
-      asrModel: localInferenceSettings.asrModel,
-      translationModel: localInferenceSettings.translationModel,
-      ttsModel: localInferenceSettings.ttsModel,
-      isValidating: isValidatingRef.current,
-    });
+    // Wait until model store has scanned IndexedDB
+    if (!modelInitialized) return;
 
     // Track provider ref so the API-provider effect above doesn't re-fire
     prevProviderRef.current = provider;
@@ -129,20 +115,13 @@ export function SettingsInitializer() {
     // so no flickering despite being async. It handles autoSelectModels + isProviderReady.
     if (!isValidatingRef.current) {
       isValidatingRef.current = true;
-      console.log('[SettingsInitializer] LOCAL_INFERENCE: starting validateApiKey');
       validateApiKey()
-        .then((result) => {
-          console.log('[SettingsInitializer] LOCAL_INFERENCE: validateApiKey result:', result);
-        })
         .catch((error) => {
           console.error('[SettingsInitializer] Failed to validate LOCAL_INFERENCE provider:', error);
         })
         .finally(() => {
           isValidatingRef.current = false;
-          console.debug('[SettingsInitializer] LOCAL_INFERENCE: isValidatingRef reset to false');
         });
-    } else {
-      console.warn('[SettingsInitializer] LOCAL_INFERENCE effect: SKIPPED — already validating');
     }
   }, [settingsLoaded, provider, modelInitialized, modelStatuses, localInferenceSettings,
       validateApiKey]);

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -160,6 +160,7 @@
     "helpEmailTooltip": "Report bugs or get help",
     "helpDiscussions": "Discussions",
     "helpDiscussionsTooltip": "Feature requests, feedback, and community discussions",
+    "participantModelHint": "Switch to {{source}} → {{target}} to change participant models",
     "auto": "Auto",
     "low": "Low",
     "medium": "Medium",

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -120,3 +120,110 @@ describe('getParticipantModelStatus', () => {
     expect(status.translationModelId).toBeNull();
   });
 });
+
+describe('rememberModels / recallModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useModelStore.setState({ modelPreferences: {} });
+  });
+
+  it('remembers and recalls models for a language pair', () => {
+    useModelStore.setState({
+      modelStatuses: {
+        'sensevoice-int8': 'downloaded',
+        'opus-mt-ja-en': 'downloaded',
+        'piper-en': 'downloaded',
+      },
+    });
+
+    useModelStore.getState().rememberModels('ja', 'en', 'sensevoice-int8', 'opus-mt-ja-en', 'piper-en');
+    const recalled = useModelStore.getState().recallModels('ja', 'en');
+
+    expect(recalled).toEqual({
+      asrModel: 'sensevoice-int8',
+      translationModel: 'opus-mt-ja-en',
+      ttsModel: 'piper-en',
+    });
+  });
+
+  it('returns null when no record exists', () => {
+    const recalled = useModelStore.getState().recallModels('ja', 'en');
+    expect(recalled).toBeNull();
+  });
+
+  it('treats different directions as separate keys', () => {
+    useModelStore.setState({
+      modelStatuses: {
+        'sensevoice-int8': 'downloaded',
+        'opus-mt-ja-en': 'downloaded',
+        'opus-mt-en-ja': 'downloaded',
+        'piper-en': 'downloaded',
+        'piper-ja': 'downloaded',
+      },
+    });
+
+    useModelStore.getState().rememberModels('ja', 'en', 'sensevoice-int8', 'opus-mt-ja-en', 'piper-en');
+    useModelStore.getState().rememberModels('en', 'ja', 'sensevoice-int8', 'opus-mt-en-ja', 'piper-ja');
+
+    const jaEn = useModelStore.getState().recallModels('ja', 'en');
+    const enJa = useModelStore.getState().recallModels('en', 'ja');
+
+    expect(jaEn!.translationModel).toBe('opus-mt-ja-en');
+    expect(enJa!.translationModel).toBe('opus-mt-en-ja');
+    expect(jaEn!.ttsModel).toBe('piper-en');
+    expect(enJa!.ttsModel).toBe('piper-ja');
+  });
+
+  it('degrades per-field when a model is deleted', () => {
+    useModelStore.setState({
+      modelStatuses: {
+        'sensevoice-int8': 'downloaded',
+        'opus-mt-ja-en': 'downloaded',
+        'piper-en': 'downloaded',
+      },
+    });
+
+    useModelStore.getState().rememberModels('ja', 'en', 'sensevoice-int8', 'opus-mt-ja-en', 'piper-en');
+
+    useModelStore.setState({
+      modelStatuses: {
+        'sensevoice-int8': 'downloaded',
+        'opus-mt-ja-en': 'downloaded',
+        'piper-en': 'not_downloaded',
+      },
+    });
+
+    const recalled = useModelStore.getState().recallModels('ja', 'en');
+
+    expect(recalled).not.toBeNull();
+    expect(recalled!.asrModel).toBe('sensevoice-int8');
+    expect(recalled!.translationModel).toBe('opus-mt-ja-en');
+    expect(recalled!.ttsModel).toBe('');
+  });
+
+  it('degrades all fields when all models deleted', () => {
+    useModelStore.setState({
+      modelStatuses: {
+        'sensevoice-int8': 'downloaded',
+        'opus-mt-ja-en': 'downloaded',
+        'piper-en': 'downloaded',
+      },
+    });
+
+    useModelStore.getState().rememberModels('ja', 'en', 'sensevoice-int8', 'opus-mt-ja-en', 'piper-en');
+
+    useModelStore.setState({
+      modelStatuses: {
+        'sensevoice-int8': 'not_downloaded',
+        'opus-mt-ja-en': 'not_downloaded',
+        'piper-en': 'not_downloaded',
+      },
+    });
+
+    const recalled = useModelStore.getState().recallModels('ja', 'en');
+    expect(recalled).not.toBeNull();
+    expect(recalled!.asrModel).toBe('');
+    expect(recalled!.translationModel).toBe('');
+    expect(recalled!.ttsModel).toBe('');
+  });
+});

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -336,36 +336,66 @@ export const useModelStore = create<ModelStoreState>()(
       const participantSourceLang = targetLang;
       const participantTargetLang = sourceLang;
 
-      // 1. ASR: check if current model supports participant source language
-      //    (same logic as autoSelectModels)
+      // Check recalled preferences for the reverse direction
+      const recalled = get().recallModels(participantSourceLang, participantTargetLang);
+
+      // 1. ASR: prefer recalled > current model > fallback
       let asrModelId: string | null = null;
       let asrFallback = false;
 
       const allAsrModels = [...getManifestByType('asr'), ...getManifestByType('asr-stream')];
-      const currentAsr = allAsrModels.find(m => m.id === currentAsrModelId);
-      const currentAsrOk = currentAsr
-        && (currentAsr.multilingual || currentAsr.languages.includes(participantSourceLang))
-        && modelStatuses[currentAsrModelId] === 'downloaded'
-        && !(currentAsr.requiredDevice === 'webgpu' && !webgpuAvailable);
 
-      if (currentAsrOk) {
-        asrModelId = currentAsrModelId;
-      } else {
-        const match = allAsrModels.find(m =>
-          (m.multilingual || m.languages.includes(participantSourceLang))
-          && modelStatuses[m.id] === 'downloaded'
-          && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
-        );
-        if (match) {
-          asrModelId = match.id;
-          asrFallback = true;
+      // Try recalled ASR first
+      if (recalled?.asrModel) {
+        const recalledAsr = allAsrModels.find(m => m.id === recalled.asrModel);
+        if (recalledAsr
+          && (recalledAsr.multilingual || recalledAsr.languages.includes(participantSourceLang))
+          && modelStatuses[recalled.asrModel] === 'downloaded'
+          && !(recalledAsr.requiredDevice === 'webgpu' && !webgpuAvailable)) {
+          asrModelId = recalled.asrModel;
+          asrFallback = recalled.asrModel !== currentAsrModelId;
         }
       }
 
-      // 2. Translation: prefer current model if it supports the reverse direction,
-      //    otherwise auto-select (same logic as autoSelectModels)
+      // Try current model
+      if (!asrModelId) {
+        const currentAsr = allAsrModels.find(m => m.id === currentAsrModelId);
+        const currentAsrOk = currentAsr
+          && (currentAsr.multilingual || currentAsr.languages.includes(participantSourceLang))
+          && modelStatuses[currentAsrModelId] === 'downloaded'
+          && !(currentAsr.requiredDevice === 'webgpu' && !webgpuAvailable);
+
+        if (currentAsrOk) {
+          asrModelId = currentAsrModelId;
+        } else {
+          const match = allAsrModels.find(m =>
+            (m.multilingual || m.languages.includes(participantSourceLang))
+            && modelStatuses[m.id] === 'downloaded'
+            && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+          );
+          if (match) {
+            asrModelId = match.id;
+            asrFallback = true;
+          }
+        }
+      }
+
+      // 2. Translation: prefer recalled > current model > fallback
       let translationModelId: string | null = null;
-      if (currentTranslationModelId && modelStatuses[currentTranslationModelId] === 'downloaded') {
+
+      // Try recalled translation first
+      if (recalled?.translationModel) {
+        const recalledEntry = getManifestEntry(recalled.translationModel);
+        if (recalledEntry
+          && isTranslationModelCompatible(recalledEntry, participantSourceLang, participantTargetLang)
+          && modelStatuses[recalled.translationModel] === 'downloaded'
+          && !(recalledEntry.requiredDevice === 'webgpu' && !webgpuAvailable)) {
+          translationModelId = recalled.translationModel;
+        }
+      }
+
+      // Try current model
+      if (!translationModelId && currentTranslationModelId && modelStatuses[currentTranslationModelId] === 'downloaded') {
         const currentEntry = getManifestEntry(currentTranslationModelId);
         if (currentEntry
           && isTranslationModelCompatible(currentEntry, participantSourceLang, participantTargetLang)
@@ -373,6 +403,8 @@ export const useModelStore = create<ModelStoreState>()(
           translationModelId = currentTranslationModelId;
         }
       }
+
+      // Fallback
       if (!translationModelId) {
         const match = getManifestByType('translation').find(m =>
           isTranslationModelCompatible(m, participantSourceLang, participantTargetLang)
@@ -397,6 +429,14 @@ export const useModelStore = create<ModelStoreState>()(
     autoSelectModels: (sourceLang, targetLang, currentAsrModel, currentTranslationModel, currentTtsModel) => {
       const { modelStatuses, webgpuAvailable } = get();
       const updates: { asrModel?: string; translationModel?: string; ttsModel?: string } = {};
+
+      // Check recalled preferences — override "current" with recalled values if available
+      const recalled = get().recallModels(sourceLang, targetLang);
+      if (recalled) {
+        if (recalled.asrModel && recalled.asrModel !== currentAsrModel) currentAsrModel = recalled.asrModel;
+        if (recalled.translationModel && recalled.translationModel !== currentTranslationModel) currentTranslationModel = recalled.translationModel;
+        if (recalled.ttsModel && recalled.ttsModel !== currentTtsModel) currentTtsModel = recalled.ttsModel;
+      }
 
       // ASR: must support sourceLanguage and be downloaded
       const allAsrModels = [...getManifestByType('asr'), ...getManifestByType('asr-stream')];
@@ -446,6 +486,14 @@ export const useModelStore = create<ModelStoreState>()(
         ));
         const newId = match?.id || '';
         if (newId !== currentTtsModel) updates.ttsModel = newId;
+      }
+
+      // Remember the final selection for this language pair
+      const finalAsr = updates.asrModel ?? currentAsrModel;
+      const finalTranslation = updates.translationModel ?? currentTranslationModel;
+      const finalTts = updates.ttsModel ?? currentTtsModel;
+      if (finalAsr) {
+        get().rememberModels(sourceLang, targetLang, finalAsr, finalTranslation, finalTts);
       }
 
       return Object.keys(updates).length > 0 ? updates : null;

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -432,10 +432,23 @@ export const useModelStore = create<ModelStoreState>()(
 
       // Check recalled preferences — override "current" with recalled values if available
       const recalled = get().recallModels(sourceLang, targetLang);
+      console.log('[autoSelectModels]', `${sourceLang}→${targetLang}`, {
+        input: { currentAsrModel, currentTranslationModel, currentTtsModel },
+        recalled,
+      });
       if (recalled) {
-        if (recalled.asrModel && recalled.asrModel !== currentAsrModel) currentAsrModel = recalled.asrModel;
-        if (recalled.translationModel && recalled.translationModel !== currentTranslationModel) currentTranslationModel = recalled.translationModel;
-        if (recalled.ttsModel && recalled.ttsModel !== currentTtsModel) currentTtsModel = recalled.ttsModel;
+        if (recalled.asrModel && recalled.asrModel !== currentAsrModel) {
+          console.log('[autoSelectModels] Overriding ASR with recalled:', recalled.asrModel);
+          currentAsrModel = recalled.asrModel;
+        }
+        if (recalled.translationModel && recalled.translationModel !== currentTranslationModel) {
+          console.log('[autoSelectModels] Overriding translation with recalled:', recalled.translationModel);
+          currentTranslationModel = recalled.translationModel;
+        }
+        if (recalled.ttsModel && recalled.ttsModel !== currentTtsModel) {
+          console.log('[autoSelectModels] Overriding TTS with recalled:', recalled.ttsModel);
+          currentTtsModel = recalled.ttsModel;
+        }
       }
 
       // ASR: must support sourceLanguage and be downloaded

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -381,27 +381,29 @@ export const useModelStore = create<ModelStoreState>()(
       }
 
       // 2. Translation: prefer recalled > current model > fallback
+      //    AST short-circuit: if translation model === ASR model and isAstCompatible, it's valid
       let translationModelId: string | null = null;
 
+      // Helper: check if a model is valid as translation (standard or AST)
+      const isValidTranslation = (modelId: string, forAsrId: string | null) => {
+        if (!modelId || modelStatuses[modelId] !== 'downloaded') return false;
+        const entry = getManifestEntry(modelId);
+        if (!entry) return false;
+        if (entry.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
+        // AST: translation model === ASR model with AST support
+        if (modelId === forAsrId && isAstCompatible(entry, participantSourceLang, participantTargetLang)) return true;
+        // Standard translation model
+        return isTranslationModelCompatible(entry, participantSourceLang, participantTargetLang);
+      };
+
       // Try recalled translation first
-      if (recalled?.translationModel) {
-        const recalledEntry = getManifestEntry(recalled.translationModel);
-        if (recalledEntry
-          && isTranslationModelCompatible(recalledEntry, participantSourceLang, participantTargetLang)
-          && modelStatuses[recalled.translationModel] === 'downloaded'
-          && !(recalledEntry.requiredDevice === 'webgpu' && !webgpuAvailable)) {
-          translationModelId = recalled.translationModel;
-        }
+      if (recalled?.translationModel && isValidTranslation(recalled.translationModel, asrModelId)) {
+        translationModelId = recalled.translationModel;
       }
 
       // Try current model
-      if (!translationModelId && currentTranslationModelId && modelStatuses[currentTranslationModelId] === 'downloaded') {
-        const currentEntry = getManifestEntry(currentTranslationModelId);
-        if (currentEntry
-          && isTranslationModelCompatible(currentEntry, participantSourceLang, participantTargetLang)
-          && !(currentEntry.requiredDevice === 'webgpu' && !webgpuAvailable)) {
-          translationModelId = currentTranslationModelId;
-        }
+      if (!translationModelId && currentTranslationModelId && isValidTranslation(currentTranslationModelId, asrModelId)) {
+        translationModelId = currentTranslationModelId;
       }
 
       // Fallback

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -509,15 +509,23 @@ export const useModelStore = create<ModelStoreState>()(
     },
 
     recallModels: (src, tgt) => {
-      const { modelPreferences, modelStatuses } = get();
+      const { modelPreferences, modelStatuses, webgpuAvailable } = get();
       const key = `${src}→${tgt}`;
       const pref = modelPreferences[key];
       if (!pref) return null;
 
+      // Check downloaded + device compatibility
+      const isUsable = (id: string) => {
+        if (!id || modelStatuses[id] !== 'downloaded') return false;
+        const entry = getManifestEntry(id);
+        if (entry?.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
+        return true;
+      };
+
       return {
-        asrModel: pref.asrModel && modelStatuses[pref.asrModel] === 'downloaded' ? pref.asrModel : '',
-        translationModel: pref.translationModel && modelStatuses[pref.translationModel] === 'downloaded' ? pref.translationModel : '',
-        ttsModel: pref.ttsModel && modelStatuses[pref.ttsModel] === 'downloaded' ? pref.ttsModel : '',
+        asrModel: isUsable(pref.asrModel) ? pref.asrModel : '',
+        translationModel: isUsable(pref.translationModel) ? pref.translationModel : '',
+        ttsModel: isUsable(pref.ttsModel) ? pref.ttsModel : '',
       };
     },
   })),

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -58,6 +58,8 @@ interface ModelStoreState {
   deviceFeatures: string[];
   /** Downloaded variant key per model (modelId → variant key) */
   modelVariants: Record<string, string>;
+  /** In-memory model preferences per language pair (key: "src→tgt") */
+  modelPreferences: Record<string, { asrModel: string; translationModel: string; ttsModel: string }>;
 
   /** Initialize: scan IndexedDB for existing models */
   initialize: () => Promise<void>;
@@ -99,6 +101,10 @@ interface ModelStoreState {
     sourceLang: string, targetLang: string,
     currentAsrModel: string, currentTranslationModel: string, currentTtsModel: string,
   ) => { asrModel?: string; translationModel?: string; ttsModel?: string } | null;
+  /** Save model selection for a language pair */
+  rememberModels: (sourceLang: string, targetLang: string, asrModel: string, translationModel: string, ttsModel: string) => void;
+  /** Recall saved model selection — per-field degradation if models deleted */
+  recallModels: (sourceLang: string, targetLang: string) => { asrModel: string; translationModel: string; ttsModel: string } | null;
 }
 
 // ─── Store ───────────────────────────────────────────────────────────────────
@@ -113,6 +119,7 @@ export const useModelStore = create<ModelStoreState>()(
     webgpuAvailable: false,
     deviceFeatures: [],
     modelVariants: {},
+    modelPreferences: {},
 
     initialize: async () => {
       if (get().initialized) return;
@@ -442,6 +449,28 @@ export const useModelStore = create<ModelStoreState>()(
       }
 
       return Object.keys(updates).length > 0 ? updates : null;
+    },
+
+    rememberModels: (src, tgt, asr, translation, tts) => {
+      set(state => ({
+        modelPreferences: {
+          ...state.modelPreferences,
+          [`${src}→${tgt}`]: { asrModel: asr, translationModel: translation, ttsModel: tts },
+        },
+      }));
+    },
+
+    recallModels: (src, tgt) => {
+      const { modelPreferences, modelStatuses } = get();
+      const key = `${src}→${tgt}`;
+      const pref = modelPreferences[key];
+      if (!pref) return null;
+
+      return {
+        asrModel: pref.asrModel && modelStatuses[pref.asrModel] === 'downloaded' ? pref.asrModel : '',
+        translationModel: pref.translationModel && modelStatuses[pref.translationModel] === 'downloaded' ? pref.translationModel : '',
+        ttsModel: pref.ttsModel && modelStatuses[pref.ttsModel] === 'downloaded' ? pref.ttsModel : '',
+      };
     },
   })),
 );

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -430,6 +430,11 @@ export const useModelStore = create<ModelStoreState>()(
       const { modelStatuses, webgpuAvailable } = get();
       const updates: { asrModel?: string; translationModel?: string; ttsModel?: string } = {};
 
+      // Save original input to detect recall overrides later
+      const inputAsrModel = currentAsrModel;
+      const inputTranslationModel = currentTranslationModel;
+      const inputTtsModel = currentTtsModel;
+
       // Check recalled preferences — override "current" with recalled values if available
       const recalled = get().recallModels(sourceLang, targetLang);
       console.log('[autoSelectModels]', `${sourceLang}→${targetLang}`, {
@@ -500,6 +505,12 @@ export const useModelStore = create<ModelStoreState>()(
         const newId = match?.id || '';
         if (newId !== currentTtsModel) updates.ttsModel = newId;
       }
+
+      // Emit updates for recalled overrides that survived validation
+      // (recalled value was used as "current", passed checks, but settings still have the old value)
+      if (!updates.asrModel && currentAsrModel !== inputAsrModel) updates.asrModel = currentAsrModel;
+      if (!updates.translationModel && currentTranslationModel !== inputTranslationModel) updates.translationModel = currentTranslationModel;
+      if (!updates.ttsModel && currentTtsModel !== inputTtsModel) updates.ttsModel = currentTtsModel;
 
       // Remember the final selection for this language pair
       const finalAsr = updates.asrModel ?? currentAsrModel;

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -439,21 +439,14 @@ export const useModelStore = create<ModelStoreState>()(
 
       // Check recalled preferences — override "current" with recalled values if available
       const recalled = get().recallModels(sourceLang, targetLang);
-      console.log('[autoSelectModels]', `${sourceLang}→${targetLang}`, {
-        input: { currentAsrModel, currentTranslationModel, currentTtsModel },
-        recalled,
-      });
       if (recalled) {
         if (recalled.asrModel && recalled.asrModel !== currentAsrModel) {
-          console.log('[autoSelectModels] Overriding ASR with recalled:', recalled.asrModel);
           currentAsrModel = recalled.asrModel;
         }
         if (recalled.translationModel && recalled.translationModel !== currentTranslationModel) {
-          console.log('[autoSelectModels] Overriding translation with recalled:', recalled.translationModel);
           currentTranslationModel = recalled.translationModel;
         }
         if (recalled.ttsModel && recalled.ttsModel !== currentTtsModel) {
-          console.log('[autoSelectModels] Overriding TTS with recalled:', recalled.ttsModel);
           currentTtsModel = recalled.ttsModel;
         }
       }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -764,14 +764,6 @@ const useSettingsStore = create<SettingsStore>()(
         const { useModelStore } = await import('./modelStore');
         const modelState = useModelStore.getState();
 
-        console.log('[validateApiKey] LOCAL_INFERENCE: current settings:', {
-          sourceLanguage: localSettings.sourceLanguage,
-          targetLanguage: localSettings.targetLanguage,
-          asrModel: localSettings.asrModel,
-          translationModel: localSettings.translationModel,
-          ttsModel: localSettings.ttsModel,
-        });
-
         // Initialize model store if not yet done (scans IndexedDB for downloaded models)
         if (!modelState.initialized) {
           await modelState.initialize();
@@ -788,15 +780,10 @@ const useSettingsStore = create<SettingsStore>()(
           localSettings.ttsModel,
         );
         if (corrections) {
-          console.log('[validateApiKey] Auto-correcting stale model selections:', corrections);
+          console.log('[SettingsStore] Auto-correcting stale model selections:', corrections);
           get().updateLocalInference(corrections);
           // Re-read settings after correction
           const updated = get().localInference;
-          console.log('[validateApiKey] After correction:', {
-            asrModel: updated.asrModel,
-            translationModel: updated.translationModel,
-            ttsModel: updated.ttsModel,
-          });
           const ready = modelState.isProviderReady(
             updated.sourceLanguage,
             updated.targetLanguage,
@@ -804,7 +791,6 @@ const useSettingsStore = create<SettingsStore>()(
             updated.translationModel || undefined,
             updated.ttsModel || undefined,
           );
-          console.log('[validateApiKey] isProviderReady (after correction):', ready);
           set({
             isApiKeyValid: ready,
             availableModels: ready
@@ -816,7 +802,6 @@ const useSettingsStore = create<SettingsStore>()(
           return { valid: ready, message: ready ? '' : i18n.t('settings.localInferenceModelsRequired'), validating: false };
         }
 
-        console.log('[validateApiKey] No corrections needed, checking readiness directly');
         const ready = modelState.isProviderReady(
           localSettings.sourceLanguage,
           localSettings.targetLanguage,
@@ -824,12 +809,6 @@ const useSettingsStore = create<SettingsStore>()(
           localSettings.translationModel || undefined,
           localSettings.ttsModel || undefined,
         );
-        console.log('[validateApiKey] isProviderReady (no correction):', ready, {
-          asrModel: localSettings.asrModel,
-          translationModel: localSettings.translationModel,
-          ttsModel: localSettings.ttsModel,
-        });
-
         set({
           isApiKeyValid: ready,
           availableModels: ready

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -764,6 +764,14 @@ const useSettingsStore = create<SettingsStore>()(
         const { useModelStore } = await import('./modelStore');
         const modelState = useModelStore.getState();
 
+        console.log('[validateApiKey] LOCAL_INFERENCE: current settings:', {
+          sourceLanguage: localSettings.sourceLanguage,
+          targetLanguage: localSettings.targetLanguage,
+          asrModel: localSettings.asrModel,
+          translationModel: localSettings.translationModel,
+          ttsModel: localSettings.ttsModel,
+        });
+
         // Initialize model store if not yet done (scans IndexedDB for downloaded models)
         if (!modelState.initialized) {
           await modelState.initialize();
@@ -780,10 +788,15 @@ const useSettingsStore = create<SettingsStore>()(
           localSettings.ttsModel,
         );
         if (corrections) {
-          console.log('[SettingsStore] Auto-correcting stale model selections:', corrections);
+          console.log('[validateApiKey] Auto-correcting stale model selections:', corrections);
           get().updateLocalInference(corrections);
           // Re-read settings after correction
           const updated = get().localInference;
+          console.log('[validateApiKey] After correction:', {
+            asrModel: updated.asrModel,
+            translationModel: updated.translationModel,
+            ttsModel: updated.ttsModel,
+          });
           const ready = modelState.isProviderReady(
             updated.sourceLanguage,
             updated.targetLanguage,
@@ -791,6 +804,7 @@ const useSettingsStore = create<SettingsStore>()(
             updated.translationModel || undefined,
             updated.ttsModel || undefined,
           );
+          console.log('[validateApiKey] isProviderReady (after correction):', ready);
           set({
             isApiKeyValid: ready,
             availableModels: ready
@@ -802,6 +816,7 @@ const useSettingsStore = create<SettingsStore>()(
           return { valid: ready, message: ready ? '' : i18n.t('settings.localInferenceModelsRequired'), validating: false };
         }
 
+        console.log('[validateApiKey] No corrections needed, checking readiness directly');
         const ready = modelState.isProviderReady(
           localSettings.sourceLanguage,
           localSettings.targetLanguage,
@@ -809,6 +824,11 @@ const useSettingsStore = create<SettingsStore>()(
           localSettings.translationModel || undefined,
           localSettings.ttsModel || undefined,
         );
+        console.log('[validateApiKey] isProviderReady (no correction):', ready, {
+          asrModel: localSettings.asrModel,
+          translationModel: localSettings.translationModel,
+          ttsModel: localSettings.ttsModel,
+        });
 
         set({
           isApiKeyValid: ready,


### PR DESCRIPTION
## Summary

- Remember ASR, Translation, and TTS model selections per language pair (in-memory, directional key like `ja→en`)
- Switching languages restores previously selected models instead of always auto-selecting
- Participant mode uses recalled reverse-direction preferences
- Per-field degradation: if a remembered model is deleted, that field falls back to auto-select while others stay remembered

## Changes

### modelStore
- Add `modelPreferences` map, `rememberModels()`, `recallModels()` with per-field download validation
- `autoSelectModels()`: check recalled preferences before auto-selecting, remember final result
- `getParticipantModelStatus()`: check recalled reverse-direction preferences (recalled > current > fallback)

### ModelManagementSection
- Call `rememberModels()` on every model selection (6 manual callbacks + 1 auto-select completion)

### ProviderSection
- Add hint text below participant chips: "Switch to en → ja to change participant models"

### Tests
- 5 new tests: remember/recall, directional separation, per-field degradation, full degradation

## Test plan

- [ ] Select models for ja→en, switch to en→ja, switch back → ja→en models restored
- [ ] Delete a remembered TTS model → that field auto-selects, ASR + Translation stay remembered
- [ ] Enable system audio → participant shows recalled reverse-direction models
- [ ] Participant hint text appears with correct language direction
- [ ] Refresh page → preferences reset (in-memory only, not persisted)
- [ ] Run `npm run test` → 62/62 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Model selections are now remembered per language pair and automatically restored when you switch between languages
  * Added a hint in Local Inference settings guiding users on how to change participant models

* **Tests**
  * Added comprehensive tests for model preference persistence functionality
<!-- end of auto-generated comment: release notes by coderabbit.ai -->