### PR TITLE
fix: move Cohere Transcribe from asr-stream to asr type

### DIFF
--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -1257,7 +1257,8 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
           </div>
         </div>
 
-        {localInferenceSettings.turnDetectionMode === 'Auto' && getManifestEntry(localInferenceSettings.asrModel)?.type !== 'asr-stream' && (
+        {/* Show VAD settings for all models except sherpa-onnx streaming (which uses endpoint detection, not VAD) */}
+        {localInferenceSettings.turnDetectionMode === 'Auto' && !(getManifestEntry(localInferenceSettings.asrModel)?.type === 'asr-stream' && !getManifestEntry(localInferenceSettings.asrModel)?.asrWorkerType) && (
         <div className="settings-section">
           <h2>
             {t('settings.vadSettings', 'VAD Settings')}

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -19,7 +19,7 @@ import { ModelManager } from '../ModelManager';
 
 export interface AsrResult {
   text: string;
-  startSample: number;
+  startSample?: number;
   durationMs: number;
   recognitionTimeMs: number;
 }
@@ -73,6 +73,11 @@ export class AsrEngine {
     const fileUrls = await manager.getModelBlobUrls(modelId);
 
     const workerType = model.asrWorkerType || 'sherpa-onnx';
+
+    // Cohere Transcribe requires an explicit source language
+    if (workerType === 'cohere-transcribe-webgpu' && !language) {
+      throw new Error('Cohere Transcribe requires a source language');
+    }
 
     return new Promise((resolve, reject) => {
       // Create worker based on type
@@ -128,7 +133,7 @@ export class AsrEngine {
           case 'result':
             this.onResult?.({
               text: msg.text,
-              startSample: 'startSample' in msg ? msg.startSample : 0,
+              startSample: 'startSample' in msg ? msg.startSample : undefined,
               durationMs: msg.durationMs,
               recognitionTimeMs: msg.recognitionTimeMs,
             });
@@ -157,18 +162,7 @@ export class AsrEngine {
       };
 
       // Send init message — format depends on worker type
-      if (workerType === 'whisper-webgpu') {
-        this.worker.postMessage({
-          type: 'init',
-          fileUrls,
-          hfModelId: model.hfModelId,
-          language,
-          vadConfig,
-          dtype,
-          ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
-          vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
-        });
-      } else if (workerType === 'cohere-transcribe-webgpu') {
+      if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu') {
         this.worker.postMessage({
           type: 'init',
           fileUrls,

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -5,9 +5,10 @@
  * Supports multiple worker backends:
  * - sherpa-onnx (classic Worker): VAD + OfflineRecognizer via Emscripten/WASM
  * - whisper-webgpu (module Worker): VAD + Whisper via Transformers.js/WebGPU
+ * - cohere-transcribe-webgpu (module Worker): VAD + Cohere Transcribe via Transformers.js/WebGPU
  */
 
-import type { AsrWorkerOutMessage } from '../types';
+import type { AsrWorkerOutMessage, StreamingAsrWorkerOutMessage } from '../types';
 import {
   getManifestEntry,
   getManifestByType,
@@ -24,6 +25,7 @@ export interface AsrResult {
 }
 
 type ResultCallback = (result: AsrResult) => void;
+type PartialResultCallback = (text: string) => void;
 type StatusCallback = (message: string) => void;
 type ErrorCallback = (error: string) => void;
 
@@ -33,6 +35,7 @@ export class AsrEngine {
   private currentModel: ModelManifestEntry | null = null;
 
   onResult: ResultCallback | null = null;
+  onPartialResult: PartialResultCallback | null = null;
   onSpeechStart: (() => void) | null = null;
   onStatus: StatusCallback | null = null;
   onError: ErrorCallback | null = null;
@@ -80,6 +83,12 @@ export class AsrEngine {
             { type: 'module' },
           );
           break;
+        case 'cohere-transcribe-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/cohere-transcribe-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
         case 'granite-speech-webgpu':
           this.worker = new Worker(
             new URL('../workers/granite-speech-webgpu.worker.ts', import.meta.url),
@@ -91,7 +100,9 @@ export class AsrEngine {
           break;
       }
 
-      this.worker.onmessage = (event: MessageEvent<AsrWorkerOutMessage>) => {
+      // Cohere worker emits StreamingAsrWorkerOutMessage (includes 'partial'),
+      // other workers emit AsrWorkerOutMessage. Handle the union.
+      this.worker.onmessage = (event: MessageEvent<AsrWorkerOutMessage | StreamingAsrWorkerOutMessage>) => {
         const msg = event.data;
         switch (msg.type) {
           case 'ready':
@@ -110,10 +121,14 @@ export class AsrEngine {
             this.onSpeechStart?.();
             break;
 
+          case 'partial':
+            this.onPartialResult?.(msg.text);
+            break;
+
           case 'result':
             this.onResult?.({
               text: msg.text,
-              startSample: msg.startSample,
+              startSample: 'startSample' in msg ? msg.startSample : 0,
               durationMs: msg.durationMs,
               recognitionTimeMs: msg.recognitionTimeMs,
             });
@@ -143,6 +158,17 @@ export class AsrEngine {
 
       // Send init message — format depends on worker type
       if (workerType === 'whisper-webgpu') {
+        this.worker.postMessage({
+          type: 'init',
+          fileUrls,
+          hfModelId: model.hfModelId,
+          language,
+          vadConfig,
+          dtype,
+          ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
+          vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
+        });
+      } else if (workerType === 'cohere-transcribe-webgpu') {
         this.worker.postMessage({
           type: 'init',
           fileUrls,

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -8,7 +8,7 @@
  * - cohere-transcribe-webgpu (module Worker): VAD + Cohere Transcribe via Transformers.js/WebGPU
  */
 
-import type { AsrWorkerOutMessage, StreamingAsrWorkerOutMessage } from '../types';
+import type { AsrWorkerOutMessage, StreamingAsrWorkerOutMessage, VadWebConfig } from '../types';
 import {
   getManifestEntry,
   getManifestByType,
@@ -47,7 +47,7 @@ export class AsrEngine {
    * @param modelId - Model identifier (e.g. 'sensevoice-int8', 'moonshine-tiny-en-quant')
    * @returns Promise that resolves with load time when ready
    */
-  async init(modelId: string, vadConfig?: { threshold?: number; minSilenceDuration?: number; minSpeechDuration?: number }, language?: string, taskConfig?: { task: 'transcribe' | 'translate'; targetLanguage?: string }): Promise<{ loadTimeMs: number }> {
+  async init(modelId: string, vadConfig?: VadWebConfig, language?: string, taskConfig?: { task: 'transcribe' | 'translate'; targetLanguage?: string }): Promise<{ loadTimeMs: number }> {
     const model = getManifestEntry(modelId);
     if (!model || model.type !== 'asr') {
       const available = getManifestByType('asr').map(m => m.id).join(', ');

--- a/src/lib/local-inference/engine/StreamingAsrEngine.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.ts
@@ -73,12 +73,6 @@ export class StreamingAsrEngine {
               { type: 'module' },
             );
             break;
-          case 'cohere-transcribe-webgpu':
-            this.worker = new Worker(
-              new URL('../workers/cohere-transcribe-webgpu.worker.ts', import.meta.url),
-              { type: 'module' },
-            );
-            break;
           default: // sherpa-onnx streaming
             this.worker = new Worker('./workers/sherpa-onnx-streaming-asr.worker.js');
             break;
@@ -134,7 +128,7 @@ export class StreamingAsrEngine {
         };
 
         // Send init message based on worker type
-        if (workerType === 'voxtral-webgpu' || workerType === 'cohere-transcribe-webgpu') {
+        if (workerType === 'voxtral-webgpu') {
           if (!await manager.isModelReady(modelId)) {
             throw new Error(`Model "${modelId}" is not downloaded.`);
           }

--- a/src/lib/local-inference/engine/StreamingAsrEngine.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.ts
@@ -11,7 +11,7 @@
  * when an endpoint is detected.
  */
 
-import type { StreamingAsrWorkerOutMessage } from '../types';
+import type { StreamingAsrWorkerOutMessage, VadWebConfig } from '../types';
 import {
   getManifestEntry,
   getManifestByType,
@@ -43,7 +43,7 @@ export class StreamingAsrEngine {
   onStatus: StatusCallback | null = null;
   onError: ErrorCallback | null = null;
 
-  async init(modelId: string, options?: { language?: string }): Promise<{ loadTimeMs: number }> {
+  async init(modelId: string, options?: { language?: string; vadConfig?: VadWebConfig }): Promise<{ loadTimeMs: number }> {
     const model = getManifestEntry(modelId);
     if (!model || model.type !== 'asr-stream') {
       const available = getManifestByType('asr-stream').map(m => m.id).join(', ');
@@ -151,6 +151,7 @@ export class StreamingAsrEngine {
             fileUrls,
             hfModelId: model.hfModelId,
             language: options?.language,
+            vadConfig: options?.vadConfig,
             dtype,
             vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
             ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -833,7 +833,7 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
   // Batch ASR with VAD chunking + TextStreamer for token-level partial results.
   {
     id: 'cohere-transcribe-webgpu',
-    type: 'asr-stream',
+    type: 'asr',
     name: 'Cohere Transcribe (WebGPU)',
     languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'],
     hfModelId: 'onnx-community/cohere-transcribe-03-2026-ONNX',

--- a/src/lib/local-inference/types.ts
+++ b/src/lib/local-inference/types.ts
@@ -151,6 +151,15 @@ export interface CohereTranscribeAsrInitMessage {
   language?: string;
   /** ONNX dtype config — 'q4f16' or 'q4', or per-component mapping */
   dtype: string | Record<string, string>;
+  /** VAD configuration overrides from user settings */
+  vadConfig?: {
+    threshold?: number;
+    negativeThreshold?: number;
+    minSilenceDuration?: number;
+    minSpeechDuration?: number;
+    preSpeechPadDuration?: number;
+    maxSpeechDuration?: number;
+  };
   /** Resolved absolute URL for bundled VAD model */
   vadModelUrl: string;
   /** Resolved absolute URL for bundled ORT WASM files */

--- a/src/lib/local-inference/types.ts
+++ b/src/lib/local-inference/types.ts
@@ -2,6 +2,42 @@
  * Shared type definitions for local inference workers and engines.
  */
 
+// ─── VAD Configuration ──────────────────────────────────────────────────────
+
+/**
+ * VAD config for vad-web FrameProcessor (Silero VAD v5 + @ricky0123/vad-web).
+ * Used by whisper, cohere, granite, and voxtral workers.
+ * All durations in seconds. All fields optional — workers use vad-web defaults.
+ *
+ * NOTE: sherpa-onnx workers use a different VAD engine (C++ Silero via Emscripten)
+ * with different semantics (single threshold with internal hysteresis). They use
+ * SherpaOnnxVadConfig instead.
+ */
+export interface VadWebConfig {
+  /** Positive speech threshold (default 0.3) */
+  threshold?: number;
+  /** Negative threshold to confirm silence — hysteresis gap prevents oscillation (default 0.25) */
+  negativeThreshold?: number;
+  /** Min silence duration in seconds before ending speech segment (default 1.4) */
+  minSilenceDuration?: number;
+  /** Min speech duration in seconds to emit a segment (default 0.4) */
+  minSpeechDuration?: number;
+  /** Pre-speech pad in seconds — audio context prepended before speech start (default 0.8) */
+  preSpeechPadDuration?: number;
+  /** Max speech segment duration in seconds before forced split (default 20) */
+  maxSpeechDuration?: number;
+}
+
+/**
+ * VAD config for sherpa-onnx C++ engine. Different semantics from vad-web:
+ * single threshold with internal hysteresis (threshold - 0.15).
+ */
+export interface SherpaOnnxVadConfig {
+  threshold?: number;
+  minSilenceDuration?: number;
+  minSpeechDuration?: number;
+}
+
 // ─── ASR Worker Messages (Main → Worker) ─────────────────────────────────────
 
 export interface AsrInitMessage {
@@ -11,11 +47,7 @@ export interface AsrInitMessage {
   /** ASR engine type — determines which config builder the worker uses */
   asrEngine: string;
   /** Optional VAD configuration to override defaults */
-  vadConfig?: {
-    threshold?: number;
-    minSilenceDuration?: number;
-    minSpeechDuration?: number;
-  };
+  vadConfig?: SherpaOnnxVadConfig;
   /** Base URL for bundled ASR runtime (JS/WASM shared across all models) */
   runtimeBaseUrl: string;
   /** Emscripten loadPackage metadata (file offsets/sizes from package-metadata.json) */
@@ -43,20 +75,7 @@ export interface WhisperAsrInitMessage {
   /** Source language for Whisper (e.g. 'ja', 'en') or undefined for auto-detect */
   language?: string;
   /** VAD configuration overrides (durations in seconds). Defaults match @ricky0123/vad-web. */
-  vadConfig?: {
-    /** Positive speech threshold (default 0.3, matching vad-web) */
-    threshold?: number;
-    /** Negative threshold to confirm silence — hysteresis gap prevents oscillation (default 0.25) */
-    negativeThreshold?: number;
-    /** Redemption / min silence duration in seconds before ending speech (default 1.4) */
-    minSilenceDuration?: number;
-    /** Min speech duration in seconds to emit a segment (default 0.4) */
-    minSpeechDuration?: number;
-    /** Max speech segment duration in seconds before forced flush (default 20) */
-    maxSpeechDuration?: number;
-    /** Pre-speech pad duration in seconds — audio context prepended before speech start (default 0.8) */
-    preSpeechPadDuration?: number;
-  };
+  vadConfig?: VadWebConfig;
   /** ONNX dtype config for WebGPU models */
   dtype?: string | Record<string, string>;
   /** Resolved absolute URL for bundled ORT WASM files */
@@ -133,6 +152,8 @@ export interface VoxtralAsrInitMessage {
   hfModelId: string;
   /** Source language hint (optional, for future use) */
   language?: string;
+  /** VAD configuration overrides */
+  vadConfig?: VadWebConfig;
   /** ONNX dtype config — 'q4f16' or 'q4', or per-component mapping */
   dtype: string | Record<string, string>;
   /** Resolved absolute URL for bundled VAD model */
@@ -152,14 +173,7 @@ export interface CohereTranscribeAsrInitMessage {
   /** ONNX dtype config — 'q4f16' or 'q4', or per-component mapping */
   dtype: string | Record<string, string>;
   /** VAD configuration overrides from user settings */
-  vadConfig?: {
-    threshold?: number;
-    negativeThreshold?: number;
-    minSilenceDuration?: number;
-    minSpeechDuration?: number;
-    preSpeechPadDuration?: number;
-    maxSpeechDuration?: number;
-  };
+  vadConfig?: VadWebConfig;
   /** Resolved absolute URL for bundled VAD model */
   vadModelUrl: string;
   /** Resolved absolute URL for bundled ORT WASM files */
@@ -175,11 +189,7 @@ export interface GraniteSpeechInitMessage {
   /** Source language hint (e.g. 'ja', 'en') */
   language?: string;
   /** Optional VAD configuration to override defaults */
-  vadConfig?: {
-    threshold?: number;
-    minSilenceDuration?: number;
-    minSpeechDuration?: number;
-  };
+  vadConfig?: VadWebConfig;
   /** Task: 'transcribe' for ASR, 'translate' for AST (speech translation) */
   task: 'transcribe' | 'translate';
   /** Target language for AST (only when task === 'translate') */

--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -91,23 +91,33 @@ function vadResetStates() {
   vadSession.state = new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]);
 }
 
-async function initVad(vadModelUrl: string): Promise<void> {
-  const session = await InferenceSession.create(vadModelUrl, {
+async function initVad(vadConfig?: CohereTranscribeAsrInitMessage['vadConfig'], vadModelUrl?: string): Promise<void> {
+  const session = await InferenceSession.create(vadModelUrl || './wasm/vad/silero_vad_v5.onnx', {
     executionProviders: ['wasm'],
   });
   vadSession = {
     session,
     state: new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]),
   };
+
+  const positiveSpeechThreshold = vadConfig?.threshold ?? 0.3;
+  const negativeSpeechThreshold = vadConfig?.negativeThreshold ?? 0.25;
+  const redemptionMs = (vadConfig?.minSilenceDuration ?? 1.4) * 1000;
+  const minSpeechMs = (vadConfig?.minSpeechDuration ?? 0.4) * 1000;
+  const preSpeechPadMs = (vadConfig?.preSpeechPadDuration ?? 0.8) * 1000;
+  const maxSpeechDurationMs = (vadConfig?.maxSpeechDuration ?? 20) * 1000;
+
+  maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
+
   frameProcessor = new FrameProcessor(
     vadInfer,
     vadResetStates,
     {
-      positiveSpeechThreshold: 0.3,
-      negativeSpeechThreshold: 0.25,
-      redemptionMs: 1400,
-      minSpeechMs: 400,
-      preSpeechPadMs: 800,
+      positiveSpeechThreshold,
+      negativeSpeechThreshold,
+      redemptionMs,
+      minSpeechMs,
+      preSpeechPadMs,
       submitUserSpeechOnPause: false,
     },
     VAD_FRAME_MS,
@@ -306,7 +316,7 @@ async function handleInit(msg: CohereTranscribeAsrInitMessage): Promise<void> {
 
     // 1. Init VAD
     post({ type: 'status', message: 'Loading VAD model...' });
-    await initVad(msg.vadModelUrl);
+    await initVad(msg.vadConfig, msg.vadModelUrl);
 
     // 2. Configure Transformers.js for IndexedDB blob URL cache
     env.allowRemoteModels = false;

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -118,18 +118,23 @@ async function initVad(vadConfig?: GraniteSpeechInitMessage['vadConfig'], vadMod
   };
 
   const positiveSpeechThreshold = vadConfig?.threshold ?? 0.3;
+  const negativeSpeechThreshold = vadConfig?.negativeThreshold ?? 0.25;
   const redemptionMs = (vadConfig?.minSilenceDuration ?? 1.4) * 1000;
   const minSpeechMs = (vadConfig?.minSpeechDuration ?? 0.4) * 1000;
+  const preSpeechPadMs = (vadConfig?.preSpeechPadDuration ?? 0.8) * 1000;
+  const maxSpeechDurationMs = (vadConfig?.maxSpeechDuration ?? 20) * 1000;
+
+  maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
 
   frameProcessor = new FrameProcessor(
     vadInfer,
     vadResetStates,
     {
       positiveSpeechThreshold,
-      negativeSpeechThreshold: 0.25,
+      negativeSpeechThreshold,
       redemptionMs,
       minSpeechMs,
-      preSpeechPadMs: 800,
+      preSpeechPadMs,
       submitUserSpeechOnPause: false,
     },
     VAD_FRAME_MS,

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -92,23 +92,33 @@ function vadResetStates() {
   vadSession.state = new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]);
 }
 
-async function initVad(vadModelUrl: string): Promise<void> {
-  const session = await InferenceSession.create(vadModelUrl, {
+async function initVad(vadConfig?: VoxtralAsrInitMessage['vadConfig'], vadModelUrl?: string): Promise<void> {
+  const session = await InferenceSession.create(vadModelUrl || './wasm/vad/silero_vad_v5.onnx', {
     executionProviders: ['wasm'],
   });
   vadSession = {
     session,
     state: new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]),
   };
+
+  const positiveSpeechThreshold = vadConfig?.threshold ?? 0.3;
+  const negativeSpeechThreshold = vadConfig?.negativeThreshold ?? 0.25;
+  const redemptionMs = (vadConfig?.minSilenceDuration ?? 1.4) * 1000;
+  const minSpeechMs = (vadConfig?.minSpeechDuration ?? 0.4) * 1000;
+  const preSpeechPadMs = (vadConfig?.preSpeechPadDuration ?? 0.8) * 1000;
+  const maxSpeechDurationMs = (vadConfig?.maxSpeechDuration ?? 20) * 1000;
+
+  maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
+
   frameProcessor = new FrameProcessor(
     vadInfer,
     vadResetStates,
     {
-      positiveSpeechThreshold: 0.3,
-      negativeSpeechThreshold: 0.25,
-      redemptionMs: 1400,
-      minSpeechMs: 400,
-      preSpeechPadMs: 800,
+      positiveSpeechThreshold,
+      negativeSpeechThreshold,
+      redemptionMs,
+      minSpeechMs,
+      preSpeechPadMs,
       submitUserSpeechOnPause: false,
     },
     VAD_FRAME_MS,
@@ -434,7 +444,7 @@ async function handleInit(msg: VoxtralAsrInitMessage): Promise<void> {
 
     // 1. Init VAD
     post({ type: 'status', message: 'Loading VAD model...' });
-    await initVad(msg.vadModelUrl);
+    await initVad(msg.vadConfig, msg.vadModelUrl);
 
     // 2. Configure Transformers.js for IndexedDB blob URL cache
     env.allowRemoteModels = false;

--- a/src/services/clients/LocalInferenceClient.ts
+++ b/src/services/clients/LocalInferenceClient.ts
@@ -136,6 +136,11 @@ export class LocalInferenceClient implements IClient {
           this.emitEvent('local.asr.start', 'server', { modelId: this.config?.asrModelId });
         };
 
+        engine.onPartialResult = (text) => {
+          if (this.disposed) return;
+          this.handlePartialAsrResult(text);
+        };
+
         engine.onResult = (result) => {
           if (this.disposed) return;
           const text = result.text.trim();

--- a/src/services/clients/LocalInferenceClient.ts
+++ b/src/services/clients/LocalInferenceClient.ts
@@ -192,17 +192,18 @@ export class LocalInferenceClient implements IClient {
       // --- Fire all init() calls in parallel ---
 
       const asrPromise = this.trackInit('asr', config.asrModelId, () => {
+        const vadConfig = {
+          threshold: config.vadThreshold,
+          minSilenceDuration: config.vadMinSilenceDuration,
+          minSpeechDuration: config.vadMinSpeechDuration,
+        };
         if (asrModel?.type === 'asr-stream') {
-          return (this.asrEngine as StreamingAsrEngine).init(config.asrModelId, { language: config.sourceLanguage });
+          return (this.asrEngine as StreamingAsrEngine).init(config.asrModelId, { language: config.sourceLanguage, vadConfig });
         } else {
           const taskConfig = isAstMode
             ? { task: 'translate' as const, targetLanguage: config.targetLanguage }
             : undefined;
-          return (this.asrEngine as AsrEngine).init(config.asrModelId, {
-            threshold: config.vadThreshold,
-            minSilenceDuration: config.vadMinSilenceDuration,
-            minSpeechDuration: config.vadMinSpeechDuration,
-          }, config.sourceLanguage, taskConfig);
+          return (this.asrEngine as AsrEngine).init(config.asrModelId, vadConfig, config.sourceLanguage, taskConfig);
         }
       });
 


### PR DESCRIPTION
## Summary
- Cohere Transcribe is a batch ASR model (VAD → complete segment → decode) but was incorrectly registered as `asr-stream`, causing it to go through `StreamingAsrEngine` where `vadConfig` is not passed
- User VAD slider settings (threshold, min silence, min speech duration) had no effect on Cohere, and the VAD Settings UI section was hidden when Cohere was selected
- Moves Cohere to `type: 'asr'` / `AsrEngine`, wires up `vadConfig`, and adds `onPartialResult` support to `AsrEngine` so Cohere's token-level streaming still works

## Changes
- **modelManifest.ts**: `type: 'asr-stream'` → `type: 'asr'`
- **AsrEngine.ts**: Add `cohere-transcribe-webgpu` worker, `onPartialResult` callback, handle `partial` messages
- **cohere-transcribe-webgpu.worker.ts**: Accept `vadConfig` from init message instead of hardcoded values
- **types.ts**: Add `vadConfig` to `CohereTranscribeAsrInitMessage`
- **LocalInferenceClient.ts**: Wire up `onPartialResult` in `AsrEngine` path
- **StreamingAsrEngine.ts**: Remove Cohere worker case

## Test plan
- [x] Select Cohere Transcribe model → VAD Settings sliders should now be visible
- [x] Adjust VAD threshold/silence/speech duration → changes should take effect on next session
- [x] Cohere partial results (token-level streaming) still display during inference
- [x] PTT flush still works with Cohere
- [x] Other ASR models (Whisper, Granite, sherpa-onnx) unaffected
- [x] Streaming ASR models (Voxtral, sherpa streaming) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Real-time partial transcriptions for both streaming and non-streaming ASR.

* **Improvements**
  * New WebGPU ASR backend option available.
  * Centralized, user-configurable VAD settings with sensible defaults for better voice activity detection.
  * VAD settings visibility expanded for more ASR model cases.

* **Validation**
  * New backend now requires language to be specified during initialization to avoid misconfiguration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->