### PR TITLE
feat(audio): replace per-chunk HTMLAudioElement with SharedArrayBuffer ring buffer

### DIFF
--- a/docs/superpowers/plans/2026-04-04-audio-pipeline-redesign.md
+++ b/docs/superpowers/plans/2026-04-04-audio-pipeline-redesign.md
@@ -1,0 +1,1226 @@
+# Audio Pipeline Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace per-chunk HTMLAudioElement playback with an AudioWorklet ring buffer feeding a single persistent HTMLAudioElement, eliminating inter-chunk gaps that cause crackling (issue #172).
+
+**Architecture:** A `PlaybackRingWorkletProcessor` AudioWorklet maintains a circular buffer and outputs audio continuously. The main thread writes PCM chunks into it via `postMessage`. The worklet output connects through GainNode → AnalyserNode → MediaStreamDestinationNode → a single persistent HTMLAudioElement (preserving AEC compatibility).
+
+**Tech Stack:** Web Audio API (AudioWorklet, AudioContext, GainNode, AnalyserNode, MediaStreamDestinationNode), HTMLAudioElement
+
+---
+
+### Task 1: Create PlaybackRingWorkletProcessor
+
+**Files:**
+- Create: `src/lib/modern-audio/worklets/playback-ring-processor.js`
+
+- [ ] **Step 1: Create the worklet processor file**
+
+```javascript
+// src/lib/modern-audio/worklets/playback-ring-processor.js
+
+/**
+ * AudioWorklet processor that maintains a circular buffer for gapless audio playback.
+ * Receives PCM samples via postMessage, outputs continuously via process().
+ * When buffer is empty, outputs silence (no clicks or pops).
+ */
+class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Ring buffer: 2 seconds capacity at whatever sample rate the context uses
+    // sampleRate is a global in AudioWorkletGlobalScope
+    this._capacity = Math.floor(sampleRate * 2);
+    this._buffer = new Float32Array(this._capacity);
+    this._writeIndex = 0;
+    this._readIndex = 0;
+    this._playing = true;
+
+    // State tracking for notifications
+    this._state = 'stopped'; // 'stopped' | 'playing' | 'starving'
+    this._samplesPlayed = 0;
+    this._lastPositionReport = 0;
+    // Report position every ~50ms worth of samples
+    this._positionReportInterval = Math.floor(sampleRate * 0.05);
+
+    this.port.onmessage = (e) => {
+      const msg = e.data;
+      if (msg.type === 'write') {
+        this._write(msg.samples);
+      } else if (msg.type === 'clear') {
+        this._clear();
+      } else if (msg.type === 'setPlaying') {
+        this._playing = msg.playing;
+      }
+    };
+  }
+
+  _available() {
+    const avail = this._writeIndex - this._readIndex;
+    return avail >= 0 ? avail : avail + this._capacity;
+  }
+
+  _write(samples) {
+    const len = samples.length;
+
+    // Check for overflow — if writing would exceed capacity, drop oldest
+    if (len > this._capacity) {
+      // Extremely large write — only keep the last _capacity samples
+      const offset = len - this._capacity;
+      this._buffer.set(samples.subarray(offset), 0);
+      this._writeIndex = this._capacity;
+      this._readIndex = 0;
+      return;
+    }
+
+    const available = this._available();
+    const freeSpace = this._capacity - available;
+
+    if (len > freeSpace) {
+      // Overflow: advance readIndex to make room
+      const overflow = len - freeSpace;
+      this._readIndex = (this._readIndex + overflow) % this._capacity;
+    }
+
+    // Write samples into ring buffer (handle wrap-around)
+    const writePos = this._writeIndex % this._capacity;
+    const firstPart = Math.min(len, this._capacity - writePos);
+    this._buffer.set(samples.subarray(0, firstPart), writePos);
+
+    if (firstPart < len) {
+      this._buffer.set(samples.subarray(firstPart), 0);
+    }
+
+    this._writeIndex = (writePos + len) % this._capacity;
+  }
+
+  _clear() {
+    this._readIndex = 0;
+    this._writeIndex = 0;
+    this._samplesPlayed = 0;
+    this._lastPositionReport = 0;
+    this._setState('stopped');
+  }
+
+  _setState(newState) {
+    if (this._state !== newState) {
+      this._state = newState;
+      this.port.postMessage({ type: 'stateChange', state: newState });
+    }
+  }
+
+  process(inputs, outputs) {
+    const output = outputs[0];
+    if (!output || output.length === 0) return true;
+
+    const channel = output[0];
+    const frameSize = channel.length; // typically 128
+
+    if (!this._playing) {
+      // Output silence when paused
+      channel.fill(0);
+      return true;
+    }
+
+    const available = this._available();
+
+    if (available === 0) {
+      // Buffer empty — output silence
+      channel.fill(0);
+      if (this._state === 'playing') {
+        this._setState('starving');
+      }
+      return true;
+    }
+
+    // We have data — read from ring buffer
+    if (this._state !== 'playing') {
+      this._setState('playing');
+    }
+
+    const samplesToRead = Math.min(frameSize, available);
+    const readPos = this._readIndex % this._capacity;
+    const firstPart = Math.min(samplesToRead, this._capacity - readPos);
+
+    // Copy first part
+    channel.set(this._buffer.subarray(readPos, readPos + firstPart));
+
+    if (firstPart < samplesToRead) {
+      // Wrap around
+      channel.set(this._buffer.subarray(0, samplesToRead - firstPart), firstPart);
+    }
+
+    // Zero-fill remainder if buffer didn't have enough for full frame
+    if (samplesToRead < frameSize) {
+      channel.fill(0, samplesToRead);
+    }
+
+    this._readIndex = (readPos + samplesToRead) % this._capacity;
+    this._samplesPlayed += samplesToRead;
+
+    // Periodic position report
+    if (this._samplesPlayed - this._lastPositionReport >= this._positionReportInterval) {
+      this._lastPositionReport = this._samplesPlayed;
+      this.port.postMessage({ type: 'readPosition', samplesPlayed: this._samplesPlayed });
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('playback-ring-processor', PlaybackRingWorkletProcessor);
+```
+
+- [ ] **Step 2: Verify file is in place**
+
+Run: `ls -la src/lib/modern-audio/worklets/playback-ring-processor.js`
+Expected: File exists
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/modern-audio/worklets/playback-ring-processor.js
+git commit -m "feat(audio): add PlaybackRingWorkletProcessor for gapless playback"
+```
+
+---
+
+### Task 2: Rewrite ModernAudioPlayer — constructor and initialization
+
+**Files:**
+- Modify: `src/lib/modern-audio/ModernAudioPlayer.js` (full rewrite)
+
+This task replaces the entire file. The constructor and `connect()` method set up the AudioContext → worklet → audio graph → single HTMLAudioElement pipeline.
+
+- [ ] **Step 1: Replace the file with the new constructor and connect()**
+
+Replace the entire contents of `src/lib/modern-audio/ModernAudioPlayer.js` with:
+
+```javascript
+/**
+ * Modern Audio Player using AudioWorklet ring buffer for gapless playback.
+ * Output routes through a single persistent HTMLAudioElement for AEC compatibility.
+ *
+ * Architecture:
+ *   PCM chunks → postMessage → AudioWorkletNode (ring buffer)
+ *     → GainNode → AnalyserNode → MediaStreamDestinationNode
+ *       → HTMLAudioElement.srcObject → Speakers (AEC-visible)
+ */
+export class ModernAudioPlayer {
+  constructor({ sampleRate = 24000 } = {}) {
+    this.sampleRate = sampleRate;
+
+    // AudioContext graph nodes (initialized in connect())
+    this.context = null;
+    this.workletNode = null;
+    this.gainNode = null;
+    this.analyser = null;
+    this.destinationNode = null;
+    this.audioElement = null;
+
+    // Output device
+    this.outputDeviceId = null;
+    this.isSettingDevice = false;
+    this.pendingDeviceId = null;
+    this.deviceChangePromise = null;
+
+    // Streaming buffer accumulation (same as before)
+    this.streamingBuffers = new Map();
+    this.streamingTimeouts = new Map();
+    this.trackQueues = new Map();
+    this.interruptedTracks = new Set();
+
+    // Sequence tracking for ordering (same as before)
+    this.lastSequenceNumbers = new Map();
+    this.outOfOrderBuffers = new Map();
+    this.sequenceGapTimeout = new Map();
+
+    // Global volume control (default muted — monitor off)
+    this.globalVolumeMultiplier = 0.0;
+
+    // Playback status tracking
+    this.currentPlayingItemId = null;
+    this.onPlaybackStatusChange = null;
+    this.totalBufferedDuration = new Map(); // itemId -> total seconds buffered
+    this.totalPlayedSamples = 0; // from worklet readPosition reports
+    this.itemStartSample = 0; // sample count when current item started
+    this.itemEndTimeout = null;
+
+    // Worklet state
+    this._workletReady = false;
+    this._workletState = 'stopped'; // 'stopped' | 'playing' | 'starving'
+  }
+
+  /**
+   * Initialize the audio player — creates AudioContext, loads worklet, builds audio graph.
+   */
+  async connect() {
+    if (this.context) {
+      if (this.context.state === 'suspended') {
+        await this.context.resume();
+      }
+      return true;
+    }
+
+    this.context = new AudioContext({ sampleRate: this.sampleRate });
+    if (this.context.state === 'suspended') {
+      await this.context.resume();
+    }
+
+    // Load worklet
+    const workletUrl = new URL('./worklets/playback-ring-processor.js', import.meta.url).href;
+    await this.context.audioWorklet.addModule(workletUrl);
+    this.workletNode = new AudioWorkletNode(this.context, 'playback-ring-processor');
+    this._workletReady = true;
+
+    // Listen for worklet messages
+    this.workletNode.port.onmessage = (e) => this._handleWorkletMessage(e.data);
+
+    // Build audio graph
+    this.gainNode = this.context.createGain();
+    this.gainNode.gain.setValueAtTime(this.globalVolumeMultiplier, this.context.currentTime);
+
+    this.analyser = this.context.createAnalyser();
+    this.analyser.fftSize = 8192;
+    this.analyser.smoothingTimeConstant = 0.1;
+
+    this.destinationNode = this.context.createMediaStreamDestination();
+
+    // Connect: worklet → gain → analyser → mediaStreamDestination
+    this.workletNode.connect(this.gainNode);
+    this.gainNode.connect(this.analyser);
+    this.analyser.connect(this.destinationNode);
+
+    // Single persistent HTMLAudioElement for AEC-visible output
+    this.audioElement = new Audio();
+    this.audioElement.srcObject = this.destinationNode.stream;
+
+    // Apply output device if previously set
+    if (this.outputDeviceId && typeof this.audioElement.setSinkId === 'function') {
+      try {
+        await this.audioElement.setSinkId(this.outputDeviceId);
+      } catch (e) {
+        console.warn('[ModernAudioPlayer] Failed to set initial output device:', e.message);
+      }
+    }
+
+    await this.audioElement.play().catch((e) => {
+      console.warn('[ModernAudioPlayer] Initial play() blocked (will retry on user gesture):', e.message);
+    });
+
+    return true;
+  }
+
+  /**
+   * Handle messages from the playback ring worklet.
+   */
+  _handleWorkletMessage(msg) {
+    if (msg.type === 'stateChange') {
+      const prevState = this._workletState;
+      this._workletState = msg.state;
+
+      if (msg.state === 'playing' && prevState !== 'playing') {
+        // Audio started or resumed — cancel any pending end notification
+        this._cancelEndNotification();
+        if (this.currentPlayingItemId && this.onPlaybackStatusChange) {
+          this.onPlaybackStatusChange({
+            itemId: this.currentPlayingItemId,
+            status: 'playing',
+            trackId: ''
+          });
+        }
+      } else if (msg.state === 'starving' && prevState === 'playing') {
+        // Buffer ran dry — might be end of speech or network stall
+        if (this.currentPlayingItemId) {
+          this._scheduleEndNotification(this.currentPlayingItemId);
+        }
+      }
+    } else if (msg.type === 'readPosition') {
+      this.totalPlayedSamples = msg.samplesPlayed;
+    }
+  }
+
+  // --- remaining methods will be added in subsequent tasks ---
+}
+
+// Make available globally for compatibility
+globalThis.ModernAudioPlayer = ModernAudioPlayer;
+```
+
+- [ ] **Step 2: Verify file parses correctly**
+
+Run: `node -e "import('./src/lib/modern-audio/ModernAudioPlayer.js').then(() => console.log('OK')).catch(e => console.error(e.message))" --input-type=module`
+
+If this fails due to `import.meta.url`, that's expected in Node — just verify no syntax errors:
+
+Run: `node --check src/lib/modern-audio/ModernAudioPlayer.js 2>&1 || echo "Module syntax - checking with parse..." && node -e "const fs=require('fs'); const code=fs.readFileSync('src/lib/modern-audio/ModernAudioPlayer.js','utf8'); try{new Function(code)}catch(e){if(!e.message.includes('import')){console.error(e.message);process.exit(1)}}; console.log('Syntax OK')"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/modern-audio/ModernAudioPlayer.js
+git commit -m "feat(audio): rewrite ModernAudioPlayer core with AudioWorklet ring buffer
+
+Replaces per-chunk HTMLAudioElement with AudioWorklet → MediaStream →
+single persistent HTMLAudioElement pipeline. This task adds constructor
+and connect() only; remaining methods follow in subsequent commits."
+```
+
+---
+
+### Task 3: Add streaming input methods
+
+**Files:**
+- Modify: `src/lib/modern-audio/ModernAudioPlayer.js` (add methods after `_handleWorkletMessage`)
+
+These methods handle PCM chunk input, sequence ordering, accumulation, and flushing to the ring buffer worklet.
+
+- [ ] **Step 1: Add all streaming input methods**
+
+Insert the following methods into `ModernAudioPlayer` class, replacing the `// --- remaining methods will be added in subsequent tasks ---` comment:
+
+```javascript
+  // =========================================================================
+  // Streaming Input
+  // =========================================================================
+
+  /**
+   * Add streaming audio chunks — core method for queue-based playback.
+   * @param {ArrayBuffer|Int16Array} audioData - Audio data to add
+   * @param {string} trackId - Track identifier
+   * @param {number} volume - Volume level (0-1) applied to PCM before ring buffer
+   * @param {Object} metadata - Optional metadata (e.g., itemId, sequenceNumber)
+   */
+  addStreamingAudio(audioData, trackId = 'default', volume = 1.0, metadata = {}) {
+    if (this.interruptedTracks.has(trackId)) {
+      return new Int16Array(0);
+    }
+
+    const buffer = this._normalizeAudioData(audioData);
+
+    if (metadata.sequenceNumber !== undefined) {
+      return this._handleSequencedAudio(buffer, trackId, volume, metadata);
+    }
+
+    this._accumulateChunk(trackId, buffer, volume, metadata);
+    this._checkAndTriggerPlayback(trackId);
+
+    return buffer;
+  }
+
+  /**
+   * Add complete audio for immediate playback (used by manual play buttons).
+   */
+  add16BitPCM(audioData, trackId = 'default', volume = 1.0, metadata = {}) {
+    if (this.interruptedTracks.has(trackId)) {
+      return new Int16Array(0);
+    }
+
+    const buffer = this._normalizeAudioData(audioData);
+    this._writeToRingBuffer(buffer, volume, metadata);
+    return buffer;
+  }
+
+  /**
+   * Add audio to passthrough buffer — with optional delay for echo cancellation.
+   */
+  addToPassthroughBuffer(audioData, volume = 1.0, delay = 50) {
+    if (this.globalVolumeMultiplier === 0) return;
+
+    const effectiveVolume = volume * this.globalVolumeMultiplier;
+    if (effectiveVolume < 0.01) return;
+
+    const buffer = this._normalizeAudioData(audioData);
+
+    if (delay > 0) {
+      setTimeout(() => {
+        if (this.globalVolumeMultiplier > 0) {
+          this._writeToRingBuffer(buffer, effectiveVolume, {});
+        }
+      }, delay);
+    } else {
+      this._writeToRingBuffer(buffer, effectiveVolume, {});
+    }
+  }
+
+  // =========================================================================
+  // Sequence Ordering (unchanged logic, private methods)
+  // =========================================================================
+
+  _handleSequencedAudio(buffer, trackId, volume, metadata) {
+    const sequence = metadata.sequenceNumber;
+    const lastSequence = this.lastSequenceNumbers.get(trackId) || 0;
+
+    if (sequence === lastSequence + 1) {
+      this.lastSequenceNumbers.set(trackId, sequence);
+      this._accumulateChunk(trackId, buffer, volume, metadata);
+      this._checkAndTriggerPlayback(trackId);
+      this._processBufferedSequences(trackId, volume);
+      return buffer;
+    }
+
+    if (sequence > lastSequence + 1) {
+      if (!this.outOfOrderBuffers.has(trackId)) {
+        this.outOfOrderBuffers.set(trackId, new Map());
+      }
+      this.outOfOrderBuffers.get(trackId).set(sequence, { buffer, volume, metadata });
+      this._setSequenceGapTimeout(trackId, volume);
+      return buffer;
+    }
+
+    // Duplicate or old sequence — skip
+    return buffer;
+  }
+
+  _processBufferedSequences(trackId, volume) {
+    const outOfOrderMap = this.outOfOrderBuffers.get(trackId);
+    if (!outOfOrderMap || outOfOrderMap.size === 0) return;
+
+    let lastSequence = this.lastSequenceNumbers.get(trackId) || 0;
+
+    while (outOfOrderMap.has(lastSequence + 1)) {
+      const nextSequence = lastSequence + 1;
+      const { buffer, volume: origVolume, metadata } = outOfOrderMap.get(nextSequence);
+      this._accumulateChunk(trackId, buffer, origVolume || volume, metadata);
+      this._checkAndTriggerPlayback(trackId);
+      outOfOrderMap.delete(nextSequence);
+      lastSequence = nextSequence;
+    }
+
+    this.lastSequenceNumbers.set(trackId, lastSequence);
+  }
+
+  _setSequenceGapTimeout(trackId, volume) {
+    if (this.sequenceGapTimeout.has(trackId)) {
+      clearTimeout(this.sequenceGapTimeout.get(trackId));
+    }
+
+    const timeoutId = setTimeout(() => {
+      this._forceProcessBufferedSequences(trackId, volume);
+    }, 100);
+
+    this.sequenceGapTimeout.set(trackId, timeoutId);
+  }
+
+  _forceProcessBufferedSequences(trackId, volume) {
+    const outOfOrderMap = this.outOfOrderBuffers.get(trackId);
+    if (!outOfOrderMap || outOfOrderMap.size === 0) return;
+
+    const sequences = Array.from(outOfOrderMap.keys()).sort((a, b) => a - b);
+
+    for (const sequence of sequences) {
+      const { buffer, volume: origVolume, metadata } = outOfOrderMap.get(sequence);
+      this._accumulateChunk(trackId, buffer, origVolume || volume, metadata);
+      this._checkAndTriggerPlayback(trackId);
+      outOfOrderMap.delete(sequence);
+    }
+
+    if (sequences.length > 0) {
+      this.lastSequenceNumbers.set(trackId, sequences[sequences.length - 1]);
+    }
+  }
+
+  // =========================================================================
+  // Chunk Accumulation & Ring Buffer Write
+  // =========================================================================
+
+  _accumulateChunk(trackId, buffer, volume, metadata = {}) {
+    if (!this.streamingBuffers.has(trackId)) {
+      this.streamingBuffers.set(trackId, {
+        volume,
+        chunks: [],
+        totalLength: 0,
+        metadata
+      });
+    }
+
+    const streamData = this.streamingBuffers.get(trackId);
+    streamData.chunks.push(buffer);
+    streamData.totalLength += buffer.length;
+
+    if (metadata.itemId) {
+      streamData.metadata = metadata;
+    }
+  }
+
+  _checkAndTriggerPlayback(trackId) {
+    const streamData = this.streamingBuffers.get(trackId);
+    if (!streamData) return;
+
+    const minBufferSize = this.sampleRate * 0.02; // 20ms
+
+    if (streamData.totalLength >= minBufferSize) {
+      this._flushStreamingBuffer(trackId);
+    } else {
+      this._scheduleFlush(trackId);
+    }
+  }
+
+  _flushStreamingBuffer(trackId) {
+    const streamData = this.streamingBuffers.get(trackId);
+    if (!streamData || streamData.chunks.length === 0) return;
+
+    // Combine chunks into single Int16Array
+    const combined = new Int16Array(streamData.totalLength);
+    let offset = 0;
+    for (const chunk of streamData.chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    // Write to ring buffer
+    this._writeToRingBuffer(combined, streamData.volume, streamData.metadata);
+
+    // Reset accumulator (keep metadata for next chunks of same stream)
+    streamData.chunks = [];
+    streamData.totalLength = 0;
+
+    this._clearStreamingTimeout(trackId);
+  }
+
+  _scheduleFlush(trackId) {
+    if (this.streamingTimeouts.has(trackId)) return;
+
+    const timeoutId = setTimeout(() => {
+      this.streamingTimeouts.delete(trackId);
+      this._flushStreamingBuffer(trackId);
+    }, 20);
+
+    this.streamingTimeouts.set(trackId, timeoutId);
+  }
+
+  /**
+   * Convert Int16 PCM to Float32, apply per-track volume, and post to worklet.
+   */
+  _writeToRingBuffer(int16Buffer, volume, metadata) {
+    if (!this._workletReady || !this.workletNode) return;
+
+    // Track item and buffered duration
+    if (metadata && metadata.itemId) {
+      if (this.currentPlayingItemId !== metadata.itemId) {
+        // New item — clean up old state
+        if (this.currentPlayingItemId !== null) {
+          this.totalBufferedDuration.delete(this.currentPlayingItemId);
+        }
+        this.currentPlayingItemId = metadata.itemId;
+        this.totalBufferedDuration.set(metadata.itemId, 0);
+        this.itemStartSample = this.totalPlayedSamples;
+      }
+
+      const bufferDuration = int16Buffer.length / this.sampleRate;
+      const prev = this.totalBufferedDuration.get(metadata.itemId) || 0;
+      this.totalBufferedDuration.set(metadata.itemId, prev + bufferDuration);
+    }
+
+    // Convert Int16 → Float32 with volume
+    const float32 = new Float32Array(int16Buffer.length);
+    const scale = (volume !== 1.0) ? volume / 32768 : 1 / 32768;
+    for (let i = 0; i < int16Buffer.length; i++) {
+      float32[i] = int16Buffer[i] * scale;
+    }
+
+    // Post to worklet — transfer the buffer for zero-copy
+    this.workletNode.port.postMessage(
+      { type: 'write', samples: float32 },
+      [float32.buffer]
+    );
+  }
+
+  _normalizeAudioData(audioData) {
+    if (audioData instanceof Int16Array) return audioData;
+    if (audioData instanceof ArrayBuffer) return new Int16Array(audioData);
+    throw new Error('Audio data must be Int16Array or ArrayBuffer');
+  }
+
+  _clearStreamingTimeout(trackId) {
+    if (this.streamingTimeouts.has(trackId)) {
+      clearTimeout(this.streamingTimeouts.get(trackId));
+      this.streamingTimeouts.delete(trackId);
+    }
+  }
+
+  // --- volume, status, cleanup methods added in next tasks ---
+```
+
+- [ ] **Step 2: Verify no syntax errors**
+
+Run: `npx acorn --ecma2022 --module src/lib/modern-audio/ModernAudioPlayer.js > /dev/null 2>&1 && echo "Syntax OK" || echo "Syntax error"`
+
+If acorn isn't available:
+Run: `npx -y acorn --ecma2022 --module src/lib/modern-audio/ModernAudioPlayer.js > /dev/null 2>&1 && echo "Syntax OK" || node -e "require('fs').readFileSync('src/lib/modern-audio/ModernAudioPlayer.js','utf8')" && echo "File readable"`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/modern-audio/ModernAudioPlayer.js
+git commit -m "feat(audio): add streaming input, sequence ordering, and ring buffer write
+
+Ports addStreamingAudio, add16BitPCM, addToPassthroughBuffer, and all
+sequence ordering logic. Chunks are accumulated, combined, converted
+to Float32, and posted to the ring buffer worklet via transferable."
+```
+
+---
+
+### Task 4: Add volume, device switching, and visualization methods
+
+**Files:**
+- Modify: `src/lib/modern-audio/ModernAudioPlayer.js` (add methods, replace placeholder comment)
+
+- [ ] **Step 1: Add volume, device, and visualization methods**
+
+Replace the `// --- volume, status, cleanup methods added in next tasks ---` comment with:
+
+```javascript
+  // =========================================================================
+  // Volume Control
+  // =========================================================================
+
+  /**
+   * Set global volume multiplier (for monitor on/off).
+   * @param {number} volume - Volume from 0 to 1
+   */
+  setGlobalVolume(volume) {
+    this.globalVolumeMultiplier = Math.max(0, Math.min(1, volume));
+
+    if (this.gainNode && this.context) {
+      this.gainNode.gain.setValueAtTime(this.globalVolumeMultiplier, this.context.currentTime);
+    }
+  }
+
+  // =========================================================================
+  // Output Device Switching
+  // =========================================================================
+
+  /**
+   * Set audio output device.
+   */
+  async setSinkId(deviceId) {
+    if (this.outputDeviceId === deviceId) return true;
+
+    if (this.deviceChangePromise && this.pendingDeviceId === deviceId) {
+      return this.deviceChangePromise;
+    }
+
+    this.pendingDeviceId = deviceId;
+    this.deviceChangePromise = this._performDeviceChange(deviceId);
+
+    try {
+      return await this.deviceChangePromise;
+    } finally {
+      if (this.pendingDeviceId === deviceId) {
+        this.deviceChangePromise = null;
+        this.pendingDeviceId = null;
+      }
+    }
+  }
+
+  async _performDeviceChange(deviceId) {
+    if (!this.context) {
+      try {
+        await this.connect();
+      } catch (error) {
+        console.error('[ModernAudioPlayer] Failed to initialize AudioContext:', error);
+        return false;
+      }
+    }
+
+    try {
+      // Set on HTMLAudioElement (preferred — routes through OS audio path for AEC)
+      if (this.audioElement && typeof this.audioElement.setSinkId === 'function') {
+        await this.audioElement.setSinkId(deviceId);
+      }
+      // Also set on AudioContext if supported (for future-proofing)
+      if (this.context && typeof this.context.setSinkId === 'function') {
+        await this.context.setSinkId(deviceId).catch(() => {
+          // AudioContext.setSinkId may not be available everywhere
+        });
+      }
+
+      this.outputDeviceId = deviceId;
+      return true;
+    } catch (error) {
+      console.error('[ModernAudioPlayer] Failed to set sink ID:', error);
+      return false;
+    }
+  }
+
+  // =========================================================================
+  // Visualization
+  // =========================================================================
+
+  /**
+   * Get frequency data for visualization.
+   */
+  getFrequencies() {
+    if (!this.context || !this.analyser) {
+      return { values: new Float32Array(1024), peaks: [] };
+    }
+
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteFrequencyData(dataArray);
+
+    const result = new Float32Array(bufferLength);
+    for (let i = 0; i < bufferLength; i++) {
+      result[i] = dataArray[i] / 255.0;
+    }
+
+    return { values: result, peaks: [] };
+  }
+
+  // --- playback status, interruption, cleanup methods added in next tasks ---
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/modern-audio/ModernAudioPlayer.js
+git commit -m "feat(audio): add volume control, device switching, and visualization"
+```
+
+---
+
+### Task 5: Add playback status tracking
+
+**Files:**
+- Modify: `src/lib/modern-audio/ModernAudioPlayer.js` (add methods, replace placeholder comment)
+
+- [ ] **Step 1: Add playback status methods**
+
+Replace the `// --- playback status, interruption, cleanup methods added in next tasks ---` comment with:
+
+```javascript
+  // =========================================================================
+  // Playback Status Tracking
+  // =========================================================================
+
+  /**
+   * Set playback status callback.
+   */
+  setPlaybackStatusCallback(callback) {
+    this.onPlaybackStatusChange = callback;
+  }
+
+  /**
+   * Get current playback status.
+   */
+  getCurrentPlaybackStatus() {
+    if (!this.currentPlayingItemId) return null;
+
+    const totalBufferedTime = this.getBufferedDuration(this.currentPlayingItemId);
+
+    // Calculate played time from worklet's sample counter
+    const samplesPlayedForItem = this.totalPlayedSamples - this.itemStartSample;
+    const currentTime = Math.max(0, samplesPlayedForItem / this.sampleRate);
+
+    return {
+      itemId: this.currentPlayingItemId,
+      trackId: '',
+      currentTime: Math.min(currentTime, totalBufferedTime),
+      duration: totalBufferedTime,
+      isPlaying: this._workletState === 'playing',
+      bufferedTime: totalBufferedTime
+    };
+  }
+
+  /**
+   * Get buffered duration for an item.
+   */
+  getBufferedDuration(itemId) {
+    return this.totalBufferedDuration.get(itemId) || 0;
+  }
+
+  /**
+   * Schedule an 'ended' notification after buffer goes empty.
+   * Defers by 2s in case more audio is still being generated by the AI.
+   */
+  _scheduleEndNotification(itemId) {
+    this._cancelEndNotification();
+
+    this.itemEndTimeout = setTimeout(() => {
+      // Only fire if still the same item and still starving
+      if (this.currentPlayingItemId === itemId && this._workletState !== 'playing') {
+        this.totalBufferedDuration.delete(itemId);
+
+        if (this.onPlaybackStatusChange) {
+          this.onPlaybackStatusChange({
+            itemId,
+            status: 'ended',
+            trackId: ''
+          });
+        }
+        this.currentPlayingItemId = null;
+      }
+      this.itemEndTimeout = null;
+    }, 2000);
+  }
+
+  _cancelEndNotification() {
+    if (this.itemEndTimeout) {
+      clearTimeout(this.itemEndTimeout);
+      this.itemEndTimeout = null;
+    }
+  }
+
+  // --- interruption and cleanup methods added in next task ---
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/lib/modern-audio/ModernAudioPlayer.js
+git commit -m "feat(audio): add playback status tracking with worklet sample counter"
+```
+
+---
+
+### Task 6: Add interruption, cleanup, and diagnostics
+
+**Files:**
+- Modify: `src/lib/modern-audio/ModernAudioPlayer.js` (add final methods, replace placeholder comment)
+
+- [ ] **Step 1: Add remaining methods**
+
+Replace the `// --- interruption and cleanup methods added in next task ---` comment with:
+
+```javascript
+  // =========================================================================
+  // Interruption & Track Management
+  // =========================================================================
+
+  /**
+   * Interrupt audio playback — returns estimated position.
+   */
+  async interrupt() {
+    if (!this.currentPlayingItemId) {
+      return { trackId: null, offset: 0, currentTime: 0 };
+    }
+
+    const samplesPlayedForItem = this.totalPlayedSamples - this.itemStartSample;
+    const currentTime = samplesPlayedForItem / this.sampleRate;
+    const estimatedOffset = Math.floor(samplesPlayedForItem);
+
+    // Clear the ring buffer immediately
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({ type: 'clear' });
+    }
+
+    // Mark all active tracks as interrupted
+    const trackId = 'default';
+    this.interruptedTracks.add(trackId);
+
+    return { trackId, offset: estimatedOffset, currentTime };
+  }
+
+  /**
+   * Clear streaming data for a track.
+   */
+  clearStreamingTrack(trackId) {
+    this.streamingBuffers.delete(trackId);
+    this._clearStreamingTimeout(trackId);
+    this.trackQueues.delete(trackId);
+    this.interruptedTracks.delete(trackId);
+
+    // Clear sequence tracking
+    this.lastSequenceNumbers.delete(trackId);
+    this.outOfOrderBuffers.delete(trackId);
+    if (this.sequenceGapTimeout.has(trackId)) {
+      clearTimeout(this.sequenceGapTimeout.get(trackId));
+      this.sequenceGapTimeout.delete(trackId);
+    }
+
+    // Clear ring buffer
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({ type: 'clear' });
+    }
+  }
+
+  /**
+   * Clear all interrupted tracks.
+   */
+  clearInterruptedTracks() {
+    this.interruptedTracks.clear();
+  }
+
+  /**
+   * Check if track is currently playing.
+   */
+  isTrackPlaying(_trackId) {
+    return this._workletState === 'playing';
+  }
+
+  // =========================================================================
+  // Stop & Cleanup
+  // =========================================================================
+
+  /**
+   * Stop all audio playback.
+   */
+  stopAll() {
+    this._cancelEndNotification();
+
+    // Clear ring buffer
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({ type: 'clear' });
+    }
+
+    // Clear all accumulation and queue state
+    for (const timeoutId of this.streamingTimeouts.values()) {
+      clearTimeout(timeoutId);
+    }
+    this.streamingTimeouts.clear();
+    this.streamingBuffers.clear();
+    this.trackQueues.clear();
+
+    // Clear tracking
+    this.totalBufferedDuration.clear();
+    this.currentPlayingItemId = null;
+    this.totalPlayedSamples = 0;
+    this.itemStartSample = 0;
+  }
+
+  /**
+   * Cleanup all resources.
+   */
+  cleanup() {
+    this._cancelEndNotification();
+    this.stopAll();
+
+    // Clear sequence gap timeouts
+    for (const timeoutId of this.sequenceGapTimeout.values()) {
+      clearTimeout(timeoutId);
+    }
+    this.sequenceGapTimeout.clear();
+
+    // Clear all data
+    this.interruptedTracks.clear();
+    this.lastSequenceNumbers.clear();
+    this.outOfOrderBuffers.clear();
+
+    // Disconnect audio graph
+    if (this.workletNode) {
+      try { this.workletNode.disconnect(); } catch (e) { /* ignore */ }
+      this.workletNode = null;
+    }
+    if (this.gainNode) {
+      try { this.gainNode.disconnect(); } catch (e) { /* ignore */ }
+      this.gainNode = null;
+    }
+    if (this.analyser) {
+      try { this.analyser.disconnect(); } catch (e) { /* ignore */ }
+      this.analyser = null;
+    }
+    if (this.destinationNode) {
+      try { this.destinationNode.disconnect(); } catch (e) { /* ignore */ }
+      this.destinationNode = null;
+    }
+
+    // Stop and release HTMLAudioElement
+    if (this.audioElement) {
+      this.audioElement.pause();
+      this.audioElement.srcObject = null;
+      this.audioElement = null;
+    }
+
+    // Close AudioContext
+    if (this.context && this.context.state !== 'closed') {
+      this.context.close().catch(console.error);
+      this.context = null;
+    }
+
+    this._workletReady = false;
+    this._workletState = 'stopped';
+  }
+
+  // =========================================================================
+  // Diagnostics
+  // =========================================================================
+
+  /**
+   * Get diagnostic information for audio sequencing.
+   */
+  getSequenceDiagnostics() {
+    const diagnostics = {
+      tracks: {},
+      outOfOrderCount: 0,
+      totalBuffered: 0,
+      gaps: [],
+      workletState: this._workletState,
+      totalPlayedSamples: this.totalPlayedSamples
+    };
+
+    for (const [trackId, lastSeq] of this.lastSequenceNumbers) {
+      const outOfOrder = this.outOfOrderBuffers.get(trackId);
+      const outOfOrderSeqs = outOfOrder
+        ? Array.from(outOfOrder.keys()).sort((a, b) => a - b)
+        : [];
+
+      diagnostics.tracks[trackId] = {
+        lastSequence: lastSeq,
+        outOfOrderSequences: outOfOrderSeqs,
+        gaps: this._findSequenceGaps(lastSeq, outOfOrderSeqs),
+        queueLength: this.trackQueues.get(trackId)?.length || 0
+      };
+
+      diagnostics.outOfOrderCount += outOfOrderSeqs.length;
+
+      if (diagnostics.tracks[trackId].gaps.length > 0) {
+        diagnostics.gaps.push(
+          ...diagnostics.tracks[trackId].gaps.map((g) => ({ trackId, ...g }))
+        );
+      }
+    }
+
+    return diagnostics;
+  }
+
+  _findSequenceGaps(lastSeq, outOfOrderSeqs) {
+    const gaps = [];
+    if (outOfOrderSeqs.length === 0) return gaps;
+
+    if (outOfOrderSeqs[0] > lastSeq + 1) {
+      gaps.push({
+        from: lastSeq + 1,
+        to: outOfOrderSeqs[0] - 1,
+        size: outOfOrderSeqs[0] - lastSeq - 1
+      });
+    }
+
+    for (let i = 1; i < outOfOrderSeqs.length; i++) {
+      if (outOfOrderSeqs[i] > outOfOrderSeqs[i - 1] + 1) {
+        gaps.push({
+          from: outOfOrderSeqs[i - 1] + 1,
+          to: outOfOrderSeqs[i] - 1,
+          size: outOfOrderSeqs[i] - outOfOrderSeqs[i - 1] - 1
+        });
+      }
+    }
+
+    return gaps;
+  }
+```
+
+**Important:** This code replaces only the placeholder comment. The class closing `}` and `globalThis.ModernAudioPlayer = ModernAudioPlayer;` line already exist in the file from Task 2 — do NOT duplicate them.
+
+- [ ] **Step 2: Verify complete file has no syntax issues**
+
+Run: `wc -l src/lib/modern-audio/ModernAudioPlayer.js` — should be ~500-550 lines.
+
+Run: `grep -c 'class ModernAudioPlayer' src/lib/modern-audio/ModernAudioPlayer.js` — should be `1`.
+
+Run: `grep -c 'globalThis.ModernAudioPlayer' src/lib/modern-audio/ModernAudioPlayer.js` — should be `1` (at end of file, not inside class).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/modern-audio/ModernAudioPlayer.js
+git commit -m "feat(audio): add interruption, cleanup, diagnostics — complete rewrite
+
+ModernAudioPlayer rewrite is now complete. All public methods preserved:
+addStreamingAudio, add16BitPCM, addToPassthroughBuffer, connect,
+setSinkId, setGlobalVolume, getFrequencies, interrupt, clearStreamingTrack,
+clearInterruptedTracks, stopAll, cleanup, setPlaybackStatusCallback,
+getCurrentPlaybackStatus, getBufferedDuration, getSequenceDiagnostics."
+```
+
+---
+
+### Task 7: Verify build and remove dead code
+
+**Files:**
+- Modify: `src/lib/modern-audio/ModernAudioPlayer.js` (if build errors)
+
+- [ ] **Step 1: Run the development build**
+
+Run: `npm run build 2>&1 | head -50`
+
+Expected: Build succeeds. The worklet file at `src/lib/modern-audio/worklets/playback-ring-processor.js` should be handled by Vite's `new URL(..., import.meta.url)` pattern (same as other worklets in the project).
+
+- [ ] **Step 2: Verify no TypeScript errors from consumers**
+
+Run: `npx tsc --noEmit 2>&1 | grep -i "ModernAudioPlayer\|modern-audio" | head -20`
+
+Fix any type errors. Common issues:
+- `ModernBrowserAudioService.ts` may reference removed properties (e.g., `player.audioElements`, `player.context`) — these should still exist in the new code. Check if any direct property access needs updating.
+
+- [ ] **Step 3: Check for any references to removed methods/properties**
+
+Run: `grep -rn "createWavBlob\|createWavHeader\|connectToAnalyser\|createAudioElement\|cleanupAudioElement\|cleanupAudio\|processQueue\|queueAudio\|scheduleNextPlayback\|applyVolume\|audioGainNodes\|audioSourceNodes\|cumulativePlayedTime\|lastChunkAudioId\|audioElements" src/ --include="*.ts" --include="*.tsx" --include="*.js" | grep -v "ModernAudioPlayer.js" | grep -v node_modules`
+
+If any external references to removed internals are found, fix them:
+- `player.context` → still exists, OK
+- `player.analyser` → still exists, OK
+- `player.audioElements` → removed. If referenced externally, replace with `player.isTrackPlaying(trackId)` check
+
+- [ ] **Step 4: Run tests**
+
+Run: `npm run test 2>&1 | tail -20`
+
+Expected: Existing tests pass. There are no unit tests for `ModernAudioPlayer` itself (AudioWorklet can't run in jsdom), so test failures would indicate breakage in other modules.
+
+- [ ] **Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix(audio): resolve build errors from audio pipeline rewrite"
+```
+
+---
+
+### Task 8: Manual integration testing
+
+No code changes — this task is a manual verification checklist.
+
+- [ ] **Step 1: Test basic playback (Electron)**
+
+1. Run `npm run electron:dev`
+2. Connect to Gemini provider with audio output enabled
+3. Send a message that produces a long response (10+ words)
+4. **Verify:** Audio plays smoothly with no crackling or gaps
+5. **Verify:** Audio continues playing without artifacts for the full response
+
+- [ ] **Step 2: Test AEC (Electron)**
+
+1. With speakers (no headphones), start a translation session
+2. Speak while TTS is playing back
+3. **Verify:** The AI does not echo back its own TTS output (AEC is working)
+
+- [ ] **Step 3: Test volume control**
+
+1. Toggle monitor on/off in the UI
+2. **Verify:** Audio mutes and unmutes without glitches
+3. Adjust volume slider
+4. **Verify:** Volume changes take effect immediately
+
+- [ ] **Step 4: Test track interruption**
+
+1. Start a long TTS response
+2. Interrupt mid-playback (e.g., press stop or send new input)
+3. **Verify:** Audio stops immediately, no residual sound
+4. Start a new response
+5. **Verify:** New audio plays cleanly
+
+- [ ] **Step 5: Test output device switching**
+
+1. Change the output device in settings while audio is playing
+2. **Verify:** Audio switches to new device
+
+- [ ] **Step 6: Test visualization**
+
+1. During playback, observe the waveform visualization
+2. **Verify:** Waveform renders and moves with the audio
+
+- [ ] **Step 7: Test browser extension**
+
+1. Load the extension in Chrome
+2. Open a supported platform (e.g., Google Meet)
+3. Start a translation session
+4. **Verify:** Audio plays in side panel without crackling
+5. **Verify:** Virtual microphone receives audio (other participants can hear translation)
+
+- [ ] **Step 8: Test multiple providers**
+
+Test with: OpenAI, Gemini, Palabra AI, Kizuna AI
+**Verify:** All providers play audio without crackling

