### PR TITLE
feat: Linux AppImage packaging + auto-update support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,10 +314,12 @@ jobs:
         run: |
           mkdir -p release-assets
           find linux-x64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
-          find linux-x64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
+          find linux-x64-artifacts -name "*.AppImage" -exec cp {} release-assets/ \;
+          find linux-x64-artifacts -name "latest-linux.yml" -exec cp {} release-assets/ \;
           find linux-x64-artifacts -name "sokuji-extension-*.zip" -exec cp {} release-assets/ \;
           find linux-arm64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
-          find linux-arm64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
+          find linux-arm64-artifacts -name "*.AppImage" -exec cp {} release-assets/ \;
+          find linux-arm64-artifacts -name "latest-linux-arm64.yml" -exec cp {} release-assets/ \;
           find windows-signed -name "*.exe" -exec cp {} release-assets/ \;
           find windows-nupkg -name "*.nupkg" -exec cp {} release-assets/ \;
           find macos-arm64-artifacts -name "*.pkg" -exec cp {} release-assets/ \;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -103,7 +103,11 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false
-          USE_SYSTEM_FPM: ${{ matrix.arch == 'arm64' && 'true' || '' }}
+          # Must be literal 'false' (not empty string) on x64 — electron-builder
+          # reads this via `(USE_SYSTEM_FPM ?? "false") !== "false"`, and an
+          # empty string passes that check (truthy) which skips the bundled-fpm
+          # download and then fails on missing system `fpm`.
+          USE_SYSTEM_FPM: ${{ matrix.arch == 'arm64' && 'true' || 'false' }}
           VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL_PROD || 'https://sokuji-api.kizuna.ai' }}
           VITE_ENVIRONMENT: production
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           - os: ubuntu-latest
             artifact_name: linux-x64
             name: linux-x64
-          - os: ubuntu-latest
+          - os: ubuntu-24.04-arm
             artifact_name: linux-arm64
             name: linux-arm64
             arch: arm64
@@ -73,13 +73,26 @@ jobs:
           VITE_EXTENSION_ID: ${{ startsWith(github.ref, 'refs/tags/v') && secrets.VITE_EXTENSION_ID_PROD || '' }}
 
       - name: Build Electron app with Forge
-        if: runner.os != 'macOS'
+        if: runner.os == 'Windows'
         run: npx electron-forge make --arch=${{ matrix.arch || 'x64' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false
           # Prevent actual publishing during CI builds
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ !startsWith(github.ref, 'refs/tags/v') && 'false' || '' }}
+          VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL_PROD || 'https://sokuji-api.kizuna.ai' }}
+          VITE_ENVIRONMENT: production
+          VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+          VITE_ENABLE_VOLCENGINE_ST: ${{ secrets.VITE_ENABLE_VOLCENGINE_ST }}
+          VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
+          VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
+
+      - name: Build Linux packages (electron-builder)
+        if: runner.os == 'Linux'
+        run: npx electron-builder --linux AppImage deb --${{ matrix.arch || 'x64' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CI: false
           VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL_PROD || 'https://sokuji-api.kizuna.ai' }}
           VITE_ENVIRONMENT: production
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,12 +87,23 @@ jobs:
           VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
           VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
 
+      # electron-builder bundles an x86_64-only `fpm` for building .deb packages.
+      # On the arm64 runner, install `fpm` via Ruby gem and tell electron-builder
+      # to use it via USE_SYSTEM_FPM.
+      - name: Install system fpm (arm64 only)
+        if: runner.os == 'Linux' && matrix.arch == 'arm64'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends ruby-dev build-essential
+          sudo gem install --no-document fpm
+
       - name: Build Linux packages (electron-builder)
         if: runner.os == 'Linux'
         run: npx electron-builder --linux AppImage deb --${{ matrix.arch || 'x64' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false
+          USE_SYSTEM_FPM: ${{ matrix.arch == 'arm64' && 'true' || '' }}
           VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL_PROD || 'https://sokuji-api.kizuna.ai' }}
           VITE_ENVIRONMENT: production
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,14 @@ jobs:
 
       - name: Build Linux packages (electron-builder)
         if: runner.os == 'Linux'
-        run: npx electron-builder --linux AppImage deb --${{ matrix.arch || 'x64' }}
+        # --publish never: the CI's `release` job uploads artifacts via
+        # softprops/action-gh-release. electron-builder auto-publishes on tag
+        # builds when GH_TOKEN is set (default policy onTagOrDraft + GitHub
+        # provider configured in package.json), which would race with the
+        # release job and create duplicate releases. Keep publishing in one
+        # place. package.json's `build.publish` is retained because it is
+        # still required for `latest-linux*.yml` generation during the build.
+        run: npx electron-builder --linux AppImage deb --${{ matrix.arch || 'x64' }} --publish never
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,8 +165,9 @@ jobs:
         with:
           name: linux-x64-artifacts
           path: |
