### PR TITLE
feat(extension): auto-open sidebar on supported sites

### DIFF
--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -132,10 +132,13 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       // Enable side panel and auto-open on icon click for supported sites
       await chrome.sidePanel.setOptions({
         tabId: tabId,
-        path: `fullpage.html?tabId=${tabId}&trigger=action_click&site=${url.hostname}`,
+        path: `fullpage.html?tabId=${tabId}&trigger=action_click&site=${encodeURIComponent(url.hostname)}`,
         enabled: true
       });
-      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+      // Only update global panel behavior if this is the active tab
+      if (tab.active) {
+        await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+      }
       console.debug('[Sokuji] [Background] Enabled Sokuji side panel with auto-open for site:', url.hostname);
     } else {
       // Disable side panel for other sites, fall back to popup on icon click
@@ -143,7 +146,10 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
         tabId: tabId,
         enabled: false
       });
-      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+      // Only update global panel behavior if this is the active tab
+      if (tab.active) {
+        await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
+      }
       // Remove from tracking if URL changed to a non-enabled site
       if (tabsWithSidePanelOpen.has(tabId)) {
         tabsWithSidePanelOpen.delete(tabId);
@@ -171,13 +177,14 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
     if (isEnabledSite) {
       await chrome.sidePanel.setOptions({
         tabId: tabId,
-        path: `fullpage.html?tabId=${tabId}&trigger=action_click&site=${url.hostname}`,
+        path: `fullpage.html?tabId=${tabId}&trigger=action_click&site=${encodeURIComponent(url.hostname)}`,
         enabled: true,
       });
       await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
       console.debug('[Sokuji] [Background] Maintaining side panel with auto-open for supported site:', url.hostname);
     } else {
       await chrome.sidePanel.setOptions({
+        tabId: tabId,
         enabled: false,
       });
       await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });

--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -100,10 +100,6 @@ async function updateUninstallURL(distinctId = null) {
   }
 }
 
-// Remove automatic side panel opening behavior - now handled by popup
-// chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true })
-//   .catch((error) => console.error('[Sokuji] [Background] Error setting panel behavior:', error));
-
 // Initialize configuration in storage if not already set
 chrome.runtime.onInstalled.addListener(async () => {
   try {
@@ -133,19 +129,21 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
       url.hostname === site || url.hostname.endsWith('.' + site));
     
     if (isEnabledSite) {
-      // Enable side panel for this site (but don't auto-open)
+      // Enable side panel and auto-open on icon click for supported sites
       await chrome.sidePanel.setOptions({
         tabId: tabId,
-        path: `fullpage.html?tabId=${tabId}`,
+        path: `fullpage.html?tabId=${tabId}&trigger=action_click&site=${url.hostname}`,
         enabled: true
       });
-      console.debug('[Sokuji] [Background] Enabled Sokuji side panel for site:', url.hostname);
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+      console.debug('[Sokuji] [Background] Enabled Sokuji side panel with auto-open for site:', url.hostname);
     } else {
-      // Disable side panel for other sites
+      // Disable side panel for other sites, fall back to popup on icon click
       await chrome.sidePanel.setOptions({
         tabId: tabId,
         enabled: false
       });
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
       // Remove from tracking if URL changed to a non-enabled site
       if (tabsWithSidePanelOpen.has(tabId)) {
         tabsWithSidePanelOpen.delete(tabId);
@@ -173,14 +171,16 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
     if (isEnabledSite) {
       await chrome.sidePanel.setOptions({
         tabId: tabId,
-        path: `fullpage.html?tabId=${tabId}`,
+        path: `fullpage.html?tabId=${tabId}&trigger=action_click&site=${url.hostname}`,
         enabled: true,
       });
-      console.debug('[Sokuji] [Background] Maintaining side panel for supported site:', url.hostname);
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+      console.debug('[Sokuji] [Background] Maintaining side panel with auto-open for supported site:', url.hostname);
     } else {
       await chrome.sidePanel.setOptions({
         enabled: false,
       });
+      await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });
     }
   } catch (error) {
     console.error('[Sokuji] [Background] Error updating side panel for switched tab:', error);

--- a/extension/background/background.js
+++ b/extension/background/background.js
@@ -184,7 +184,6 @@ chrome.tabs.onActivated.addListener(async (activeInfo) => {
       console.debug('[Sokuji] [Background] Maintaining side panel with auto-open for supported site:', url.hostname);
     } else {
       await chrome.sidePanel.setOptions({
-        tabId: tabId,
         enabled: false,
       });
       await chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: false });

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -14,6 +14,16 @@ export function RootLayout() {
     // Track app startup - version, platform, environment are automatically included via Super Properties
     trackEvent('app_startup', {});
 
+    // Track side panel auto-opened via extension icon click on supported sites
+    const urlParams = new URLSearchParams(window.location.search);
+    const trigger = urlParams.get('trigger');
+    if (trigger === 'action_click') {
+      trackEvent('extension_side_panel_opened', {
+        trigger: 'action',
+        site: urlParams.get('site') || undefined,
+      });
+    }
+
     // Track app shutdown on beforeunload
     const handleBeforeUnload = () => {
       const sessionStart = sessionStorage.getItem('session_start');


### PR DESCRIPTION
## Summary

Closes #191

- On **supported sites** (Google Meet, Zoom, Teams, etc.), clicking the extension icon now opens the sidebar directly — no popup
- On **unsupported sites**, the popup appears as before with the site list and guidance
- Tracks `extension_side_panel_opened` analytics event with `trigger: 'action'` and the tab's hostname

## Changes

- `extension/background/background.js`: Dynamically toggle `setPanelBehavior({ openPanelOnActionClick })` in existing `onUpdated` and `onActivated` listeners. Pass `trigger=action_click&site=` query params to the side panel URL.
- `src/layouts/RootLayout.tsx`: Read `trigger` query param on mount and fire PostHog analytics event.

## Test plan

- [ ] Load extension in Chrome, navigate to `meet.google.com`, click icon → sidebar opens directly
- [ ] Navigate to `github.com`, click icon → popup appears with site list
- [ ] Switch between supported/unsupported tabs and verify correct behavior
- [ ] Check DevTools console in sidebar for `extension_side_panel_opened` event with `trigger: 'action'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Side panel now auto-opens when clicking the extension icon on supported sites; auto-open is applied only to the active tab.

* **Improvements**
  * Side panel is explicitly disabled on unsupported sites and will not auto-open there.
  * Side panel behavior updates occur on tab navigations and switches for more consistent UX.
  * Enhanced analytics: open events include trigger type ("action") and optional site info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->