--- a/docs/superpowers/specs/2026-04-04-audio-pipeline-redesign.md
+++ b/docs/superpowers/specs/2026-04-04-audio-pipeline-redesign.md
@@ -1,0 +1,260 @@
+# Audio Pipeline Redesign: AudioWorklet Ring Buffer Player
+
+**Date:** 2026-04-04
+**Issue:** [#172](https://github.com/kizuna-ai-lab/sokuji/issues/172) — Audio artifacts and crackling in TTS playback
+**Branch:** `worktree-audio-pipeline-redesign`
+
+## Problem
+
+The current `ModernAudioPlayer` creates a **new HTMLAudioElement per audio chunk** (~20ms each):
+
+```
+PCM chunk → createWavBlob() → URL.createObjectURL() → new Audio() → play()
+  → onended → next chunk → new Audio() → play() → ...
+```
+
+This causes:
+1. **Inter-chunk gaps**: Each HTMLAudioElement has its own media pipeline setup time. Even 1-2ms gaps between elements produce audible clicks/pops that compound into crackling.
+2. **GC pressure**: Dozens of Audio elements, blob URLs, and WAV buffers created per second.
+3. **Independent resampling**: Each small 24kHz chunk is resampled independently by the browser, introducing artifacts at boundaries.
+
+The previous fix attempt (increasing buffer threshold to 200ms, commit 09d53da) was reverted because the added latency was unacceptable for real-time translation.
+
+## Constraints
+
+1. **AEC compatibility**: The final audio output must go through HTMLAudioElement so Chromium's echo cancellation can use it as a reference signal. This works in both Chrome (ChromeWideEchoCancellation) and Electron 40 (Chromium 134).
+2. **Low latency**: Real-time simultaneous translation requires minimal playback delay.
+3. **Virtual microphone path unchanged**: The extension's `sendPcmDataToTabs()` → content script → `MediaStreamTrackGenerator` path is unaffected. The crackling bug only manifests in local speaker playback.
+4. **Preserved API surface**: `ModernAudioPlayer`'s public API (addStreamingAudio, stopTrack, setGlobalVolume, etc.) must remain compatible with `ModernBrowserAudioService`.
+
+## Design
+
+### Architecture
+
+Replace the per-chunk HTMLAudioElement playback with a continuous AudioWorklet ring buffer that feeds a single persistent HTMLAudioElement via MediaStream:
+
+```
+PCM chunks
+  → postMessage to AudioWorkletNode
+    → Ring buffer (continuous pull, 128 samples per process() call)
+      → GainNode (volume control)
+        → AnalyserNode (visualization)
+          → MediaStreamDestinationNode
+            → Single persistent HTMLAudioElement.srcObject
+              → Speakers (AEC-visible)
+```
+
+### Component 1: PlaybackRingWorkletProcessor (new file)
+
+**File:** `src/lib/modern-audio/worklets/playback-ring-processor.js`
+
+An AudioWorkletProcessor that maintains a circular buffer and outputs audio continuously.
+
+```
+Ring Buffer (capacity: 2s = sampleRate * 2 samples)
+  ├── writeIndex: where new data is written
+  ├── readIndex: where process() reads from
+  └── available(): writeIndex - readIndex (modular)
+```
+
+**Messages received via port.onmessage:**
+- `{ type: 'write', samples: Float32Array }` — append PCM to ring buffer
+- `{ type: 'clear' }` — reset ring buffer (on track interruption)
+- `{ type: 'setPlaying', playing: boolean }` — pause/resume output
+
+**Messages sent via port.postMessage:**
+- `{ type: 'stateChange', state: 'playing' | 'starving' | 'stopped' }` — buffer state transitions
+- `{ type: 'readPosition', readIndex: number }` — periodic position report for progress tracking
+
+**process() behavior:**
+- If buffer has data → copy 128 samples to output, advance readIndex
+- If buffer empty → output silence (zeros). No click, no pop.
+- State transitions: `playing` when data available, `starving` when buffer runs empty after having had data
+
+### Component 2: Redesigned ModernAudioPlayer
+
+**File:** `src/lib/modern-audio/ModernAudioPlayer.js` (rewrite)
+
+#### Initialization
+
+```javascript
+async init() {
+  this.audioContext = new AudioContext({ sampleRate: this.sampleRate });
+  
+  // Load worklet
+  await this.audioContext.audioWorklet.addModule(workletUrl);
+  this.workletNode = new AudioWorkletNode(this.audioContext, 'playback-ring-processor');
+  
+  // Build audio graph
+  this.gainNode = this.audioContext.createGain();
+  this.analyserNode = this.audioContext.createAnalyser();
+  this.destinationNode = this.audioContext.createMediaStreamDestination();
+  
+  this.workletNode.connect(this.gainNode);
+  this.gainNode.connect(this.analyserNode);
+  this.analyserNode.connect(this.destinationNode);
+  
+  // Single persistent HTMLAudioElement
+  this.audioElement = new Audio();
+  this.audioElement.srcObject = this.destinationNode.stream;
+  this.audioElement.play();
+}
+```
+
+#### addStreamingAudio(data, trackId, volume, metadata)
+
+Same sequence-ordering logic as current implementation:
+1. Handle out-of-order chunks (reorder by sequenceNumber)
+2. Accumulate in streamingBuffers
+3. On flush: convert Int16Array → Float32Array, post to worklet
+
+```javascript
+flushStreamingBuffer(trackId) {
+  const chunks = this.streamingBuffers.get(trackId);
+  const combined = combineChunks(chunks);
+  
+  // Convert Int16 → Float32
+  const float32 = new Float32Array(combined.length);
+  for (let i = 0; i < combined.length; i++) {
+    float32[i] = combined[i] / 32768;
+  }
+  
+  // Write to ring buffer
+  this.workletNode.port.postMessage({ type: 'write', samples: float32 });
+  
+  // Track metadata for progress reporting
+  this.trackBufferedDuration(trackId, combined.length, metadata);
+}
+```
+
+#### Volume Control
+
+Two levels of volume, same as current code:
+- **Per-track volume** (e.g. passthrough at 30%): applied to PCM data before writing to ring buffer (`applyVolume()`, same as current)
+- **Global volume multiplier** (monitor on/off): controlled via GainNode
+
+```javascript
+setGlobalVolume(multiplier) {
+  this.globalVolumeMultiplier = multiplier;
+  this.gainNode.gain.setValueAtTime(multiplier, this.audioContext.currentTime);
+}
+```
+
+#### Track Interruption (stopTrack / stopAll)
+
+```javascript
+stopTrack(trackId) {
+  // Clear pending buffers
+  this.streamingBuffers.delete(trackId);
+  this.trackQueues.delete(trackId);
+  
+  // Clear ring buffer immediately
+  this.workletNode.port.postMessage({ type: 'clear' });
+  
+  // Reset progress tracking
+  this.resetTrackMetadata(trackId);
+}
+```
+
+#### Output Device Switching
+
+```javascript
+async setOutputDevice(deviceId) {
+  if (this.audioElement && typeof this.audioElement.setSinkId === 'function') {
+    await this.audioElement.setSinkId(deviceId);
+  }
+  this.outputDeviceId = deviceId;
+}
+```
+
+#### Playback Progress Tracking
+
+Current code tracks progress via `audio.onended` and `audio.duration`. New approach:
+
+- On each `write` to ring buffer, accumulate `totalBufferedDuration` per itemId
+- Worklet periodically reports `readPosition` via postMessage
+- Calculate `cumulativePlayedTime = readPosition / sampleRate`
+- `onPlaybackStatusChange` fires on worklet state transitions (`playing` / `starving` → map to `playing` / `ended`)
+
+```javascript
+this.workletNode.port.onmessage = (e) => {
+  if (e.data.type === 'stateChange') {
+    if (e.data.state === 'starving' && this.currentPlayingItemId) {
+      // Buffer ran out — might be end of speech or network stall
+      // Defer 'ended' notification (same 2s timeout as current code)
+      this.scheduleEndNotification(this.currentPlayingItemId);
+    } else if (e.data.state === 'playing') {
+      this.cancelEndNotification();
+    }
+  }
+  if (e.data.type === 'readPosition') {
+    this.updatePlaybackProgress(e.data.readIndex);
+  }
+};
+```
+
+### Component 3: Passthrough Audio
+
+Current passthrough uses a separate delayed playback path. In the new design:
+
+- Passthrough audio still accumulates separately (different trackId)
+- Written to the same ring buffer (mixed in the worklet), OR uses a separate worklet instance at lower volume
+- **Recommended: separate worklet instance** to allow independent volume control and the 50ms delay
+
+### What's NOT Changing
+
+- `ModernAudioRecorder` — unchanged
+- `ModernBrowserAudioService.addAudioData()` — unchanged (calls same `addStreamingAudio` API)
+- `ModernBrowserAudioService.sendPcmDataToTabs()` — unchanged (PCM message passing)
+- `virtual-microphone.js` — unchanged
+- All AI client audio emission — unchanged
+- Sequence ordering / out-of-order handling — same algorithm, different output target
+- `MainPanel` integration — unchanged (same callbacks)
+
+### Buffer Sizing
+
+| Parameter | Value | Rationale |
+|-----------|-------|-----------|
+| Ring buffer capacity | 2 seconds (48,000 samples at 24kHz) | Large enough to absorb network jitter without overflow |
+| No pre-buffering | 0ms | Start playback immediately when first data arrives. The ring buffer outputs silence when empty (no pop), so there's no need to pre-buffer. |
+| Worklet process() frame | 128 samples (~5.3ms at 24kHz) | Web Audio API standard quantum size |
+| Flush threshold | 20ms (480 samples) — same as current | Unchanged; controls when accumulated chunks get written to ring buffer |
+
+### Error Handling
+
+- **AudioContext suspended**: Resume on user interaction (same as current)
+- **Worklet load failure**: Fall back to current HTMLAudioElement approach
+- **Ring buffer overflow** (writer faster than reader — shouldn't happen in real-time): Drop oldest samples, log warning
+- **Ring buffer underrun** (reader faster than writer — normal during gaps): Output silence, report `starving` state
+
+### Migration Strategy
+
+1. New `PlaybackRingWorkletProcessor` worklet file — no conflict with existing code
+2. Rewrite `ModernAudioPlayer.js` — replace playback engine while preserving public API
+3. Keep old `createWavBlob` / HTMLAudioElement code path as fallback (behind a flag or try/catch on worklet load)
+4. No changes needed to any consumer (`ModernBrowserAudioService`, `MainPanel`, clients)
+
+## Files to Create/Modify
+
+| File | Action | Description |
+|------|--------|-------------|
+| `src/lib/modern-audio/worklets/playback-ring-processor.js` | **Create** | AudioWorklet ring buffer processor |
+| `src/lib/modern-audio/ModernAudioPlayer.js` | **Rewrite** | Replace per-chunk HTMLAudioElement with AudioWorklet + single HTMLAudioElement |
+| `vite.config.ts` | **Possibly modify** | Ensure worklet file is served correctly (may already work via existing worklet config) |
+
+## Testing Plan
+
+- [ ] Verify gapless playback with Gemini provider (long responses, 10+ words)
+- [ ] Verify no crackling/artifacts across multiple consecutive responses
+- [ ] Verify AEC works in Electron (speak while TTS plays, confirm no echo feedback)
+- [ ] Verify AEC works in Chrome extension side panel
+- [ ] Verify virtual microphone injection still works (audio reaches content script)
+- [ ] Verify volume control (global mute, volume slider)
+- [ ] Verify output device switching (setSinkId)
+- [ ] Verify track interruption (stop mid-playback, start new response)
+- [ ] Verify visualization (AnalyserNode waveform still renders)
+- [ ] Verify playback progress callbacks (itemId status: playing/ended)
+- [ ] Verify passthrough audio works
+- [ ] Verify fallback to old approach if AudioWorklet fails to load
+- [ ] Test with OpenAI, Gemini, Palabra, KizunaAI providers
+- [ ] Test with poor network conditions (irregular chunk timing)

--- a/electron/main.js
+++ b/electron/main.js
@@ -69,6 +69,10 @@ app.commandLine.appendSwitch('jack-name', 'sokuji');
 app.commandLine.appendSwitch('enable-unsafe-webgpu');
 app.commandLine.appendSwitch('enable-features', 'Vulkan');
 
+// Enable SharedArrayBuffer for audio worklet ring buffer
+// Requires Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers
+app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
+
 // Keep a global reference of the window object to prevent garbage collection
 let mainWindow;
 
@@ -260,6 +264,17 @@ function createWindow() {
   // Set custom User Agent for the window
   mainWindow.webContents.setUserAgent(customUserAgent);
   console.log('[Sokuji] [Main] Custom User Agent set:', customUserAgent);
+
+  // Set COOP/COEP headers to enable SharedArrayBuffer for audio worklet ring buffer
+  mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Cross-Origin-Opener-Policy': ['same-origin'],
+        'Cross-Origin-Embedder-Policy': ['require-corp']
+      }
+    });
+  });
 
   // Load the app
   console.log('[Sokuji] [Main] Development mode:', isDev, 'MODE:', import.meta.env.MODE, 'isPackaged:', app.isPackaged);

