### PR TITLE
feat(mainpanel): compact conversation mode + role-colored translation badge

### DIFF
--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -93,9 +93,17 @@
   }
 
   &.tr {
-    background: rgba(16, 163, 127, 0.2);
-    color: #10a37f;
-    border: 1px solid rgba(16, 163, 127, 0.4);
+    &.source-speaker {
+      background: rgba(16, 163, 127, 0.2);
+      color: #10a37f;
+      border: 1px solid rgba(16, 163, 127, 0.4);
+    }
+
+    &.source-participant {
+      background: rgba(243, 156, 18, 0.2);
+      color: #f39c12;
+      border: 1px solid rgba(243, 156, 18, 0.4);
+    }
   }
 }
 
@@ -145,5 +153,35 @@
   &:disabled {
     opacity: 0.4;
     cursor: not-allowed;
+  }
+}
+
+.row-role-dot {
+  position: absolute;
+  left: 2px;
+  top: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &.source-speaker {
+    background: #10a37f;
+  }
+
+  &.source-participant {
+    background: #f39c12;
+  }
+}
+
+.conversation-row.compact {
+  .row-body {
+    position: relative;
+    padding-left: 16px;
+  }
+
+  // Compact disables the grouped indent that normally aligns text under the header.
+  &.grouped .row-body {
+    padding-left: 16px;
   }
 }

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -178,9 +178,4 @@
     position: relative;
     padding-left: 16px;
   }
-
-  // Compact disables the grouped indent that normally aligns text under the header.
-  &.grouped .row-body {
-    padding-left: 16px;
-  }
 }

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -163,7 +163,6 @@
   width: 6px;
   height: 6px;
   border-radius: 50%;
-  flex-shrink: 0;
 
   &.source-speaker {
     background: #10a37f;

--- a/src/components/MainPanel/ConversationRow.test.tsx
+++ b/src/components/MainPanel/ConversationRow.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import { render } from '@testing-library/react';
 import type { ConversationItem } from '../../services/interfaces/IClient';

--- a/src/components/MainPanel/ConversationRow.test.tsx
+++ b/src/components/MainPanel/ConversationRow.test.tsx
@@ -1,0 +1,212 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import type { ConversationItem } from '../../services/interfaces/IClient';
+import ConversationRow from './ConversationRow';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+type RowItem = ConversationItem & { source?: 'speaker' | 'participant' };
+
+function makeItem(over: Partial<RowItem>): RowItem {
+  return {
+    id: 'i1',
+    role: 'user',
+    type: 'message',
+    status: 'completed',
+    formatted: { text: 'hello' },
+    source: 'speaker',
+    createdAt: 1700000000000,
+    ...over,
+  } as RowItem;
+}
+
+const baseProps = {
+  sourceLanguage: 'zh',
+  targetLanguage: 'en',
+  isPlaying: false,
+  highlightedChars: 0,
+};
+
+describe('ConversationRow — expanded (default) mode', () => {
+  it('renders the row header when there is no previous item', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+      />,
+    );
+    expect(container.querySelector('.row-header')).not.toBeNull();
+  });
+
+  it('renders the lang-badge', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+      />,
+    );
+    expect(container.querySelector('.lang-badge')).not.toBeNull();
+  });
+
+  it('renders the row play button when canPlay is true', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        canPlay
+        onPlay={() => {}}
+      />,
+    );
+    expect(container.querySelector('.row-play-btn')).not.toBeNull();
+  });
+
+  it('does not render a role dot in expanded mode', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+      />,
+    );
+    expect(container.querySelector('.row-role-dot')).toBeNull();
+  });
+
+  it('tags the translation badge with source-speaker on speaker rows', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker', role: 'assistant' })}
+        prevItem={null}
+      />,
+    );
+    const badge = container.querySelector('.lang-badge.tr');
+    expect(badge).not.toBeNull();
+    expect(badge?.classList.contains('source-speaker')).toBe(true);
+  });
+
+  it('tags the translation badge with source-participant on participant rows', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'participant', role: 'assistant' })}
+        prevItem={null}
+      />,
+    );
+    const badge = container.querySelector('.lang-badge.tr');
+    expect(badge).not.toBeNull();
+    expect(badge?.classList.contains('source-participant')).toBe(true);
+  });
+
+  it('tags the source badge with source-<role> too (for future theming)', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'participant', role: 'user' })}
+        prevItem={null}
+      />,
+    );
+    const badge = container.querySelector('.lang-badge.src');
+    expect(badge?.classList.contains('source-participant')).toBe(true);
+  });
+});
+
+describe('ConversationRow — compact mode', () => {
+  it('hides the row header', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        compact
+      />,
+    );
+    expect(container.querySelector('.row-header')).toBeNull();
+  });
+
+  it('hides the lang-badge', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        compact
+      />,
+    );
+    expect(container.querySelector('.lang-badge')).toBeNull();
+  });
+
+  it('hides the row play button even when canPlay is true', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        canPlay
+        onPlay={() => {}}
+        compact
+      />,
+    );
+    expect(container.querySelector('.row-play-btn')).toBeNull();
+  });
+
+  it('renders a speaker-colored role dot on the first row of a speaker run', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        compact
+      />,
+    );
+    const dot = container.querySelector('.row-role-dot');
+    expect(dot).not.toBeNull();
+    expect(dot?.classList.contains('source-speaker')).toBe(true);
+  });
+
+  it('renders a participant-colored role dot on the first row of a participant run', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'participant' })}
+        prevItem={makeItem({ source: 'speaker' })}
+        compact
+      />,
+    );
+    const dot = container.querySelector('.row-role-dot');
+    expect(dot).not.toBeNull();
+    expect(dot?.classList.contains('source-participant')).toBe(true);
+  });
+
+  it('does NOT render a role dot when prevItem has the same source', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker', id: 'b' })}
+        prevItem={makeItem({ source: 'speaker', id: 'a' })}
+        compact
+      />,
+    );
+    expect(container.querySelector('.row-role-dot')).toBeNull();
+  });
+
+  it('adds a compact class on the root element', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        compact
+      />,
+    );
+    const root = container.querySelector('.conversation-row');
+    expect(root?.classList.contains('compact')).toBe(true);
+  });
+});