-            out/make/**/*.deb
-            out/make/**/*.zip
+            out/make-linux/*.AppImage
+            out/make-linux/*.deb
+            out/make-linux/latest-linux.yml
             extension/sokuji-extension-*.zip
             CHANGELOG.md
 
@@ -176,8 +177,9 @@ jobs:
         with:
           name: linux-arm64-artifacts
           path: |
-            out/make/**/*.deb
-            out/make/**/*.zip
+            out/make-linux/*.AppImage
+            out/make-linux/*.deb
+            out/make-linux/latest-linux-arm64.yml
 
       - name: Upload unsigned Windows installer for signing
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'

--- a/docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md
+++ b/docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md
@@ -1,0 +1,1218 @@
+# Linux AppImage Packaging + Auto-Update Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add AppImage (x64 + arm64) as the recommended Linux format with native `electron-updater` auto-update. Keep `.deb`; drop `.zip`. `.deb` users see a "migrate to AppImage" banner.
+
+**Architecture:** Linux packaging migrates from Forge (`maker-deb` + `maker-zip`) to `electron-builder` (AppImage + deb). Forge continues to handle Windows (Squirrel) and macOS (PKG). `UpdateManager` branches on `process.env.APPIMAGE`: AppImage users get the full `electron-updater` download/install cycle; `.deb` users get a migration banner with AppImage + deb download links.
+
+**Tech Stack:** electron-builder, electron-updater (already installed, v6.8.3), @electron/fuses (already installed, v2.0.0), Zustand store, React + i18next UI.
+
+**Spec:** `docs/superpowers/specs/2026-04-20-linux-appimage-auto-update-design.md`
+
+---
+
+## Phase 1 — Build system migration
+
+### Task 1: Add electron-builder devDependency
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install electron-builder**
+
+Run:
+```bash
+npm install --save-dev electron-builder@^25.1.8
+```
+
+Expected: adds `"electron-builder": "^25.x.x"` to `devDependencies`; `package-lock.json` updated.
+
+- [ ] **Step 2: Verify install**
+
+Run: `npx electron-builder --version`
+Expected: prints a version number (25.x or newer), no error.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json
+git commit -m "chore(deps): add electron-builder for Linux AppImage build"
+```
+
+---
+
+### Task 2: Create afterPack Fuses script
+
+Forge's `@electron-forge/plugin-fuses` applies Electron Fuses at package time. electron-builder has no built-in Fuses integration, so we mirror the behavior in an `afterPack` hook.
+
+**Files:**
+- Create: `scripts/electron-builder-fuses.js`
+
+- [ ] **Step 1: Create the script**
+
+Create `scripts/electron-builder-fuses.js`:
+```js
+const path = require('path');
+const fs = require('fs');
+const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
+
+// Apply Electron Fuses to the packaged binary, mirroring the options
+// previously set by @electron-forge/plugin-fuses in forge.config.js.
+module.exports = async function applyFuses(context) {
+  const executableName = context.packager.executableName || context.packager.appInfo.productFilename;
+  const execPath = path.join(context.appOutDir, executableName);
+
+  if (!fs.existsSync(execPath)) {
+    throw new Error(`[electron-builder-fuses] Executable not found at ${execPath}`);
+  }
+
+  await flipFuses(execPath, {
+    version: FuseVersion.V1,
+    resetAdHocDarwinSignature: false,
+    [FuseV1Options.RunAsNode]: false,
+    [FuseV1Options.EnableCookieEncryption]: true,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+    [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+    [FuseV1Options.OnlyLoadAppFromAsar]: true,
+  });
+
+  console.log(`[electron-builder-fuses] Applied Fuses to ${execPath}`);
+};
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add scripts/electron-builder-fuses.js
+git commit -m "chore(build): add afterPack Fuses script for electron-builder"
+```
+
+---
+
+### Task 3: Add electron-builder build config to package.json
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Add the `build` field**
+
+Add this top-level field to `package.json` (place near `"main"` or at the end of the object):
+```jsonc
+"build": {
+  "appId": "com.kizunaai.sokuji",
+  "productName": "Sokuji",
+  "asar": true,
+  "directories": {
+    "output": "out/make-linux"
+  },
+  "files": [
+    "package.json",
+    "dist-electron/**/*",
+    "build/**/*",
+    "!build/**/*.map",
+    "!build/assets/test-tone.mp3",
+    "!build/wasm/**",
+    "build/wasm/sherpa-onnx-asr/**",
+    "build/wasm/sherpa-onnx-asr-stream/**",
+    "build/wasm/sherpa-onnx-tts/**",
+    "build/wasm/ort/**",
+    "build/wasm/vad/**",
+    "build/wasm/piper-plus/**",
+    "build/wasm/gtcrn/**"
+  ],
+  "extraResources": ["assets", "resources"],
+  "linux": {
+    "target": [
+      { "target": "AppImage", "arch": ["x64", "arm64"] },
+      { "target": "deb",      "arch": ["x64", "arm64"] }
+    ],
+    "category": "AudioVideo",
+    "icon": "assets/icon.png",
+    "executableName": "sokuji"
+  },
+  "appImage": {
+    "artifactName": "${productName}-${version}-${arch}.${ext}"
+  },
+  "deb": {
+    "artifactName": "${name}_${version}_${arch}.${ext}"
+  },
+  "publish": null,
+  "afterPack": "./scripts/electron-builder-fuses.js"
+}
+```
+
+Notes for the reader:
+- `files` is processed in order; later patterns override earlier ones. The order matters: include `build/**/*` first, then exclude source maps, the test-tone file, and all of `build/wasm/**`, then re-include specific wasm runtime dirs.
+- `node_modules/` does not need to be listed — electron-builder auto-includes production node_modules regardless of the `files` value.
+- `extraResources` copies `assets/` and `resources/` into `Contents/Resources/` on macOS / `resources/` on Linux — same semantics as Forge's `packagerConfig.extraResource`.
+
+- [ ] **Step 2: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('package.json', 'utf8'))"`
+Expected: no output (JSON is valid).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json
+git commit -m "chore(build): add electron-builder Linux AppImage + deb config"
+```
+
+---
+
+### Task 4: Remove Forge Linux makers
+
+Linux output is now handled by electron-builder. Remove the redundant Forge makers.
+
+**Files:**
+- Modify: `forge.config.js`
+- Modify: `package.json`
+
+- [ ] **Step 1: Remove makers from `forge.config.js`**
+
+Delete the `maker-zip` and `maker-deb` entries from the `makers` array. The resulting `makers` array should contain only `maker-squirrel` and `maker-dmg`:
+```js
+makers: [
+  {
+    name: '@electron-forge/maker-squirrel',
+    config: { /* unchanged */ }
+  },
+  {
+    name: '@electron-forge/maker-dmg',
+    config: { name: 'Sokuji', overwrite: true }
+  }
+],
+```
+
+- [ ] **Step 2: Uninstall the unused Forge maker packages**
+
+Run:
+```bash
+npm uninstall @electron-forge/maker-deb @electron-forge/maker-zip
+```
+
+Expected: both packages removed from `devDependencies` in `package.json`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add package.json package-lock.json forge.config.js
+git commit -m "chore(build): remove Forge Linux makers (deb/zip now via electron-builder)"
+```
+
+---
+
+### Task 5: Local build verification
+
+Verify the new electron-builder pipeline produces usable Linux artifacts before touching runtime or CI code.
+
+**Files:** none modified.
+
+- [ ] **Step 1: Build the React bundle**
+
+Run: `npm run build`
+Expected: `build/` dir populated with `index.html`, JS bundles, and `build/wasm/**` runtime dirs.
+
+- [ ] **Step 2: Build Linux packages for x64**
+
+Run: `npx electron-builder --linux AppImage deb --x64`
+Expected: `out/make-linux/` contains:
+- `Sokuji-<version>-x64.AppImage`
+- `sokuji_<version>_amd64.deb`
+- `latest-linux.yml`
+
+Build log should include `[electron-builder-fuses] Applied Fuses to ...`.
+
+- [ ] **Step 3: Validate `latest-linux.yml` shape**
+
+Run: `cat out/make-linux/latest-linux.yml`
+Expected content looks like:
+```yaml
+version: <current-version>
+files:
+  - url: Sokuji-<version>-x64.AppImage
+    sha512: <base64-hash>
+    size: <bytes>
+path: Sokuji-<version>-x64.AppImage
+sha512: <base64-hash>
+releaseDate: '<iso-timestamp>'
+```
+
+- [ ] **Step 4: Smoke-test the AppImage**
+
+Run: `chmod +x out/make-linux/Sokuji-*-x64.AppImage && out/make-linux/Sokuji-*-x64.AppImage`
+Expected: app window opens. In the main-process console, look for `Initializing Better Auth adapter` and `electron-audio-loopback initialized for linux`. No crashes within first 5 seconds.
+
+- [ ] **Step 5: Smoke-test the deb (only if on a Debian-based dev host)**
+
+Run: `sudo dpkg -i out/make-linux/sokuji_*_amd64.deb && sokuji`
+Expected: installs without errors; `sokuji` binary launches the app. (Skip if dev host isn't Debian-based; CI will cover this.)
+
+- [ ] **Step 6: Commit (no changes expected)**
+
+No changes to commit from this task unless build surfaced issues. If build issues were found, fix them now and commit fixes under `fix(build): ...` before proceeding.
+
+---
+
+## Phase 2 — Audio runtime verification in AppImage
+
+### Task 6: AppImage audio compatibility check
+
+Spec pre-requisite verification. The electron-audio-loopback migration is already done for the `.deb` path (confirmed from real v0.18.1 logs); we now verify the remaining `pactl` / `pw-link` calls for virtual TTS devices still work from within an AppImage process.
+
+**Files:** none modified (verification only).
+
+- [ ] **Step 1: Ensure `process.env.APPIMAGE` detection works**
+
+With the AppImage from Task 5 step 4 still running, check its stdout for any log line emitted from `electron/main.js` startup. Add one if none exists — temporarily insert at the top of `app.whenReady()` in `electron/main.js`:
+```js
+console.log('[Sokuji] [Main] process.env.APPIMAGE =', process.env.APPIMAGE || '<unset>');
+```
+
+Re-build (`npx electron-builder --linux AppImage --x64`) and launch again.
+
+Expected stdout: `[Sokuji] [Main] process.env.APPIMAGE = /tmp/.mount_Sokuji...` (a real path, not `<unset>`).
+
+- [ ] **Step 2: Verify `pactl` is reachable from inside AppImage**
+
+In the same AppImage session, check the main-process logs for `[Sokuji] [PulseAudio] Checking sinks: pactl list sinks short`. Confirm the subsequent `Orphaned device check completed` line appears without any `ENOENT` / `command not found` errors.
+
+- [ ] **Step 3: Verify virtual TTS devices are created**
+
+Check logs for:
+- `[Sokuji] [PulseAudio] virtual sink created (ID: <n>)`
+- `[Sokuji] [PulseAudio] virtual mic created (ID: <n>)`
+- `[Sokuji] [PulseAudio] Connected: sokuji_virtual_output:monitor_FL -> input.sokuji_virtual_mic:input_FL`
+- `[Sokuji] [PulseAudio] Virtual audio devices created successfully`
+
+From a separate host terminal, also confirm: `pactl list sinks short | grep sokuji_virtual_output` returns a line.
+
+- [ ] **Step 4: End-to-end translation session**
+
+In the running AppImage: sign in (if needed), select Kizuna AI or any provider, start a translation session, speak into the mic, confirm TTS output is audible and also reaches the virtual mic. (Follow existing CLAUDE.md guidance — monitor LogsPanel.)
+
+Expected: full pipeline works identically to the `.deb` install.
+
+- [ ] **Step 5: Revert the temporary debug log**
+
+Remove the `console.log('[Sokuji] [Main] process.env.APPIMAGE ...')` line added in Step 1. (We will re-add it as a real field in Task 8, not as a console.log.)
+
+- [ ] **Step 6: Commit if any fixes were required**
+
+If any audio check failed and required a code fix (e.g., falling back to `module-loopback` as documented in the spec), commit those fixes now. Otherwise, no commit.
+
+---
+
+## Phase 3 — updateStore extensions
+
+### Task 7: Add new fields to updateStore
+
+New state fields: `supportsAutoUpdate`, `appImageUrl`, `debUrl`, `releasePageUrl`. Existing `downloadUrl` is retained (used by Windows / legacy path).
+
+**Files:**
+- Modify: `src/stores/updateStore.ts`
+- Test: `src/stores/updateStore.test.ts` (create new)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/stores/updateStore.test.ts`:
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import useUpdateStore from './updateStore';
+
+describe('updateStore', () => {
+  beforeEach(() => {
+    useUpdateStore.setState({
+      status: 'idle',
+      newVersion: null,
+      changelog: null,
+      downloadProgress: 0,
+      downloadSpeed: 0,
+      downloadTransferred: 0,
+      downloadTotal: 0,
+      errorMessage: null,
+      downloadUrl: null,
+      supportsAutoUpdate: true,
+      appImageUrl: null,
+      debUrl: null,
+      releasePageUrl: null,
+      bannerDismissed: false,
+      dialogOpen: false,
+    });
+  });
+
+  it('defaults supportsAutoUpdate to true (matches Windows behavior)', () => {
+    expect(useUpdateStore.getState().supportsAutoUpdate).toBe(true);
+  });
+
+  it('exposes appImageUrl, debUrl, releasePageUrl as null by default', () => {
+    const s = useUpdateStore.getState();
+    expect(s.appImageUrl).toBeNull();
+    expect(s.debUrl).toBeNull();
+    expect(s.releasePageUrl).toBeNull();
+  });
+
+  it('allows setting the new fields', () => {
+    useUpdateStore.setState({
+      supportsAutoUpdate: false,
+      appImageUrl: 'https://example.com/app.AppImage',
+      debUrl: 'https://example.com/app.deb',
+      releasePageUrl: 'https://example.com/release',
+    });
+    const s = useUpdateStore.getState();
+    expect(s.supportsAutoUpdate).toBe(false);
+    expect(s.appImageUrl).toBe('https://example.com/app.AppImage');
+    expect(s.debUrl).toBe('https://example.com/app.deb');
+    expect(s.releasePageUrl).toBe('https://example.com/release');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect failure**
+
+Run: `npx vitest run src/stores/updateStore.test.ts`
+Expected: all three tests fail with TypeScript errors / undefined property access on the new fields.
+
+- [ ] **Step 3: Add fields to the `UpdateState` interface**
+
+In `src/stores/updateStore.ts`, extend the `UpdateState` interface:
+```ts
+interface UpdateState {
+  status: UpdateStatus;
+  newVersion: string | null;
+  changelog: string | null;
+  downloadProgress: number;
+  downloadSpeed: number;
+  downloadTransferred: number;
+  downloadTotal: number;
+  errorMessage: string | null;
+  downloadUrl: string | null;
+  // NEW fields for Linux AppImage/deb split:
+  supportsAutoUpdate: boolean;
+  appImageUrl: string | null;
+  debUrl: string | null;
+  releasePageUrl: string | null;
+  bannerDismissed: boolean;
+  dialogOpen: boolean;
+}
+```
+
+- [ ] **Step 4: Add default values to the store creator**
+
+In the `create<UpdateStore>()(...)` call, add the new defaults to the state initialization block:
+```ts
+supportsAutoUpdate: true,
+appImageUrl: null,
+debUrl: null,
+releasePageUrl: null,
+```
+
+Add these alongside the existing `downloadUrl: null,` line.
+
+- [ ] **Step 5: Populate from IPC payload in `statusHandler`**
+
+Find the `statusHandler = (data: any) => {` block. After the existing `if (data.downloadUrl) update.downloadUrl = data.downloadUrl;` line, add:
+```ts
+if (typeof data.supportsAutoUpdate === 'boolean') update.supportsAutoUpdate = data.supportsAutoUpdate;
+if (data.appImageUrl !== undefined) update.appImageUrl = data.appImageUrl;
+if (data.debUrl !== undefined) update.debUrl = data.debUrl;
+if (data.releasePageUrl !== undefined) update.releasePageUrl = data.releasePageUrl;
+```
+
+- [ ] **Step 6: Add selectors**
+
+Add these to the selector-exports block at the bottom of `updateStore.ts`:
+```ts
+export const useUpdateSupportsAutoUpdate = () => useUpdateStore(state => state.supportsAutoUpdate);
+export const useUpdateAppImageUrl = () => useUpdateStore(state => state.appImageUrl);
+export const useUpdateDebUrl = () => useUpdateStore(state => state.debUrl);
+export const useUpdateReleasePageUrl = () => useUpdateStore(state => state.releasePageUrl);
+```
+
+- [ ] **Step 7: Run the test — expect pass**
+
+Run: `npx vitest run src/stores/updateStore.test.ts`
+Expected: all three tests pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/stores/updateStore.ts src/stores/updateStore.test.ts
+git commit -m "feat(updateStore): add supportsAutoUpdate + AppImage/deb url fields"
+```
+
+---
+
+## Phase 4 — UpdateManager Linux branching
+
+### Task 8: Populate AppImage/deb URLs on `update-available`
+
+**Files:**
+- Modify: `electron/update-manager.js`
+
+- [ ] **Step 1: Add `isAppImage` constant near the top of the class**
+
+In `electron/update-manager.js`, inside the `UpdateManager` constructor (after the `fullChangelog = true` line), add:
+```js
+this.isAppImage = process.platform === 'linux' && !!process.env.APPIMAGE;
+```
+
+Also log it once for easier debugging:
+```js
+if (process.platform === 'linux') {
+  console.log(`[Sokuji] [UpdateManager] Linux runtime: isAppImage=${this.isAppImage}, APPIMAGE=${process.env.APPIMAGE || '<unset>'}`);
+}
+```
+
+- [ ] **Step 2: Replace the existing Linux `update-available` block**
+
+Find the block in `_setupAutoUpdaterEvents()` inside the `autoUpdater.on('update-available', ...)` handler:
+```js
+// On Linux, include download URL instead of auto-download
+if (process.platform === 'linux') {
+  payload.downloadUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${info.version}`;
+}
+```
+
+Replace with:
+```js
+if (process.platform === 'linux') {
+  const version = info.version;
+  const appImageArch = process.arch; // 'x64' or 'arm64'
+  const debArch = process.arch === 'x64' ? 'amd64' : 'arm64';
+  const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
+
+  payload.supportsAutoUpdate = this.isAppImage;
+  payload.appImageUrl = `${base}/Sokuji-${version}-${appImageArch}.AppImage`;
+  payload.debUrl = `${base}/sokuji_${version}_${debArch}.deb`;
+  payload.releasePageUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${version}`;
+  // Legacy field kept for Windows / backward compat callers of updateStore:
+  if (!this.isAppImage) {
+    payload.downloadUrl = payload.releasePageUrl;
+  }
+}
+```
+
+- [ ] **Step 3: Smoke-test the IPC payload shape**
+
+Run: `npm test` (full test suite; currently should still pass — no Update-Manager unit tests exist yet, and updateStore tests from Task 7 should pass).
+
+Expected: all existing tests pass. No new test in this step — we verify end-to-end in Task 17.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add electron/update-manager.js
+git commit -m "feat(update-manager): add AppImage detection + Linux url payload"
+```
+
+---
+
+### Task 9: Route `update-download` and `update-install` by AppImage flag
+
+**Files:**
+- Modify: `electron/update-manager.js`
+
+- [ ] **Step 1: Branch the `update-download` handler**
+
+Find the `ipcMain.handle('update-download', async () => { ... })` block. Replace its body with:
+```js
+ipcMain.handle('update-download', async () => {
+  if (!this._updateInfo) {
+    this._sendStatus({ status: 'error', message: 'No update available to download' });
+    return { success: false, error: 'No update available' };
+  }
+
+  // Linux AppImage: use electron-updater's native AppImageUpdater flow
+  if (process.platform === 'linux' && this.isAppImage) {
+    if (this._downloadPromise) return this._downloadPromise;
+    this._downloadPromise = (async () => {
+      try {
+        this._sendStatus({ status: 'downloading' });
+        // Hook download-progress events from autoUpdater to IPC
+        const onProgress = (p) => this._sendProgress({
+          percent: p.percent || 0,
+          bytesPerSecond: p.bytesPerSecond || 0,
+          transferred: p.transferred || 0,
+          total: p.total || 0,
+        });
+        const onDownloaded = () => this._sendStatus({ status: 'downloaded' });
+        autoUpdater.on('download-progress', onProgress);
+        autoUpdater.once('update-downloaded', onDownloaded);
+
+        await autoUpdater.downloadUpdate();
+        // `update-downloaded` event is what flips status to 'downloaded';
+        // it also populates this.downloadPath implicitly via electron-updater.
+        this.downloadPath = '__appimage__'; // sentinel so install handler proceeds
+        return { success: true };
+      } catch (err) {
+        this._sendStatus({ status: 'error', message: err.message || String(err) });
+        return { success: false, error: err.message };
+      } finally {
+        this._downloadPromise = null;
+      }
+    })();
+    return this._downloadPromise;
+  }
+
+  // Non-AppImage Linux: no auto-download; renderer opens links manually
+  if (process.platform === 'linux' && !this.isAppImage) {
+    return { success: false, error: 'auto-update-not-supported' };
+  }
+
+  // Windows (existing Squirrel-compatible manual download) — unchanged
+  if (this._downloadPromise) return this._downloadPromise;
+  this._downloadPromise = (async () => {
+    try {
+      await this._downloadUpdate();
+      return { success: true };
+    } catch (err) {
+      console.error('Update download failed:', err);
+      this._sendStatus({ status: 'error', message: err.message || String(err) });
+      return { success: false, error: err.message };
+    } finally {
+      this._downloadPromise = null;
+    }
+  })();
+  return this._downloadPromise;
+});
+```
+
+- [ ] **Step 2: Branch the `update-install` handler**
+
+Replace the body of `ipcMain.handle('update-install', ...)` with:
+```js
+ipcMain.handle('update-install', async () => {
+  if (!this.downloadPath) {
+    this._sendStatus({ status: 'error', message: 'No downloaded update to install' });
+    return { success: false, error: 'No downloaded update' };
+  }
+
+  // Linux AppImage: native quitAndInstall replaces the AppImage in place
+  if (process.platform === 'linux' && this.isAppImage) {
+    try {
+      autoUpdater.quitAndInstall();
+      return { success: true };
+    } catch (err) {
+      this._sendStatus({ status: 'error', message: err.message || String(err) });
+      return { success: false, error: err.message };
+    }
+  }
+
+  // Windows (existing Squirrel launch path) — unchanged
+  try {
+    await this._installUpdate();
+    return { success: true };
+  } catch (err) {
+    console.error('Update install failed:', err);
+    this._sendStatus({ status: 'error', message: err.message || String(err) });
+    return { success: false, error: err.message };
+  }
+});
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add electron/update-manager.js
+git commit -m "feat(update-manager): route download/install by AppImage vs legacy"
+```
+
+---
+
+## Phase 5 — UI variants
+
+### Task 10: Add i18n keys in English first
+
+Spec keys: `update.autoUpdateNote`, `update.downloadAppImage`, `update.downloadDeb`, `update.linuxMigrateTitle`, `update.linuxMigrateBody`.
+
+**Files:**
+- Modify: `src/locales/en/translation.json`
+
+- [ ] **Step 1: Add the new keys to the English locale**
+
+In `src/locales/en/translation.json`, find the existing `"update": { ... }` block. Add these keys inside it (alongside the existing keys):
+```json
+"autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+"downloadAppImage": "Download AppImage (recommended)",
+"downloadDeb": "Download .deb",
+"linuxMigrateTitle": "New version v{{version}} available",
+"linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+```
+
+- [ ] **Step 2: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('src/locales/en/translation.json', 'utf8'))"`
+Expected: no output (valid JSON).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/locales/en/translation.json
+git commit -m "feat(i18n): add Linux AppImage/deb update keys (en)"
+```
+
+---
+
+### Task 11: Propagate i18n keys to all 29 other locales
+
+English fallback covers missing translations, but we want first-class localization in all 30 locales. Use English copy as a safe placeholder; native speakers can tighten later.
+
+**Files:**
+- Modify: `src/locales/{ar,bn,de,es,fa,fi,fil,fr,he,hi,id,it,ja,ko,ms,nl,pl,pt_BR,pt_PT,ru,sv,ta,te,th,tr,uk,vi,zh_CN,zh_TW}/translation.json`
+
+- [ ] **Step 1: Script the copy (ensures exact consistency)**
+
+Run this shell one-liner from the repo root:
+```bash
+node -e "
+const fs = require('fs');
+const path = require('path');
+const keys = {
+  autoUpdateNote: 'AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.',
+  downloadAppImage: 'Download AppImage (recommended)',
+  downloadDeb: 'Download .deb',
+  linuxMigrateTitle: 'New version v{{version}} available',
+  linuxMigrateBody: 'Auto-updates are available on AppImage. Pick a format to download v{{version}}.',
+};
+const dirs = fs.readdirSync('src/locales', { withFileTypes: true })
+  .filter(d => d.isDirectory() && d.name !== 'en')
+  .map(d => d.name);
+for (const locale of dirs) {
+  const p = path.join('src/locales', locale, 'translation.json');
+  if (!fs.existsSync(p)) continue;
+  const json = JSON.parse(fs.readFileSync(p, 'utf8'));
+  json.update = json.update || {};
+  for (const [k, v] of Object.entries(keys)) {
+    if (!(k in json.update)) json.update[k] = v;
+  }
+  fs.writeFileSync(p, JSON.stringify(json, null, 2) + '\n');
+  console.log('Updated', p);
+}
+"
+```
+
+Expected: prints `Updated src/locales/<locale>/translation.json` for 29 locales.
+
+- [ ] **Step 2: Validate all locales parse as JSON**
+
+Run:
+```bash
+for f in src/locales/*/translation.json; do node -e "JSON.parse(require('fs').readFileSync('$f', 'utf8'))" || echo "BAD: $f"; done
+```
+
+Expected: no `BAD:` lines.
+
+- [ ] **Step 3: Localize native strings where convenient (optional)**
+
+For `zh_CN`, `zh_TW`, `ja`, `ko`, `de`, `fr`, `es`, `pt_BR`, `ru` — translate the five keys inline. (Use existing translation style in each file as reference. This is cosmetic; English fallback handles missed locales.)
+
+Skip if time-pressed; other locales will fall back to English.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/locales
+git commit -m "feat(i18n): add Linux AppImage/deb update keys to all locales"
+```
+
+---
+
+### Task 12: UpdateDialog — non-AppImage Linux variant
+
+**Files:**
+- Modify: `src/components/UpdateDialog/UpdateDialog.tsx`
+- Modify: `src/components/UpdateDialog/UpdateDialog.scss` (add tertiary-button class)
+
+- [ ] **Step 1: Add the tertiary button style**
+
+In `src/components/UpdateDialog/UpdateDialog.scss`, add a tertiary button style matching the existing secondary style. Find the `.secondary-button` rule and add adjacent:
+```scss
+.tertiary-button {
+  background: transparent;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  color: #ccc;
+  &:hover {
+    background: rgba(255, 255, 255, 0.05);
+  }
+}
+```
+
+- [ ] **Step 2: Import the new selectors**
+
+In `src/components/UpdateDialog/UpdateDialog.tsx`, extend the imports from `../../stores/updateStore`:
+```ts
+import {
+  useUpdateStatus,
+  useUpdateNewVersion,
+  useUpdateChangelog,
+  useUpdateProgressPercent,
+  useUpdateProgressTransferred,
+  useUpdateProgressTotal,
+  useUpdateDownloadUrl,
+  useUpdateDialogOpen,
+  useCloseUpdateDialog,
+  useDownloadUpdate,
+  useInstallUpdate,
+  // NEW:
+  useUpdateSupportsAutoUpdate,
+  useUpdateAppImageUrl,
+  useUpdateDebUrl,
+} from '../../stores/updateStore';
+```
+
+- [ ] **Step 3: Consume the new state in the component**
+
+Inside the `UpdateDialog` component body (near the other hook calls):
+```ts
+const supportsAutoUpdate = useUpdateSupportsAutoUpdate();
+const appImageUrl = useUpdateAppImageUrl();
+const debUrl = useUpdateDebUrl();
+```
+
+- [ ] **Step 4: Render the migration variant in the footer**
+
+Find the `status === 'available'` block in the footer (starts with `{status === 'available' && (<>...</>)}`). Replace the inner JSX with this logic:
+```tsx
+{status === 'available' && (
+  <>
+    {!supportsAutoUpdate && (appImageUrl || debUrl) ? (
+      // Non-AppImage Linux: offer two download paths
+      <>
+        {appImageUrl && (
+          <button
+            className="primary-button"
+            onClick={() => {
+              if (isElectron() && (window as any).electron?.invoke) {
+                (window as any).electron.invoke('open-external', appImageUrl);
+              } else {
+                window.open(appImageUrl, '_blank');
+              }
+              closeDialog();
+            }}
+          >
+            {t('update.downloadAppImage')}
+          </button>
+        )}
+        {debUrl && (
+          <button
+            className="tertiary-button"
+            onClick={() => {
+              if (isElectron() && (window as any).electron?.invoke) {
+                (window as any).electron.invoke('open-external', debUrl);
+              } else {
+                window.open(debUrl, '_blank');
+              }
+              closeDialog();
+            }}
+          >
+            {t('update.downloadDeb')}
+          </button>
+        )}
+        <button className="secondary-button" onClick={closeDialog}>
+          {t('update.later')}
+        </button>
+      </>
+    ) : downloadUrl ? (
+      // Legacy (any platform passing a generic downloadUrl, e.g. old callers)
+      <>
+        <button
+          className="primary-button"
+          onClick={() => {
+            if (isElectron() && (window as any).electron?.invoke) {
+              (window as any).electron.invoke('open-external', downloadUrl);
+            } else {
+              window.open(downloadUrl, '_blank');
+            }
+            closeDialog();
+          }}
+        >
+          {t('update.goToDownload')}
+        </button>
+        <button className="secondary-button" onClick={closeDialog}>
+          {t('update.later')}
+        </button>
+      </>
+    ) : (
+      // Windows / AppImage Linux: full auto-update flow
+      <>
+        <button className="primary-button" onClick={downloadUpdate}>
+          {t('update.downloadNow')}
+        </button>
+        <button className="secondary-button" onClick={closeDialog}>
+          {t('update.later')}
+        </button>
+      </>
+    )}
+  </>
+)}
+```
+
+- [ ] **Step 5: Add the auto-update note to the body for non-AppImage Linux**
+
+Find the `status === 'available' && newVersion && (...)` block in `update-dialog-body`. Right after the `version-info` div (and before the `changelog` render), add:
+```tsx
+{status === 'available' && !supportsAutoUpdate && (
+  <div className="auto-update-note">
+    {t('update.autoUpdateNote')}
+  </div>
+)}
+```
+
+Add minimal styling to `UpdateDialog.scss`:
+```scss
+.auto-update-note {
+  margin: 12px 0;
+  padding: 12px;
+  border-radius: 6px;
+  background: rgba(16, 163, 127, 0.08);
+  color: #b8d4c9;
+  font-size: 0.9em;
+  line-height: 1.5;
+}
+```
+
+- [ ] **Step 6: Build and smoke-test in the dev renderer**
+
+Run: `npm run dev`
+In browser dev tools console:
+```js
+window.__updateStore.setState({
+  status: 'available',
+  newVersion: '0.99.0',
+  supportsAutoUpdate: false,
+  appImageUrl: 'https://example.com/test.AppImage',
+  debUrl: 'https://example.com/test.deb',
+  dialogOpen: true,
+});
+```
+
+Expected: dialog renders with "Download AppImage (recommended)", "Download .deb", "Later" buttons plus the auto-update note.
+
+Also test the normal AppImage path:
+```js
+window.__updateStore.setState({
+  status: 'available',
+  newVersion: '0.99.0',
+  supportsAutoUpdate: true,
+  appImageUrl: null,
+  debUrl: null,
+  dialogOpen: true,
+});
+```
+
+Expected: classic "Download Now", "Later" buttons; no migration note.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/UpdateDialog
+git commit -m "feat(UpdateDialog): add Linux deb → AppImage migration variant"
+```
+
+---
+
+### Task 13: UpdateBanner — non-AppImage Linux variant
+
+Minimal change: the banner message text swaps to the migrate title when `supportsAutoUpdate === false`. Clicking it still opens the dialog.
+
+**Files:**
+- Modify: `src/components/UpdateBanner/UpdateBanner.tsx`
+
+- [ ] **Step 1: Extend imports**
+
+Extend the store imports to include `useUpdateSupportsAutoUpdate`:
+```ts
+import {
+  useUpdateStatus,
+  useUpdateNewVersion,
+  useUpdateProgressPercent,
+  useUpdateError,
+  useUpdateBannerDismissed,
+  useDismissBanner,
+  useOpenUpdateDialog,
+  useInstallUpdate,
+  useUpdateSupportsAutoUpdate,   // NEW
+} from '../../stores/updateStore';
+```
+
+- [ ] **Step 2: Read the flag**
+
+Add near the other hook calls:
+```ts
+const supportsAutoUpdate = useUpdateSupportsAutoUpdate();
+```
+
+- [ ] **Step 3: Swap the banner label for non-AppImage Linux**
+
+Find the `{status === 'available' && (<>...</>)}` JSX block. Replace the `span` label line:
+```tsx
+<span>{t('update.available', { version: newVersion })}</span>
+```
+With:
+```tsx
+<span>
+  {supportsAutoUpdate
+    ? t('update.available', { version: newVersion })
+    : t('update.linuxMigrateTitle', { version: newVersion })}
+</span>
+```
+
+- [ ] **Step 4: Smoke-test in the dev renderer**
+
+Run: `npm run dev` and in dev-tools console:
+```js
+window.__updateStore.setState({
+  status: 'available',
+  newVersion: '0.99.0',
+  supportsAutoUpdate: false,
+});
+```
+
+Expected: banner shows "New version v0.99.0 available" (migrate title). Clicking opens the dialog (which shows the two-button migration variant from Task 12).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/UpdateBanner
+git commit -m "feat(UpdateBanner): relabel non-AppImage Linux banner"
+```
+
+---
+
+## Phase 6 — CI changes
+
+### Task 14: Matrix + native ARM runner + electron-builder Linux step
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+- [ ] **Step 1: Switch arm64 matrix row to native runner**
+
+In the `build.matrix.include` list, change the arm64 Linux row. Replace:
+```yaml
+- os: ubuntu-latest
+  artifact_name: linux-arm64
+  name: linux-arm64
+  arch: arm64
+```
+With:
+```yaml
+- os: ubuntu-24.04-arm
+  artifact_name: linux-arm64
+  name: linux-arm64
+  arch: arm64
+```
+
+- [ ] **Step 2: Make the existing Forge build step Linux-exempt**
+
+Find the `- name: Build Electron app with Forge` step. Change its `if:` from `runner.os != 'macOS'` to:
+```yaml
+if: runner.os == 'Windows'
+```
+
+- [ ] **Step 3: Add a new electron-builder step for Linux**
+
+Immediately after the Forge step, add:
+```yaml
+- name: Build Linux packages (electron-builder)
+  if: runner.os == 'Linux'
+  run: npx electron-builder --linux AppImage deb --${{ matrix.arch || 'x64' }}
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    CI: false
+    VITE_BACKEND_URL: ${{ secrets.VITE_BACKEND_URL_PROD || 'https://sokuji-api.kizuna.ai' }}
+    VITE_ENVIRONMENT: production
+    VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
+    VITE_ENABLE_VOLCENGINE_ST: ${{ secrets.VITE_ENABLE_VOLCENGINE_ST }}
+    VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
+    VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: switch Linux build to electron-builder (AppImage + deb)"
+```
+
+---
+
+### Task 15: Update CI artifact uploads for Linux
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+- [ ] **Step 1: Update Linux x64 upload paths**
+
+Find the `- name: Upload Linux x64 artifacts` step. Replace its `path:` block with:
+```yaml
+path: |
+  out/make-linux/*.AppImage
+  out/make-linux/*.deb
+  out/make-linux/latest-linux.yml
+  extension/sokuji-extension-*.zip
+  CHANGELOG.md
+```
+
+- [ ] **Step 2: Update Linux ARM64 upload paths**
+
+Find the `- name: Upload Linux ARM64 artifacts` step. Replace its `path:` block with:
+```yaml
+path: |
+  out/make-linux/*.AppImage
+  out/make-linux/*.deb
+  out/make-linux/latest-linux-arm64.yml
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: upload AppImage + latest-linux*.yml in Linux artifacts"
+```
+
+---
+
+### Task 16: Update release-job asset collection
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+- [ ] **Step 1: Replace Linux asset-collection lines**
+
+Find the `- name: Collect release assets` step. In its `run:` block, locate these lines:
+```bash
+find linux-x64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "sokuji-extension-*.zip" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
+```
+
+Replace them with:
+```bash
+find linux-x64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "*.AppImage" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "latest-linux.yml" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "sokuji-extension-*.zip" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "*.AppImage" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "latest-linux-arm64.yml" -exec cp {} release-assets/ \;
+```
+
+Note: the chromium `.zip` from Forge `maker-zip` is gone; we no longer cp it.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: replace .zip with AppImage + latest-linux*.yml in release assets"
+```
+
+---
+
+## Phase 7 — End-to-end validation
+
+### Task 17: Pre-release test tag (AppImage self-update cycle)
+
+Validate the full AppImage auto-update cycle on a real Linux host before calling the feature done.
+
+**Files:** no code changes (validation only).
+
+- [ ] **Step 1: Cut a pre-release tag `vX.Y.Z-rc1`**
+
+Run (replace version):
+```bash
+git tag -a v0.20.0-rc1 -m "Release v0.20.0-rc1 (AppImage auto-update test)"
+git push origin v0.20.0-rc1
+```
+
+Expected: CI builds kick off; after build + sign-windows + release jobs succeed, a draft release is created with `Sokuji-0.20.0-rc1-x64.AppImage`, `Sokuji-0.20.0-rc1-arm64.AppImage`, two `.deb` files, `latest-linux.yml`, `latest-linux-arm64.yml`, and the existing Windows `.exe` + `latest.yml` + macOS `.pkg` assets.
+
+- [ ] **Step 2: Publish the draft release (required for electron-updater to see it)**
+
+On GitHub, find the draft release, edit it, un-check "Set as a pre-release" if needed, and click "Publish release". electron-updater only reads from published (non-draft) releases.
+
+- [ ] **Step 3: Install `Sokuji-0.20.0-rc1-x64.AppImage` on a Linux host, verify it runs**
+
+Download the AppImage from the release, `chmod +x`, run. Confirm basic function (audio, translation).
+
+- [ ] **Step 4: Cut a second tag `vX.Y.Z-rc2`**
+
+Make a trivial change (e.g., bump version number in `package.json`), commit, tag, and push:
+```bash
+npm version --no-git-tag-version 0.20.0-rc2
+git add package.json package-lock.json
+git commit -m "chore(release): v0.20.0-rc2"
+git tag -a v0.20.0-rc2 -m "Release v0.20.0-rc2 (AppImage auto-update test)"
+git push origin main
+git push origin v0.20.0-rc2
+```
+
+Wait for CI → publish release.
+
+- [ ] **Step 5: Trigger auto-update from running rc1 AppImage**
+
+With rc1 still running, click "Check for Updates" in the app (or wait for startup check). Expected behavior:
+- Banner appears: "New version v0.20.0-rc2 available"
+- Click banner → UpdateDialog → "Download Now" → progress bar
+- On completion → "Restart and Update" → app quits, relaunches as rc2
+- Verify in rc2 the version number in Settings → About shows 0.20.0-rc2
+
+- [ ] **Step 6: Confirm the old AppImage binary was replaced in place**
+
+Check that the AppImage file you originally downloaded now has the rc2 version string inside it (e.g., `strings Sokuji-0.20.0-rc1-x64.AppImage | grep -o '0\.20\.0-rc[12]'` should show `0.20.0-rc2`). This confirms AppImageUpdater did in-place replacement.
+
+- [ ] **Step 7: Commit the rc2 version bump if it's still dangling**
+
+(Already committed in step 4; nothing extra here.)
+
+---
+
+### Task 18: .deb migration banner validation
+
+**Files:** no code changes (validation only).
+
+- [ ] **Step 1: Install `sokuji_0.20.0-rc1_amd64.deb`**
+
+Run:
+```bash
+sudo dpkg -i sokuji_0.20.0-rc1_amd64.deb
+sokuji
+```
+
+Expected: app starts, main log shows `[UpdateManager] Linux runtime: isAppImage=false, APPIMAGE=<unset>` once rc2 is the latest published release.
+
+- [ ] **Step 2: Wait for startup update check (or click "Check for Updates")**
+
+Expected:
+- Main log shows `APPIMAGE env is not defined, current application is not an AppImage` (still emitted by electron-updater — expected noise)
+- `update-status` IPC fires with `status: 'available'`, `supportsAutoUpdate: false`, `appImageUrl: '...AppImage'`, `debUrl: '...deb'`
+- Banner appears with text "New version v0.20.0-rc2 available"
+- Click banner → UpdateDialog opens with: auto-update note, "Download AppImage (recommended)", "Download .deb", "Later"
+- Click "Download AppImage (recommended)" → browser opens the AppImage release asset URL
+- Dialog closes
+
+- [ ] **Step 3: Confirm no auto-download/install is attempted**
+
+In logs, confirm there is NO `download-progress` event, NO `update-downloaded` event, and NO `autoUpdater.quitAndInstall` call. The .deb user's update flow is entirely browser-based.
+
+- [ ] **Step 4: Cleanup — final commit if anything adjusted during validation**
+
+If validation surfaced bugs, fix and commit. Otherwise this task has no commit.
+
+---
+
+## Completion Criteria
+
+- [ ] Local `npx electron-builder --linux AppImage deb --x64` produces valid artifacts with `latest-linux.yml`
+- [ ] AppImage build launches, audio pipeline works end-to-end, `process.env.APPIMAGE` is set
+- [ ] `npx vitest run src/stores/updateStore.test.ts` passes
+- [ ] CI green on Linux x64 (`ubuntu-latest`) and arm64 (`ubuntu-24.04-arm`)
+- [ ] Draft release contains 2 AppImages, 2 debs, `latest-linux.yml`, `latest-linux-arm64.yml`, and all existing Windows/macOS assets
+- [ ] AppImage self-update cycle: rc1 → rc2 via in-app "Restart and Update" works
+- [ ] .deb user sees migration banner with both download links; no auto-download happens
+- [ ] No regressions in Windows Squirrel update path or macOS PKG build

--- a/docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md
+++ b/docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md
@@ -480,7 +480,9 @@ Replace with:
 ```js
 if (process.platform === 'linux') {
   const version = info.version;
-  const appImageArch = process.arch; // 'x64' or 'arm64'
+  // electron-builder names AppImage artifacts with `x86_64` (not `x64`) for
+  // x64 Linux builds, and `arm64` for arm64. Translate Node's process.arch.
+  const appImageArch = process.arch === 'x64' ? 'x86_64' : 'arm64';
   const debArch = process.arch === 'x64' ? 'amd64' : 'arm64';
   const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
 

--- a/docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md
+++ b/docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md
@@ -219,7 +219,7 @@ Expected: `build/` dir populated with `index.html`, JS bundles, and `build/wasm/
 
 Run: `npx electron-builder --linux AppImage deb --x64`
 Expected: `out/make-linux/` contains:
-- `Sokuji-<version>-x64.AppImage`
+- `Sokuji-<version>-x86_64.AppImage` (electron-builder uses `x86_64` for x64 Linux AppImage filenames)
 - `sokuji_<version>_amd64.deb`
 - `latest-linux.yml`
 
@@ -232,17 +232,17 @@ Expected content looks like:
 ```yaml
 version: <current-version>
 files:
-  - url: Sokuji-<version>-x64.AppImage
+  - url: Sokuji-<version>-x86_64.AppImage
     sha512: <base64-hash>
     size: <bytes>
-path: Sokuji-<version>-x64.AppImage
+path: Sokuji-<version>-x86_64.AppImage
 sha512: <base64-hash>
 releaseDate: '<iso-timestamp>'
 ```
 
 - [ ] **Step 4: Smoke-test the AppImage**
 
-Run: `chmod +x out/make-linux/Sokuji-*-x64.AppImage && out/make-linux/Sokuji-*-x64.AppImage`
+Run: `chmod +x out/make-linux/Sokuji-*-x86_64.AppImage && out/make-linux/Sokuji-*-x86_64.AppImage`
 Expected: app window opens. In the main-process console, look for `Initializing Better Auth adapter` and `electron-audio-loopback initialized for linux`. No crashes within first 5 seconds.
 
 - [ ] **Step 5: Smoke-test the deb (only if on a Debian-based dev host)**
@@ -1132,13 +1132,13 @@ git tag -a v0.20.0-rc1 -m "Release v0.20.0-rc1 (AppImage auto-update test)"
 git push origin v0.20.0-rc1
 ```
 
-Expected: CI builds kick off; after build + sign-windows + release jobs succeed, a draft release is created with `Sokuji-0.20.0-rc1-x64.AppImage`, `Sokuji-0.20.0-rc1-arm64.AppImage`, two `.deb` files, `latest-linux.yml`, `latest-linux-arm64.yml`, and the existing Windows `.exe` + `latest.yml` + macOS `.pkg` assets.
+Expected: CI builds kick off; after build + sign-windows + release jobs succeed, a draft release is created with `Sokuji-0.20.0-rc1-x86_64.AppImage`, `Sokuji-0.20.0-rc1-arm64.AppImage`, two `.deb` files, `latest-linux.yml`, `latest-linux-arm64.yml`, and the existing Windows `.exe` + `latest.yml` + macOS `.pkg` assets.
 
 - [ ] **Step 2: Publish the draft release (required for electron-updater to see it)**
 
 On GitHub, find the draft release, edit it, un-check "Set as a pre-release" if needed, and click "Publish release". electron-updater only reads from published (non-draft) releases.
 
-- [ ] **Step 3: Install `Sokuji-0.20.0-rc1-x64.AppImage` on a Linux host, verify it runs**
+- [ ] **Step 3: Install `Sokuji-0.20.0-rc1-x86_64.AppImage` on a Linux host, verify it runs**
 
 Download the AppImage from the release, `chmod +x`, run. Confirm basic function (audio, translation).
 
@@ -1166,7 +1166,7 @@ With rc1 still running, click "Check for Updates" in the app (or wait for startu
 
 - [ ] **Step 6: Confirm the old AppImage binary was replaced in place**
 
-Check that the AppImage file you originally downloaded now has the rc2 version string inside it (e.g., `strings Sokuji-0.20.0-rc1-x64.AppImage | grep -o '0\.20\.0-rc[12]'` should show `0.20.0-rc2`). This confirms AppImageUpdater did in-place replacement.
+Check that the AppImage file you originally downloaded now has the rc2 version string inside it (e.g., `strings Sokuji-0.20.0-rc1-x86_64.AppImage | grep -o '0\.20\.0-rc[12]'` should show `0.20.0-rc2`). This confirms AppImageUpdater did in-place replacement.
 
 - [ ] **Step 7: Commit the rc2 version bump if it's still dangling**
 

--- a/docs/superpowers/specs/2026-04-20-linux-appimage-auto-update-design.md
+++ b/docs/superpowers/specs/2026-04-20-linux-appimage-auto-update-design.md
@@ -105,7 +105,11 @@ This change fixes that as a side effect: once CI produces `latest-linux.yml` and
     "deb": {
       "artifactName": "${name}_${version}_${arch}.${ext}"
     },
-    "publish": null,
+    "publish": {
+      "provider": "github",
+      "owner": "kizuna-ai-lab",
+      "repo": "sokuji"
+    },
     "afterPack": "./scripts/electron-builder-fuses.js"
   }
 }
@@ -115,9 +119,9 @@ Notes:
 - `files` is the glob equivalent of Forge's function-based `ignore`. Exclude `build/wasm/**` then re-include runtime dirs explicitly (same semantics as current whitelist).
 - `extraResources` preserves `assets/` and `resources/` in the app resource dir.
 - Artifact names:
-  - **AppImage**: `Sokuji-${version}-${arch}.AppImage` where `${arch}` is `x64` / `arm64` (electron-builder's internal arch names for AppImage).
-  - **deb**: `sokuji_${version}_${arch}.deb` where `${arch}` is auto-mapped by electron-builder's deb target to Debian conventions (`x64` → `amd64`, `arm64` → `arm64`). UpdateManager must use the Debian-mapped value when constructing `debUrl`.
-- `publish: null` — we don't use electron-builder's publisher; GitHub Release upload stays in the existing CI workflow.
+  - **AppImage**: `Sokuji-${version}-${arch}.AppImage` where `${arch}` resolves to `x86_64` (for x64 builds) / `arm64` — electron-builder uses `x86_64` in Linux AppImage filenames, not the config's `x64`. `package.json` `linux.target.arch` still lists `x64` (the config name); the substitution in `artifactName` is what flips to `x86_64`.
+  - **deb**: `sokuji_${version}_${arch}.deb` where `${arch}` is auto-mapped by electron-builder's deb target to Debian conventions (config `x64` → filename `amd64`, `arm64` → `arm64`). UpdateManager must use the Debian-mapped value when constructing `debUrl`.
+- `publish` is configured with the GitHub provider **for manifest generation only** — without a publisher configured, electron-builder does not emit `latest-linux*.yml`, which `electron-updater` needs to detect updates. The CI invokes `npx electron-builder --publish never` so no actual upload happens; the existing `release` job continues to upload artifacts via `softprops/action-gh-release`.
 
 ### 2. Fuses parity (`scripts/electron-builder-fuses.js`)
 
@@ -156,12 +160,14 @@ const isAppImage = process.platform === 'linux' && !!process.env.APPIMAGE;
 // In 'update-available' handler:
 if (process.platform === 'linux') {
   const version = info.version;
-  const arch = process.arch; // 'x64' or 'arm64'
-  const debArch = arch === 'x64' ? 'amd64' : 'arm64';
+  // electron-builder names AppImage artifacts with `x86_64` (not `x64`) for
+  // x64 Linux builds, and `arm64` for arm64. Translate Node's process.arch.
+  const appImageArch = process.arch === 'x64' ? 'x86_64' : 'arm64';
+  const debArch = process.arch === 'x64' ? 'amd64' : 'arm64';
   const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
 
   payload.supportsAutoUpdate = isAppImage;
-  payload.appImageUrl = `${base}/Sokuji-${version}-${arch}.AppImage`;
+  payload.appImageUrl = `${base}/Sokuji-${version}-${appImageArch}.AppImage`;
   payload.debUrl = `${base}/sokuji_${version}_${debArch}.deb`;
   payload.releasePageUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${version}`;
 }
@@ -341,7 +347,7 @@ AppImage runs unsandboxed with the host's `$PATH` and sockets accessible, so the
 - **FUSE missing**: AppImage needs FUSE 2 to mount itself. Every major desktop distro ships it; minimal/container environments may not. Error message from AppImage is self-explanatory. Document in release notes: `./Sokuji.AppImage --appimage-extract-and-run` as fallback. No code change.
 - **Executable bit after update**: `electron-updater`'s `AppImageUpdater` sets `chmod +x` on the replacement binary automatically.
 - **`--no-sandbox`**: some exotic distros require this flag for Chromium sandbox compatibility. Our app currently doesn't set it in Forge builds; if AppImage users hit sandbox errors in QA, add `--no-sandbox` to the AppRun command (electron-builder config: `linux.executableArgs`). Not pre-emptively added.
-- **Filename collisions**: With the pinned `artifactName` patterns, AppImage uses `x64`/`arm64` and `.deb` uses `amd64`/`arm64` (auto-mapped by electron-builder's deb target). Extensions differ anyway; no ambiguity in the release assets.
+- **Filename collisions**: With the pinned `artifactName` patterns, AppImage uses `x86_64`/`arm64` (electron-builder's Linux AppImage arch naming) and `.deb` uses `amd64`/`arm64` (auto-mapped by electron-builder's deb target from the config `x64` arch). Extensions differ anyway; no ambiguity in the release assets.
 - **Existing users on `.zip`**: the `.zip` format is dropped. Users who discovered it will see it disappear from releases; the update banner will point them at AppImage. Impact expected to be near-zero (AppImage is strictly more useful than a directory ZIP).
 
 ## Out of Scope / Future Work

--- a/docs/superpowers/specs/2026-04-20-linux-appimage-auto-update-design.md
+++ b/docs/superpowers/specs/2026-04-20-linux-appimage-auto-update-design.md
@@ -1,0 +1,373 @@
+# Linux AppImage Packaging + Auto-Update Design
+
+GitHub issue: [#124](https://github.com/kizuna-ai-lab/sokuji/issues/124)
+
+## Summary
+
+Add AppImage as the recommended Linux distribution format with full `electron-updater` auto-update support (x64 + arm64). Keep `.deb` for existing Debian/Ubuntu users but drop `.zip`. Users on non-AppImage Linux installs see an update notification that links to both the new AppImage and the new `.deb`, encouraging migration to the auto-updating format over time.
+
+Linux packaging moves entirely from Electron Forge to `electron-builder`; Windows and macOS packaging stay on Forge. This split keeps a single tool per platform boundary and takes advantage of `electron-builder`'s native `electron-updater` integration (auto-generated `latest-linux.yml`, `AppImageUpdater` drop-in) without paying the cost of migrating the already-working Windows/macOS flows.
+
+## Requirements
+
+| Requirement | Decision |
+|---|---|
+| Linux packaging formats | AppImage (new, recommended) + `.deb` (retain); drop `.zip` |
+| Architectures | x64 + arm64 |
+| Build tool for Linux | `electron-builder` (replaces Forge `maker-deb` / `maker-zip`) |
+| Build tool for Win/Mac | Electron Forge (unchanged) |
+| Auto-update for AppImage | Full `electron-updater` flow (download + in-place replace + restart) |
+| Auto-update for `.deb` | Not supported by electron-updater; show banner + links to AppImage (recommended) and `.deb` |
+| AppImage detection | `process.env.APPIMAGE` at runtime |
+| Update channel | Single stable channel (no beta/alpha segmentation for now) |
+| ARM64 CI runner | `ubuntu-24.04-arm` (native ARM GitHub-hosted runner) |
+| AppImage signing | Unsigned (consistent with current `.deb`); revisit in a future issue |
+| FUSE fallback | Documented in release notes; no code change (user runs `--appimage-extract-and-run`) |
+
+## Current Behavior vs After This Change
+
+The existing auto-update spec (`2026-03-16-auto-update-design.md`) describes a "Linux: show update available + GitHub Release link" flow. **In practice this flow never triggers on current .deb builds** — CI only produces `latest.yml` for Windows, so `electron-updater`'s Linux check silently 404s on manifest fetch, `update-available` never fires, and the banner code path stays dormant. A real v0.18.1 `.deb` install shows no update UI at all; logs just include the soft warning `APPIMAGE env is not defined, current application is not an AppImage` from electron-updater's init.
+
+This change fixes that as a side effect: once CI produces `latest-linux.yml` and `latest-linux-arm64.yml`, `update-available` fires on all Linux builds. AppImage users get full auto-update; `.deb` users finally get the "new version + migrate to AppImage" banner the original spec promised.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     Build pipeline                           │
+│                                                              │
+│  Forge                         electron-builder              │
+│  ├── Windows (Squirrel)        └── Linux x64/arm64           │
+│  └── macOS (PKG)                   ├── AppImage              │
+│                                    └── .deb                  │
+│                                    + latest-linux.yml        │
+│                                    + latest-linux-arm64.yml  │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│                     Update runtime (Linux)                   │
+│                                                              │
+│  isAppImage = !!process.env.APPIMAGE                         │
+│                                                              │
+│  AppImage path                  .deb / zip / dev path        │
+│  ──────────────                 ─────────────────────        │
+│  autoUpdater                    autoUpdater                  │
+│   .checkForUpdates()             .checkForUpdates()          │
+│   → update-available             → update-available          │
+│   → downloadUpdate()             → (no auto download)        │
+│   → quitAndInstall()             → banner shows 2 links:     │
+│                                    AppImage (auto-update)    │
+│                                    .deb (manual install)     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Module Design
+
+### 1. electron-builder configuration (`package.json` `build` field)
+
+```jsonc
+{
+  "build": {
+    "appId": "com.kizunaai.sokuji",
+    "productName": "Sokuji",
+    "asar": true,
+    "directories": {
+      "output": "out/make-linux"
+    },
+    "files": [
+      "package.json",
+      "dist-electron/**/*",
+      "build/**/*",
+      "!build/**/*.map",
+      "!build/assets/test-tone.mp3",
+      "!build/wasm/**",
+      "build/wasm/sherpa-onnx-asr/**",
+      "build/wasm/sherpa-onnx-asr-stream/**",
+      "build/wasm/sherpa-onnx-tts/**",
+      "build/wasm/ort/**",
+      "build/wasm/vad/**",
+      "build/wasm/piper-plus/**",
+      "build/wasm/gtcrn/**"
+    ],
+    "extraResources": ["assets", "resources"],
+    "linux": {
+      "target": [
+        { "target": "AppImage", "arch": ["x64", "arm64"] },
+        { "target": "deb",      "arch": ["x64", "arm64"] }
+      ],
+      "category": "AudioVideo",
+      "icon": "assets/icon.png",
+      "executableName": "sokuji"
+    },
+    "appImage": {
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "deb": {
+      "artifactName": "${name}_${version}_${arch}.${ext}"
+    },
+    "publish": null,
+    "afterPack": "./scripts/electron-builder-fuses.js"
+  }
+}
+```
+
+Notes:
+- `files` is the glob equivalent of Forge's function-based `ignore`. Exclude `build/wasm/**` then re-include runtime dirs explicitly (same semantics as current whitelist).
+- `extraResources` preserves `assets/` and `resources/` in the app resource dir.
+- Artifact names:
+  - **AppImage**: `Sokuji-${version}-${arch}.AppImage` where `${arch}` is `x64` / `arm64` (electron-builder's internal arch names for AppImage).
+  - **deb**: `sokuji_${version}_${arch}.deb` where `${arch}` is auto-mapped by electron-builder's deb target to Debian conventions (`x64` → `amd64`, `arm64` → `arm64`). UpdateManager must use the Debian-mapped value when constructing `debUrl`.
+- `publish: null` — we don't use electron-builder's publisher; GitHub Release upload stays in the existing CI workflow.
+
+### 2. Fuses parity (`scripts/electron-builder-fuses.js`)
+
+Forge's `@electron-forge/plugin-fuses` applies Fuse V1 options at package time. electron-builder has no built-in Fuses integration, so we add an `afterPack` hook that calls `@electron/fuses` directly:
+
+```js
+const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
+const path = require('path');
+
+exports.default = async function applyFuses(context) {
+  const execPath = path.join(
+    context.appOutDir,
+    context.packager.executableName
+  );
+  await flipFuses(execPath, {
+    version: FuseVersion.V1,
+    [FuseV1Options.RunAsNode]: false,
+    [FuseV1Options.EnableCookieEncryption]: true,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+    [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+    [FuseV1Options.OnlyLoadAppFromAsar]: true,
+  });
+};
+```
+
+This produces a Linux binary with the same security posture as the Forge-built Linux binary today.
+
+### 3. UpdateManager changes (`electron/update-manager.js`)
+
+Replace the current Linux branch with an AppImage-aware split. Key additions:
+
+```js
+const isAppImage = process.platform === 'linux' && !!process.env.APPIMAGE;
+
+// In 'update-available' handler:
+if (process.platform === 'linux') {
+  const version = info.version;
+  const arch = process.arch; // 'x64' or 'arm64'
+  const debArch = arch === 'x64' ? 'amd64' : 'arm64';
+  const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
+
+  payload.supportsAutoUpdate = isAppImage;
+  payload.appImageUrl = `${base}/Sokuji-${version}-${arch}.AppImage`;
+  payload.debUrl = `${base}/sokuji_${version}_${debArch}.deb`;
+  payload.releasePageUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${version}`;
+}
+```
+
+In the `update-download` IPC handler:
+
+```js
+if (process.platform === 'linux' && isAppImage) {
+  // electron-updater handles AppImage natively
+  await autoUpdater.downloadUpdate();
+  // success: 'update-downloaded' event fires → UI shows "Restart and Update"
+  return { success: true };
+}
+if (process.platform === 'linux' && !isAppImage) {
+  // No auto-download; renderer handles links via shell.openExternal
+  return { success: false, error: 'not-supported' };
+}
+// Windows: existing manual .exe download path — unchanged
+```
+
+In the `update-install` IPC handler:
+
+```js
+if (process.platform === 'linux' && isAppImage) {
+  autoUpdater.quitAndInstall();
+  return { success: true };
+}
+// Non-AppImage Linux: never called (no install button shown)
+// Windows: existing Squirrel launch path — unchanged
+```
+
+`autoUpdater.autoDownload` stays `false` globally — user always confirms before a download starts, on every platform.
+
+### 4. updateStore changes (`src/stores/updateStore.ts`)
+
+Add three fields to the state:
+
+```ts
+interface UpdateState {
+  // ... existing fields ...
+  supportsAutoUpdate: boolean;   // true on Win / AppImage Linux; false on .deb Linux
+  appImageUrl: string | null;    // Linux only
+  debUrl: string | null;         // Linux only
+  releasePageUrl: string | null; // Linux only (used as fallback)
+}
+```
+
+Populated from the `update-status` IPC payload when `status === 'available'`.
+
+### 5. UI changes
+
+**UpdateBanner**: when `supportsAutoUpdate === false` and status is `'available'`, render a distinct variant ("New version v{version} — auto-updates supported on AppImage") that opens UpdateDialog.
+
+**UpdateDialog**: when `supportsAutoUpdate === false`, the button row switches from **[Download Now] [Later]** to:
+- **[Download AppImage (recommended)]** — opens `appImageUrl` via `shell.openExternal`
+- **[Download .deb]** — opens `debUrl`
+- **[Later]** — dismiss for session
+
+Include a one-line note: "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed."
+
+Existing AppImage auto-update UX (Download Now → progress → Restart and Update) is identical to the Windows path; no UI changes needed there.
+
+### 6. New i18n keys
+
+Under `update` namespace:
+
+- `update.autoUpdateNote` — "AppImage supports automatic updates."
+- `update.downloadAppImage` — "Download AppImage (recommended)"
+- `update.downloadDeb` — "Download .deb"
+- `update.linuxMigrateTitle` — "New version v{{version}} available"
+- `update.linuxMigrateBody` — "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+
+## CI/CD Changes
+
+### Linux build jobs in `.github/workflows/build.yml`
+
+**Matrix update**: change the arm64 row to use the native ARM runner:
+
+```yaml
+matrix:
+  include:
+    - os: ubuntu-latest         # x64
+      name: linux-x64
+    - os: ubuntu-24.04-arm      # native arm64 runner (was ubuntu-latest)
+      name: linux-arm64
+      arch: arm64
+    # Windows / macOS rows unchanged
+```
+
+**Replace the Forge build step on Linux** with an `electron-builder` invocation:
+
+```yaml
+- name: Build Linux packages (electron-builder)
+  if: runner.os == 'Linux'
+  run: npx electron-builder --linux AppImage deb --${{ matrix.arch || 'x64' }}
+  env:
+    CI: false
+    # Same VITE_* env block as the existing Forge step
+```
+
+The existing `npx electron-forge make` step stays exclusive to Windows (`runner.os == 'Windows'`); macOS keeps its current `build-pkg.sh` path.
+
+**Upload artifacts** — add AppImage and `latest-linux*.yml` to the Linux uploads:
+
+```yaml
+- name: Upload Linux x64 artifacts
+  if: startsWith(github.ref, 'refs/tags/v') && matrix.name == 'linux-x64'
+  uses: actions/upload-artifact@v4
+  with:
+    name: linux-x64-artifacts
+    path: |
+      out/make-linux/*.AppImage
+      out/make-linux/*.deb
+      out/make-linux/latest-linux.yml
+      extension/sokuji-extension-*.zip
+      CHANGELOG.md
+
+- name: Upload Linux ARM64 artifacts
+  if: startsWith(github.ref, 'refs/tags/v') && matrix.name == 'linux-arm64'
+  uses: actions/upload-artifact@v4
+  with:
+    name: linux-arm64-artifacts
+    path: |
+      out/make-linux/*.AppImage
+      out/make-linux/*.deb
+      out/make-linux/latest-linux-arm64.yml
+```
+
+**Release job** — extend `Collect release assets` to cp AppImage + `latest-linux*.yml`; drop the old `.zip` copy line:
+
+```yaml
+find linux-x64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "*.AppImage" -exec cp {} release-assets/ \;
+find linux-x64-artifacts -name "latest-linux.yml" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "*.deb" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "*.AppImage" -exec cp {} release-assets/ \;
+find linux-arm64-artifacts -name "latest-linux-arm64.yml" -exec cp {} release-assets/ \;
+# remove previous .zip cp lines
+```
+
+`latest.yml` (Windows) is still generated by the existing hand-rolled step — unchanged.
+
+### `forge.config.js` cleanup
+
+Remove `@electron-forge/maker-deb` and `@electron-forge/maker-zip` (Linux output is now electron-builder's job). `maker-squirrel` (Windows) and `maker-dmg` (macOS) stay.
+
+### Dependencies
+
+Add to `devDependencies`:
+- `electron-builder` (Linux packaging + `latest-linux.yml` generation)
+- `@electron/fuses` (if not already pulled in transitively via Forge's plugin-fuses; explicit dep keeps it stable for the afterPack hook)
+
+Keep `electron-updater` as a runtime `dependency` (already present).
+
+Remove from `devDependencies`:
+- `@electron-forge/maker-deb`
+- `@electron-forge/maker-zip`
+
+## Audio Compatibility (Pre-Implementation Verification)
+
+Context: the `electron-audio-loopback` migration for system audio capture is **already done** (`LinuxLoopbackRecorder.ts` deleted, `LoopbackRecorder.ts` handles capture on all platforms). The remaining Linux-specific audio surface is the virtual TTS devices created by `electron/pulseaudio-utils.js` (`sokuji_virtual_output` + `sokuji_virtual_mic`), which rely on host `pactl` + `pw-link`.
+
+AppImage runs unsandboxed with the host's `$PATH` and sockets accessible, so these commands are expected to work. Verify on first dev AppImage build:
+
+1. Build a dev AppImage: `npx electron-builder --linux AppImage --x64`
+2. Launch it and confirm `process.env.APPIMAGE` is set (print to main log)
+3. Confirm `pactl info` succeeds from within the AppImage process (host audio socket reachable)
+4. Trigger `createVirtualAudioDevices()` and verify `sokuji_virtual_output` appears in host `pactl list sinks short`
+5. Verify `electron-audio-loopback` (`getDisplayMedia`) works — requires `xdg-desktop-portal` on the host, which is present on all target desktop distros
+6. Run an end-to-end translation session and confirm TTS output is routed through the virtual mic to the AI provider
+
+**Fallback if `pw-link` fails inside AppImage** (low probability): replace pw-link connection with `pactl load-module module-loopback source=... sink=...`. This is a pure `pactl` call, uses no pipewire-specific tooling, and works on both PulseAudio and PipeWire (PipeWire emulates module-loopback). Implementation-time fallback only; not part of the initial change.
+
+## Edge Cases
+
+- **FUSE missing**: AppImage needs FUSE 2 to mount itself. Every major desktop distro ships it; minimal/container environments may not. Error message from AppImage is self-explanatory. Document in release notes: `./Sokuji.AppImage --appimage-extract-and-run` as fallback. No code change.
+- **Executable bit after update**: `electron-updater`'s `AppImageUpdater` sets `chmod +x` on the replacement binary automatically.
+- **`--no-sandbox`**: some exotic distros require this flag for Chromium sandbox compatibility. Our app currently doesn't set it in Forge builds; if AppImage users hit sandbox errors in QA, add `--no-sandbox` to the AppRun command (electron-builder config: `linux.executableArgs`). Not pre-emptively added.
+- **Filename collisions**: With the pinned `artifactName` patterns, AppImage uses `x64`/`arm64` and `.deb` uses `amd64`/`arm64` (auto-mapped by electron-builder's deb target). Extensions differ anyway; no ambiguity in the release assets.
+- **Existing users on `.zip`**: the `.zip` format is dropped. Users who discovered it will see it disappear from releases; the update banner will point them at AppImage. Impact expected to be near-zero (AppImage is strictly more useful than a directory ZIP).
+
+## Out of Scope / Future Work
+
+- **Windows NSIS migration** (Forge `maker-squirrel` → electron-builder NSIS) — would unify with Linux and unlock native `electron-updater` auto-update on Windows too, removing the manual `.exe` download workaround. Tracked as a separate GitHub issue.
+- **AppImage GPG signing** — electron-builder supports it via `GPG_NAME` + `CSC_LINK`; we don't have a Linux signing key yet. Keep unsigned, consistent with current `.deb`.
+- **Flatpak packaging** — tracked separately as #107.
+- **apt repository hosting** — would enable true auto-update for `.deb` users. Infrastructure project, separate from this work.
+- **Update channels** (beta / nightly) — not needed yet; single stable channel only.
+
+## Files to Create/Modify
+
+**New files:**
+- `scripts/electron-builder-fuses.js` — afterPack hook applying `@electron/fuses` options.
+
+**Modified files:**
+- `package.json` — add `build` field (electron-builder config); add `electron-builder` + `@electron/fuses` to devDependencies; remove `@electron-forge/maker-deb` + `@electron-forge/maker-zip`.
+- `forge.config.js` — remove Linux makers; keep Windows + macOS.
+- `.github/workflows/build.yml` — replace Forge Linux build step with electron-builder; switch arm64 to `ubuntu-24.04-arm`; update artifact paths; update release-asset collection (drop `.zip`, add AppImage + `latest-linux*.yml`).
+- `electron/update-manager.js` — add `isAppImage` branch; split download/install flows; populate `appImageUrl` / `debUrl` / `supportsAutoUpdate` on `update-available`.
+- `src/stores/updateStore.ts` — add `supportsAutoUpdate`, `appImageUrl`, `debUrl`, `releasePageUrl` state fields.
+- `src/components/UpdateBanner.tsx` / `.scss` — variant for non-auto-update Linux.
+- `src/components/UpdateDialog.tsx` / `.scss` — variant with two download buttons + migration note.
+- `src/i18n/locales/*/translation.json` — add `update.downloadAppImage` / `update.downloadDeb` / `update.linuxMigrateTitle` / `update.linuxMigrateBody` / `update.autoUpdateNote` (35+ locales).
+
+**Unchanged:**
+- Windows Squirrel flow (`maker-squirrel`, hand-written `latest.yml`, manual `.exe` download).
+- macOS PKG flow (`build-pkg.sh`).
+- Audio stack (`electron-audio-loopback`, `LoopbackRecorder.ts`, `pulseaudio-utils.js`).

--- a/electron/update-manager.js
+++ b/electron/update-manager.js
@@ -136,20 +136,22 @@ class UpdateManager {
       // Linux AppImage: use electron-updater's native AppImageUpdater flow
       if (process.platform === 'linux' && this.isAppImage) {
         if (this._downloadPromise) return this._downloadPromise;
-        this._downloadPromise = (async () => {
-          try {
-            this._sendStatus({ status: 'downloading' });
-            // Hook download-progress events from autoUpdater to IPC
-            const onProgress = (p) => this._sendProgress({
-              percent: p.percent || 0,
-              bytesPerSecond: p.bytesPerSecond || 0,
-              transferred: p.transferred || 0,
-              total: p.total || 0,
-            });
-            const onDownloaded = () => this._sendStatus({ status: 'downloaded' });
-            autoUpdater.on('download-progress', onProgress);
-            autoUpdater.once('update-downloaded', onDownloaded);
 
+        // Hook download-progress events from autoUpdater to IPC
+        const onProgress = (p) => this._sendProgress({
+          percent: p.percent || 0,
+          bytesPerSecond: p.bytesPerSecond || 0,
+          transferred: p.transferred || 0,
+          total: p.total || 0,
+        });
+        const onDownloaded = () => this._sendStatus({ status: 'downloaded' });
+
+        this._downloadPromise = (async () => {
+          this._sendStatus({ status: 'downloading' });
+          autoUpdater.on('download-progress', onProgress);
+          autoUpdater.once('update-downloaded', onDownloaded);
+
+          try {
             await autoUpdater.downloadUpdate();
             // `update-downloaded` event is what flips status to 'downloaded';
             // it also populates this.downloadPath implicitly via electron-updater.
@@ -159,6 +161,9 @@ class UpdateManager {
             this._sendStatus({ status: 'error', message: err.message || String(err) });
             return { success: false, error: err.message };
           } finally {
+            autoUpdater.removeListener('download-progress', onProgress);
+            // removeListener on a `.once` registration is a no-op if it already fired
+            autoUpdater.removeListener('update-downloaded', onDownloaded);
             this._downloadPromise = null;
           }
         })();

--- a/electron/update-manager.js
+++ b/electron/update-manager.js
@@ -132,10 +132,46 @@ class UpdateManager {
         this._sendStatus({ status: 'error', message: 'No update available to download' });
         return { success: false, error: 'No update available' };
       }
-      // If a download is already in progress, return the existing promise
-      if (this._downloadPromise) {
+
+      // Linux AppImage: use electron-updater's native AppImageUpdater flow
+      if (process.platform === 'linux' && this.isAppImage) {
+        if (this._downloadPromise) return this._downloadPromise;
+        this._downloadPromise = (async () => {
+          try {
+            this._sendStatus({ status: 'downloading' });
+            // Hook download-progress events from autoUpdater to IPC
+            const onProgress = (p) => this._sendProgress({
+              percent: p.percent || 0,
+              bytesPerSecond: p.bytesPerSecond || 0,
+              transferred: p.transferred || 0,
+              total: p.total || 0,
+            });
+            const onDownloaded = () => this._sendStatus({ status: 'downloaded' });
+            autoUpdater.on('download-progress', onProgress);
+            autoUpdater.once('update-downloaded', onDownloaded);
+
+            await autoUpdater.downloadUpdate();
+            // `update-downloaded` event is what flips status to 'downloaded';
+            // it also populates this.downloadPath implicitly via electron-updater.
+            this.downloadPath = '__appimage__'; // sentinel so install handler proceeds
+            return { success: true };
+          } catch (err) {
+            this._sendStatus({ status: 'error', message: err.message || String(err) });
+            return { success: false, error: err.message };
+          } finally {
+            this._downloadPromise = null;
+          }
+        })();
         return this._downloadPromise;
       }
+
+      // Non-AppImage Linux: no auto-download; renderer opens links manually
+      if (process.platform === 'linux' && !this.isAppImage) {
+        return { success: false, error: 'auto-update-not-supported' };
+      }
+
+      // Windows (existing Squirrel-compatible manual download) — unchanged
+      if (this._downloadPromise) return this._downloadPromise;
       this._downloadPromise = (async () => {
         try {
           await this._downloadUpdate();
@@ -153,12 +189,23 @@ class UpdateManager {
 
     ipcMain.handle('update-install', async () => {
       if (!this.downloadPath) {
-        // #6: Notify renderer on invalid state
         this._sendStatus({ status: 'error', message: 'No downloaded update to install' });
         return { success: false, error: 'No downloaded update' };
       }
+
+      // Linux AppImage: native quitAndInstall replaces the AppImage in place
+      if (process.platform === 'linux' && this.isAppImage) {
+        try {
+          autoUpdater.quitAndInstall();
+          return { success: true };
+        } catch (err) {
+          this._sendStatus({ status: 'error', message: err.message || String(err) });
+          return { success: false, error: err.message };
+        }
+      }
+
+      // Windows (existing Squirrel launch path) — unchanged
       try {
-        // #7: await installer launch before quitting
         await this._installUpdate();
         return { success: true };
       } catch (err) {

--- a/electron/update-manager.js
+++ b/electron/update-manager.js
@@ -17,6 +17,13 @@ class UpdateManager {
     // Include release notes for all versions between current and latest
     autoUpdater.fullChangelog = true;
 
+    this.isAppImage = process.platform === 'linux' && !!process.env.APPIMAGE;
+
+    // Log once at startup for easier debugging
+    if (process.platform === 'linux') {
+      console.log(`[Sokuji] [UpdateManager] Linux runtime: isAppImage=${this.isAppImage}, APPIMAGE=${process.env.APPIMAGE || '<unset>'}`);
+    }
+
     // Configure GitHub provider
     autoUpdater.setFeedURL({
       provider: 'github',
@@ -73,9 +80,22 @@ class UpdateManager {
         releaseNotes,
       };
 
-      // On Linux, include download URL instead of auto-download
       if (process.platform === 'linux') {
-        payload.downloadUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${info.version}`;
+        const version = info.version;
+        // electron-builder names AppImage artifacts with `x86_64` (not `x64`) for
+        // x64 Linux builds, and `arm64` for arm64. Translate Node's process.arch.
+        const appImageArch = process.arch === 'x64' ? 'x86_64' : 'arm64';
+        const debArch = process.arch === 'x64' ? 'amd64' : 'arm64';
+        const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
+
+        payload.supportsAutoUpdate = this.isAppImage;
+        payload.appImageUrl = `${base}/Sokuji-${version}-${appImageArch}.AppImage`;
+        payload.debUrl = `${base}/sokuji_${version}_${debArch}.deb`;
+        payload.releasePageUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${version}`;
+        // Legacy field kept for Windows / backward compat callers of updateStore:
+        if (!this.isAppImage) {
+          payload.downloadUrl = payload.releasePageUrl;
+        }
       }
 
       this._updateInfo = info;

--- a/forge.config.js
+++ b/forge.config.js
@@ -78,22 +78,6 @@ module.exports = {
       }
     },
     {
-      name: '@electron-forge/maker-zip',
-      platforms: ['linux'],
-    },
-    {
-      name: '@electron-forge/maker-deb',
-      config: {
-        options: {
-          categories: ['Audio'],
-          icon: 'assets/icon.png',
-          name: 'sokuji',
-          productName: 'Sokuji',
-          bin: 'sokuji'
-        }
-      },
-    },
-    {
       name: '@electron-forge/maker-dmg',
       config: {
         name: 'Sokuji',

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,13 +49,11 @@
       },
       "devDependencies": {
         "@electron-forge/cli": "^7.11.1",
-        "@electron-forge/maker-deb": "^7.11.1",
         "@electron-forge/maker-dmg": "^7.11.1",
         "@electron-forge/maker-flatpak": "^7.11.1",
         "@electron-forge/maker-pkg": "^7.11.1",
         "@electron-forge/maker-snap": "^7.11.1",
         "@electron-forge/maker-squirrel": "^7.11.1",
-        "@electron-forge/maker-zip": "^7.11.1",
         "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
         "@electron-forge/plugin-fuses": "^7.11.1",
         "@electron/fuses": "^2.0.0",
@@ -1138,23 +1136,6 @@
         "node": ">= 16.4.0"
       }
     },
-    "node_modules/@electron-forge/maker-deb": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-deb/-/maker-deb-7.11.1.tgz",
-      "integrity": "sha512-QTYiryQLYPDkq6pIfBmx0GQ6D8QatUkowH7rTlW5MnCUa0uumX0Xu7yGIjesuwW37fxT3Lv4xi+FSXMCm2eC1w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
-      },
-      "optionalDependencies": {
-        "electron-installer-debian": "^3.2.0"
-      }
-    },
     "node_modules/@electron-forge/maker-dmg": {
       "version": "7.11.1",
       "resolved": "https://registry.npmjs.org/@electron-forge/maker-dmg/-/maker-dmg-7.11.1.tgz",
@@ -1239,23 +1220,6 @@
       },
       "optionalDependencies": {
         "electron-winstaller": "^5.3.0"
-      }
-    },
-    "node_modules/@electron-forge/maker-zip": {
-      "version": "7.11.1",
-      "resolved": "https://registry.npmjs.org/@electron-forge/maker-zip/-/maker-zip-7.11.1.tgz",
-      "integrity": "sha512-30rcp0AbJLfkFBX2hmO14LKXx7z9V61LffTVbTCFMh5vUB2kZvcA5xAhsBk2oUJWfGVxe1DuSEU0rDR9bUMHUg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@electron-forge/maker-base": "7.11.1",
-        "@electron-forge/shared-types": "7.11.1",
-        "cross-zip": "^4.0.0",
-        "fs-extra": "^10.0.0",
-        "got": "^11.8.5"
-      },
-      "engines": {
-        "node": ">= 16.4.0"
       }
     },
     "node_modules/@electron-forge/plugin-auto-unpack-natives": {
@@ -8123,30 +8087,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/cross-zip": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/cross-zip/-/cross-zip-4.0.1.tgz",
-      "integrity": "sha512-n63i0lZ0rvQ6FXiGQ+/JFCKAUyPFhLQYJIqKaa+tSJtfKeULF/IDNDAbdnSIxgS4NTuw2b0+lj8LzfITuq+ZxQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.10"
-      }
-    },
     "node_modules/css.escape": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
@@ -8802,173 +8742,6 @@
         "jsonfile": "^6.0.1",
         "universalify": "^2.0.0"
       },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/electron-installer-debian": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/electron-installer-debian/-/electron-installer-debian-3.2.0.tgz",
-      "integrity": "sha512-58ZrlJ1HQY80VucsEIG9tQ//HrTlG6sfofA3nRGr6TmkX661uJyu4cMPPh6kXW+aHdq/7+q25KyQhDrXvRL7jw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin",
-        "linux"
-      ],
-      "dependencies": {
-        "@malept/cross-spawn-promise": "^1.0.0",
-        "debug": "^4.1.1",
-        "electron-installer-common": "^0.10.2",
-        "fs-extra": "^9.0.0",
-        "get-folder-size": "^2.0.1",
-        "lodash": "^4.17.4",
-        "word-wrap": "^1.2.3",
-        "yargs": "^16.0.2"
-      },
-      "bin": {
-        "electron-installer-debian": "src/cli.js"
-      },
-      "engines": {
-        "node": ">= 10.0.0"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/@malept/cross-spawn-promise": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-1.1.1.tgz",
-      "integrity": "sha512-RTBGWL5FWQcg9orDOCcp4LvItNzUPcyEU9bwaeJX0rJ1IQxzucC48Y0/sQLp/g6t99IQgAlGIaesJS+gTn7tVQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/malept"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
-        }
-      ],
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "cross-spawn": "^7.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/electron-installer-debian/node_modules/fs-extra": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
-      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "at-least-node": "^1.0.0",
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/electron-installer-debian/node_modules/yargs-parser": {
-      "version": "20.2.9",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -10415,15 +10188,6 @@
         "node": ">= 12"
       }
     },
-    "node_modules/gar": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/gar/-/gar-1.0.4.tgz",
-      "integrity": "sha512-w4n9cPWyP7aHxKxYHFQMegj7WIAsL/YX/C4Bs5Rr8s1H9M1rNtRWRsw+ovYMkXDQ5S4ZbYHsHAPmevPjPgw44w==",
-      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/gauge": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
@@ -10570,21 +10334,6 @@
       "license": "ISC",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-folder-size": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/get-folder-size/-/get-folder-size-2.0.1.tgz",
-      "integrity": "sha512-+CEb+GDCM7tkOS2wdMKTn9vU7DgnKUTuDlehkNJKNSovdCOVxs14OfKCk4cvSaR3za4gj+OBdl9opPN9xrJ0zA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "gar": "^1.0.4",
-        "tiny-each-async": "2.0.3"
-      },
-      "bin": {
-        "get-folder-size": "bin/get-folder-size"
       }
     },
     "node_modules/get-intrinsic": {
@@ -16171,14 +15920,6 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/tiny-each-async": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/tiny-each-async/-/tiny-each-async-2.0.3.tgz",
-      "integrity": "sha512-5ROII7nElnAirvFn8g7H7MtpfV1daMcyfTGQwsn/x2VtyV+VPiO5CjReCJtWLvoKTDEDmZocf3cNPraiMnBXLA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/tiny-typed-emitter": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sokuji",
-  "version": "0.18.1",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sokuji",
-      "version": "0.18.1",
+      "version": "0.19.0",
       "hasInstallScript": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.15",
@@ -69,6 +69,7 @@
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
         "electron": "40.6.0",
+        "electron-builder": "^25.1.8",
         "jsdom": "^24.0.0",
         "protobufjs-cli": "^2.0.0",
         "tsx": "^4.21.0",
@@ -669,6 +670,58 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/@develar/schema-utils/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@electron-forge/cli": {
       "version": "7.11.1",
@@ -1966,69 +2019,6 @@
       "license": "ISC",
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@electron/node-gyp/node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@electron/node-gyp/node_modules/socks-proxy-agent": {
@@ -4039,7 +4029,6 @@
       "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.0",
@@ -4056,7 +4045,6 @@
       "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "at-least-node": "^1.0.0",
         "graceful-fs": "^4.2.0",
@@ -4179,23 +4167,6 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@npmcli/move-file/node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
@@ -5259,6 +5230,16 @@
         "assertion-error": "^2.0.1"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/deep-eql": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
@@ -5301,7 +5282,6 @@
       "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -5372,6 +5352,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/mute-stream": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/mute-stream/-/mute-stream-0.0.4.tgz",
@@ -5389,6 +5376,18 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
       }
     },
     "node_modules/@types/prop-types": {
@@ -5469,6 +5468,14 @@
       "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "license": "MIT"
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/wrap-ansi": {
       "version": "3.0.0",
@@ -5834,6 +5841,13 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/abbrev": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-3.0.1.tgz",
@@ -6003,6 +6017,781 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
+      "integrity": "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
+      "integrity": "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.1",
+        "@electron/rebuild": "3.6.1",
+        "@electron/universal": "2.0.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chromium-pickle-js": "^0.2.0",
+        "config-file-ts": "0.2.8-rc1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "25.1.7",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.0",
+        "resedit": "^1.7.0",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "25.1.8",
+        "electron-builder-squirrel-windows": "25.1.8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/osx-sign": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
+      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/rebuild": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
+      "integrity": "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "chalk": "^4.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "fs-extra": "^10.0.0",
+        "got": "^11.7.0",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
+        "node-gyp": "^9.0.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^6.0.5",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/universal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.3.4",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+      "integrity": "sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/app-builder-lib/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/app-builder-lib/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/cacache/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib/node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/cacache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/appdmg": {
       "version": "0.6.6",
       "resolved": "https://registry.npmjs.org/appdmg/-/appdmg-0.6.6.tgz",
@@ -6031,6 +6820,28 @@
       },
       "engines": {
         "node": ">=8.5"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/argparse": {
@@ -6069,6 +6880,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -6079,6 +6901,17 @@
         "node": ">=12"
       }
     },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
@@ -6086,6 +6919,16 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -6358,6 +7201,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.5"
+      }
+    },
     "node_modules/boolean": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
@@ -6484,6 +7337,31 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/builder-util": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
+      "integrity": "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.10",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
     "node_modules/builder-util-runtime": {
       "version": "9.5.1",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.5.1.tgz",
@@ -6495,6 +7373,40 @@
       },
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/builder-util/node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/cacache": {
@@ -6770,6 +7682,29 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/clean-stack": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
@@ -6942,6 +7877,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
     },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
     "node_modules/colorette": {
       "version": "2.0.20",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
@@ -7033,6 +7978,72 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/config-file-ts": {
+      "version": "0.2.8-rc1",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
+      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.3.12",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -7051,6 +8062,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
       }
     },
     "node_modules/cross-dirname": {
@@ -7371,6 +8401,13 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -7408,11 +8445,158 @@
         "p-limit": "^3.1.0 "
       }
     },
+    "node_modules/dmg-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
+      "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/dmg-builder/node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dmg-license/node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/dmg-license/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/dom-accessibility-api": {
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/ds-store": {
       "version": "0.1.6",
@@ -7457,6 +8641,22 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/electron": {
       "version": "40.6.0",
       "resolved": "https://registry.npmjs.org/electron/-/electron-40.6.0.tgz",
@@ -7483,6 +8683,46 @@
       "license": "MIT",
       "peerDependencies": {
         "electron": ">=31.0.1"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
+      "integrity": "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.1.8",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-conf": {
@@ -7921,6 +9161,36 @@
       "optional": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
+      "integrity": "sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/electron-squirrel-startup": {
@@ -8701,6 +9971,17 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8723,6 +10004,13 @@
       "engines": {
         "node": ">=8.6.0"
       }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -8814,6 +10102,39 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/filename-reserved-regex": {
       "version": "2.0.0",
@@ -9102,6 +10423,66 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/gauge/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/gauge/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/gauge/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/gauge/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/gaxios": {
       "version": "7.1.4",
@@ -9547,6 +10928,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -9684,6 +11072,101 @@
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.23.2"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-corefoundation/node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/iconv-corefoundation/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/iconv-corefoundation/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iconv-corefoundation/node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/iconv-corefoundation/node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/iconv-corefoundation/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/iconv-lite": {
@@ -9927,6 +11410,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
       }
     },
     "node_modules/is-core-module": {
@@ -10265,6 +11761,31 @@
       "optionalDependencies": {
         "@pkgjs/parseargs": "^0.11.0"
       }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jake/node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/jest-diff": {
       "version": "27.5.1",
@@ -11223,6 +12744,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -11809,6 +13343,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
     "node_modules/nwsapi": {
@@ -13399,6 +14950,23 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/roarr": {
       "version": "2.15.4",
       "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
@@ -13561,6 +15129,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
     },
     "node_modules/sass": {
       "version": "1.98.0",
@@ -13750,6 +15328,13 @@
       "dependencies": {
         "randombytes": "^2.1.0"
       }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
@@ -13959,6 +15544,19 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/simple-yenc": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/simple-yenc/-/simple-yenc-1.0.4.tgz",
@@ -14139,6 +15737,16 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/std-env": {
       "version": "4.0.0",
@@ -14463,6 +16071,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
     "node_modules/temp/node_modules/mkdirp": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -14643,7 +16262,6 @@
       "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tmp": "^0.2.0"
       }
@@ -14654,7 +16272,6 @@
       "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
       "dev": true,
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14.14"
       }
@@ -14774,6 +16391,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
       }
     },
     "node_modules/ts-debounce": {
@@ -14967,6 +16594,16 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/url-parse": {
       "version": "1.5.10",
       "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
@@ -14991,6 +16628,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
@@ -15021,6 +16665,22 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
       }
     },
     "node_modules/vite": {
@@ -15527,6 +17187,48 @@
       },
       "bin": {
         "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wide-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/wide-align/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wide-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -63,7 +63,11 @@
     "deb": {
       "artifactName": "${name}_${version}_${arch}.${ext}"
     },
-    "publish": null,
+    "publish": {
+      "provider": "github",
+      "owner": "kizuna-ai-lab",
+      "repo": "sokuji"
+    },
     "afterPack": "./scripts/electron-builder-fuses.js"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,11 +32,26 @@
       "build/wasm/piper-plus/**",
       "build/wasm/gtcrn/**"
     ],
-    "extraResources": ["assets", "resources"],
+    "extraResources": [
+      "assets",
+      "resources"
+    ],
     "linux": {
       "target": [
-        { "target": "AppImage", "arch": ["x64", "arm64"] },
-        { "target": "deb",      "arch": ["x64", "arm64"] }
+        {
+          "target": "AppImage",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        },
+        {
+          "target": "deb",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
+        }
       ],
       "category": "AudioVideo",
       "icon": "assets/icon.png",
@@ -101,13 +116,11 @@
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",
-    "@electron-forge/maker-deb": "^7.11.1",
     "@electron-forge/maker-dmg": "^7.11.1",
     "@electron-forge/maker-flatpak": "^7.11.1",
     "@electron-forge/maker-pkg": "^7.11.1",
     "@electron-forge/maker-snap": "^7.11.1",
     "@electron-forge/maker-squirrel": "^7.11.1",
-    "@electron-forge/maker-zip": "^7.11.1",
     "@electron-forge/plugin-auto-unpack-natives": "^7.11.1",
     "@electron-forge/plugin-fuses": "^7.11.1",
     "@electron/fuses": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,47 @@
     "name": "Kizuna AI Lab",
     "email": "contact@kizuna.ai"
   },
+  "build": {
+    "appId": "com.kizunaai.sokuji",
+    "productName": "Sokuji",
+    "asar": true,
+    "directories": {
+      "output": "out/make-linux"
+    },
+    "files": [
+      "package.json",
+      "dist-electron/**/*",
+      "build/**/*",
+      "!build/**/*.map",
+      "!build/assets/test-tone.mp3",
+      "!build/wasm/**",
+      "build/wasm/sherpa-onnx-asr/**",
+      "build/wasm/sherpa-onnx-asr-stream/**",
+      "build/wasm/sherpa-onnx-tts/**",
+      "build/wasm/ort/**",
+      "build/wasm/vad/**",
+      "build/wasm/piper-plus/**",
+      "build/wasm/gtcrn/**"
+    ],
+    "extraResources": ["assets", "resources"],
+    "linux": {
+      "target": [
+        { "target": "AppImage", "arch": ["x64", "arm64"] },
+        { "target": "deb",      "arch": ["x64", "arm64"] }
+      ],
+      "category": "AudioVideo",
+      "icon": "assets/icon.png",
+      "executableName": "sokuji"
+    },
+    "appImage": {
+      "artifactName": "${productName}-${version}-${arch}.${ext}"
+    },
+    "deb": {
+      "artifactName": "${name}_${version}_${arch}.${ext}"
+    },
+    "publish": null,
+    "afterPack": "./scripts/electron-builder-fuses.js"
+  },
   "dependencies": {
     "@floating-ui/react": "^0.27.15",
     "@google/genai": "^1.46.0",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
     "electron": "40.6.0",
+    "electron-builder": "^25.1.8",
     "jsdom": "^24.0.0",
     "protobufjs-cli": "^2.0.0",
     "tsx": "^4.21.0",

--- a/scripts/electron-builder-fuses.js
+++ b/scripts/electron-builder-fuses.js
@@ -1,0 +1,27 @@
+const path = require('path');
+const fs = require('fs');
+const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
+
+// Apply Electron Fuses to the packaged binary, mirroring the options
+// previously set by @electron-forge/plugin-fuses in forge.config.js.
+module.exports = async function applyFuses(context) {
+  const executableName = context.packager.executableName || context.packager.appInfo.productFilename;
+  const execPath = path.join(context.appOutDir, executableName);
+
+  if (!fs.existsSync(execPath)) {
+    throw new Error(`[electron-builder-fuses] Executable not found at ${execPath}`);
+  }
+
+  await flipFuses(execPath, {
+    version: FuseVersion.V1,
+    resetAdHocDarwinSignature: false,
+    [FuseV1Options.RunAsNode]: false,
+    [FuseV1Options.EnableCookieEncryption]: true,
+    [FuseV1Options.EnableNodeOptionsEnvironmentVariable]: false,
+    [FuseV1Options.EnableNodeCliInspectArguments]: false,
+    [FuseV1Options.EnableEmbeddedAsarIntegrityValidation]: true,
+    [FuseV1Options.OnlyLoadAppFromAsar]: true,
+  });
+
+  console.log(`[electron-builder-fuses] Applied Fuses to ${execPath}`);
+};

--- a/src/components/UpdateBanner/UpdateBanner.tsx
+++ b/src/components/UpdateBanner/UpdateBanner.tsx
@@ -10,6 +10,7 @@ import {
   useDismissBanner,
   useOpenUpdateDialog,
   useInstallUpdate,
+  useUpdateSupportsAutoUpdate,
 } from '../../stores/updateStore';
 import './UpdateBanner.scss';
 
@@ -23,6 +24,7 @@ const UpdateBanner: React.FC = () => {
   const dismissBanner = useDismissBanner();
   const openDialog = useOpenUpdateDialog();
   const installUpdate = useInstallUpdate();
+  const supportsAutoUpdate = useUpdateSupportsAutoUpdate();
 
   if (status === 'idle' || status === 'checking' || status === 'not-available') {
     return null;
@@ -67,7 +69,11 @@ const UpdateBanner: React.FC = () => {
         {status === 'available' && (
           <>
             <Download size={14} />
-            <span>{t('update.available', { version: newVersion })}</span>
+            <span>
+              {supportsAutoUpdate
+                ? t('update.available', { version: newVersion })
+                : t('update.linuxMigrateTitle', { version: newVersion })}
+            </span>
           </>
         )}
 

--- a/src/components/UpdateDialog/UpdateDialog.scss
+++ b/src/components/UpdateDialog/UpdateDialog.scss
@@ -163,6 +163,16 @@
       color: #999;
       font-size: 13px;
     }
+
+    .auto-update-note {
+      margin: 12px 0;
+      padding: 12px;
+      border-radius: 6px;
+      background: rgba(16, 163, 127, 0.08);
+      color: #b8d4c9;
+      font-size: 0.9em;
+      line-height: 1.5;
+    }
   }
 
   .update-dialog-footer {
@@ -198,6 +208,20 @@
       &:hover {
         color: #fff;
         border-color: #666;
+      }
+    }
+
+    .tertiary-button {
+      background: transparent;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      color: #ccc;
+      border-radius: 4px;
+      padding: 8px 16px;
+      font-size: 13px;
+      cursor: pointer;
+
+      &:hover {
+        background: rgba(255, 255, 255, 0.05);
       }
     }
   }

--- a/src/components/UpdateDialog/UpdateDialog.tsx
+++ b/src/components/UpdateDialog/UpdateDialog.tsx
@@ -14,6 +14,9 @@ import {
   useCloseUpdateDialog,
   useDownloadUpdate,
   useInstallUpdate,
+  useUpdateSupportsAutoUpdate,
+  useUpdateAppImageUrl,
+  useUpdateDebUrl,
 } from '../../stores/updateStore';
 import './UpdateDialog.scss';
 
@@ -30,6 +33,9 @@ const UpdateDialog: React.FC = () => {
   const closeDialog = useCloseUpdateDialog();
   const downloadUpdate = useDownloadUpdate();
   const installUpdate = useInstallUpdate();
+  const supportsAutoUpdate = useUpdateSupportsAutoUpdate();
+  const appImageUrl = useUpdateAppImageUrl();
+  const debUrl = useUpdateDebUrl();
 
   const [currentVersion, setCurrentVersion] = React.useState('?');
 
@@ -95,6 +101,12 @@ const UpdateDialog: React.FC = () => {
             </div>
           )}
 
+          {status === 'available' && !supportsAutoUpdate && (
+            <div className="auto-update-note">
+              {t('update.autoUpdateNote')}
+            </div>
+          )}
+
           {changelog && (status === 'available' || status === 'downloading' || status === 'downloaded') && (
             <div
               className="changelog"
@@ -124,28 +136,74 @@ const UpdateDialog: React.FC = () => {
         <div className="update-dialog-footer">
           {status === 'available' && (
             <>
-              {downloadUrl ? (
-                <button
-                  className="primary-button"
-                  onClick={() => {
-                    if (isElectron() && (window as any).electron?.invoke) {
-                      (window as any).electron.invoke('open-external', downloadUrl);
-                    } else {
-                      window.open(downloadUrl, '_blank');
-                    }
-                    closeDialog();
-                  }}
-                >
-                  {t('update.goToDownload')}
-                </button>
+              {!supportsAutoUpdate && (appImageUrl || debUrl) ? (
+                // Non-AppImage Linux: offer two download paths
+                <>
+                  {appImageUrl && (
+                    <button
+                      className="primary-button"
+                      onClick={() => {
+                        if (isElectron() && (window as any).electron?.invoke) {
+                          (window as any).electron.invoke('open-external', appImageUrl);
+                        } else {
+                          window.open(appImageUrl, '_blank');
+                        }
+                        closeDialog();
+                      }}
+                    >
+                      {t('update.downloadAppImage')}
+                    </button>
+                  )}
+                  {debUrl && (
+                    <button
+                      className="tertiary-button"
+                      onClick={() => {
+                        if (isElectron() && (window as any).electron?.invoke) {
+                          (window as any).electron.invoke('open-external', debUrl);
+                        } else {
+                          window.open(debUrl, '_blank');
+                        }
+                        closeDialog();
+                      }}
+                    >
+                      {t('update.downloadDeb')}
+                    </button>
+                  )}
+                  <button className="secondary-button" onClick={closeDialog}>
+                    {t('update.later')}
+                  </button>
+                </>
+              ) : downloadUrl ? (
+                // Legacy (any platform passing a generic downloadUrl, e.g. old callers)
+                <>
+                  <button
+                    className="primary-button"
+                    onClick={() => {
+                      if (isElectron() && (window as any).electron?.invoke) {
+                        (window as any).electron.invoke('open-external', downloadUrl);
+                      } else {
+                        window.open(downloadUrl, '_blank');
+                      }
+                      closeDialog();
+                    }}
+                  >
+                    {t('update.goToDownload')}
+                  </button>
+                  <button className="secondary-button" onClick={closeDialog}>
+                    {t('update.later')}
+                  </button>
+                </>
               ) : (
-                <button className="primary-button" onClick={downloadUpdate}>
-                  {t('update.downloadNow')}
-                </button>
+                // Windows / AppImage Linux: full auto-update flow
+                <>
+                  <button className="primary-button" onClick={downloadUpdate}>
+                    {t('update.downloadNow')}
+                  </button>
+                  <button className="secondary-button" onClick={closeDialog}>
+                    {t('update.later')}
+                  </button>
+                </>
               )}
-              <button className="secondary-button" onClick={closeDialog}>
-                {t('update.later')}
-              </button>
             </>
           )}
 

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -775,6 +775,11 @@
     "error": "فشل التحقق من التحديثات",
     "errorWithMessage": "خطأ في التحديث: {{message}}",
     "currentVersion": "الإصدار الحالي: v{{version}}",
-    "newVersion": "الإصدار الجديد: v{{version}}"
+    "newVersion": "الإصدار الجديد: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -781,6 +781,11 @@
     "error": "আপডেট পরীক্ষা করতে ব্যর্থ",
     "errorWithMessage": "আপডেট ত্রুটি: {{message}}",
     "currentVersion": "বর্তমান সংস্করণ: v{{version}}",
-    "newVersion": "নতুন সংস্করণ: v{{version}}"
+    "newVersion": "নতুন সংস্করণ: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -774,6 +774,11 @@
     "error": "Fehler beim Suchen nach Updates",
     "errorWithMessage": "Update-Fehler: {{message}}",
     "currentVersion": "Aktuelle Version: v{{version}}",
-    "newVersion": "Neue Version: v{{version}}"
+    "newVersion": "Neue Version: v{{version}}",
+    "autoUpdateNote": "AppImage unterstützt automatische Updates. Die Installation des AppImage ersetzt deine aktuelle Installation direkt – kein separates Deinstallieren erforderlich.",
+    "downloadAppImage": "AppImage herunterladen (empfohlen)",
+    "downloadDeb": ".deb herunterladen",
+    "linuxMigrateTitle": "Neue Version v{{version}} verfügbar",
+    "linuxMigrateBody": "Automatische Updates sind mit AppImage verfügbar. Wähle ein Format, um v{{version}} herunterzuladen."
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -816,6 +816,11 @@
     "error": "Failed to check for updates",
     "errorWithMessage": "Update error: {{message}}",
     "currentVersion": "Current version: v{{version}}",
-    "newVersion": "New version: v{{version}}"
+    "newVersion": "New version: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -774,6 +774,11 @@
     "error": "Error al buscar actualizaciones",
     "errorWithMessage": "Error de actualización: {{message}}",
     "currentVersion": "Versión actual: v{{version}}",
-    "newVersion": "Nueva versión: v{{version}}"
+    "newVersion": "Nueva versión: v{{version}}",
+    "autoUpdateNote": "AppImage admite actualizaciones automáticas. Instalar el AppImage reemplaza tu instalación actual directamente — no es necesario desinstalar por separado.",
+    "downloadAppImage": "Descargar AppImage (recomendado)",
+    "downloadDeb": "Descargar .deb",
+    "linuxMigrateTitle": "Nueva versión v{{version}} disponible",
+    "linuxMigrateBody": "Las actualizaciones automáticas están disponibles con AppImage. Elige un formato para descargar v{{version}}."
   }
 }

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -781,6 +781,11 @@
     "error": "بررسی به‌روزرسانی ناموفق بود",
     "errorWithMessage": "خطای به‌روزرسانی: {{message}}",
     "currentVersion": "نسخه فعلی: v{{version}}",
-    "newVersion": "نسخه جدید: v{{version}}"
+    "newVersion": "نسخه جدید: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -731,6 +731,11 @@
     "error": "Päivitysten tarkistus epäonnistui",
     "errorWithMessage": "Päivitysvirhe: {{message}}",
     "currentVersion": "Nykyinen versio: v{{version}}",
-    "newVersion": "Uusi versio: v{{version}}"
+    "newVersion": "Uusi versio: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -731,6 +731,11 @@
     "error": "Hindi nagawang suriin ang mga update",
     "errorWithMessage": "Error sa pag-update: {{message}}",
     "currentVersion": "Kasalukuyang bersyon: v{{version}}",
-    "newVersion": "Bagong bersyon: v{{version}}"
+    "newVersion": "Bagong bersyon: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -774,6 +774,11 @@
     "error": "Échec de la vérification des mises à jour",
     "errorWithMessage": "Erreur de mise à jour : {{message}}",
     "currentVersion": "Version actuelle : v{{version}}",
-    "newVersion": "Nouvelle version : v{{version}}"
+    "newVersion": "Nouvelle version : v{{version}}",
+    "autoUpdateNote": "AppImage prend en charge les mises à jour automatiques. L'installation du nouvel AppImage remplace directement l'installation actuelle — aucune désinstallation séparée n'est nécessaire.",
+    "downloadAppImage": "Télécharger AppImage (recommandé)",
+    "downloadDeb": "Télécharger .deb",
+    "linuxMigrateTitle": "Nouvelle version v{{version}} disponible",
+    "linuxMigrateBody": "Les mises à jour automatiques sont disponibles avec AppImage. Choisissez un format pour télécharger v{{version}}."
   }
 }

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -779,6 +779,11 @@
     "error": "בדיקת עדכונים נכשלה",
     "errorWithMessage": "שגיאת עדכון: {{message}}",
     "currentVersion": "גרסה נוכחית: v{{version}}",
-    "newVersion": "גרסה חדשה: v{{version}}"
+    "newVersion": "גרסה חדשה: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -725,6 +725,11 @@
     "error": "अपडेट की जाँच विफल",
     "errorWithMessage": "अपडेट त्रुटि: {{message}}",
     "currentVersion": "वर्तमान संस्करण: v{{version}}",
-    "newVersion": "नया संस्करण: v{{version}}"
+    "newVersion": "नया संस्करण: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -773,6 +773,11 @@
     "error": "Gagal memeriksa pembaruan",
     "errorWithMessage": "Kesalahan pembaruan: {{message}}",
     "currentVersion": "Versi saat ini: v{{version}}",
-    "newVersion": "Versi baru: v{{version}}"
+    "newVersion": "Versi baru: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -773,6 +773,11 @@
     "error": "Impossibile verificare gli aggiornamenti",
     "errorWithMessage": "Errore di aggiornamento: {{message}}",
     "currentVersion": "Versione attuale: v{{version}}",
-    "newVersion": "Nuova versione: v{{version}}"
+    "newVersion": "Nuova versione: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -785,6 +785,11 @@
     "error": "アップデートの確認に失敗しました",
     "errorWithMessage": "アップデートエラー: {{message}}",
     "currentVersion": "現在のバージョン: v{{version}}",
-    "newVersion": "新しいバージョン: v{{version}}"
+    "newVersion": "新しいバージョン: v{{version}}",
+    "autoUpdateNote": "AppImage は自動更新に対応しています。新しい AppImage をインストールすると現在のバージョンをその場で置き換えます — 個別にアンインストールする必要はありません。",
+    "downloadAppImage": "AppImage をダウンロード（推奨）",
+    "downloadDeb": ".deb をダウンロード",
+    "linuxMigrateTitle": "新しいバージョン v{{version}} が利用できます",
+    "linuxMigrateBody": "AppImage 形式なら自動更新を利用できます。v{{version}} をダウンロードする形式を選択してください。"
   }
 }

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -773,6 +773,11 @@
     "error": "업데이트 확인 실패",
     "errorWithMessage": "업데이트 오류: {{message}}",
     "currentVersion": "현재 버전: v{{version}}",
-    "newVersion": "새 버전: v{{version}}"
+    "newVersion": "새 버전: v{{version}}",
+    "autoUpdateNote": "AppImage 는 자동 업데이트를 지원합니다. 새 AppImage 를 설치하면 현재 설치본이 그대로 교체됩니다 — 별도 제거가 필요 없습니다.",
+    "downloadAppImage": "AppImage 다운로드 (권장)",
+    "downloadDeb": ".deb 다운로드",
+    "linuxMigrateTitle": "새 버전 v{{version}} 사용 가능",
+    "linuxMigrateBody": "AppImage 형식에서 자동 업데이트가 지원됩니다. v{{version}} 다운로드 형식을 선택하세요."
   }
 }

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -772,6 +772,11 @@
     "error": "Gagal menyemak kemas kini",
     "errorWithMessage": "Ralat kemas kini: {{message}}",
     "currentVersion": "Versi semasa: v{{version}}",
-    "newVersion": "Versi baharu: v{{version}}"
+    "newVersion": "Versi baharu: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -773,6 +773,11 @@
     "error": "Kan niet controleren op updates",
     "errorWithMessage": "Updatefout: {{message}}",
     "currentVersion": "Huidige versie: v{{version}}",
-    "newVersion": "Nieuwe versie: v{{version}}"
+    "newVersion": "Nieuwe versie: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -772,6 +772,11 @@
     "error": "Nie udało się sprawdzić aktualizacji",
     "errorWithMessage": "Błąd aktualizacji: {{message}}",
     "currentVersion": "Aktualna wersja: v{{version}}",
-    "newVersion": "Nowa wersja: v{{version}}"
+    "newVersion": "Nowa wersja: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -773,6 +773,11 @@
     "error": "Falha ao verificar atualizações",
     "errorWithMessage": "Erro de atualização: {{message}}",
     "currentVersion": "Versão atual: v{{version}}",
-    "newVersion": "Nova versão: v{{version}}"
+    "newVersion": "Nova versão: v{{version}}",
+    "autoUpdateNote": "O AppImage suporta atualizações automáticas. Instalar o AppImage substitui sua instalação atual diretamente — não é necessário desinstalar antes.",
+    "downloadAppImage": "Baixar AppImage (recomendado)",
+    "downloadDeb": "Baixar .deb",
+    "linuxMigrateTitle": "Nova versão v{{version}} disponível",
+    "linuxMigrateBody": "Atualizações automáticas estão disponíveis no AppImage. Escolha um formato para baixar v{{version}}."
   }
 }

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -776,6 +776,11 @@
     "error": "Falha ao verificar atualizações",
     "errorWithMessage": "Erro de atualização: {{message}}",
     "currentVersion": "Versão atual: v{{version}}",
-    "newVersion": "Nova versão: v{{version}}"
+    "newVersion": "Nova versão: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -780,6 +780,11 @@
     "error": "Не удалось проверить обновления",
     "errorWithMessage": "Ошибка обновления: {{message}}",
     "currentVersion": "Текущая версия: v{{version}}",
-    "newVersion": "Новая версия: v{{version}}"
+    "newVersion": "Новая версия: v{{version}}",
+    "autoUpdateNote": "AppImage поддерживает автоматические обновления. Установка нового AppImage напрямую заменяет текущую версию — отдельное удаление не требуется.",
+    "downloadAppImage": "Скачать AppImage (рекомендуется)",
+    "downloadDeb": "Скачать .deb",
+    "linuxMigrateTitle": "Доступна новая версия v{{version}}",
+    "linuxMigrateBody": "Автоматические обновления доступны в формате AppImage. Выберите формат для скачивания v{{version}}."
   }
 }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -729,6 +729,11 @@
     "error": "Kunde inte söka efter uppdateringar",
     "errorWithMessage": "Uppdateringsfel: {{message}}",
     "currentVersion": "Nuvarande version: v{{version}}",
-    "newVersion": "Ny version: v{{version}}"
+    "newVersion": "Ny version: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -706,6 +706,11 @@
     "error": "புதுப்பிப்புகளைச் சரிபார்க்க இயலவில்லை",
     "errorWithMessage": "புதுப்பிப்புப் பிழை: {{message}}",
     "currentVersion": "தற்போதைய பதிப்பு: v{{version}}",
-    "newVersion": "புதிய பதிப்பு: v{{version}}"
+    "newVersion": "புதிய பதிப்பு: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -688,6 +688,11 @@
     "error": "అప్‌డేట్‌లు తనిఖీ చేయడం విఫలమైంది",
     "errorWithMessage": "అప్‌డేట్ లోపం: {{message}}",
     "currentVersion": "ప్రస్తుత వెర్షన్: v{{version}}",
-    "newVersion": "కొత్త వెర్షన్: v{{version}}"
+    "newVersion": "కొత్త వెర్షన్: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -695,6 +695,11 @@
     "error": "ตรวจสอบอัปเดตล้มเหลว",
     "errorWithMessage": "ข้อผิดพลาดในการอัปเดต: {{message}}",
     "currentVersion": "เวอร์ชันปัจจุบัน: v{{version}}",
-    "newVersion": "เวอร์ชันใหม่: v{{version}}"
+    "newVersion": "เวอร์ชันใหม่: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -731,6 +731,11 @@
     "error": "Güncellemeler kontrol edilemedi",
     "errorWithMessage": "Güncelleme hatası: {{message}}",
     "currentVersion": "Mevcut sürüm: v{{version}}",
-    "newVersion": "Yeni sürüm: v{{version}}"
+    "newVersion": "Yeni sürüm: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -693,6 +693,11 @@
     "error": "Не вдалося перевірити оновлення",
     "errorWithMessage": "Помилка оновлення: {{message}}",
     "currentVersion": "Поточна версія: v{{version}}",
-    "newVersion": "Нова версія: v{{version}}"
+    "newVersion": "Нова версія: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -724,6 +724,11 @@
     "error": "Không thể kiểm tra cập nhật",
     "errorWithMessage": "Lỗi cập nhật: {{message}}",
     "currentVersion": "Phiên bản hiện tại: v{{version}}",
-    "newVersion": "Phiên bản mới: v{{version}}"
+    "newVersion": "Phiên bản mới: v{{version}}",
+    "autoUpdateNote": "AppImage supports automatic updates. Installing the AppImage replaces your current installation — no separate uninstall needed.",
+    "downloadAppImage": "Download AppImage (recommended)",
+    "downloadDeb": "Download .deb",
+    "linuxMigrateTitle": "New version v{{version}} available",
+    "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   }
 }

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -782,7 +782,12 @@
     "error": "检查更新失败",
     "errorWithMessage": "更新错误：{{message}}",
     "currentVersion": "当前版本：v{{version}}",
-    "newVersion": "新版本：v{{version}}"
+    "newVersion": "新版本：v{{version}}",
+    "autoUpdateNote": "AppImage 支持自动更新。安装新版 AppImage 会直接替换当前版本 — 无需先卸载。",
+    "downloadAppImage": "下载 AppImage（推荐）",
+    "downloadDeb": "下载 .deb",
+    "linuxMigrateTitle": "有新版本 v{{version}}",
+    "linuxMigrateBody": "AppImage 格式支持自动更新。选择一种格式下载 v{{version}}。"
   },
   "connectionStatus": {
     "reconnecting": "重新连接中..."

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -743,6 +743,11 @@
     "error": "檢查更新失敗",
     "errorWithMessage": "更新錯誤：{{message}}",
     "currentVersion": "目前版本：v{{version}}",
-    "newVersion": "新版本：v{{version}}"
+    "newVersion": "新版本：v{{version}}",
+    "autoUpdateNote": "AppImage 支援自動更新。安裝新版 AppImage 會直接取代目前版本 — 無需先解除安裝。",
+    "downloadAppImage": "下載 AppImage（推薦）",
+    "downloadDeb": "下載 .deb",
+    "linuxMigrateTitle": "有新版本 v{{version}}",
+    "linuxMigrateBody": "AppImage 格式支援自動更新。選擇一種格式下載 v{{version}}。"
   }
 }

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import useUpdateStore from './updateStore';
+
+describe('updateStore', () => {
+  beforeEach(() => {
+    useUpdateStore.setState({
+      status: 'idle',
+      newVersion: null,
+      changelog: null,
+      downloadProgress: 0,
+      downloadSpeed: 0,
+      downloadTransferred: 0,
+      downloadTotal: 0,
+      errorMessage: null,
+      downloadUrl: null,
+      supportsAutoUpdate: true,
+      appImageUrl: null,
+      debUrl: null,
+      releasePageUrl: null,
+      bannerDismissed: false,
+      dialogOpen: false,
+    });
+  });
+
+  it('defaults supportsAutoUpdate to true (matches Windows behavior)', () => {
+    expect(useUpdateStore.getState().supportsAutoUpdate).toBe(true);
+  });
+
+  it('exposes appImageUrl, debUrl, releasePageUrl as null by default', () => {
+    const s = useUpdateStore.getState();
+    expect(s.appImageUrl).toBeNull();
+    expect(s.debUrl).toBeNull();
+    expect(s.releasePageUrl).toBeNull();
+  });
+
+  it('allows setting the new fields', () => {
+    useUpdateStore.setState({
+      supportsAutoUpdate: false,
+      appImageUrl: 'https://example.com/app.AppImage',
+      debUrl: 'https://example.com/app.deb',
+      releasePageUrl: 'https://example.com/release',
+    });
+    const s = useUpdateStore.getState();
+    expect(s.supportsAutoUpdate).toBe(false);
+    expect(s.appImageUrl).toBe('https://example.com/app.AppImage');
+    expect(s.debUrl).toBe('https://example.com/app.deb');
+    expect(s.releasePageUrl).toBe('https://example.com/release');
+  });
+});

--- a/src/stores/updateStore.test.ts
+++ b/src/stores/updateStore.test.ts
@@ -22,18 +22,24 @@ describe('updateStore', () => {
     });
   });
 
-  it('defaults supportsAutoUpdate to true (matches Windows behavior)', () => {
+  // NOTE: These tests do not verify the store's *initial* defaults (the
+  // singleton makes that awkward without `vi.resetModules()` + re-import).
+  // beforeEach above sets the fields explicitly to the documented baseline,
+  // so these tests serve as a schema-level guard — they fail if a field is
+  // removed or its type drifts.
+
+  it('retains supportsAutoUpdate=true after baseline reset (Windows-like default)', () => {
     expect(useUpdateStore.getState().supportsAutoUpdate).toBe(true);
   });
 
-  it('exposes appImageUrl, debUrl, releasePageUrl as null by default', () => {
+  it('retains appImageUrl, debUrl, releasePageUrl as null after baseline reset', () => {
     const s = useUpdateStore.getState();
     expect(s.appImageUrl).toBeNull();
     expect(s.debUrl).toBeNull();
     expect(s.releasePageUrl).toBeNull();
   });
 
-  it('allows setting the new fields', () => {
+  it('accepts setState writes to the new fields', () => {
     useUpdateStore.setState({
       supportsAutoUpdate: false,
       appImageUrl: 'https://example.com/app.AppImage',

--- a/src/stores/updateStore.ts
+++ b/src/stores/updateStore.ts
@@ -14,6 +14,11 @@ interface UpdateState {
   downloadTotal: number;
   errorMessage: string | null;
   downloadUrl: string | null;
+  // NEW fields for Linux AppImage/deb split:
+  supportsAutoUpdate: boolean;
+  appImageUrl: string | null;
+  debUrl: string | null;
+  releasePageUrl: string | null;
   bannerDismissed: boolean;
   dialogOpen: boolean;
 }
@@ -47,6 +52,10 @@ const useUpdateStore = create<UpdateStore>()(
     downloadTotal: 0,
     errorMessage: null,
     downloadUrl: null,
+    supportsAutoUpdate: true,
+    appImageUrl: null,
+    debUrl: null,
+    releasePageUrl: null,
     bannerDismissed: false,
     dialogOpen: false,
 
@@ -115,6 +124,10 @@ const useUpdateStore = create<UpdateStore>()(
         }
         if (data.message) update.errorMessage = data.message;
         if (data.downloadUrl) update.downloadUrl = data.downloadUrl;
+        if (typeof data.supportsAutoUpdate === 'boolean') update.supportsAutoUpdate = data.supportsAutoUpdate;
+        if (data.appImageUrl !== undefined) update.appImageUrl = data.appImageUrl;
+        if (data.debUrl !== undefined) update.debUrl = data.debUrl;
+        if (data.releasePageUrl !== undefined) update.releasePageUrl = data.releasePageUrl;
 
         // Reset banner dismissed when new update is available
         if (data.status === 'available') {
@@ -181,6 +194,10 @@ export const useUpdateProgressTransferred = () => useUpdateStore(state => state.
 export const useUpdateProgressTotal = () => useUpdateStore(state => state.downloadTotal);
 export const useUpdateError = () => useUpdateStore(state => state.errorMessage);
 export const useUpdateDownloadUrl = () => useUpdateStore(state => state.downloadUrl);
+export const useUpdateSupportsAutoUpdate = () => useUpdateStore(state => state.supportsAutoUpdate);
+export const useUpdateAppImageUrl = () => useUpdateStore(state => state.appImageUrl);
+export const useUpdateDebUrl = () => useUpdateStore(state => state.debUrl);
+export const useUpdateReleasePageUrl = () => useUpdateStore(state => state.releasePageUrl);
 export const useUpdateBannerDismissed = () => useUpdateStore(state => state.bannerDismissed);
 export const useUpdateDialogOpen = () => useUpdateStore(state => state.dialogOpen);
 


### PR DESCRIPTION
Closes #124.

## Summary

Add AppImage (x64 + arm64) as the recommended Linux distribution format with native `electron-updater` auto-update. Keep `.deb` for existing users but drop `.zip`. `.deb` users now see a banner proposing migration to AppImage with two download buttons.

Linux packaging moves from Electron Forge (`maker-deb` + `maker-zip`) to `electron-builder` (AppImage + deb). Windows (Squirrel) and macOS (PKG) remain on Forge.

## Why

- `electron-updater`'s `AppImageUpdater` provides first-class in-place auto-update for AppImage, which neither `.deb` nor `.zip` supports.
- The existing "Linux shows update available + download link" flow was dormant anyway — no `latest-linux*.yml` was produced, so `electron-updater`'s check always silently 404'd. This PR finally makes Linux notifications work for all formats.
- `electron-builder` is the reference implementation for the `electron-updater` ecosystem — we stop paying Windows's Squirrel-compatibility tax on Linux.

## What changed

**Build pipeline:**
- `package.json`: added `build` field (electron-builder config, Linux AppImage + deb targets, publish provider for `latest-linux*.yml` generation); added `electron-builder` devDep; removed `@electron-forge/maker-deb` + `@electron-forge/maker-zip`.
- `scripts/electron-builder-fuses.js` (new): `afterPack` hook applying the same Electron Fuses the Forge `FusesPlugin` set.
- `forge.config.js`: Linux makers deleted; Windows/macOS makers + FusesPlugin + `packageAfterPrune` hook untouched.
- `.github/workflows/build.yml`: arm64 Linux row switched from `ubuntu-latest` (cross-compile) to native `ubuntu-24.04-arm`; Forge build step now Windows-only; new `electron-builder` step for Linux; release asset collection swaps `.zip` for `.AppImage` + `latest-linux*.yml`.

**Runtime:**
- `electron/update-manager.js`: added `this.isAppImage = !!process.env.APPIMAGE` detection; Linux `update-available` branch populates `supportsAutoUpdate`, `appImageUrl`, `debUrl`, `releasePageUrl`; `update-download`/`update-install` handlers branch on AppImage: native `autoUpdater.downloadUpdate()` + `quitAndInstall()` on AppImage, no-op on non-AppImage Linux, Windows Squirrel path preserved. Listener cleanup on error/retry.
- `src/stores/updateStore.ts`: 4 new state fields + 4 selectors + 3 unit tests (151 → 154 tests).

**UI & i18n:**
- `UpdateDialog`: three-way footer (non-AppImage Linux → two-button migration variant; legacy `downloadUrl` → Go to Download; else Download Now) + auto-update note + `.tertiary-button` style.
- `UpdateBanner`: label swaps to `linuxMigrateTitle` when `supportsAutoUpdate === false`.
- 5 new i18n keys (`autoUpdateNote`, `downloadAppImage`, `downloadDeb`, `linuxMigrateTitle`, `linuxMigrateBody`) added to all 30 locales; native localizations for zh_CN, zh_TW, ja, ko, de, fr, es, pt_BR, ru.

## Out of scope

- **Windows NSIS migration** — Forge `maker-squirrel` → `electron-builder` NSIS would unify with Linux and unlock native Windows auto-update too. Tracked as #207.
- **AppImage GPG signing** — electron-builder supports it; we have no Linux signing key yet. Keep unsigned (consistent with current `.deb`).
- **Flatpak / apt repo** — tracked separately.

## Test plan

- [x] Local build: `npx electron-builder --linux AppImage deb --x64` produces `Sokuji-0.19.0-x86_64.AppImage` (264 MB), `sokuji_0.19.0_amd64.deb` (140 MB), `latest-linux.yml` with SHA512 hashes for both.
- [x] Audio pipeline verification: real AppImage launched on Linux host; `process.env.APPIMAGE` set; `pactl` reachable from inside AppImage; virtual TTS devices (`sokuji_virtual_output` + `sokuji_virtual_mic`) created successfully; end-to-end translation session works.
- [x] Test suite: 154/154 passing (+3 new tests in `updateStore.test.ts`).
- [ ] **E2E auto-update cycle** (post-merge; requires published releases):
  - [ ] Cut `v0.20.0-rc1`, wait for CI, publish draft on GitHub
  - [ ] Install `Sokuji-0.20.0-rc1-x86_64.AppImage` on Linux host
  - [ ] Cut `v0.20.0-rc2`, publish
  - [ ] From running rc1: Check for Updates → download → "Restart and Update" → relaunches as rc2
  - [ ] Verify AppImage binary replaced in place
- [ ] **E2E .deb migration banner** (post-merge):
  - [ ] Install `sokuji_0.20.0-rc1_amd64.deb`
  - [ ] Trigger update check
  - [ ] Banner reads "New version v0.20.0-rc2 available" (migrate title)
  - [ ] Dialog shows auto-update note + Download AppImage (recommended) + Download .deb + Later
  - [ ] "Download AppImage" opens correct browser URL
  - [ ] No auto-download / no `update-downloaded` event in logs

## Design docs

- Spec: `docs/superpowers/specs/2026-04-20-linux-appimage-auto-update-design.md`
- Plan: `docs/superpowers/plans/2026-04-20-linux-appimage-auto-update.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AppImage is the recommended Linux format with native in-app auto-update; non‑AppImage Linux users get migration UI and external download options.

* **Packaging / Build**
  * CI now builds AppImage and .deb for x64/arm64, uses an arm64 Linux runner, and uploads AppImage/deb plus update manifests.

* **UI**
  * Update banner/dialog show format-specific copy and buttons for AppImage/.deb when appropriate.

* **Localization**
  * Added translations for the Linux/AppImage update flow.

* **Documentation**
  * Added design and migration planning docs.

* **Tests**
  * Added tests for the update store fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->