--- a/electron/main.js
+++ b/electron/main.js
@@ -67,11 +67,9 @@ app.commandLine.appendSwitch('jack-name', 'sokuji');
 
 // Enable WebGPU for ONNX Runtime acceleration
 app.commandLine.appendSwitch('enable-unsafe-webgpu');
-app.commandLine.appendSwitch('enable-features', 'Vulkan');
-
-// Enable SharedArrayBuffer for audio worklet ring buffer
-// Requires Cross-Origin-Opener-Policy and Cross-Origin-Embedder-Policy headers
-app.commandLine.appendSwitch('enable-features', 'SharedArrayBuffer');
+// Enable required Chromium features as a single comma-separated list
+// (multiple appendSwitch calls for the same flag would override each other)
+app.commandLine.appendSwitch('enable-features', 'Vulkan,SharedArrayBuffer');
 
 // Keep a global reference of the window object to prevent garbage collection
 let mainWindow;
@@ -265,15 +263,23 @@ function createWindow() {
   mainWindow.webContents.setUserAgent(customUserAgent);
   console.log('[Sokuji] [Main] Custom User Agent set:', customUserAgent);
 
-  // Set COOP/COEP headers to enable SharedArrayBuffer for audio worklet ring buffer
+  // Set COOP/COEP headers to enable SharedArrayBuffer for audio worklet ring buffer.
+  // Only apply to same-origin responses — external API calls (OpenAI, Google, etc.)
+  // must not receive require-corp as it would block their responses.
   mainWindow.webContents.session.webRequest.onHeadersReceived((details, callback) => {
-    callback({
-      responseHeaders: {
-        ...details.responseHeaders,
-        'Cross-Origin-Opener-Policy': ['same-origin'],
-        'Cross-Origin-Embedder-Policy': ['require-corp']
-      }
-    });
+    const url = new URL(details.url);
+    const isLocal = url.hostname === 'localhost' || url.protocol === 'file:';
+    if (isLocal) {
+      callback({
+        responseHeaders: {
+          ...details.responseHeaders,
+          'Cross-Origin-Opener-Policy': ['same-origin'],
+          'Cross-Origin-Embedder-Policy': ['require-corp']
+        }
+      });
+    } else {
+      callback({ responseHeaders: details.responseHeaders });
+    }
   });
 
   // Load the app

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -6,6 +6,12 @@
   "default_locale": "en",
   "minimum_chrome_version": "116",
   "offline_enabled": false,
+  "cross_origin_embedder_policy": {
+    "value": "require-corp"
+  },
+  "cross_origin_opener_policy": {
+    "value": "same-origin"
+  },
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -51,10 +51,13 @@ export class ModernAudioPlayer {
     this._workletReady = false;
     this._workletState = 'stopped'; // 'stopped' | 'playing' | 'starving'
 
-    // Pending write queue for large buffers that exceed ring buffer capacity
-    this._pendingWrites = [];
+    // Send queue for drip-feeding large audio into the ring buffer.
+    // The worklet ring buffer is 2s; writes larger than ~1s are chunked
+    // and fed gradually so nothing is dropped.
+    this._sendQueue = []; // Array of Float32Array chunks
     this._drainTimer = null;
-    this._ringCapacity = this.sampleRate * 2; // 2 seconds — must match worklet
+    this._totalSentSamples = 0; // samples posted to worklet
+    this._ringBufferCapacity = this.sampleRate * 2; // must match worklet
   }
 
   /**
@@ -354,8 +357,9 @@ export class ModernAudioPlayer {
   }
 
   /**
-   * Convert Int16 PCM to Float32, apply per-track volume, and post to worklet.
-   * Large buffers are queued and drained incrementally to avoid ring buffer overflow.
+   * Convert Int16 PCM to Float32, apply per-track volume, and enqueue for worklet.
+   * Small writes (≤1s) are posted directly; larger writes are drip-fed via _sendQueue
+   * to avoid overflowing the worklet's 2-second ring buffer.
    */
   _writeToRingBuffer(int16Buffer, volume, metadata) {
     if (!this._workletReady || !this.workletNode) return;
@@ -384,57 +388,77 @@ export class ModernAudioPlayer {
       float32[i] = int16Buffer[i] * scale;
     }
 
-    // If small enough, post directly to worklet
-    const safeThreshold = Math.floor(this._ringCapacity * 0.75);
-    if (float32.length <= safeThreshold && this._pendingWrites.length === 0) {
-      this.workletNode.port.postMessage(
-        { type: 'write', samples: float32 },
-        [float32.buffer]
-      );
+    // Fast path: small writes go directly to worklet (covers streaming case)
+    const maxDirectWrite = this.sampleRate; // 1 second
+    if (float32.length <= maxDirectWrite && this._sendQueue.length === 0) {
+      this._postToWorklet(float32);
       return;
     }
 
-    // Large buffer or queue already active — split into 0.5s chunks and drain
-    const chunkSize = Math.floor(this.sampleRate * 0.5); // 0.5 seconds per chunk
-    for (let i = 0; i < float32.length; i += chunkSize) {
-      const end = Math.min(i + chunkSize, float32.length);
-      this._pendingWrites.push(new Float32Array(float32.subarray(i, end)));
+    // Large write or queue already active: chunk into ~0.5s pieces and drip-feed
+    const chunkSize = Math.floor(this.sampleRate * 0.5); // 0.5 second chunks
+    for (let offset = 0; offset < float32.length; offset += chunkSize) {
+      const end = Math.min(offset + chunkSize, float32.length);
+      this._sendQueue.push(float32.slice(offset, end));
     }
-    this._drainPendingWrites();
+
+    this._startDraining();
   }
 
   /**
-   * Drain pending write queue into the worklet ring buffer incrementally.
+   * Post a Float32Array to the worklet ring buffer (zero-copy via transfer).
    */
-  _drainPendingWrites() {
-    if (this._pendingWrites.length === 0) return;
-    if (this._drainTimer) return; // Already scheduled
-
-    // Write one chunk now
-    const chunk = this._pendingWrites.shift();
-    if (this.workletNode) {
-      this.workletNode.port.postMessage(
-        { type: 'write', samples: chunk },
-        [chunk.buffer]
-      );
-    }
-
-    if (this._pendingWrites.length === 0) return; // Done
-
-    // Schedule next write — drain at ~2x playback rate (every 250ms for 0.5s chunks)
-    this._drainTimer = setTimeout(() => {
-      this._drainTimer = null;
-      this._drainPendingWrites();
-    }, 250);
+  _postToWorklet(float32) {
+    if (!this.workletNode) return;
+    this._totalSentSamples += float32.length;
+    this.workletNode.port.postMessage(
+      { type: 'write', samples: float32 },
+      [float32.buffer]
+    );
   }
 
   /**
-   * Cancel pending write drain.
+   * Start the drain timer that feeds queued audio to the worklet.
    */
-  _cancelPendingWrites() {
-    this._pendingWrites = [];
-    if (this._drainTimer) {
-      clearTimeout(this._drainTimer);
+  _startDraining() {
+    if (this._drainTimer !== null) return;
+    // Drain immediately, then every 100ms
+    this._drainQueue();
+    this._drainTimer = setInterval(() => this._drainQueue(), 100);
+  }
+
+  /**
+   * Feed the next chunk from _sendQueue to the worklet, if there's room.
+   */
+  _drainQueue() {
+    if (this._sendQueue.length === 0) {
+      if (this._drainTimer !== null) {
+        clearInterval(this._drainTimer);
+        this._drainTimer = null;
+      }
+      return;
+    }
+
+    // Estimate how much audio is currently buffered in the worklet ring buffer
+    const bufferedInWorklet = this._totalSentSamples - this.totalPlayedSamples;
+    const headroom = this._ringBufferCapacity - bufferedInWorklet;
+
+    // Only send if there's at least 0.25s of headroom
+    const minHeadroom = Math.floor(this.sampleRate * 0.25);
+    if (headroom < minHeadroom) return;
+
+    // Send the next chunk
+    const chunk = this._sendQueue.shift();
+    this._postToWorklet(chunk);
+  }
+
+  /**
+   * Clear the send queue (used on stop/interrupt).
+   */
+  _clearSendQueue() {
+    this._sendQueue.length = 0;
+    if (this._drainTimer !== null) {
+      clearInterval(this._drainTimer);
       this._drainTimer = null;
     }
   }
@@ -636,8 +660,8 @@ export class ModernAudioPlayer {
     const currentTime = samplesPlayedForItem / this.sampleRate;
     const estimatedOffset = Math.floor(samplesPlayedForItem);
 
-    // Clear pending writes and ring buffer immediately
-    this._cancelPendingWrites();
+    // Clear send queue and ring buffer immediately
+    this._clearSendQueue();
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }
@@ -666,8 +690,8 @@ export class ModernAudioPlayer {
       this.sequenceGapTimeout.delete(trackId);
     }
 
-    // Clear pending writes and ring buffer
-    this._cancelPendingWrites();
+    // Clear send queue and ring buffer
+    this._clearSendQueue();
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }
@@ -696,12 +720,13 @@ export class ModernAudioPlayer {
    */
   stopAll() {
     this._cancelEndNotification();
-    this._cancelPendingWrites();
 
-    // Clear ring buffer
+    // Clear send queue and ring buffer
+    this._clearSendQueue();
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }
+    this._totalSentSamples = 0;
 
     // Clear all accumulation and queue state
     for (const timeoutId of this.streamingTimeouts.values()) {

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -1,92 +1,153 @@
 /**
- * Modern Audio Player using HTMLAudioElement for echo cancellation compatibility
- * Simplified version focused on chunk queuing and sequential playback
+ * Modern Audio Player using AudioWorklet ring buffer for gapless playback.
+ * Output routes through a single persistent HTMLAudioElement for AEC compatibility.
+ *
+ * Architecture:
+ *   PCM chunks → postMessage → AudioWorkletNode (ring buffer)
+ *     → GainNode → AnalyserNode → MediaStreamDestinationNode
+ *       → HTMLAudioElement.srcObject → Speakers (AEC-visible)
  */
 export class ModernAudioPlayer {
   constructor({ sampleRate = 24000 } = {}) {
     this.sampleRate = sampleRate;
+
+    // AudioContext graph nodes (initialized in connect())
     this.context = null;
+    this.workletNode = null;
+    this.gainNode = null;
     this.analyser = null;
-    
-    // Audio playback management
-    this.audioElements = new Map(); // Track active audio elements
-    this.currentAudioId = 0;
+    this.destinationNode = null;
+    this.audioElement = null;
+
+    // Output device
     this.outputDeviceId = null;
-    
-    // No pooling - create new audio elements each time to avoid connection issues
-    
-    // Queue system for sequential playback
-    this.trackQueues = new Map(); // Queue system for each trackId
-    this.streamingBuffers = new Map(); // Accumulate chunks before queuing
-    this.streamingTimeouts = new Map(); // Timeout management
-    this.interruptedTracks = new Set(); // Track interrupted trackIds
-    
-    // Sequence tracking for ordering
-    this.lastSequenceNumbers = new Map(); // trackId -> last processed sequence number
-    this.outOfOrderBuffers = new Map(); // trackId -> Map of sequence -> buffer data
-    this.sequenceGapTimeout = new Map(); // trackId -> timeout for missing sequences
-    
-    // Global volume control for monitor on/off
-    // Default to 0 (muted) since isMonitorDeviceOn defaults to false in AudioContext
-    this.globalVolumeMultiplier = 0.0;
-    
-    // Device switching state
     this.isSettingDevice = false;
     this.pendingDeviceId = null;
     this.deviceChangePromise = null;
-    
-    // Store gain nodes for volume control
-    this.audioGainNodes = new WeakMap();
-    
-    // Store source nodes for proper cleanup
-    this.audioSourceNodes = new WeakMap();
-    
+
+    // Streaming buffer accumulation (same as before)
+    this.streamingBuffers = new Map();
+    this.streamingTimeouts = new Map();
+    this.trackQueues = new Map();
+    this.interruptedTracks = new Set();
+
+    // Sequence tracking for ordering (same as before)
+    this.lastSequenceNumbers = new Map();
+    this.outOfOrderBuffers = new Map();
+    this.sequenceGapTimeout = new Map();
+
+    // Global volume control (default muted — monitor off)
+    this.globalVolumeMultiplier = 0.0;
+
     // Playback status tracking
     this.currentPlayingItemId = null;
     this.onPlaybackStatusChange = null;
-    
-    // Track cumulative played time for smooth progress across chunks
-    this.cumulativePlayedTime = new Map(); // itemId -> total seconds played
-    this.lastChunkAudioId = new Map(); // itemId -> last audio element ID to detect chunk transitions
-
-    // Track total buffered duration (played + playing + queued) per item
-    this.totalBufferedDuration = new Map(); // itemId -> total seconds of audio received
-
-    // Deferred cleanup timeout for current item (prevents race condition between sentences)
+    this.totalBufferedDuration = new Map(); // itemId -> total seconds buffered
+    this.totalPlayedSamples = 0; // from worklet readPosition reports
+    this.itemStartSample = 0; // sample count when current item started
     this.itemEndTimeout = null;
+
+    // Worklet state
+    this._workletReady = false;
+    this._workletState = 'stopped'; // 'stopped' | 'playing' | 'starving'
   }
 
   /**
-   * Initialize the audio player
+   * Initialize the audio player — creates AudioContext, loads worklet, builds audio graph.
    */
   async connect() {
-    // Make this method idempotent - only create context if it doesn't exist
     if (this.context) {
-      console.debug('[ModernAudioPlayer] AudioContext already initialized');
       if (this.context.state === 'suspended') {
         await this.context.resume();
       }
       return true;
     }
-    
+
     this.context = new AudioContext({ sampleRate: this.sampleRate });
     if (this.context.state === 'suspended') {
       await this.context.resume();
     }
 
-    // Create analyser for frequency analysis
+    // Load worklet
+    const workletUrl = new URL('./worklets/playback-ring-processor.js', import.meta.url).href;
+    await this.context.audioWorklet.addModule(workletUrl);
+    this.workletNode = new AudioWorkletNode(this.context, 'playback-ring-processor');
+    this._workletReady = true;
+
+    // Listen for worklet messages
+    this.workletNode.port.onmessage = (e) => this._handleWorkletMessage(e.data);
+
+    // Build audio graph
+    this.gainNode = this.context.createGain();
+    this.gainNode.gain.setValueAtTime(this.globalVolumeMultiplier, this.context.currentTime);
+
     this.analyser = this.context.createAnalyser();
     this.analyser.fftSize = 8192;
     this.analyser.smoothingTimeConstant = 0.1;
+
+    this.destinationNode = this.context.createMediaStreamDestination();
+
+    // Connect: worklet → gain → analyser → mediaStreamDestination
+    this.workletNode.connect(this.gainNode);
+    this.gainNode.connect(this.analyser);
+    this.analyser.connect(this.destinationNode);
+
+    // Single persistent HTMLAudioElement for AEC-visible output
+    this.audioElement = new Audio();
+    this.audioElement.srcObject = this.destinationNode.stream;
+
+    // Apply output device if previously set
+    if (this.outputDeviceId && typeof this.audioElement.setSinkId === 'function') {
+      try {
+        await this.audioElement.setSinkId(this.outputDeviceId);
+      } catch (e) {
+        console.warn('[ModernAudioPlayer] Failed to set initial output device:', e.message);
+      }
+    }
+
+    await this.audioElement.play().catch((e) => {
+      console.warn('[ModernAudioPlayer] Initial play() blocked (will retry on user gesture):', e.message);
+    });
 
     return true;
   }
 
   /**
-   * Add streaming audio chunks - core method for queue-based playback
+   * Handle messages from the playback ring worklet.
+   */
+  _handleWorkletMessage(msg) {
+    if (msg.type === 'stateChange') {
+      const prevState = this._workletState;
+      this._workletState = msg.state;
+
+      if (msg.state === 'playing' && prevState !== 'playing') {
+        this._cancelEndNotification();
+        if (this.currentPlayingItemId && this.onPlaybackStatusChange) {
+          this.onPlaybackStatusChange({
+            itemId: this.currentPlayingItemId,
+            status: 'playing',
+            trackId: ''
+          });
+        }
+      } else if (msg.state === 'starving' && prevState === 'playing') {
+        if (this.currentPlayingItemId) {
+          this._scheduleEndNotification(this.currentPlayingItemId);
+        }
+      }
+    } else if (msg.type === 'readPosition') {
+      this.totalPlayedSamples = msg.samplesPlayed;
+    }
+  }
+
+  // =========================================================================
+  // Streaming Input
+  // =========================================================================
+
+  /**
+   * Add streaming audio chunks — core method for queue-based playback.
    * @param {ArrayBuffer|Int16Array} audioData - Audio data to add
    * @param {string} trackId - Track identifier
-   * @param {number} volume - Volume level
+   * @param {number} volume - Volume level (0-1) applied to PCM before ring buffer
    * @param {Object} metadata - Optional metadata (e.g., itemId, sequenceNumber)
    */
   addStreamingAudio(audioData, trackId = 'default', volume = 1.0, metadata = {}) {
@@ -94,730 +155,294 @@ export class ModernAudioPlayer {
       return new Int16Array(0);
     }
 
-    const buffer = this.normalizeAudioData(audioData);
-    
-    // Handle sequence ordering if sequence number is provided
+    const buffer = this._normalizeAudioData(audioData);
+
     if (metadata.sequenceNumber !== undefined) {
-      return this.handleSequencedAudio(buffer, trackId, volume, metadata);
+      return this._handleSequencedAudio(buffer, trackId, volume, metadata);
     }
-    
-    this.accumulateChunk(trackId, buffer, volume, metadata);
-    this.checkAndTriggerPlayback(trackId);
-    
+
+    this._accumulateChunk(trackId, buffer, volume, metadata);
+    this._checkAndTriggerPlayback(trackId);
+
     return buffer;
-  }
-  
-  /**
-   * Handle audio with sequence numbers for proper ordering
-   */
-  handleSequencedAudio(buffer, trackId, volume, metadata) {
-    const sequence = metadata.sequenceNumber;
-    const lastSequence = this.lastSequenceNumbers.get(trackId) || 0;
-    
-    console.debug('[AudioSequence] Processing chunk:', {
-      trackId,
-      sequence,
-      lastSequence,
-      isInOrder: sequence === lastSequence + 1,
-      bufferSize: buffer.length
-    });
-    
-    // If this is the next expected sequence, process immediately
-    if (sequence === lastSequence + 1) {
-      this.lastSequenceNumbers.set(trackId, sequence);
-      this.accumulateChunk(trackId, buffer, volume, metadata);
-      this.checkAndTriggerPlayback(trackId);
-      
-      // Check if we can now process any buffered out-of-order chunks
-      this.processBufferedSequences(trackId, volume);
-      
-      return buffer;
-    }
-    
-    // If this is out of order, buffer it
-    if (sequence > lastSequence + 1) {
-      console.warn('[AudioSequence] Out of order chunk detected:', {
-        trackId,
-        sequence,
-        expected: lastSequence + 1,
-        gap: sequence - lastSequence - 1
-      });
-      
-      // Store out-of-order buffer
-      if (!this.outOfOrderBuffers.has(trackId)) {
-        this.outOfOrderBuffers.set(trackId, new Map());
-      }
-      this.outOfOrderBuffers.get(trackId).set(sequence, { buffer, volume, metadata });
-      
-      // Set timeout to process anyway if gap isn't filled
-      this.setSequenceGapTimeout(trackId, volume);
-      
-      return buffer;
-    }
-    
-    // If this is a duplicate or old sequence, skip it
-    console.warn('[AudioSequence] Duplicate or old sequence, skipping:', {
-      trackId,
-      sequence,
-      lastSequence
-    });
-    
-    return buffer;
-  }
-  
-  /**
-   * Process any buffered sequences that are now in order
-   */
-  processBufferedSequences(trackId, volume) {
-    const outOfOrderMap = this.outOfOrderBuffers.get(trackId);
-    if (!outOfOrderMap || outOfOrderMap.size === 0) return;
-    
-    let lastSequence = this.lastSequenceNumbers.get(trackId) || 0;
-    let processed = [];
-    
-    // Process sequences in order
-    while (outOfOrderMap.has(lastSequence + 1)) {
-      const nextSequence = lastSequence + 1;
-      const { buffer, volume: origVolume, metadata } = outOfOrderMap.get(nextSequence);
-      
-      console.debug('[AudioSequence] Processing buffered sequence:', nextSequence);
-      
-      this.accumulateChunk(trackId, buffer, origVolume || volume, metadata);
-      this.checkAndTriggerPlayback(trackId);
-      
-      outOfOrderMap.delete(nextSequence);
-      processed.push(nextSequence);
-      lastSequence = nextSequence;
-    }
-    
-    if (processed.length > 0) {
-      this.lastSequenceNumbers.set(trackId, lastSequence);
-      console.debug('[AudioSequence] Processed buffered sequences:', processed);
-    }
-  }
-  
-  /**
-   * Set timeout to process buffered audio even if gap isn't filled
-   */
-  setSequenceGapTimeout(trackId, volume) {
-    // Clear existing timeout
-    if (this.sequenceGapTimeout.has(trackId)) {
-      clearTimeout(this.sequenceGapTimeout.get(trackId));
-    }
-    
-    // Set new timeout - wait 100ms for missing sequences
-    const timeoutId = setTimeout(() => {
-      console.warn('[AudioSequence] Gap timeout reached, processing buffered audio anyway');
-      this.forceProcessBufferedSequences(trackId, volume);
-    }, 100);
-    
-    this.sequenceGapTimeout.set(trackId, timeoutId);
-  }
-  
-  /**
-   * Force process buffered sequences even with gaps
-   */
-  forceProcessBufferedSequences(trackId, volume) {
-    const outOfOrderMap = this.outOfOrderBuffers.get(trackId);
-    if (!outOfOrderMap || outOfOrderMap.size === 0) return;
-    
-    // Get all sequences and sort them
-    const sequences = Array.from(outOfOrderMap.keys()).sort((a, b) => a - b);
-    
-    console.warn('[AudioSequence] Force processing sequences with gaps:', sequences);
-    
-    for (const sequence of sequences) {
-      const { buffer, volume: origVolume, metadata } = outOfOrderMap.get(sequence);
-      this.accumulateChunk(trackId, buffer, origVolume || volume, metadata);
-      this.checkAndTriggerPlayback(trackId);
-      outOfOrderMap.delete(sequence);
-    }
-    
-    // Update last sequence to highest processed
-    if (sequences.length > 0) {
-      this.lastSequenceNumbers.set(trackId, sequences[sequences.length - 1]);
-    }
   }
 
   /**
-   * Add complete audio for immediate playback (used by manual play buttons)
-   * @param {ArrayBuffer|Int16Array} audioData - Audio data to add
-   * @param {string} trackId - Track identifier
-   * @param {number} volume - Volume level
-   * @param {Object} metadata - Optional metadata (e.g., itemId)
+   * Add complete audio for immediate playback (used by manual play buttons).
    */
   add16BitPCM(audioData, trackId = 'default', volume = 1.0, metadata = {}) {
     if (this.interruptedTracks.has(trackId)) {
       return new Int16Array(0);
     }
 
-    const buffer = this.normalizeAudioData(audioData);
-    this.queueAudio(trackId, buffer, volume, metadata);
-    this.processQueue(trackId);
-    
+    const buffer = this._normalizeAudioData(audioData);
+    this._writeToRingBuffer(buffer, volume, metadata);
     return buffer;
   }
 
   /**
-   * Add audio to passthrough buffer - with optional delay for echo cancellation
+   * Add audio to passthrough buffer — with optional delay for echo cancellation.
    */
   addToPassthroughBuffer(audioData, volume = 1.0, delay = 50) {
-    // Performance: Early return if muted
-    if (this.globalVolumeMultiplier === 0) {
-      return;
-    }
-    
-    const trackId = 'passthrough';
+    if (this.globalVolumeMultiplier === 0) return;
+
     const effectiveVolume = volume * this.globalVolumeMultiplier;
-    
-    // Performance: Skip processing if effective volume is too low
-    if (effectiveVolume < 0.01) {
-      return;
-    }
-    
-    const buffer = this.normalizeAudioData(audioData);
-    
+    if (effectiveVolume < 0.01) return;
+
+    const buffer = this._normalizeAudioData(audioData);
+
     if (delay > 0) {
-      // Delayed playback for echo cancellation safety
       setTimeout(() => {
-        // Check again in case volume was muted during delay
         if (this.globalVolumeMultiplier > 0) {
-          this.queueAudio(trackId, buffer, effectiveVolume);
-          this.processQueue(trackId);
+          this._writeToRingBuffer(buffer, effectiveVolume, {});
         }
       }, delay);
     } else {
-      // Immediate playback
-      this.queueAudio(trackId, buffer, effectiveVolume);
-      this.processQueue(trackId);
+      this._writeToRingBuffer(buffer, effectiveVolume, {});
     }
   }
 
-  /**
-   * Normalize audio data to Int16Array
-   */
-  normalizeAudioData(audioData) {
-    if (audioData instanceof Int16Array) {
-      return audioData;
-    } else if (audioData instanceof ArrayBuffer) {
-      return new Int16Array(audioData);
-    } else {
-      throw new Error('Audio data must be Int16Array or ArrayBuffer');
+  // =========================================================================
+  // Sequence Ordering (unchanged logic, private methods)
+  // =========================================================================
+
+  _handleSequencedAudio(buffer, trackId, volume, metadata) {
+    const sequence = metadata.sequenceNumber;
+    const lastSequence = this.lastSequenceNumbers.get(trackId) || 0;
+
+    if (sequence === lastSequence + 1) {
+      this.lastSequenceNumbers.set(trackId, sequence);
+      this._accumulateChunk(trackId, buffer, volume, metadata);
+      this._checkAndTriggerPlayback(trackId);
+      this._processBufferedSequences(trackId, volume);
+      return buffer;
+    }
+
+    if (sequence > lastSequence + 1) {
+      if (!this.outOfOrderBuffers.has(trackId)) {
+        this.outOfOrderBuffers.set(trackId, new Map());
+      }
+      this.outOfOrderBuffers.get(trackId).set(sequence, { buffer, volume, metadata });
+      this._setSequenceGapTimeout(trackId, volume);
+      return buffer;
+    }
+
+    // Duplicate or old sequence — skip
+    return buffer;
+  }
+
+  _processBufferedSequences(trackId, volume) {
+    const outOfOrderMap = this.outOfOrderBuffers.get(trackId);
+    if (!outOfOrderMap || outOfOrderMap.size === 0) return;
+
+    let lastSequence = this.lastSequenceNumbers.get(trackId) || 0;
+
+    while (outOfOrderMap.has(lastSequence + 1)) {
+      const nextSequence = lastSequence + 1;
+      const { buffer, volume: origVolume, metadata } = outOfOrderMap.get(nextSequence);
+      this._accumulateChunk(trackId, buffer, origVolume || volume, metadata);
+      this._checkAndTriggerPlayback(trackId);
+      outOfOrderMap.delete(nextSequence);
+      lastSequence = nextSequence;
+    }
+
+    this.lastSequenceNumbers.set(trackId, lastSequence);
+  }
+
+  _setSequenceGapTimeout(trackId, volume) {
+    if (this.sequenceGapTimeout.has(trackId)) {
+      clearTimeout(this.sequenceGapTimeout.get(trackId));
+    }
+
+    const timeoutId = setTimeout(() => {
+      this._forceProcessBufferedSequences(trackId, volume);
+    }, 100);
+
+    this.sequenceGapTimeout.set(trackId, timeoutId);
+  }
+
+  _forceProcessBufferedSequences(trackId, volume) {
+    const outOfOrderMap = this.outOfOrderBuffers.get(trackId);
+    if (!outOfOrderMap || outOfOrderMap.size === 0) return;
+
+    const sequences = Array.from(outOfOrderMap.keys()).sort((a, b) => a - b);
+
+    for (const sequence of sequences) {
+      const { buffer, volume: origVolume, metadata } = outOfOrderMap.get(sequence);
+      this._accumulateChunk(trackId, buffer, origVolume || volume, metadata);
+      this._checkAndTriggerPlayback(trackId);
+      outOfOrderMap.delete(sequence);
+    }
+
+    if (sequences.length > 0) {
+      this.lastSequenceNumbers.set(trackId, sequences[sequences.length - 1]);
     }
   }
 
-  /**
-   * Accumulate streaming chunks until buffer is large enough
-   */
-  accumulateChunk(trackId, buffer, volume, metadata = {}) {
+  // =========================================================================
+  // Chunk Accumulation & Ring Buffer Write
+  // =========================================================================
+
+  _accumulateChunk(trackId, buffer, volume, metadata = {}) {
     if (!this.streamingBuffers.has(trackId)) {
       this.streamingBuffers.set(trackId, {
-        buffer: new Int16Array(0),
-        volume: volume,
-        chunks: [], // Performance: Store chunks separately to avoid constant reallocation
-        metadata: metadata // Store metadata for this stream
+        volume,
+        chunks: [],
+        totalLength: 0,
+        metadata
       });
     }
 
     const streamData = this.streamingBuffers.get(trackId);
-    
-    // Performance optimization: Store chunks separately instead of concatenating
-    streamData.chunks = streamData.chunks || [];
     streamData.chunks.push(buffer);
-    
-    // Update metadata if provided
+    streamData.totalLength += buffer.length;
+
     if (metadata.itemId) {
       streamData.metadata = metadata;
     }
-    
-    // Calculate total length for threshold checking
-    const totalLength = streamData.chunks.reduce((sum, chunk) => sum + chunk.length, 0);
-    streamData.totalLength = totalLength;
   }
 
-  /**
-   * Check if accumulated buffer is ready for playback
-   */
-  checkAndTriggerPlayback(trackId) {
+  _checkAndTriggerPlayback(trackId) {
     const streamData = this.streamingBuffers.get(trackId);
     if (!streamData) return;
 
-    const minBufferSize = this.sampleRate * 0.02; // Reduced to 0.02 seconds (20ms) for faster response
-    const totalLength = streamData.totalLength || 0;
-    
-    if (totalLength >= minBufferSize) {
-      this.flushStreamingBuffer(trackId);
+    const minBufferSize = this.sampleRate * 0.02; // 20ms
+
+    if (streamData.totalLength >= minBufferSize) {
+      this._flushStreamingBuffer(trackId);
     } else {
-      this.scheduleFlush(trackId);
+      this._scheduleFlush(trackId);
     }
   }
 
-  /**
-   * Move accumulated buffer to queue and start playback if needed
-   */
-  flushStreamingBuffer(trackId) {
+  _flushStreamingBuffer(trackId) {
     const streamData = this.streamingBuffers.get(trackId);
-    if (!streamData || (!streamData.chunks || streamData.chunks.length === 0)) return;
+    if (!streamData || streamData.chunks.length === 0) return;
 
-    // Performance: Combine chunks efficiently
-    const chunks = streamData.chunks || [];
-    if (chunks.length > 0) {
-      const totalLength = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
-      const combinedBuffer = new Int16Array(totalLength);
-      let offset = 0;
-      
-      for (const chunk of chunks) {
-        combinedBuffer.set(chunk, offset);
-        offset += chunk.length;
-      }
-      
-      // Move to queue with metadata
-      this.queueAudio(trackId, combinedBuffer, streamData.volume, streamData.metadata);
-      
-      // Clear streaming buffer
-      streamData.chunks = [];
-      streamData.totalLength = 0;
-      // Keep metadata for next chunks of the same stream
-      // streamData.metadata is preserved
+    // Combine chunks into single Int16Array
+    const combined = new Int16Array(streamData.totalLength);
+    let offset = 0;
+    for (const chunk of streamData.chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.length;
     }
-    
-    this.clearTimeout(trackId);
-    
-    // Process queue if nothing is playing
-    if (!this.isTrackPlaying(trackId)) {
-      this.processQueue(trackId);
-    }
+
+    // Write to ring buffer
+    this._writeToRingBuffer(combined, streamData.volume, streamData.metadata);
+
+    // Reset accumulator (keep metadata for next chunks of same stream)
+    streamData.chunks = [];
+    streamData.totalLength = 0;
+
+    this._clearStreamingTimeout(trackId);
   }
 
-  /**
-   * Schedule flush for remaining data
-   */
-  scheduleFlush(trackId) {
-    if (this.streamingTimeouts.has(trackId)) return; // Already scheduled
+  _scheduleFlush(trackId) {
+    if (this.streamingTimeouts.has(trackId)) return;
 
     const timeoutId = setTimeout(() => {
-      this.flushStreamingBuffer(trackId);
-    }, 20); // Reduced to 20ms for faster flushing
-    
+      this.streamingTimeouts.delete(trackId);
+      this._flushStreamingBuffer(trackId);
+    }, 20);
+
     this.streamingTimeouts.set(trackId, timeoutId);
   }
 
   /**
-   * Add audio to queue with metadata
+   * Convert Int16 PCM to Float32, apply per-track volume, and post to worklet.
    */
-  queueAudio(trackId, buffer, volume, metadata = {}) {
-    if (!this.trackQueues.has(trackId)) {
-      this.trackQueues.set(trackId, []);
-    }
-    
-    // Performance optimization: Only copy if necessary (when buffer might be reused)
-    // In most cases, the buffer is not reused, so we can avoid the copy
-    const isSharedBuffer = buffer.buffer && buffer.buffer.byteLength > buffer.byteLength;
-    
-    this.trackQueues.get(trackId).push({
-      buffer: isSharedBuffer ? new Int16Array(buffer) : buffer,
-      volume: volume,
-      metadata: metadata // Store metadata with queue item
-    });
-  }
+  _writeToRingBuffer(int16Buffer, volume, metadata) {
+    if (!this._workletReady || !this.workletNode) return;
 
-  /**
-   * Process queue for a track
-   */
-  processQueue(trackId) {
-    const queue = this.trackQueues.get(trackId);
-    if (!queue || queue.length === 0) return;
-
-    const item = queue.shift();
-    this.playAudio(trackId, item.buffer, item.volume, item.metadata);
-    
-    // Schedule next item
-    this.scheduleNextPlayback(trackId);
-  }
-
-  /**
-   * Schedule processing of next queue item using event-driven approach
-   */
-  scheduleNextPlayback(trackId) {
-    // Use event-driven approach instead of polling
-    // The next queue item will be processed when current audio ends
-    // This is handled in the audio.onended callback in playAudio()
-  }
-
-  /**
-   * Create new audio element
-   */
-  createAudioElement() {
-    return new Audio();
-  }
-
-  /**
-   * Cleanup audio element
-   */
-  cleanupAudioElement(audio) {
-    // Disconnect source node if exists
-    const sourceNode = this.audioSourceNodes.get(audio);
-    if (sourceNode) {
-      try {
-        sourceNode.disconnect();
-      } catch (e) {
-        // Ignore disconnect errors
-      }
-      this.audioSourceNodes.delete(audio);
-    }
-    
-    // Clean up gain node
-    const gainNode = this.audioGainNodes.get(audio);
-    if (gainNode) {
-      try {
-        gainNode.disconnect();
-      } catch (e) {
-        // Ignore disconnect errors
-      }
-      this.audioGainNodes.delete(audio);
-    }
-    
-    // Reset audio element state
-    audio.pause();
-    audio.currentTime = 0;
-    audio.src = '';
-    audio.onended = null;
-    audio.onerror = null;
-    audio.onplay = null;
-  }
-
-  /**
-   * Play audio buffer with metadata tracking
-   */
-  playAudio(trackId, buffer, volume = 1.0, metadata = {}) {
-    try {
-      // Update current playing item ID
-      if (metadata.itemId) {
-        // Cancel any deferred cleanup if same item continues
-        if (this.itemEndTimeout) {
-          clearTimeout(this.itemEndTimeout);
-          this.itemEndTimeout = null;
+    // Track item and buffered duration
+    if (metadata && metadata.itemId) {
+      if (this.currentPlayingItemId !== metadata.itemId) {
+        // New item — clean up old state
+        if (this.currentPlayingItemId !== null) {
+          this.totalBufferedDuration.delete(this.currentPlayingItemId);
         }
-
-        if (this.currentPlayingItemId !== metadata.itemId) {
-          // Genuinely new item — clean up old item's state
-          if (this.currentPlayingItemId !== null) {
-            this.cumulativePlayedTime.delete(this.currentPlayingItemId);
-            this.lastChunkAudioId.delete(this.currentPlayingItemId);
-            this.totalBufferedDuration.delete(this.currentPlayingItemId);
-          }
-          // Only initialize if not already tracking (handles null→sameId resume)
-          if (!this.cumulativePlayedTime.has(metadata.itemId)) {
-            this.cumulativePlayedTime.set(metadata.itemId, 0);
-          }
-        }
-
         this.currentPlayingItemId = metadata.itemId;
-        // Notify status change
-        if (this.onPlaybackStatusChange) {
-          this.onPlaybackStatusChange({
-            itemId: metadata.itemId,
-            status: 'playing',
-            trackId: trackId
-          });
-        }
-      }
-      
-      // Accumulate total buffered duration for this item
-      if (metadata.itemId) {
-        const bufferDuration = buffer.length / this.sampleRate;
-        const prev = this.totalBufferedDuration.get(metadata.itemId) || 0;
-        this.totalBufferedDuration.set(metadata.itemId, prev + bufferDuration);
+        this.totalBufferedDuration.set(metadata.itemId, 0);
+        this.itemStartSample = this.totalPlayedSamples;
       }
 
-      // Apply volume if needed
-      const processedBuffer = this.applyVolume(buffer, volume);
-      
-      // Create WAV blob
-      const wavBlob = this.createWavBlob(processedBuffer);
-      const audioUrl = URL.createObjectURL(wavBlob);
-      
-      // Create new audio element
-      const audio = this.createAudioElement();
-      audio.src = audioUrl;
-      // Keep audio element volume at max to ensure data flows to analyser
-      // Volume control will be done via GainNode in Web Audio API
-      audio.volume = volume; // Only apply the track volume, not global multiplier
-      audio.crossOrigin = 'anonymous';
+      const bufferDuration = int16Buffer.length / this.sampleRate;
+      const prev = this.totalBufferedDuration.get(metadata.itemId) || 0;
+      this.totalBufferedDuration.set(metadata.itemId, prev + bufferDuration);
+    }
 
-      const audioId = ++this.currentAudioId;
-      this.audioElements.set(audioId, {
-        element: audio,
-        url: audioUrl,
-        trackId: `${trackId}-stream`,
-        startTime: Date.now(),
-        metadata: metadata // Store metadata with audio element
-      });
+    // Convert Int16 → Float32 with volume
+    const float32 = new Float32Array(int16Buffer.length);
+    const scale = (volume !== 1.0) ? volume / 32768 : 1 / 32768;
+    for (let i = 0; i < int16Buffer.length; i++) {
+      float32[i] = int16Buffer[i] * scale;
+    }
 
-      // Connect to analyser BEFORE playing
-      this.connectToAnalyser(audio);
-      
-      // Note: Output device is set on AudioContext level, not on individual audio elements
+    // Post to worklet — transfer the buffer for zero-copy
+    this.workletNode.port.postMessage(
+      { type: 'write', samples: float32 },
+      [float32.buffer]
+    );
+  }
 
-      // Setup event handlers with queue processing
-      audio.onended = () => {
-        // Track cumulative played time for this chunk
-        if (metadata.itemId) {
-          const currentCumulative = this.cumulativePlayedTime.get(metadata.itemId) || 0;
-          const chunkDuration = audio.duration || 0;
-          this.cumulativePlayedTime.set(metadata.itemId, currentCumulative + chunkDuration);
-        }
-        
-        // Check if this was the last item for this itemId
-        const queue = this.trackQueues.get(trackId);
-        const hasMoreForItem = queue && queue.some(item => 
-          item.metadata && item.metadata.itemId === metadata.itemId
-        );
-        
-        if (!hasMoreForItem && metadata.itemId === this.currentPlayingItemId) {
-          // Defer cleanup — TTS may still be generating the next sentence
-          if (this.itemEndTimeout) clearTimeout(this.itemEndTimeout);
-          this.itemEndTimeout = setTimeout(() => {
-            // Only clean up if still the same item and still no audio playing
-            if (this.currentPlayingItemId === metadata.itemId && !this.isTrackPlaying(trackId)) {
-              this.cumulativePlayedTime.delete(metadata.itemId);
-              this.lastChunkAudioId.delete(metadata.itemId);
-              this.totalBufferedDuration.delete(metadata.itemId);
+  _normalizeAudioData(audioData) {
+    if (audioData instanceof Int16Array) return audioData;
+    if (audioData instanceof ArrayBuffer) return new Int16Array(audioData);
+    throw new Error('Audio data must be Int16Array or ArrayBuffer');
+  }
 
-              if (this.onPlaybackStatusChange) {
-                this.onPlaybackStatusChange({
-                  itemId: metadata.itemId,
-                  status: 'ended',
-                  trackId: trackId
-                });
-              }
-              this.currentPlayingItemId = null;
-            }
-            this.itemEndTimeout = null;
-          }, 2000);
-        }
-        
-        this.cleanupAudio(audioId);
-        // Process next item in queue when current audio ends
-        setTimeout(() => this.processQueue(trackId), 0);
-      };
-      audio.onerror = () => {
-        this.cleanupAudio(audioId);
-        // Process next item even on error to prevent queue stalling
-        setTimeout(() => this.processQueue(trackId), 0);
-      };
-
-      audio.play().catch(error => {
-        console.error('[ModernAudioPlayer] Playback failed:', error);
-        this.cleanupAudio(audioId);
-        // Process next item even on play error to prevent queue stalling
-        setTimeout(() => this.processQueue(trackId), 0);
-      });
-
-    } catch (error) {
-      console.error('[ModernAudioPlayer] Error playing audio:', error);
-      // Process next item even on error to prevent queue stalling
-      setTimeout(() => this.processQueue(trackId), 0);
+  _clearStreamingTimeout(trackId) {
+    if (this.streamingTimeouts.has(trackId)) {
+      clearTimeout(this.streamingTimeouts.get(trackId));
+      this.streamingTimeouts.delete(trackId);
     }
   }
 
-  /**
-   * Apply volume to buffer
-   */
-  applyVolume(buffer, volume) {
-    if (volume === 1.0) return buffer;
-    
-    const result = new Int16Array(buffer.length);
-    for (let i = 0; i < buffer.length; i++) {
-      result[i] = Math.round(buffer[i] * volume);
-    }
-    return result;
-  }
+  // =========================================================================
+  // Volume Control
+  // =========================================================================
 
   /**
-   * Connect audio to analyser for visualization
-   */
-  connectToAnalyser(audio) {
-    if (!this.context || !this.analyser) return;
-    
-    
-    try {
-      // Create MediaElementSource (can only be done once per audio element)
-      const source = this.context.createMediaElementSource(audio);
-      
-      // Create a gain node for volume control
-      const gainNode = this.context.createGain();
-      gainNode.gain.value = this.globalVolumeMultiplier;
-      
-      // Connect: source -> analyser (for visualization)
-      //          source -> gainNode -> destination (for playback with volume control)
-      source.connect(this.analyser);
-      source.connect(gainNode);
-      gainNode.connect(this.context.destination);
-      
-      // Store the nodes for this audio element
-      this.audioGainNodes.set(audio, gainNode);
-      this.audioSourceNodes.set(audio, source);
-      
-    } catch (error) {
-      // This might happen if the audio element was already connected elsewhere
-      console.warn('[ModernAudioPlayer] Could not connect audio to analyser:', error.message);
-    }
-  }
-
-  /**
-   * Check if track is currently playing
-   */
-  isTrackPlaying(trackId) {
-    for (const [, audioInfo] of this.audioElements) {
-      if (audioInfo.trackId.startsWith(`${trackId}-stream`)) {
-        const audio = audioInfo.element;
-        if (!audio.paused && !audio.ended) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Create WAV blob from PCM data
-   */
-  createWavBlob(pcmData) {
-    const arrayBuffer = pcmData.buffer.slice(pcmData.byteOffset, pcmData.byteOffset + pcmData.byteLength);
-    const wavHeader = this.createWavHeader(arrayBuffer.byteLength);
-    const wavArray = new Uint8Array(44 + arrayBuffer.byteLength);
-    
-    wavArray.set(wavHeader, 0);
-    wavArray.set(new Uint8Array(arrayBuffer), 44);
-    
-    return new Blob([wavArray], { type: 'audio/wav' });
-  }
-
-  /**
-   * Create WAV file header
-   */
-  createWavHeader(dataSize) {
-    const header = new ArrayBuffer(44);
-    const view = new DataView(header);
-    
-    const numChannels = 1;
-    const bitsPerSample = 16;
-    const byteRate = this.sampleRate * numChannels * bitsPerSample / 8;
-    const blockAlign = numChannels * bitsPerSample / 8;
-    
-    // RIFF header
-    view.setUint32(0, 0x52494646, false); // "RIFF"
-    view.setUint32(4, dataSize + 36, true); // file size - 8
-    view.setUint32(8, 0x57415645, false); // "WAVE"
-    
-    // fmt chunk
-    view.setUint32(12, 0x666d7420, false); // "fmt "
-    view.setUint32(16, 16, true); // chunk size
-    view.setUint16(20, 1, true); // PCM format
-    view.setUint16(22, numChannels, true);
-    view.setUint32(24, this.sampleRate, true);
-    view.setUint32(28, byteRate, true);
-    view.setUint16(32, blockAlign, true);
-    view.setUint16(34, bitsPerSample, true);
-    
-    // data chunk
-    view.setUint32(36, 0x64617461, false); // "data"
-    view.setUint32(40, dataSize, true);
-    
-    return new Uint8Array(header);
-  }
-
-  /**
-   * Get frequency data for visualization
-   */
-  getFrequencies() {
-    if (!this.context || !this.analyser) {
-      return {
-        values: new Float32Array(1024),
-        peaks: []
-      };
-    }
-
-    const bufferLength = this.analyser.frequencyBinCount;
-    const dataArray = new Uint8Array(bufferLength);
-    this.analyser.getByteFrequencyData(dataArray);
-    
-    
-    const result = new Float32Array(bufferLength);
-    for (let i = 0; i < bufferLength; i++) {
-      result[i] = dataArray[i] / 255.0;
-    }
-    
-    return {
-      values: result,
-      peaks: []
-    };
-  }
-
-  /**
-   * Set global volume multiplier (for monitor on/off)
+   * Set global volume multiplier (for monitor on/off).
    * @param {number} volume - Volume from 0 to 1
    */
   setGlobalVolume(volume) {
     this.globalVolumeMultiplier = Math.max(0, Math.min(1, volume));
-    
-    // Apply to all gain nodes of currently playing audio elements
-    for (const [, audioInfo] of this.audioElements) {
-      const gainNode = this.audioGainNodes.get(audioInfo.element);
-      if (gainNode) {
-        // Use setValueAtTime for immediate change without clicks
-        gainNode.gain.setValueAtTime(this.globalVolumeMultiplier, this.context.currentTime);
-      }
+
+    if (this.gainNode && this.context) {
+      this.gainNode.gain.setValueAtTime(this.globalVolumeMultiplier, this.context.currentTime);
     }
-    
-    console.debug(`[ModernAudioPlayer] Global volume set to: ${this.globalVolumeMultiplier}`);
   }
 
+  // =========================================================================
+  // Output Device Switching
+  // =========================================================================
+
   /**
-   * Set audio output device
+   * Set audio output device.
    */
   async setSinkId(deviceId) {
-    console.debug('[ModernAudioPlayer] setSinkId called with:', deviceId, 'current state:', {
-      hasContext: !!this.context,
-      isSettingDevice: this.isSettingDevice,
-      currentDeviceId: this.outputDeviceId
-    });
-    
-    // Check if device is already set
-    if (this.outputDeviceId === deviceId) {
-      console.debug('[ModernAudioPlayer] Device already set to:', deviceId);
-      return true;
-    }
-    
-    // If there's an ongoing device change, wait for it if it's the same device
+    if (this.outputDeviceId === deviceId) return true;
+
     if (this.deviceChangePromise && this.pendingDeviceId === deviceId) {
-      console.debug('[ModernAudioPlayer] Waiting for ongoing device change to same device');
       return this.deviceChangePromise;
     }
-    
-    // Create a new promise for this device change
+
     this.pendingDeviceId = deviceId;
     this.deviceChangePromise = this._performDeviceChange(deviceId);
-    
+
     try {
       return await this.deviceChangePromise;
     } finally {
-      // Clear the promise when done
       if (this.pendingDeviceId === deviceId) {
         this.deviceChangePromise = null;
         this.pendingDeviceId = null;
       }
     }
   }
-  
-  /**
-   * Internal method to perform the actual device change
-   */
+
   async _performDeviceChange(deviceId) {
-    // Ensure audio context is initialized
     if (!this.context) {
-      console.warn('[ModernAudioPlayer] AudioContext not initialized, initializing now...');
       try {
         await this.connect();
       } catch (error) {
@@ -825,16 +450,19 @@ export class ModernAudioPlayer {
         return false;
       }
     }
-    
+
     try {
-      // Set output device on AudioContext instead of individual audio elements
-      if (this.context && this.context.setSinkId) {
-        await this.context.setSinkId(deviceId);
-        console.info('[ModernAudioPlayer] Successfully set AudioContext output device to:', deviceId);
-      } else {
-        console.warn('[ModernAudioPlayer] AudioContext.setSinkId not supported in this browser');
+      // Set on HTMLAudioElement (preferred — routes through OS audio path for AEC)
+      if (this.audioElement && typeof this.audioElement.setSinkId === 'function') {
+        await this.audioElement.setSinkId(deviceId);
       }
-      
+      // Also set on AudioContext if supported (for future-proofing)
+      if (this.context && typeof this.context.setSinkId === 'function') {
+        await this.context.setSinkId(deviceId).catch(() => {
+          // AudioContext.setSinkId may not be available everywhere
+        });
+      }
+
       this.outputDeviceId = deviceId;
       return true;
     } catch (error) {
@@ -843,56 +471,138 @@ export class ModernAudioPlayer {
     }
   }
 
+  // =========================================================================
+  // Visualization
+  // =========================================================================
+
   /**
-   * Interrupt audio playback
+   * Get frequency data for visualization.
    */
-  async interrupt() {
-    let latestTrack = null;
-    let latestTime = 0;
-
-    for (const [, audioInfo] of this.audioElements) {
-      if (audioInfo.startTime > latestTime) {
-        latestTime = audioInfo.startTime;
-        latestTrack = audioInfo;
-      }
+  getFrequencies() {
+    if (!this.context || !this.analyser) {
+      return { values: new Float32Array(1024), peaks: [] };
     }
 
-    if (!latestTrack) {
-      return { trackId: null, offset: 0, currentTime: 0 };
+    const bufferLength = this.analyser.frequencyBinCount;
+    const dataArray = new Uint8Array(bufferLength);
+    this.analyser.getByteFrequencyData(dataArray);
+
+    const result = new Float32Array(bufferLength);
+    for (let i = 0; i < bufferLength; i++) {
+      result[i] = dataArray[i] / 255.0;
     }
 
-    const audio = latestTrack.element;
-    const estimatedOffset = Math.floor(audio.currentTime * this.sampleRate);
-    
-    // Extract original trackId (remove -stream suffix)
-    const originalTrackId = latestTrack.trackId.replace('-stream', '');
-    this.interruptedTracks.add(originalTrackId);
-    
-    audio.pause();
+    return { values: result, peaks: [] };
+  }
+
+  // =========================================================================
+  // Playback Status Tracking
+  // =========================================================================
+
+  /**
+   * Set playback status callback.
+   */
+  setPlaybackStatusCallback(callback) {
+    this.onPlaybackStatusChange = callback;
+  }
+
+  /**
+   * Get current playback status.
+   */
+  getCurrentPlaybackStatus() {
+    if (!this.currentPlayingItemId) return null;
+
+    const totalBufferedTime = this.getBufferedDuration(this.currentPlayingItemId);
+
+    // Calculate played time from worklet's sample counter
+    const samplesPlayedForItem = this.totalPlayedSamples - this.itemStartSample;
+    const currentTime = Math.max(0, samplesPlayedForItem / this.sampleRate);
 
     return {
-      trackId: originalTrackId,
-      offset: estimatedOffset,
-      currentTime: audio.currentTime
+      itemId: this.currentPlayingItemId,
+      trackId: '',
+      currentTime: Math.min(currentTime, totalBufferedTime),
+      duration: totalBufferedTime,
+      isPlaying: this._workletState === 'playing',
+      bufferedTime: totalBufferedTime
     };
   }
 
   /**
-   * Clear streaming data for a track
+   * Get buffered duration for an item.
+   */
+  getBufferedDuration(itemId) {
+    return this.totalBufferedDuration.get(itemId) || 0;
+  }
+
+  /**
+   * Schedule an 'ended' notification after buffer goes empty.
+   * Defers by 2s in case more audio is still being generated by the AI.
+   */
+  _scheduleEndNotification(itemId) {
+    this._cancelEndNotification();
+
+    this.itemEndTimeout = setTimeout(() => {
+      if (this.currentPlayingItemId === itemId && this._workletState !== 'playing') {
+        this.totalBufferedDuration.delete(itemId);
+
+        if (this.onPlaybackStatusChange) {
+          this.onPlaybackStatusChange({
+            itemId,
+            status: 'ended',
+            trackId: ''
+          });
+        }
+        this.currentPlayingItemId = null;
+      }
+      this.itemEndTimeout = null;
+    }, 2000);
+  }
+
+  _cancelEndNotification() {
+    if (this.itemEndTimeout) {
+      clearTimeout(this.itemEndTimeout);
+      this.itemEndTimeout = null;
+    }
+  }
+
+  // =========================================================================
+  // Interruption & Track Management
+  // =========================================================================
+
+  /**
+   * Interrupt audio playback — returns estimated position.
+   */
+  async interrupt() {
+    if (!this.currentPlayingItemId) {
+      return { trackId: null, offset: 0, currentTime: 0 };
+    }
+
+    const samplesPlayedForItem = this.totalPlayedSamples - this.itemStartSample;
+    const currentTime = samplesPlayedForItem / this.sampleRate;
+    const estimatedOffset = Math.floor(samplesPlayedForItem);
+
+    // Clear the ring buffer immediately
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({ type: 'clear' });
+    }
+
+    // Mark all active tracks as interrupted
+    const trackId = 'default';
+    this.interruptedTracks.add(trackId);
+
+    return { trackId, offset: estimatedOffset, currentTime };
+  }
+
+  /**
+   * Clear streaming data for a track.
    */
   clearStreamingTrack(trackId) {
-    // Clear streaming buffer
     this.streamingBuffers.delete(trackId);
-    
-    // Clear timeout
-    this.clearTimeout(trackId);
-    
-    // Clear queue
+    this._clearStreamingTimeout(trackId);
     this.trackQueues.delete(trackId);
-    
-    // Remove from interrupted tracks
     this.interruptedTracks.delete(trackId);
-    
+
     // Clear sequence tracking
     this.lastSequenceNumbers.delete(trackId);
     this.outOfOrderBuffers.delete(trackId);
@@ -900,184 +610,156 @@ export class ModernAudioPlayer {
       clearTimeout(this.sequenceGapTimeout.get(trackId));
       this.sequenceGapTimeout.delete(trackId);
     }
-  }
-  
-  /**
-   * Set playback status callback
-   */
-  setPlaybackStatusCallback(callback) {
-    this.onPlaybackStatusChange = callback;
-  }
-  
-  /**
-   * Get current playback status
-   */
-  getCurrentPlaybackStatus() {
-    if (!this.currentPlayingItemId) return null;
-    
-    // Find the currently playing audio element
-    let currentAudio = null;
-    let currentAudioInfo = null;
-    let currentAudioId = null;
-    
-    for (const [audioId, audioInfo] of this.audioElements) {
-      if (audioInfo.metadata && audioInfo.metadata.itemId === this.currentPlayingItemId) {
-        const audio = audioInfo.element;
-        if (!audio.paused && !audio.ended) {
-          currentAudio = audio;
-          currentAudioInfo = audioInfo;
-          currentAudioId = audioId;
-          break;
-        }
-      }
+
+    // Clear ring buffer
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({ type: 'clear' });
     }
-    
-    if (!currentAudio) {
-      // Check if we're in a transition between chunks
-      const cumulativeTime = this.cumulativePlayedTime.get(this.currentPlayingItemId);
-      if (cumulativeTime !== undefined) {
-        // Between chunks — report cumulative time as current position
-        const totalBuffered = this.getBufferedDuration(this.currentPlayingItemId);
-        console.debug(`[Karaoke] Chunk transition: itemId=${this.currentPlayingItemId}, cumulativeTime=${cumulativeTime.toFixed(3)}`);
-        return {
-          itemId: this.currentPlayingItemId,
-          trackId: '',
-          currentTime: cumulativeTime,
-          duration: totalBuffered,
-          isPlaying: true,  // still conceptually playing (next chunk pending)
-          bufferedTime: totalBuffered
-        };
-      }
-      return null;
-    }
-    
-    // Get cumulative played time for smooth progress
-    const cumulativeTime = this.cumulativePlayedTime.get(this.currentPlayingItemId) || 0;
-    
-    // Check if we've moved to a new chunk
-    const lastAudioId = this.lastChunkAudioId.get(this.currentPlayingItemId);
-    this.lastChunkAudioId.set(this.currentPlayingItemId, currentAudioId);
-    
-    // Calculate total progress: cumulative time + current chunk progress
-    const totalBufferedTime = this.getBufferedDuration(this.currentPlayingItemId);
-    const totalCurrentTime = cumulativeTime + currentAudio.currentTime;
-    
-    // For display, use the total buffered time as duration
-    const effectiveDuration = totalBufferedTime > 0 ? totalBufferedTime : currentAudio.duration;
-    
-    const status = {
-      itemId: this.currentPlayingItemId,
-      trackId: currentAudioInfo.trackId.replace('-stream', ''),
-      currentTime: totalCurrentTime,
-      duration: effectiveDuration,
-      isPlaying: !currentAudio.paused && !currentAudio.ended,
-      bufferedTime: totalBufferedTime
-    };
-    
-    return status;
   }
-  
+
   /**
-   * Get buffered duration for an item
-   */
-  getBufferedDuration(itemId) {
-    return this.totalBufferedDuration.get(itemId) || 0;
-  }
-  
-  /**
-   * Clear all interrupted tracks
+   * Clear all interrupted tracks.
    */
   clearInterruptedTracks() {
     this.interruptedTracks.clear();
-    console.debug('[ModernAudioPlayer] Cleared all interrupted tracks');
   }
 
   /**
-   * Clear timeout for a track
+   * Check if track is currently playing.
    */
-  clearTimeout(trackId) {
-    if (this.streamingTimeouts.has(trackId)) {
-      clearTimeout(this.streamingTimeouts.get(trackId));
-      this.streamingTimeouts.delete(trackId);
-    }
+  isTrackPlaying(_trackId) {
+    return this._workletState === 'playing';
   }
 
-  /**
-
-   * Cleanup audio element and resources
-   */
-  cleanupAudio(audioId) {
-    const audioInfo = this.audioElements.get(audioId);
-    if (audioInfo) {
-      URL.revokeObjectURL(audioInfo.url);
-      this.cleanupAudioElement(audioInfo.element);
-      this.audioElements.delete(audioId);
-    }
-  }
+  // =========================================================================
+  // Stop & Cleanup
+  // =========================================================================
 
   /**
-   * Stop all audio playback
+   * Stop all audio playback.
    */
   stopAll() {
-    if (this.itemEndTimeout) {
-      clearTimeout(this.itemEndTimeout);
-      this.itemEndTimeout = null;
+    this._cancelEndNotification();
+
+    // Clear ring buffer
+    if (this.workletNode) {
+      this.workletNode.port.postMessage({ type: 'clear' });
     }
-    for (const [audioId, audioInfo] of this.audioElements) {
-      audioInfo.element.pause();
-      this.cleanupAudio(audioId);
+
+    // Clear all accumulation and queue state
+    for (const timeoutId of this.streamingTimeouts.values()) {
+      clearTimeout(timeoutId);
     }
-    this.audioElements.clear();
-    this.cumulativePlayedTime.clear();
-    this.lastChunkAudioId.clear();
+    this.streamingTimeouts.clear();
+    this.streamingBuffers.clear();
+    this.trackQueues.clear();
+
+    // Clear tracking
     this.totalBufferedDuration.clear();
     this.currentPlayingItemId = null;
+    this.totalPlayedSamples = 0;
+    this.itemStartSample = 0;
   }
 
   /**
-   * Get diagnostic information for audio sequencing
+   * Cleanup all resources.
+   */
+  cleanup() {
+    this._cancelEndNotification();
+    this.stopAll();
+
+    // Clear sequence gap timeouts
+    for (const timeoutId of this.sequenceGapTimeout.values()) {
+      clearTimeout(timeoutId);
+    }
+    this.sequenceGapTimeout.clear();
+
+    // Clear all data
+    this.interruptedTracks.clear();
+    this.lastSequenceNumbers.clear();
+    this.outOfOrderBuffers.clear();
+
+    // Disconnect audio graph
+    if (this.workletNode) {
+      try { this.workletNode.disconnect(); } catch (e) { /* ignore */ }
+      this.workletNode = null;
+    }
+    if (this.gainNode) {
+      try { this.gainNode.disconnect(); } catch (e) { /* ignore */ }
+      this.gainNode = null;
+    }
+    if (this.analyser) {
+      try { this.analyser.disconnect(); } catch (e) { /* ignore */ }
+      this.analyser = null;
+    }
+    if (this.destinationNode) {
+      try { this.destinationNode.disconnect(); } catch (e) { /* ignore */ }
+      this.destinationNode = null;
+    }
+
+    // Stop and release HTMLAudioElement
+    if (this.audioElement) {
+      this.audioElement.pause();
+      this.audioElement.srcObject = null;
+      this.audioElement = null;
+    }
+
+    // Close AudioContext
+    if (this.context && this.context.state !== 'closed') {
+      this.context.close().catch(console.error);
+      this.context = null;
+    }
+
+    this._workletReady = false;
+    this._workletState = 'stopped';
+  }
+
+  // =========================================================================
+  // Diagnostics
+  // =========================================================================
+
+  /**
+   * Get diagnostic information for audio sequencing.
    */
   getSequenceDiagnostics() {
     const diagnostics = {
       tracks: {},
       outOfOrderCount: 0,
       totalBuffered: 0,
-      gaps: []
+      gaps: [],
+      workletState: this._workletState,
+      totalPlayedSamples: this.totalPlayedSamples
     };
-    
+
     for (const [trackId, lastSeq] of this.lastSequenceNumbers) {
       const outOfOrder = this.outOfOrderBuffers.get(trackId);
-      const outOfOrderSeqs = outOfOrder ? Array.from(outOfOrder.keys()).sort((a, b) => a - b) : [];
-      
+      const outOfOrderSeqs = outOfOrder
+        ? Array.from(outOfOrder.keys()).sort((a, b) => a - b)
+        : [];
+
       diagnostics.tracks[trackId] = {
         lastSequence: lastSeq,
         outOfOrderSequences: outOfOrderSeqs,
-        gaps: this.findSequenceGaps(lastSeq, outOfOrderSeqs),
+        gaps: this._findSequenceGaps(lastSeq, outOfOrderSeqs),
         queueLength: this.trackQueues.get(trackId)?.length || 0
       };
-      
+
       diagnostics.outOfOrderCount += outOfOrderSeqs.length;
-      
+
       if (diagnostics.tracks[trackId].gaps.length > 0) {
-        diagnostics.gaps.push(...diagnostics.tracks[trackId].gaps.map(g => ({
-          trackId,
-          ...g
-        })));
+        diagnostics.gaps.push(
+          ...diagnostics.tracks[trackId].gaps.map((g) => ({ trackId, ...g }))
+        );
       }
     }
-    
+
     return diagnostics;
   }
-  
-  /**
-   * Find gaps in sequence numbers
-   */
-  findSequenceGaps(lastSeq, outOfOrderSeqs) {
+
+  _findSequenceGaps(lastSeq, outOfOrderSeqs) {
     const gaps = [];
-    
     if (outOfOrderSeqs.length === 0) return gaps;
-    
-    // Check gap between last processed and first buffered
+
     if (outOfOrderSeqs[0] > lastSeq + 1) {
       gaps.push({
         from: lastSeq + 1,
@@ -1085,8 +767,7 @@ export class ModernAudioPlayer {
         size: outOfOrderSeqs[0] - lastSeq - 1
       });
     }
-    
-    // Check gaps between buffered sequences
+
     for (let i = 1; i < outOfOrderSeqs.length; i++) {
       if (outOfOrderSeqs[i] > outOfOrderSeqs[i - 1] + 1) {
         gaps.push({
@@ -1096,46 +777,8 @@ export class ModernAudioPlayer {
         });
       }
     }
-    
-    return gaps;
-  }
-  
-  /**
-   * Cleanup resources
-   */
-  cleanup() {
-    if (this.itemEndTimeout) {
-      clearTimeout(this.itemEndTimeout);
-      this.itemEndTimeout = null;
-    }
-    this.stopAll();
 
-    // Clear all timeouts
-    for (const timeoutId of this.streamingTimeouts.values()) {
-      clearTimeout(timeoutId);
-    }
-    this.streamingTimeouts.clear();
-    
-    // Clear sequence gap timeouts
-    for (const timeoutId of this.sequenceGapTimeout.values()) {
-      clearTimeout(timeoutId);
-    }
-    this.sequenceGapTimeout.clear();
-    
-    // Clear all data
-    this.streamingBuffers.clear();
-    this.trackQueues.clear();
-    this.interruptedTracks.clear();
-    this.lastSequenceNumbers.clear();
-    this.outOfOrderBuffers.clear();
-    this.cumulativePlayedTime.clear();
-    this.lastChunkAudioId.clear();
-    this.totalBufferedDuration.clear();
-    this.currentPlayingItemId = null;
-    
-    if (this.context && this.context.state !== 'closed') {
-      this.context.close().catch(console.error);
-    }
+    return gaps;
   }
 }
 

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -59,7 +59,7 @@ export class ModernAudioPlayer {
     this._sab = null;
     this._indices = null;  // Int32Array view [writeIndex, readIndex, capacity, flags]
     this._data = null;     // Float32Array view (audio samples)
-    this._ringCapacity = Math.floor(sampleRate * 2); // 2 seconds
+    this._ringCapacity = Math.floor(sampleRate * 120); // 120 seconds (~11.5MB)
 
     // Main-thread overflow queue — holds data that doesn't fit in ring buffer
     this._pendingWrites = []; // Array of Float32Array chunks

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -83,6 +83,10 @@ export class ModernAudioPlayer {
     }
 
     // Create SharedArrayBuffer: 16 bytes header (4x Int32) + capacity * 4 bytes (Float32)
+    // Requires cross-origin isolation (COOP/COEP headers)
+    if (typeof SharedArrayBuffer === 'undefined') {
+      throw new Error('[ModernAudioPlayer] SharedArrayBuffer not available — cross-origin isolation (COOP/COEP) required');
+    }
     const sabSize = 16 + this._ringCapacity * 4;
     this._sab = new SharedArrayBuffer(sabSize);
     this._indices = new Int32Array(this._sab, 0, 4);
@@ -339,20 +343,19 @@ export class ModernAudioPlayer {
    */
   addToPassthroughBuffer(audioData, volume = 1.0, delay = 50) {
     if (this.globalVolumeMultiplier === 0) return;
-
-    const effectiveVolume = volume * this.globalVolumeMultiplier;
-    if (effectiveVolume < 0.01) return;
+    // Only check per-track volume — GainNode handles globalVolumeMultiplier
+    if (volume < 0.01) return;
 
     const buffer = this._normalizeAudioData(audioData);
 
     if (delay > 0) {
       setTimeout(() => {
         if (this.globalVolumeMultiplier > 0) {
-          this._writeToRingBuffer(buffer, effectiveVolume, {});
+          this._writeToRingBuffer(buffer, volume, {});
         }
       }, delay);
     } else {
-      this._writeToRingBuffer(buffer, effectiveVolume, {});
+      this._writeToRingBuffer(buffer, volume, {});
     }
   }
 
@@ -729,13 +732,14 @@ export class ModernAudioPlayer {
     this._pendingWrites = [];
     this._cancelDrain();
 
-    // Reset SAB indices
+    // SPSC-safe clear: producer (main thread) only modifies writeIndex.
+    // Set writeIdx = readIdx to mark buffer as empty without touching readIndex.
     if (this._indices) {
-      Atomics.store(this._indices, 0, 0);
-      Atomics.store(this._indices, 1, 0);
+      const readIdx = Atomics.load(this._indices, 1);
+      Atomics.store(this._indices, 0, readIdx);
     }
 
-    // Also tell worklet to reset its internal state (samplesPlayed etc.)
+    // Tell worklet to reset its internal state (samplesPlayed etc.)
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -1,11 +1,15 @@
 /**
- * Modern Audio Player using AudioWorklet ring buffer for gapless playback.
+ * Modern Audio Player using SharedArrayBuffer ring buffer for gapless playback.
  * Output routes through a single persistent HTMLAudioElement for AEC compatibility.
  *
  * Architecture:
- *   PCM chunks → postMessage → AudioWorkletNode (ring buffer)
+ *   PCM chunks → SharedArrayBuffer (lock-free SPSC ring buffer) → AudioWorkletNode
  *     → GainNode → AnalyserNode → MediaStreamDestinationNode
  *       → HTMLAudioElement.srcObject → Speakers (AEC-visible)
+ *
+ * The main thread writes directly to shared memory. The worklet reads directly.
+ * No postMessage for audio data — only for low-frequency control signals.
+ * Overflow is handled by a main-thread queue that drains as the worklet consumes.
  */
 export class ModernAudioPlayer {
   constructor({ sampleRate = 24000 } = {}) {
@@ -25,13 +29,13 @@ export class ModernAudioPlayer {
     this.pendingDeviceId = null;
     this.deviceChangePromise = null;
 
-    // Streaming buffer accumulation (same as before)
+    // Streaming buffer accumulation
     this.streamingBuffers = new Map();
     this.streamingTimeouts = new Map();
     this.trackQueues = new Map();
     this.interruptedTracks = new Set();
 
-    // Sequence tracking for ordering (same as before)
+    // Sequence tracking for ordering
     this.lastSequenceNumbers = new Map();
     this.outOfOrderBuffers = new Map();
     this.sequenceGapTimeout = new Map();
@@ -51,13 +55,15 @@ export class ModernAudioPlayer {
     this._workletReady = false;
     this._workletState = 'stopped'; // 'stopped' | 'playing' | 'starving'
 
-    // Send queue for drip-feeding large audio into the ring buffer.
-    // The worklet ring buffer is 2s; writes larger than ~1s are chunked
-    // and fed gradually so nothing is dropped.
-    this._sendQueue = []; // Array of Float32Array chunks
+    // SharedArrayBuffer ring buffer
+    this._sab = null;
+    this._indices = null;  // Int32Array view [writeIndex, readIndex, capacity, flags]
+    this._data = null;     // Float32Array view (audio samples)
+    this._ringCapacity = Math.floor(sampleRate * 2); // 2 seconds
+
+    // Main-thread overflow queue — holds data that doesn't fit in ring buffer
+    this._pendingWrites = []; // Array of Float32Array chunks
     this._drainTimer = null;
-    this._totalSentSamples = 0; // samples posted to worklet
-    this._ringBufferCapacity = this.sampleRate * 2; // must match worklet
   }
 
   /**
@@ -76,13 +82,28 @@ export class ModernAudioPlayer {
       await this.context.resume();
     }
 
+    // Create SharedArrayBuffer: 16 bytes header (4x Int32) + capacity * 4 bytes (Float32)
+    const sabSize = 16 + this._ringCapacity * 4;
+    this._sab = new SharedArrayBuffer(sabSize);
+    this._indices = new Int32Array(this._sab, 0, 4);
+    this._data = new Float32Array(this._sab, 16);
+
+    // Initialize header
+    Atomics.store(this._indices, 0, 0); // writeIndex
+    Atomics.store(this._indices, 1, 0); // readIndex
+    Atomics.store(this._indices, 2, this._ringCapacity); // capacity
+    Atomics.store(this._indices, 3, 0); // flags
+
     // Load worklet
     const workletUrl = new URL('./worklets/playback-ring-processor.js', import.meta.url).href;
     await this.context.audioWorklet.addModule(workletUrl);
     this.workletNode = new AudioWorkletNode(this.context, 'playback-ring-processor');
     this._workletReady = true;
 
-    // Listen for worklet messages
+    // Send SharedArrayBuffer to worklet
+    this.workletNode.port.postMessage({ type: 'init', sab: this._sab });
+
+    // Listen for worklet messages (state changes + position reports only)
     this.workletNode.port.onmessage = (e) => this._handleWorkletMessage(e.data);
 
     // Build audio graph
@@ -144,6 +165,137 @@ export class ModernAudioPlayer {
       }
     } else if (msg.type === 'readPosition') {
       this.totalPlayedSamples = msg.samplesPlayed;
+      // Worklet consumed data — try to drain pending writes
+      if (this._pendingWrites.length > 0) {
+        this._drainPendingWrites();
+      }
+    }
+  }
+
+  // =========================================================================
+  // SharedArrayBuffer Ring Buffer Write
+  // =========================================================================
+
+  /**
+   * Get free space in the ring buffer by reading indices atomically.
+   */
+  _getFreeSpace() {
+    const writeIdx = Atomics.load(this._indices, 0);
+    const readIdx = Atomics.load(this._indices, 1);
+    const used = writeIdx - readIdx;
+    return this._ringCapacity - used;
+  }
+
+  /**
+   * Write Float32 samples directly into the SharedArrayBuffer ring buffer.
+   * Returns the number of samples actually written.
+   */
+  _writeToSAB(float32, offset, count) {
+    const writeIdx = Atomics.load(this._indices, 0);
+    const cap = this._ringCapacity;
+
+    for (let i = 0; i < count; i++) {
+      this._data[(writeIdx + i) % cap] = float32[offset + i];
+    }
+
+    // Update writeIndex — worklet will see the new data on next process() call
+    Atomics.store(this._indices, 0, writeIdx + count);
+    return count;
+  }
+
+  /**
+   * Write audio to the ring buffer. If it doesn't all fit, queue the overflow.
+   */
+  _writeToRingBuffer(int16Buffer, volume, metadata) {
+    if (!this._workletReady || !this._indices) return;
+
+    // Track item and buffered duration
+    if (metadata && metadata.itemId) {
+      if (this.currentPlayingItemId !== metadata.itemId) {
+        if (this.currentPlayingItemId !== null) {
+          this.totalBufferedDuration.delete(this.currentPlayingItemId);
+        }
+        this.currentPlayingItemId = metadata.itemId;
+        this.totalBufferedDuration.set(metadata.itemId, 0);
+        this.itemStartSample = this.totalPlayedSamples;
+      }
+
+      const bufferDuration = int16Buffer.length / this.sampleRate;
+      const prev = this.totalBufferedDuration.get(metadata.itemId) || 0;
+      this.totalBufferedDuration.set(metadata.itemId, prev + bufferDuration);
+    }
+
+    // Convert Int16 → Float32 with volume
+    const float32 = new Float32Array(int16Buffer.length);
+    const scale = (volume !== 1.0) ? volume / 32768 : 1 / 32768;
+    for (let i = 0; i < int16Buffer.length; i++) {
+      float32[i] = int16Buffer[i] * scale;
+    }
+
+    // Write as much as fits into ring buffer
+    const freeSpace = this._getFreeSpace();
+    const immediate = Math.min(float32.length, freeSpace);
+
+    if (immediate > 0) {
+      this._writeToSAB(float32, 0, immediate);
+    }
+
+    // Queue remainder for later delivery
+    if (immediate < float32.length) {
+      this._pendingWrites.push(float32.subarray(immediate));
+      this._scheduleDrain();
+    }
+  }
+
+  /**
+   * Drain pending writes into the ring buffer as space becomes available.
+   */
+  _drainPendingWrites() {
+    if (this._pendingWrites.length === 0) {
+      this._cancelDrain();
+      return;
+    }
+
+    let freeSpace = this._getFreeSpace();
+
+    while (this._pendingWrites.length > 0 && freeSpace > 0) {
+      const chunk = this._pendingWrites[0];
+      const toWrite = Math.min(chunk.length, freeSpace);
+
+      this._writeToSAB(chunk, 0, toWrite);
+      freeSpace -= toWrite;
+
+      if (toWrite < chunk.length) {
+        // Partial write — replace head with remainder
+        this._pendingWrites[0] = chunk.subarray(toWrite);
+        break;
+      } else {
+        // Fully written — remove from queue
+        this._pendingWrites.shift();
+      }
+    }
+
+    // If still have pending data, keep draining
+    if (this._pendingWrites.length > 0) {
+      this._scheduleDrain();
+    } else {
+      this._cancelDrain();
+    }
+  }
+
+  _scheduleDrain() {
+    if (this._drainTimer !== null) return;
+    // Drain every 50ms — matches worklet position report interval
+    this._drainTimer = setTimeout(() => {
+      this._drainTimer = null;
+      this._drainPendingWrites();
+    }, 50);
+  }
+
+  _cancelDrain() {
+    if (this._drainTimer !== null) {
+      clearTimeout(this._drainTimer);
+      this._drainTimer = null;
     }
   }
 
@@ -288,7 +440,7 @@ export class ModernAudioPlayer {
   }
 
   // =========================================================================
-  // Chunk Accumulation & Ring Buffer Write
+  // Chunk Accumulation
   // =========================================================================
 
   _accumulateChunk(trackId, buffer, volume, metadata = {}) {
@@ -335,10 +487,10 @@ export class ModernAudioPlayer {
       offset += chunk.length;
     }
 
-    // Write to ring buffer
+    // Write to ring buffer (with overflow queue)
     this._writeToRingBuffer(combined, streamData.volume, streamData.metadata);
 
-    // Reset accumulator (keep metadata for next chunks of same stream)
+    // Reset accumulator
     streamData.chunks = [];
     streamData.totalLength = 0;
 
@@ -354,113 +506,6 @@ export class ModernAudioPlayer {
     }, 20);
 
     this.streamingTimeouts.set(trackId, timeoutId);
-  }
-
-  /**
-   * Convert Int16 PCM to Float32, apply per-track volume, and enqueue for worklet.
-   * Small writes (≤1s) are posted directly; larger writes are drip-fed via _sendQueue
-   * to avoid overflowing the worklet's 2-second ring buffer.
-   */
-  _writeToRingBuffer(int16Buffer, volume, metadata) {
-    if (!this._workletReady || !this.workletNode) return;
-
-    // Track item and buffered duration
-    if (metadata && metadata.itemId) {
-      if (this.currentPlayingItemId !== metadata.itemId) {
-        // New item — clean up old state
-        if (this.currentPlayingItemId !== null) {
-          this.totalBufferedDuration.delete(this.currentPlayingItemId);
-        }
-        this.currentPlayingItemId = metadata.itemId;
-        this.totalBufferedDuration.set(metadata.itemId, 0);
-        this.itemStartSample = this.totalPlayedSamples;
-      }
-
-      const bufferDuration = int16Buffer.length / this.sampleRate;
-      const prev = this.totalBufferedDuration.get(metadata.itemId) || 0;
-      this.totalBufferedDuration.set(metadata.itemId, prev + bufferDuration);
-    }
-
-    // Convert Int16 → Float32 with volume
-    const float32 = new Float32Array(int16Buffer.length);
-    const scale = (volume !== 1.0) ? volume / 32768 : 1 / 32768;
-    for (let i = 0; i < int16Buffer.length; i++) {
-      float32[i] = int16Buffer[i] * scale;
-    }
-
-    // Fast path: small writes go directly to worklet (covers streaming case)
-    const maxDirectWrite = this.sampleRate; // 1 second
-    if (float32.length <= maxDirectWrite && this._sendQueue.length === 0) {
-      this._postToWorklet(float32);
-      return;
-    }
-
-    // Large write or queue already active: chunk into ~0.5s pieces and drip-feed
-    const chunkSize = Math.floor(this.sampleRate * 0.5); // 0.5 second chunks
-    for (let offset = 0; offset < float32.length; offset += chunkSize) {
-      const end = Math.min(offset + chunkSize, float32.length);
-      this._sendQueue.push(float32.slice(offset, end));
-    }
-
-    this._startDraining();
-  }
-
-  /**
-   * Post a Float32Array to the worklet ring buffer (zero-copy via transfer).
-   */
-  _postToWorklet(float32) {
-    if (!this.workletNode) return;
-    this._totalSentSamples += float32.length;
-    this.workletNode.port.postMessage(
-      { type: 'write', samples: float32 },
-      [float32.buffer]
-    );
-  }
-
-  /**
-   * Start the drain timer that feeds queued audio to the worklet.
-   */
-  _startDraining() {
-    if (this._drainTimer !== null) return;
-    // Drain immediately, then every 100ms
-    this._drainQueue();
-    this._drainTimer = setInterval(() => this._drainQueue(), 100);
-  }
-
-  /**
-   * Feed the next chunk from _sendQueue to the worklet, if there's room.
-   */
-  _drainQueue() {
-    if (this._sendQueue.length === 0) {
-      if (this._drainTimer !== null) {
-        clearInterval(this._drainTimer);
-        this._drainTimer = null;
-      }
-      return;
-    }
-
-    // Estimate how much audio is currently buffered in the worklet ring buffer
-    const bufferedInWorklet = this._totalSentSamples - this.totalPlayedSamples;
-    const headroom = this._ringBufferCapacity - bufferedInWorklet;
-
-    // Only send if there's at least 0.25s of headroom
-    const minHeadroom = Math.floor(this.sampleRate * 0.25);
-    if (headroom < minHeadroom) return;
-
-    // Send the next chunk
-    const chunk = this._sendQueue.shift();
-    this._postToWorklet(chunk);
-  }
-
-  /**
-   * Clear the send queue (used on stop/interrupt).
-   */
-  _clearSendQueue() {
-    this._sendQueue.length = 0;
-    if (this._drainTimer !== null) {
-      clearInterval(this._drainTimer);
-      this._drainTimer = null;
-    }
   }
 
   _normalizeAudioData(audioData) {
@@ -530,15 +575,11 @@ export class ModernAudioPlayer {
     }
 
     try {
-      // Set on HTMLAudioElement (preferred — routes through OS audio path for AEC)
       if (this.audioElement && typeof this.audioElement.setSinkId === 'function') {
         await this.audioElement.setSinkId(deviceId);
       }
-      // Also set on AudioContext if supported (for future-proofing)
       if (this.context && typeof this.context.setSinkId === 'function') {
-        await this.context.setSinkId(deviceId).catch(() => {
-          // AudioContext.setSinkId may not be available everywhere
-        });
+        await this.context.setSinkId(deviceId).catch(() => {});
       }
 
       this.outputDeviceId = deviceId;
@@ -592,7 +633,6 @@ export class ModernAudioPlayer {
 
     const totalBufferedTime = this.getBufferedDuration(this.currentPlayingItemId);
 
-    // Calculate played time from worklet's sample counter
     const samplesPlayedForItem = this.totalPlayedSamples - this.itemStartSample;
     const currentTime = Math.max(0, samplesPlayedForItem / this.sampleRate);
 
@@ -615,7 +655,6 @@ export class ModernAudioPlayer {
 
   /**
    * Schedule an 'ended' notification after buffer goes empty.
-   * Defers by 2s in case more audio is still being generated by the AI.
    */
   _scheduleEndNotification(itemId) {
     this._cancelEndNotification();
@@ -660,13 +699,9 @@ export class ModernAudioPlayer {
     const currentTime = samplesPlayedForItem / this.sampleRate;
     const estimatedOffset = Math.floor(samplesPlayedForItem);
 
-    // Clear send queue and ring buffer immediately
-    this._clearSendQueue();
-    if (this.workletNode) {
-      this.workletNode.port.postMessage({ type: 'clear' });
-    }
+    // Clear ring buffer + pending writes
+    this._clearRingBuffer();
 
-    // Mark all active tracks as interrupted
     const trackId = 'default';
     this.interruptedTracks.add(trackId);
 
@@ -682,7 +717,6 @@ export class ModernAudioPlayer {
     this.trackQueues.delete(trackId);
     this.interruptedTracks.delete(trackId);
 
-    // Clear sequence tracking
     this.lastSequenceNumbers.delete(trackId);
     this.outOfOrderBuffers.delete(trackId);
     if (this.sequenceGapTimeout.has(trackId)) {
@@ -690,8 +724,24 @@ export class ModernAudioPlayer {
       this.sequenceGapTimeout.delete(trackId);
     }
 
-    // Clear send queue and ring buffer
-    this._clearSendQueue();
+    this._clearRingBuffer();
+  }
+
+  /**
+   * Clear the ring buffer — resets SAB indices and flushes pending writes.
+   */
+  _clearRingBuffer() {
+    // Clear pending writes queue
+    this._pendingWrites = [];
+    this._cancelDrain();
+
+    // Reset SAB indices
+    if (this._indices) {
+      Atomics.store(this._indices, 0, 0);
+      Atomics.store(this._indices, 1, 0);
+    }
+
+    // Also tell worklet to reset its internal state (samplesPlayed etc.)
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }
@@ -720,15 +770,8 @@ export class ModernAudioPlayer {
    */
   stopAll() {
     this._cancelEndNotification();
+    this._clearRingBuffer();
 
-    // Clear send queue and ring buffer
-    this._clearSendQueue();
-    if (this.workletNode) {
-      this.workletNode.port.postMessage({ type: 'clear' });
-    }
-    this._totalSentSamples = 0;
-
-    // Clear all accumulation and queue state
     for (const timeoutId of this.streamingTimeouts.values()) {
       clearTimeout(timeoutId);
     }
@@ -736,7 +779,6 @@ export class ModernAudioPlayer {
     this.streamingBuffers.clear();
     this.trackQueues.clear();
 
-    // Clear tracking
     this.totalBufferedDuration.clear();
     this.currentPlayingItemId = null;
     this.totalPlayedSamples = 0;
@@ -750,18 +792,15 @@ export class ModernAudioPlayer {
     this._cancelEndNotification();
     this.stopAll();
 
-    // Clear sequence gap timeouts
     for (const timeoutId of this.sequenceGapTimeout.values()) {
       clearTimeout(timeoutId);
     }
     this.sequenceGapTimeout.clear();
 
-    // Clear all data
     this.interruptedTracks.clear();
     this.lastSequenceNumbers.clear();
     this.outOfOrderBuffers.clear();
 
-    // Disconnect audio graph
     if (this.workletNode) {
       try { this.workletNode.disconnect(); } catch (e) { /* ignore */ }
       this.workletNode = null;
@@ -779,19 +818,20 @@ export class ModernAudioPlayer {
       this.destinationNode = null;
     }
 
-    // Stop and release HTMLAudioElement
     if (this.audioElement) {
       this.audioElement.pause();
       this.audioElement.srcObject = null;
       this.audioElement = null;
     }
 
-    // Close AudioContext
     if (this.context && this.context.state !== 'closed') {
       this.context.close().catch(console.error);
       this.context = null;
     }
 
+    this._sab = null;
+    this._indices = null;
+    this._data = null;
     this._workletReady = false;
     this._workletState = 'stopped';
   }
@@ -804,13 +844,19 @@ export class ModernAudioPlayer {
    * Get diagnostic information for audio sequencing.
    */
   getSequenceDiagnostics() {
+    const writeIdx = this._indices ? Atomics.load(this._indices, 0) : 0;
+    const readIdx = this._indices ? Atomics.load(this._indices, 1) : 0;
+
     const diagnostics = {
       tracks: {},
       outOfOrderCount: 0,
       totalBuffered: 0,
       gaps: [],
       workletState: this._workletState,
-      totalPlayedSamples: this.totalPlayedSamples
+      totalPlayedSamples: this.totalPlayedSamples,
+      ringBufferUsed: writeIdx - readIdx,
+      ringBufferCapacity: this._ringCapacity,
+      pendingWriteChunks: this._pendingWrites.length
     };
 
     for (const [trackId, lastSeq] of this.lastSequenceNumbers) {

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -50,6 +50,11 @@ export class ModernAudioPlayer {
     // Worklet state
     this._workletReady = false;
     this._workletState = 'stopped'; // 'stopped' | 'playing' | 'starving'
+
+    // Pending write queue for large buffers that exceed ring buffer capacity
+    this._pendingWrites = [];
+    this._drainTimer = null;
+    this._ringCapacity = this.sampleRate * 2; // 2 seconds — must match worklet
   }
 
   /**
@@ -350,6 +355,7 @@ export class ModernAudioPlayer {
 
   /**
    * Convert Int16 PCM to Float32, apply per-track volume, and post to worklet.
+   * Large buffers are queued and drained incrementally to avoid ring buffer overflow.
    */
   _writeToRingBuffer(int16Buffer, volume, metadata) {
     if (!this._workletReady || !this.workletNode) return;
@@ -378,11 +384,59 @@ export class ModernAudioPlayer {
       float32[i] = int16Buffer[i] * scale;
     }
 
-    // Post to worklet — transfer the buffer for zero-copy
-    this.workletNode.port.postMessage(
-      { type: 'write', samples: float32 },
-      [float32.buffer]
-    );
+    // If small enough, post directly to worklet
+    const safeThreshold = Math.floor(this._ringCapacity * 0.75);
+    if (float32.length <= safeThreshold && this._pendingWrites.length === 0) {
+      this.workletNode.port.postMessage(
+        { type: 'write', samples: float32 },
+        [float32.buffer]
+      );
+      return;
+    }
+
+    // Large buffer or queue already active — split into 0.5s chunks and drain
+    const chunkSize = Math.floor(this.sampleRate * 0.5); // 0.5 seconds per chunk
+    for (let i = 0; i < float32.length; i += chunkSize) {
+      const end = Math.min(i + chunkSize, float32.length);
+      this._pendingWrites.push(new Float32Array(float32.subarray(i, end)));
+    }
+    this._drainPendingWrites();
+  }
+
+  /**
+   * Drain pending write queue into the worklet ring buffer incrementally.
+   */
+  _drainPendingWrites() {
+    if (this._pendingWrites.length === 0) return;
+    if (this._drainTimer) return; // Already scheduled
+
+    // Write one chunk now
+    const chunk = this._pendingWrites.shift();
+    if (this.workletNode) {
+      this.workletNode.port.postMessage(
+        { type: 'write', samples: chunk },
+        [chunk.buffer]
+      );
+    }
+
+    if (this._pendingWrites.length === 0) return; // Done
+
+    // Schedule next write — drain at ~2x playback rate (every 250ms for 0.5s chunks)
+    this._drainTimer = setTimeout(() => {
+      this._drainTimer = null;
+      this._drainPendingWrites();
+    }, 250);
+  }
+
+  /**
+   * Cancel pending write drain.
+   */
+  _cancelPendingWrites() {
+    this._pendingWrites = [];
+    if (this._drainTimer) {
+      clearTimeout(this._drainTimer);
+      this._drainTimer = null;
+    }
   }
 
   _normalizeAudioData(audioData) {
@@ -582,7 +636,8 @@ export class ModernAudioPlayer {
     const currentTime = samplesPlayedForItem / this.sampleRate;
     const estimatedOffset = Math.floor(samplesPlayedForItem);
 
-    // Clear the ring buffer immediately
+    // Clear pending writes and ring buffer immediately
+    this._cancelPendingWrites();
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }
@@ -611,7 +666,8 @@ export class ModernAudioPlayer {
       this.sequenceGapTimeout.delete(trackId);
     }
 
-    // Clear ring buffer
+    // Clear pending writes and ring buffer
+    this._cancelPendingWrites();
     if (this.workletNode) {
       this.workletNode.port.postMessage({ type: 'clear' });
     }
@@ -640,6 +696,7 @@ export class ModernAudioPlayer {
    */
   stopAll() {
     this._cancelEndNotification();
+    this._cancelPendingWrites();
 
     // Clear ring buffer
     if (this.workletNode) {

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -59,7 +59,7 @@ export class ModernAudioPlayer {
     this._sab = null;
     this._indices = null;  // Int32Array view [writeIndex, readIndex, capacity, flags]
     this._data = null;     // Float32Array view (audio samples)
-    this._ringCapacity = Math.floor(sampleRate * 2); // 2 seconds
+    this._ringCapacity = Math.floor(sampleRate * 30); // 30 seconds (~2.88MB)
 
     // Main-thread overflow queue — holds data that doesn't fit in ring buffer
     this._pendingWrites = []; // Array of Float32Array chunks

--- a/src/lib/modern-audio/ModernAudioPlayer.js
+++ b/src/lib/modern-audio/ModernAudioPlayer.js
@@ -59,7 +59,7 @@ export class ModernAudioPlayer {
     this._sab = null;
     this._indices = null;  // Int32Array view [writeIndex, readIndex, capacity, flags]
     this._data = null;     // Float32Array view (audio samples)
-    this._ringCapacity = Math.floor(sampleRate * 30); // 30 seconds (~2.88MB)
+    this._ringCapacity = Math.floor(sampleRate * 2); // 2 seconds
 
     // Main-thread overflow queue — holds data that doesn't fit in ring buffer
     this._pendingWrites = []; // Array of Float32Array chunks
@@ -138,6 +138,10 @@ export class ModernAudioPlayer {
       console.warn('[ModernAudioPlayer] Initial play() blocked (will retry on user gesture):', e.message);
     });
 
+    if (this.context.sampleRate !== this.sampleRate) {
+      console.error('[ModernAudioPlayer] SAMPLE RATE MISMATCH! context:', this.context.sampleRate, 'expected:', this.sampleRate);
+    }
+
     return true;
   }
 
@@ -186,10 +190,6 @@ export class ModernAudioPlayer {
     return this._ringCapacity - used;
   }
 
-  /**
-   * Write Float32 samples directly into the SharedArrayBuffer ring buffer.
-   * Returns the number of samples actually written.
-   */
   _writeToSAB(float32, offset, count) {
     const writeIdx = Atomics.load(this._indices, 0);
     const cap = this._ringCapacity;
@@ -198,18 +198,13 @@ export class ModernAudioPlayer {
       this._data[(writeIdx + i) % cap] = float32[offset + i];
     }
 
-    // Update writeIndex — worklet will see the new data on next process() call
     Atomics.store(this._indices, 0, writeIdx + count);
     return count;
   }
 
-  /**
-   * Write audio to the ring buffer. If it doesn't all fit, queue the overflow.
-   */
   _writeToRingBuffer(int16Buffer, volume, metadata) {
     if (!this._workletReady || !this._indices) return;
 
-    // Track item and buffered duration
     if (metadata && metadata.itemId) {
       if (this.currentPlayingItemId !== metadata.itemId) {
         if (this.currentPlayingItemId !== null) {
@@ -225,14 +220,21 @@ export class ModernAudioPlayer {
       this.totalBufferedDuration.set(metadata.itemId, prev + bufferDuration);
     }
 
-    // Convert Int16 → Float32 with volume
     const float32 = new Float32Array(int16Buffer.length);
     const scale = (volume !== 1.0) ? volume / 32768 : 1 / 32768;
     for (let i = 0; i < int16Buffer.length; i++) {
       float32[i] = int16Buffer[i] * scale;
     }
 
-    // Write as much as fits into ring buffer
+    // CRITICAL: if pending queue is non-empty, ALL new data must go to queue
+    // to preserve FIFO ordering. Direct SAB writes would skip ahead of queued data.
+    if (this._pendingWrites.length > 0) {
+      this._pendingWrites.push(float32);
+      this._scheduleDrain();
+      return;
+    }
+
+    // Queue is empty — safe to write directly to SAB
     const freeSpace = this._getFreeSpace();
     const immediate = Math.min(float32.length, freeSpace);
 
@@ -240,16 +242,12 @@ export class ModernAudioPlayer {
       this._writeToSAB(float32, 0, immediate);
     }
 
-    // Queue remainder for later delivery
     if (immediate < float32.length) {
       this._pendingWrites.push(float32.subarray(immediate));
       this._scheduleDrain();
     }
   }
 
-  /**
-   * Drain pending writes into the ring buffer as space becomes available.
-   */
   _drainPendingWrites() {
     if (this._pendingWrites.length === 0) {
       this._cancelDrain();
@@ -266,16 +264,13 @@ export class ModernAudioPlayer {
       freeSpace -= toWrite;
 
       if (toWrite < chunk.length) {
-        // Partial write — replace head with remainder
         this._pendingWrites[0] = chunk.subarray(toWrite);
         break;
       } else {
-        // Fully written — remove from queue
         this._pendingWrites.shift();
       }
     }
 
-    // If still have pending data, keep draining
     if (this._pendingWrites.length > 0) {
       this._scheduleDrain();
     } else {
@@ -285,7 +280,6 @@ export class ModernAudioPlayer {
 
   _scheduleDrain() {
     if (this._drainTimer !== null) return;
-    // Drain every 50ms — matches worklet position report interval
     this._drainTimer = setTimeout(() => {
       this._drainTimer = null;
       this._drainPendingWrites();

--- a/src/lib/modern-audio/worklets/playback-ring-processor.js
+++ b/src/lib/modern-audio/worklets/playback-ring-processor.js
@@ -48,10 +48,8 @@ class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
   }
 
   _clear() {
-    if (this._indices) {
-      Atomics.store(this._indices, 0, 0); // writeIndex
-      Atomics.store(this._indices, 1, 0); // readIndex
-    }
+    // SPSC-safe: consumer (worklet) only resets its own internal state.
+    // The producer (main thread) handles index reset by setting writeIdx = readIdx.
     this._samplesPlayed = 0;
     this._lastPositionReport = 0;
     this._setState('stopped');

--- a/src/lib/modern-audio/worklets/playback-ring-processor.js
+++ b/src/lib/modern-audio/worklets/playback-ring-processor.js
@@ -1,0 +1,150 @@
+/**
+ * AudioWorklet processor that maintains a circular buffer for gapless audio playback.
+ * Receives PCM samples via postMessage, outputs continuously via process().
+ * When buffer is empty, outputs silence (no clicks or pops).
+ */
+class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
+  constructor() {
+    super();
+
+    // Ring buffer: 2 seconds capacity at whatever sample rate the context uses
+    // sampleRate is a global in AudioWorkletGlobalScope
+    this._capacity = Math.floor(sampleRate * 2);
+    this._buffer = new Float32Array(this._capacity);
+    this._writeIndex = 0;
+    this._readIndex = 0;
+    this._playing = true;
+
+    // State tracking for notifications
+    this._state = 'stopped'; // 'stopped' | 'playing' | 'starving'
+    this._samplesPlayed = 0;
+    this._lastPositionReport = 0;
+    // Report position every ~50ms worth of samples
+    this._positionReportInterval = Math.floor(sampleRate * 0.05);
+
+    this.port.onmessage = (e) => {
+      const msg = e.data;
+      if (msg.type === 'write') {
+        this._write(msg.samples);
+      } else if (msg.type === 'clear') {
+        this._clear();
+      } else if (msg.type === 'setPlaying') {
+        this._playing = msg.playing;
+      }
+    };
+  }
+
+  _available() {
+    const avail = this._writeIndex - this._readIndex;
+    return avail >= 0 ? avail : avail + this._capacity;
+  }
+
+  _write(samples) {
+    const len = samples.length;
+
+    // Check for overflow — if writing would exceed capacity, drop oldest
+    if (len > this._capacity) {
+      // Extremely large write — only keep the last _capacity samples
+      const offset = len - this._capacity;
+      this._buffer.set(samples.subarray(offset), 0);
+      this._writeIndex = this._capacity;
+      this._readIndex = 0;
+      return;
+    }
+
+    const available = this._available();
+    const freeSpace = this._capacity - available;
+
+    if (len > freeSpace) {
+      // Overflow: advance readIndex to make room
+      const overflow = len - freeSpace;
+      this._readIndex = (this._readIndex + overflow) % this._capacity;
+    }
+
+    // Write samples into ring buffer (handle wrap-around)
+    const writePos = this._writeIndex % this._capacity;
+    const firstPart = Math.min(len, this._capacity - writePos);
+    this._buffer.set(samples.subarray(0, firstPart), writePos);
+
+    if (firstPart < len) {
+      this._buffer.set(samples.subarray(firstPart), 0);
+    }
+
+    this._writeIndex = (writePos + len) % this._capacity;
+  }
+
+  _clear() {
+    this._readIndex = 0;
+    this._writeIndex = 0;
+    this._samplesPlayed = 0;
+    this._lastPositionReport = 0;
+    this._setState('stopped');
+  }
+
+  _setState(newState) {
+    if (this._state !== newState) {
+      this._state = newState;
+      this.port.postMessage({ type: 'stateChange', state: newState });
+    }
+  }
+
+  process(inputs, outputs) {
+    const output = outputs[0];
+    if (!output || output.length === 0) return true;
+
+    const channel = output[0];
+    const frameSize = channel.length; // typically 128
+
+    if (!this._playing) {
+      // Output silence when paused
+      channel.fill(0);
+      return true;
+    }
+
+    const available = this._available();
+
+    if (available === 0) {
+      // Buffer empty — output silence
+      channel.fill(0);
+      if (this._state === 'playing') {
+        this._setState('starving');
+      }
+      return true;
+    }
+
+    // We have data — read from ring buffer
+    if (this._state !== 'playing') {
+      this._setState('playing');
+    }
+
+    const samplesToRead = Math.min(frameSize, available);
+    const readPos = this._readIndex % this._capacity;
+    const firstPart = Math.min(samplesToRead, this._capacity - readPos);
+
+    // Copy first part
+    channel.set(this._buffer.subarray(readPos, readPos + firstPart));
+
+    if (firstPart < samplesToRead) {
+      // Wrap around
+      channel.set(this._buffer.subarray(0, samplesToRead - firstPart), firstPart);
+    }
+
+    // Zero-fill remainder if buffer didn't have enough for full frame
+    if (samplesToRead < frameSize) {
+      channel.fill(0, samplesToRead);
+    }
+
+    this._readIndex = (readPos + samplesToRead) % this._capacity;
+    this._samplesPlayed += samplesToRead;
+
+    // Periodic position report
+    if (this._samplesPlayed - this._lastPositionReport >= this._positionReportInterval) {
+      this._lastPositionReport = this._samplesPlayed;
+      this.port.postMessage({ type: 'readPosition', samplesPlayed: this._samplesPlayed });
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('playback-ring-processor', PlaybackRingWorkletProcessor);

--- a/src/lib/modern-audio/worklets/playback-ring-processor.js
+++ b/src/lib/modern-audio/worklets/playback-ring-processor.js
@@ -1,31 +1,44 @@
 /**
- * AudioWorklet processor that maintains a circular buffer for gapless audio playback.
- * Receives PCM samples via postMessage, outputs continuously via process().
- * When buffer is empty, outputs silence (no clicks or pops).
+ * AudioWorklet processor with SharedArrayBuffer ring buffer for gapless playback.
+ *
+ * SharedArrayBuffer layout:
+ *   Int32[0] = writeIndex (main thread writes, worklet reads — monotonically increasing)
+ *   Int32[1] = readIndex  (worklet writes, main thread reads — monotonically increasing)
+ *   Int32[2] = capacity
+ *   Int32[3] = flags      (reserved)
+ *   Float32[offset 16...] = audio data (capacity floats)
+ *
+ * SPSC (Single Producer Single Consumer) lock-free pattern:
+ *   - Main thread is the sole writer of writeIndex and audio data
+ *   - Worklet is the sole writer of readIndex
+ *   - Both use Atomics for index access to ensure visibility across threads
+ *   - Data array needs no atomics (SPSC guarantees no concurrent access to same region)
  */
 class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
   constructor() {
     super();
 
-    // Ring buffer: 2 seconds capacity at whatever sample rate the context uses
-    // sampleRate is a global in AudioWorkletGlobalScope
-    this._capacity = Math.floor(sampleRate * 2);
-    this._buffer = new Float32Array(this._capacity);
-    this._writeIndex = 0;
-    this._readIndex = 0;
+    // Shared memory views (set on 'init' message)
+    this._indices = null;  // Int32Array over SAB[0..15]
+    this._data = null;     // Float32Array over SAB[16..]
+    this._capacity = 0;
+    this._ready = false;
     this._playing = true;
 
-    // State tracking for notifications
+    // State tracking
     this._state = 'stopped'; // 'stopped' | 'playing' | 'starving'
     this._samplesPlayed = 0;
     this._lastPositionReport = 0;
-    // Report position every ~50ms worth of samples
-    this._positionReportInterval = Math.floor(sampleRate * 0.05);
+    this._positionReportInterval = Math.floor(sampleRate * 0.05); // ~50ms
 
     this.port.onmessage = (e) => {
       const msg = e.data;
-      if (msg.type === 'write') {
-        this._write(msg.samples);
+      if (msg.type === 'init') {
+        // Receive SharedArrayBuffer and create views
+        this._indices = new Int32Array(msg.sab, 0, 4);
+        this._data = new Float32Array(msg.sab, 16);
+        this._capacity = Atomics.load(this._indices, 2);
+        this._ready = true;
       } else if (msg.type === 'clear') {
         this._clear();
       } else if (msg.type === 'setPlaying') {
@@ -34,48 +47,11 @@ class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
     };
   }
 
-  _available() {
-    const avail = this._writeIndex - this._readIndex;
-    return avail >= 0 ? avail : avail + this._capacity;
-  }
-
-  _write(samples) {
-    const len = samples.length;
-
-    // Check for overflow — if writing would exceed capacity, drop oldest
-    if (len > this._capacity) {
-      // Extremely large write — only keep the last _capacity samples
-      const offset = len - this._capacity;
-      this._buffer.set(samples.subarray(offset), 0);
-      this._writeIndex = this._capacity;
-      this._readIndex = 0;
-      return;
-    }
-
-    const available = this._available();
-    const freeSpace = this._capacity - available;
-
-    if (len > freeSpace) {
-      // Overflow: advance readIndex to make room
-      const overflow = len - freeSpace;
-      this._readIndex = (this._readIndex + overflow) % this._capacity;
-    }
-
-    // Write samples into ring buffer (handle wrap-around)
-    const writePos = this._writeIndex % this._capacity;
-    const firstPart = Math.min(len, this._capacity - writePos);
-    this._buffer.set(samples.subarray(0, firstPart), writePos);
-
-    if (firstPart < len) {
-      this._buffer.set(samples.subarray(firstPart), 0);
-    }
-
-    this._writeIndex = (writePos + len) % this._capacity;
-  }
-
   _clear() {
-    this._readIndex = 0;
-    this._writeIndex = 0;
+    if (this._indices) {
+      Atomics.store(this._indices, 0, 0); // writeIndex
+      Atomics.store(this._indices, 1, 0); // readIndex
+    }
     this._samplesPlayed = 0;
     this._lastPositionReport = 0;
     this._setState('stopped');
@@ -95,16 +71,17 @@ class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
     const channel = output[0];
     const frameSize = channel.length; // typically 128
 
-    if (!this._playing) {
-      // Output silence when paused
+    if (!this._ready || !this._playing) {
       channel.fill(0);
       return true;
     }
 
-    const available = this._available();
+    // Read writeIndex (written by main thread)
+    const writeIdx = Atomics.load(this._indices, 0);
+    const readIdx = Atomics.load(this._indices, 1);
+    const available = writeIdx - readIdx; // always >= 0 in SPSC with monotonic indices
 
-    if (available === 0) {
-      // Buffer empty — output silence
+    if (available <= 0) {
       channel.fill(0);
       if (this._state === 'playing') {
         this._setState('starving');
@@ -112,32 +89,29 @@ class PlaybackRingWorkletProcessor extends AudioWorkletProcessor {
       return true;
     }
 
-    // We have data — read from ring buffer
     if (this._state !== 'playing') {
       this._setState('playing');
     }
 
     const samplesToRead = Math.min(frameSize, available);
-    const readPos = this._readIndex % this._capacity;
-    const firstPart = Math.min(samplesToRead, this._capacity - readPos);
+    const cap = this._capacity;
 
-    // Copy first part
-    channel.set(this._buffer.subarray(readPos, readPos + firstPart));
-
-    if (firstPart < samplesToRead) {
-      // Wrap around
-      channel.set(this._buffer.subarray(0, samplesToRead - firstPart), firstPart);
+    // Read from ring buffer with wrap-around
+    for (let i = 0; i < samplesToRead; i++) {
+      channel[i] = this._data[(readIdx + i) % cap];
     }
 
-    // Zero-fill remainder if buffer didn't have enough for full frame
+    // Zero-fill remainder
     if (samplesToRead < frameSize) {
       channel.fill(0, samplesToRead);
     }
 
-    this._readIndex = (readPos + samplesToRead) % this._capacity;
+    // Update readIndex (only this thread writes it)
+    Atomics.store(this._indices, 1, readIdx + samplesToRead);
+
     this._samplesPlayed += samplesToRead;
 
-    // Periodic position report
+    // Periodic position report (low frequency — for UI progress tracking)
     if (this._samplesPlayed - this._lastPositionReport >= this._positionReportInterval) {
       this._lastPositionReport = this._samplesPlayed;
       this.port.postMessage({ type: 'readPosition', samplesPlayed: this._samplesPlayed });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -146,6 +146,10 @@ export default defineConfig(({ command, mode }) => {
     server: {
       port: 5173,
       host: true,
+      headers: {
+        'Cross-Origin-Opener-Policy': 'same-origin',
+        'Cross-Origin-Embedder-Policy': 'require-corp',
+      },
     },
     build: {
       outDir: 'build',


### PR DESCRIPTION
## Summary

- Replaces per-chunk `HTMLAudioElement` playback with a **SharedArrayBuffer lock-free SPSC ring buffer** feeding a single persistent `HTMLAudioElement` via `MediaStreamDestinationNode`
- Eliminates inter-chunk gaps that caused crackling/artifacts in TTS playback (fixes #172)
- Enables COOP/COEP headers for `SharedArrayBuffer` support across Electron, Chrome extension, and Vite dev server

## Architecture

```
Before (broken):
  PCM chunk → WAV blob → new Audio() → play() → onended → next Audio()
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
              Gap between each element = crackling

After:
  PCM chunk → SharedArrayBuffer (zero-copy write) → AudioWorkletNode (continuous read)
    → GainNode → AnalyserNode → MediaStreamDestinationNode
      → Single persistent HTMLAudioElement.srcObject → Speakers (AEC-visible)
```

## Key Changes

| File | Change |
|------|--------|
| `src/lib/modern-audio/worklets/playback-ring-processor.js` | **New** — AudioWorklet with SharedArrayBuffer SPSC ring buffer |
| `src/lib/modern-audio/ModernAudioPlayer.js` | **Rewritten** — zero-copy SAB writes, overflow queue with paced drain |
| `electron/main.js` | COOP/COEP headers for SharedArrayBuffer |
| `extension/manifest.json` | `cross_origin_embedder_policy` / `cross_origin_opener_policy` |
| `vite.config.ts` | Dev server COOP/COEP headers |

## Why SharedArrayBuffer

The initial implementation used `postMessage` to transfer audio data to the worklet. This had two issues:
1. Data copy/transfer overhead on every chunk
2. A 2-second ring buffer would silently drop data when large audio (debug test tone) was sent all at once

SharedArrayBuffer gives us:
- **Zero-copy** writes from main thread directly to shared memory
- **Atomic index tracking** so the main thread knows exactly how much free space remains
- **Overflow queue** on the main thread for audio exceeding buffer capacity — drained as the worklet consumes

## Preserved API

All public methods unchanged — drop-in replacement for consumers (`ModernBrowserAudioService`, `MainPanel`, all AI clients).

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 62 existing tests pass (`npm run test`)
- [x] No external references to removed internal methods
- [x] Manual: gapless playback with Gemini (long responses)
- [ ] Manual: AEC works in Electron (no echo feedback)
- [ ] Manual: volume control, device switching, visualization
- [ ] Manual: track interruption (stop mid-playback)
- [ ] Manual: browser extension side panel + virtual microphone
- [ ] Manual: debug test tone plays completely without truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gapless, low-latency audio engine with ring-buffer playback, continuous output, and underrun-safe silence
  * Streaming and immediate PCM ingestion with sequencing, accumulation thresholds, and diagnostics
  * Single persistent playback path with global volume, output device switching, interruption/clear/stop controls, buffered-duration queries, status callbacks, and real-time frequency data

* **Documentation**
  * Added design and spec docs describing the redesigned audio pipeline

* **Chores**
  * Enabled cross-origin isolation and SharedArrayBuffer support for the new pipeline (dev & app manifests)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->