--- a/src/components/MainPanel/ConversationRow.test.tsx
+++ b/src/components/MainPanel/ConversationRow.test.tsx
@@ -170,6 +170,20 @@ describe('ConversationRow — compact mode', () => {
     expect(dot?.classList.contains('source-speaker')).toBe(true);
   });
 
+  it('exposes the role dot to screen readers via role + aria-label', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker' })}
+        prevItem={null}
+        compact
+      />,
+    );
+    const dot = container.querySelector('.row-role-dot');
+    expect(dot?.getAttribute('role')).toBe('img');
+    expect(dot?.getAttribute('aria-label')).toBe('Speaker');
+  });
+
   it('renders a participant-colored role dot on the first row of a participant run', () => {
     const { container } = render(
       <ConversationRow

--- a/src/components/MainPanel/ConversationRow.tsx
+++ b/src/components/MainPanel/ConversationRow.tsx
@@ -99,7 +99,11 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
       )}
       <div className={`row-body ${isPlaying ? 'playing' : ''}`}>
         {compact && showHeader && (
-          <span className={`row-role-dot source-${source}`} aria-hidden="true" />
+          <span
+            className={`row-role-dot source-${source}`}
+            role="img"
+            aria-label={scopeName}
+          />
         )}
         {!compact && (
           <span className={`lang-badge ${isTranslation ? 'tr' : 'src'} source-${source}`}>

--- a/src/components/MainPanel/ConversationRow.tsx
+++ b/src/components/MainPanel/ConversationRow.tsx
@@ -14,6 +14,7 @@ interface ConversationRowProps {
   canPlay?: boolean;
   onPlay?: () => void;
   playDisabled?: boolean;
+  compact?: boolean;
 }
 
 function languageForItem(
@@ -50,6 +51,7 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
   canPlay = false,
   onPlay,
   playDisabled = false,
+  compact = false,
 }) => {
   const { t } = useTranslation();
   const source: 'speaker' | 'participant' = item.source ?? 'speaker';
@@ -81,8 +83,10 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
   };
 
   return (
-    <div className={`conversation-row source-${source} ${showHeader ? 'with-header' : 'grouped'}`}>
-      {showHeader && (
+    <div
+      className={`conversation-row source-${source} ${showHeader ? 'with-header' : 'grouped'} ${compact ? 'compact' : 'expanded'}`}
+    >
+      {!compact && showHeader && (
         <div className="row-header">
           <div className={`row-avatar avatar-${source}`}>
             {source === 'speaker' ? <User size={12} /> : <Users size={12} />}
@@ -94,9 +98,16 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
         </div>
       )}
       <div className={`row-body ${isPlaying ? 'playing' : ''}`}>
-        <span className={`lang-badge ${isTranslation ? 'tr' : 'src'}`}>{lang.toUpperCase()}</span>
+        {compact && showHeader && (
+          <span className={`row-role-dot source-${source}`} aria-hidden="true" />
+        )}
+        {!compact && (
+          <span className={`lang-badge ${isTranslation ? 'tr' : 'src'} source-${source}`}>
+            {lang.toUpperCase()}
+          </span>
+        )}
         <span className={`row-text ${isTranslation ? 'tr' : 'src'}`}>{renderText()}</span>
-        {canPlay && onPlay && (
+        {!compact && canPlay && onPlay && (
           <button
             type="button"
             className={`row-play-btn ${isPlaying ? 'playing' : ''}`}

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2731,6 +2731,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             <button
               className="font-size-btn"
               onClick={() => setConversationCompactMode(!conversationCompactMode)}
+              aria-pressed={conversationCompactMode}
               title={
                 conversationCompactMode
                   ? t('mainPanel.expandedView', 'Expanded view')

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import {X, Zap, Mic, MicOff, Loader, Play, Volume2, VolumeX, Wrench, Send, AlertCircle, MessageSquare, Trash2, AArrowDown, AArrowUp} from 'lucide-react';
+import {X, Zap, Mic, MicOff, Loader, Play, Volume2, VolumeX, Wrench, Send, AlertCircle, MessageSquare, Trash2, AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown} from 'lucide-react';
 import './MainPanel.scss';
 import {
   useProvider,
@@ -22,6 +22,8 @@ import {
   useNavigateToSettings,
   useConversationFontSize,
   useSetConversationFontSize,
+  useConversationCompactMode,
+  useSetConversationCompactMode,
   useSpeakerDisplayMode,
   useParticipantDisplayMode,
   useSetSpeakerDisplayMode,
@@ -107,6 +109,8 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const uiMode = useUIMode();
   const conversationFontSize = useConversationFontSize();
   const setConversationFontSize = useSetConversationFontSize();
+  const conversationCompactMode = useConversationCompactMode();
+  const setConversationCompactMode = useSetConversationCompactMode();
   const speakerDisplayMode = useSpeakerDisplayMode();
   const participantDisplayMode = useParticipantDisplayMode();
   const setSpeakerDisplayMode = useSetSpeakerDisplayMode();
@@ -2607,6 +2611,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           canPlay={canPlay}
           onPlay={() => handlePlayAudio(item)}
           playDisabled={playingItemId !== null && !isItemPlaying}
+          compact={conversationCompactMode}
         />
       );
     }
@@ -2722,6 +2727,24 @@ const MainPanel: React.FC<MainPanelProps> = () => {
               type="button"
             >
               <AArrowUp size={14} />
+            </button>
+            {/* NEW: compact/expanded toggle */}
+            <button
+              className="font-size-btn"
+              onClick={() => setConversationCompactMode(!conversationCompactMode)}
+              title={
+                conversationCompactMode
+                  ? t('mainPanel.expandedView', 'Expanded view')
+                  : t('mainPanel.compactView', 'Compact view')
+              }
+              aria-label={
+                conversationCompactMode
+                  ? t('mainPanel.expandedView', 'Expanded view')
+                  : t('mainPanel.compactView', 'Compact view')
+              }
+              type="button"
+            >
+              {conversationCompactMode ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
             </button>
             <button
               className="clear-conversation-btn"

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2728,7 +2728,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             >
               <AArrowUp size={14} />
             </button>
-            {/* NEW: compact/expanded toggle */}
             <button
               className="font-size-btn"
               onClick={() => setConversationCompactMode(!conversationCompactMode)}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -526,6 +526,8 @@
     "clearConversation": "Clear conversation",
     "decreaseFontSize": "Decrease font size",
     "increaseFontSize": "Increase font size",
+    "compactView": "Compact view",
+    "expandedView": "Expanded view",
     "displayMode": {
       "speaker": "Speaker",
       "participant": "Participant",

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -36,6 +36,7 @@ export interface CommonSettings {
   participantSystemInstructions: string;
   textOnly: boolean;
   conversationFontSize: number;
+  conversationCompactMode: boolean;
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
 }
@@ -151,6 +152,7 @@ const defaultCommonSettings: CommonSettings = {
   uiMode: 'basic',
   textOnly: false,
   conversationFontSize: 14,
+  conversationCompactMode: false,
   systemInstructions:
     "# ROLE & OBJECTIVE\n" +
     "You are a simultaneous interpreter.\n" +
@@ -347,6 +349,9 @@ interface SettingsStore {
   // Conversation font size
   conversationFontSize: number;
 
+  // Conversation compact mode — hide chat chrome (avatars, names, timestamps, badges, play button) in the conversation panel
+  conversationCompactMode: boolean;
+
   // Conversation display mode filters
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
@@ -358,6 +363,7 @@ interface SettingsStore {
   setUIMode: (mode: 'basic' | 'advanced') => void;
   setTextOnly: (textOnly: boolean) => void;
   setConversationFontSize: (size: number) => void;
+  setConversationCompactMode: (compact: boolean) => Promise<void>;
   setSpeakerDisplayMode: (mode: DisplayMode) => Promise<void>;
   setParticipantDisplayMode: (mode: DisplayMode) => Promise<void>;
   setSystemInstructions: (instructions: string) => void;
@@ -721,6 +727,18 @@ const useSettingsStore = create<SettingsStore>()(
       } catch (error) {
         console.error('[SettingsStore] Error persisting conversationFontSize setting:', error);
         set({conversationFontSize: previous});
+      }
+    },
+
+    setConversationCompactMode: async (conversationCompactMode) => {
+      const previous = get().conversationCompactMode;
+      set({conversationCompactMode});
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.conversationCompactMode', conversationCompactMode);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting conversationCompactMode setting:', error);
+        set({conversationCompactMode: previous});
       }
     },
 
@@ -1201,6 +1219,7 @@ const useSettingsStore = create<SettingsStore>()(
         const participantSystemInstructions = await service.getSetting('settings.common.participantSystemInstructions', defaultCommonSettings.participantSystemInstructions);
         const textOnly = await service.getSetting('settings.common.textOnly', defaultCommonSettings.textOnly);
         const conversationFontSize = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
+        const conversationCompactMode = await service.getSetting('settings.common.conversationCompactMode', defaultCommonSettings.conversationCompactMode);
         const speakerDisplayMode = await service.getSetting<DisplayMode>('settings.common.speakerDisplayMode', defaultCommonSettings.speakerDisplayMode);
         const participantDisplayMode = await service.getSetting<DisplayMode>('settings.common.participantDisplayMode', defaultCommonSettings.participantDisplayMode);
 
@@ -1237,6 +1256,7 @@ const useSettingsStore = create<SettingsStore>()(
           participantSystemInstructions,
           textOnly,
           conversationFontSize,
+          conversationCompactMode,
           speakerDisplayMode,
           participantDisplayMode,
           openai,
@@ -1377,6 +1397,7 @@ export const useProvider = () => useSettingsStore((state) => state.provider);
 export const useUILanguage = () => useSettingsStore((state) => state.uiLanguage);
 export const useUIMode = () => useSettingsStore((state) => state.uiMode);
 export const useConversationFontSize = () => useSettingsStore((state) => state.conversationFontSize);
+export const useConversationCompactMode = () => useSettingsStore((state) => state.conversationCompactMode);
 export const useSpeakerDisplayMode = () => useSettingsStore((state) => state.speakerDisplayMode);
 export const useParticipantDisplayMode = () => useSettingsStore((state) => state.participantDisplayMode);
 export const useSystemInstructions = () => useSettingsStore((state) => state.systemInstructions);
@@ -1424,6 +1445,7 @@ export const useSetUILanguage = () => useSettingsStore((state) => state.setUILan
 export const useSetUIMode = () => useSettingsStore((state) => state.setUIMode);
 export const useSetTextOnly = () => useSettingsStore((state) => state.setTextOnly);
 export const useSetConversationFontSize = () => useSettingsStore((state) => state.setConversationFontSize);
+export const useSetConversationCompactMode = () => useSettingsStore((state) => state.setConversationCompactMode);
 export const useSetSpeakerDisplayMode = () => useSettingsStore((state) => state.setSpeakerDisplayMode);
 export const useSetParticipantDisplayMode = () => useSettingsStore((state) => state.setParticipantDisplayMode);
 export const useSetSystemInstructions = () => useSettingsStore((state) => state.setSystemInstructions);


### PR DESCRIPTION
## Summary

Two related conversation-panel changes, shipped together.

**Compact mode (toolbar toggle)** — a new icon button between the font-size buttons and the trash button. When enabled, the conversation panel hides chat chrome (avatar, speaker name, timestamp, language badge, row-level play button) and replaces the role indicator with a single 6px dot at the start of each speaker run (green for speaker, orange for participant). First step toward a future floating-subtitle surface.

**Role-colored translation badge (expanded mode only)** — the translation-side language badge (e.g. \`EN\`) picks up the same color language as the avatar / role dot: green when it belongs to the speaker, orange when it belongs to the participant. The source-side badge stays neutral gray. The badge itself is hidden in compact mode (the role dot takes over that signaling), so this color change is visible only when compact mode is off.

Persisted via the existing settings-service pattern (mirrors \`conversationFontSize\`).

Spec: \`docs/superpowers/specs/2026-04-18-compact-conversation-mode-design.md\`
Plan: \`docs/superpowers/plans/2026-04-18-compact-conversation-mode.md\`

## Test plan

- [ ] Run \`npm test\` — 129 tests pass (114 baseline + 15 new \`ConversationRow\` component tests covering compact rendering, role dot positioning + a11y label, and badge role classes)
- [ ] In the running app, start a translation session with both speaker and participant turns, then click the new toolbar button:
  - [ ] Icon switches between \`ChevronsDownUp\` (expanded) and \`ChevronsUpDown\` (compact)
  - [ ] Compact view: no avatar, no name, no timestamp, no \`ZH\`/\`EN\` badge, no per-row ▶
  - [ ] Compact view: first row of each speaker run has a green dot, first row of each participant run has an orange dot, no divider line between role switches
  - [ ] Reload the app — selected mode is restored (persisted)
- [ ] In expanded view, verify translation badges are green on speaker rows and orange on participant rows; source badges stay gray
- [ ] Screen reader: the toggle button announces its pressed state; in compact mode, role dots announce \"Speaker\" / \"Participant\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Compact conversation view that hides headers, shows a colored role indicator, and condenses layout.
  * Toolbar toggle to switch between compact and expanded views; preference is saved and persists.
  * Play control now appears only in expanded view for clearer interaction.

* **Styles**
  * Visual updates for role badges and compact-row spacing.

* **Tests**
  * Added test coverage verifying compact vs expanded rendering and accessibility labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->