### PR TITLE
feat(local-inference): add Voxtral Mini 3B 2507 WebGPU ASR with language-hint support

### DIFF
--- a/docs/superpowers/plans/2026-04-25-voxtral-3b-webgpu-asr-integration.md
+++ b/docs/superpowers/plans/2026-04-25-voxtral-3b-webgpu-asr-integration.md
@@ -1,0 +1,995 @@
+# Voxtral Mini 3B 2507 WebGPU ASR Integration Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Voxtral Mini 3B 2507 as a batch/offline WebGPU ASR engine (`type: 'asr'`) with explicit language-hint support (`lang:XX [TRANSCRIBE]` in the chat template), routed through `AsrEngine` (not `StreamingAsrEngine`, correcting Task #3 of issue #169).
+
+**Architecture:** A new module worker `voxtral-3b-webgpu.worker.ts` follows Cohere Transcribe's batch pattern (VAD → complete utterance → `model.generate`) but uses `VoxtralForConditionalGeneration` + `VoxtralProcessor` + `apply_chat_template` instead of the `pipeline()` API. `TextStreamer` provides token-level partial results during batch decoding. `AsrEngine` already routes `type: 'asr'` models; we add one `switch` case and extend one existing init-message condition. Spec: `docs/superpowers/specs/2026-04-25-voxtral-3b-webgpu-asr-design.md`.
+
+**Tech Stack:** `@huggingface/transformers` (`VoxtralForConditionalGeneration`, `VoxtralProcessor`, `TextStreamer`, `env`), `onnxruntime-web` (Silero VAD), `@ricky0123/vad-web` (`FrameProcessor`)
+
+**Important discovery from HF file listing:** The 3B repo does **not** ship an `embed_tokens_q4f16.onnx` (unlike 4B). The q4f16 variant must mix precisions: `{ audio_encoder: 'q4f16', embed_tokens: 'q4', decoder_model_merged: 'q4f16' }`. This plan already reflects that; the design spec's "all q4f16" note is superseded here.
+
+---
+
+### Task 1: Add type definitions and type-union entries
+
+**Files:**
+- Modify: `src/lib/local-inference/types.ts:87` (`AsrWorkerInMessage` union)
+- Modify: `src/lib/local-inference/types.ts:165-181` (add new interface after `CohereTranscribeAsrInitMessage`)
+- Modify: `src/lib/local-inference/modelManifest.ts:30-34` (`AsrEngineType`)
+- Modify: `src/lib/local-inference/modelManifest.ts:90` (`asrWorkerType` union)
+
+- [ ] **Step 1: Add `Voxtral3BAsrInitMessage` interface to `types.ts`**
+
+In `src/lib/local-inference/types.ts`, insert the following **between** the existing `CohereTranscribeAsrInitMessage` block (ends at line 181) and the `GraniteSpeechInitMessage` block (starts at line 183):
+
+```typescript
+export interface Voxtral3BAsrInitMessage {
+  type: 'init';
+  /** Map of filename → blob URL for model files from IndexedDB */
+  fileUrls: Record<string, string>;
+  /** HuggingFace model ID for Transformers.js from_pretrained */
+  hfModelId: string;
+  /** Source language hint (e.g. 'ja', 'en-US'). Normalized to ISO 639-1 inside the worker. */
+  language?: string;
+  /** ONNX dtype config — per-component mapping (audio_encoder, embed_tokens, decoder_model_merged) */
+  dtype: string | Record<string, string>;
+  /** VAD configuration overrides from user settings */
+  vadConfig?: VadWebConfig;
+  /** Resolved absolute URL for bundled VAD model */
+  vadModelUrl: string;
+  /** Resolved absolute URL for bundled ORT WASM files */
+  ortWasmBaseUrl?: string;
+}
+```
+
+- [ ] **Step 2: Extend the `AsrWorkerInMessage` union in `types.ts`**
+
+At line 87, change:
+
+```typescript
+export type AsrWorkerInMessage = AsrInitMessage | WhisperAsrInitMessage | VoxtralAsrInitMessage | CohereTranscribeAsrInitMessage | GraniteSpeechInitMessage | AsrAudioMessage | AsrDisposeMessage;
+```
+
+to:
+
+```typescript
+export type AsrWorkerInMessage = AsrInitMessage | WhisperAsrInitMessage | VoxtralAsrInitMessage | Voxtral3BAsrInitMessage | CohereTranscribeAsrInitMessage | GraniteSpeechInitMessage | AsrAudioMessage | AsrDisposeMessage;
+```
+
+- [ ] **Step 3: Add `'voxtral-3b'` to `AsrEngineType` in `modelManifest.ts`**
+
+At lines 30-34, change:
+
+```typescript
+export type AsrEngineType =
+  | 'sensevoice' | 'whisper' | 'transducer' | 'nemo-transducer'
+  | 'paraformer' | 'telespeech' | 'moonshine' | 'moonshine-v2'
+  | 'dolphin' | 'zipformer-ctc' | 'nemo-ctc' | 'canary'
+  | 'wenet-ctc' | 'omnilingual' | 'granite-speech';
+```
+
+to:
+
+```typescript
+export type AsrEngineType =
+  | 'sensevoice' | 'whisper' | 'transducer' | 'nemo-transducer'
+  | 'paraformer' | 'telespeech' | 'moonshine' | 'moonshine-v2'
+  | 'dolphin' | 'zipformer-ctc' | 'nemo-ctc' | 'canary'
+  | 'wenet-ctc' | 'omnilingual' | 'granite-speech' | 'voxtral-3b';
+```
+
+Note: This is the offline `AsrEngineType`, not `StreamAsrEngineType`. The 3B model is batch-decoded.
+
+- [ ] **Step 4: Add `'voxtral-3b-webgpu'` to the `asrWorkerType` union in `modelManifest.ts`**
+
+At line 90, change:
+
+```typescript
+  asrWorkerType?: 'sherpa-onnx' | 'whisper-webgpu' | 'voxtral-webgpu' | 'cohere-transcribe-webgpu' | 'granite-speech-webgpu';
+```
+
+to:
+
+```typescript
+  asrWorkerType?: 'sherpa-onnx' | 'whisper-webgpu' | 'voxtral-webgpu' | 'voxtral-3b-webgpu' | 'cohere-transcribe-webgpu' | 'granite-speech-webgpu';
+```
+
+- [ ] **Step 5: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No errors. (There are no references to the new types yet, so only the union additions exist.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/local-inference/types.ts src/lib/local-inference/modelManifest.ts
+git commit -m "$(cat <<'EOF'
+feat(local-inference): add Voxtral 3B type and worker-type identifiers
+
+Prepares type plumbing for the Voxtral Mini 3B 2507 WebGPU ASR worker
+(issue #169). Adds Voxtral3BAsrInitMessage, extends AsrWorkerInMessage,
+AsrEngineType, and the asrWorkerType union. No runtime behavior change yet.
+EOF
+)"
+```
+
+---
+
+### Task 2: Add the model manifest entry
+
+**Files:**
+- Modify: `src/lib/local-inference/modelManifest.ts` (insert new entry after the Voxtral 4B block ending at line 830)
+
+- [ ] **Step 1: Insert the Voxtral 3B manifest entry**
+
+In `src/lib/local-inference/modelManifest.ts`, insert the following **between** the closing `},` of the Voxtral 4B entry (line 830) and the `// ── Cohere Transcribe WebGPU ASR ────...` comment (line 832):
+
+```typescript
+  // ── Voxtral Mini 3B 2507 WebGPU ASR ────────────────────────────────────────
+  // Downloaded from onnx-community repo on HuggingFace Hub. Uses hfModelId.
+  // Voxtral Mini 3B (2507) — offline/batch model with explicit language hint
+  // via chat template ("lang:XX [TRANSCRIBE]"). 8 supported languages.
+  // Note: 3B repo has no embed_tokens_q4f16; q4f16 variant mixes q4 embeddings
+  // with q4f16 audio encoder + decoder.
+  {
+    id: 'voxtral-mini-3b-webgpu',
+    type: 'asr',
+    name: 'Voxtral Mini 3B 2507 (WebGPU)',
+    languages: ['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it'],
+    multilingual: true,
+    hfModelId: 'onnx-community/Voxtral-Mini-3B-2507-ONNX',
+    requiredDevice: 'webgpu',
+    asrEngine: 'voxtral-3b',
+    asrWorkerType: 'voxtral-3b-webgpu',
+    variants: {
+      'q4f16': {
+        // 3B has no embed_tokens_q4f16 → use q4 for embeddings
+        dtype: { audio_encoder: 'q4f16', embed_tokens: 'q4', decoder_model_merged: 'q4f16' },
+        files: [
+          // Config & tokenizer (shared across variants)
+          { filename: 'config.json', sizeBytes: 2_161 },
+          { filename: 'generation_config.json', sizeBytes: 107 },
+          { filename: 'preprocessor_config.json', sizeBytes: 357 },
+          { filename: 'special_tokens_map.json', sizeBytes: 414 },
+          { filename: 'chat_template.jinja', sizeBytes: 989 },
+          { filename: 'tokenizer.json', sizeBytes: 12_603_078 },
+          { filename: 'tokenizer_config.json', sizeBytes: 178_296 },
+          { filename: 'tekken.json', sizeBytes: 14_894_206 },
+          // ONNX model files (q4f16 audio+decoder, q4 embed)
+          { filename: 'onnx/audio_encoder_q4f16.onnx', sizeBytes: 403_958 },
+          { filename: 'onnx/audio_encoder_q4f16.onnx_data', sizeBytes: 383_696_896 },
+          { filename: 'onnx/decoder_model_merged_q4f16.onnx', sizeBytes: 308_330 },
+          { filename: 'onnx/decoder_model_merged_q4f16.onnx_data', sizeBytes: 2_065_283_072 },
+          { filename: 'onnx/embed_tokens_q4.onnx', sizeBytes: 542 },
+          { filename: 'onnx/embed_tokens_q4.onnx_data', sizeBytes: 251_658_240 },
+        ],
+        requiredFeatures: ['shader-f16'],
+      },
+      'q4': {
+        dtype: { audio_encoder: 'q4', embed_tokens: 'q4', decoder_model_merged: 'q4' },
+        files: [
+          // Config & tokenizer (shared across variants)
+          { filename: 'config.json', sizeBytes: 2_161 },
+          { filename: 'generation_config.json', sizeBytes: 107 },
+          { filename: 'preprocessor_config.json', sizeBytes: 357 },
+          { filename: 'special_tokens_map.json', sizeBytes: 414 },
+          { filename: 'chat_template.jinja', sizeBytes: 989 },
+          { filename: 'tokenizer.json', sizeBytes: 12_603_078 },
+          { filename: 'tokenizer_config.json', sizeBytes: 178_296 },
+          { filename: 'tekken.json', sizeBytes: 14_894_206 },
+          // ONNX model files (q4)
+          { filename: 'onnx/audio_encoder_q4.onnx', sizeBytes: 401_545 },
+          { filename: 'onnx/audio_encoder_q4.onnx_data', sizeBytes: 440_238_080 },
+          { filename: 'onnx/decoder_model_merged_q4.onnx', sizeBytes: 306_657 },
+          { filename: 'onnx/decoder_model_merged_q4.onnx_data', sizeBytes: 2_073_260_032 },
+          { filename: 'onnx/decoder_model_merged_q4.onnx_data_1', sizeBytes: 251_658_240 },
+          { filename: 'onnx/embed_tokens_q4.onnx', sizeBytes: 542 },
+          { filename: 'onnx/embed_tokens_q4.onnx_data', sizeBytes: 251_658_240 },
+        ],
+      },
+    },
+    recommended: true,
+    sortOrder: 3,
+  },
+
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/local-inference/modelManifest.ts
+git commit -m "$(cat <<'EOF'
+feat(local-inference): add Voxtral Mini 3B 2507 WebGPU manifest entry
+
+Registers onnx-community/Voxtral-Mini-3B-2507-ONNX with q4f16 and q4
+variants. 8 languages (en, es, fr, pt, hi, de, nl, it). sortOrder: 3
+places it after Cohere (1) and 4B Realtime (2). Worker file and engine
+wiring arrive in subsequent commits.
+
+File sizes sourced from the HF API
+(huggingface.co/api/models/onnx-community/Voxtral-Mini-3B-2507-ONNX/tree/main).
+EOF
+)"
+```
+
+---
+
+### Task 3: Create the worker file
+
+**Files:**
+- Create: `src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts`
+
+- [ ] **Step 1: Create the worker file**
+
+Create `src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts` with the following complete contents:
+
+```typescript
+/**
+ * Voxtral Mini 3B 2507 WebGPU ASR Worker
+ *
+ * Streaming audio input (Int16@24kHz) → Silero VAD v5 → Voxtral Mini 3B (WebGPU)
+ * Model files loaded from IndexedDB via customCache bridge.
+ *
+ * Unlike Voxtral 4B Realtime (continuous streaming inference), 3B is an
+ * offline/batch model decoded on complete VAD-gated utterances. Token-level
+ * streaming is provided by TextStreamer during each batch inference.
+ *
+ * Key feature over 4B: explicit language hint injected into the processor
+ * chat template as `lang:XX [TRANSCRIBE]` for the 8 supported languages
+ * (en, es, fr, pt, hi, de, nl, it). Falls back to bare `[TRANSCRIBE]` for
+ * unsupported codes (auto-detect).
+ *
+ * Input messages:  Voxtral3BAsrInitMessage | AsrAudioMessage | AsrDisposeMessage | { type: 'flush' }
+ * Output messages: StreamingAsrWorkerOutMessage (ready, status, speech_start, partial, result, error, disposed)
+ */
+
+import {
+  VoxtralForConditionalGeneration,
+  VoxtralProcessor,
+  TextStreamer,
+  env,
+  type ProgressInfo,
+} from '@huggingface/transformers';
+import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+import { FrameProcessor, Message } from '@ricky0123/vad-web';
+import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
+
+import type {
+  Voxtral3BAsrInitMessage,
+  AsrAudioMessage,
+  AsrDisposeMessage,
+  StreamingAsrWorkerOutMessage,
+} from '../types';
+
+// ─── ORT / Transformers.js env setup ─────────────────────────────────────────
+
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.proxy = false;
+}
+
+// Workaround: HF CDN Range request cache pollution (same as Voxtral 4B / Cohere workers)
+const _origFetch = env.fetch;
+env.fetch = (input: any, init?: any) => {
+  const headers = init?.headers;
+  const hasRange =
+    headers instanceof Headers
+      ? headers.has('Range')
+      : Array.isArray(headers)
+        ? headers.some(([k]: [string]) => k.toLowerCase() === 'range')
+        : headers && typeof headers === 'object' && 'Range' in headers;
+  if (hasRange) {
+    return _origFetch(input, { ...init, cache: 'no-store' });
+  }
+  return _origFetch(input, init);
+};
+
+// ─── Types & Helpers ─────────────────────────────────────────────────────────
+
+type WorkerMessage = Voxtral3BAsrInitMessage | AsrAudioMessage | AsrDisposeMessage | { type: 'flush' };
+
+function post(msg: StreamingAsrWorkerOutMessage) {
+  self.postMessage(msg);
+}
+
+// ─── Silero VAD v5 ──────────────────────────────────────────────────────────
+
+const VAD_SAMPLE_RATE = 16000;
+const VAD_FRAME_SAMPLES = 512; // 32ms @ 16kHz
+const VAD_FRAME_MS = (VAD_FRAME_SAMPLES / VAD_SAMPLE_RATE) * 1000;
+
+interface VadSession {
+  session: InferenceSession;
+  state: Tensor;
+}
+
+let vadSession: VadSession | null = null;
+let frameProcessor: FrameProcessor | null = null;
+let maxSpeechFrames = 625; // ~20s at 32ms/frame
+let speechFramesSinceStart = 0;
+
+async function vadInfer(frame: Float32Array): Promise<{ isSpeech: number; notSpeech: number }> {
+  if (!vadSession) return { isSpeech: 0, notSpeech: 1 };
+  const input = new Tensor('float32', frame, [1, VAD_FRAME_SAMPLES]);
+  const sr = new Tensor('int64', BigInt64Array.from([BigInt(VAD_SAMPLE_RATE)]), []);
+  const result = await vadSession.session.run({ input, sr, state: vadSession.state });
+  vadSession.state = result.stateN as Tensor;
+  const prob = (result.output as Tensor).data[0] as number;
+  return { isSpeech: prob, notSpeech: 1 - prob };
+}
+
+function vadResetStates() {
+  if (!vadSession) return;
+  vadSession.state = new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]);
+}
+
+async function initVad(vadConfig?: Voxtral3BAsrInitMessage['vadConfig'], vadModelUrl?: string): Promise<void> {
+  const session = await InferenceSession.create(vadModelUrl || './wasm/vad/silero_vad_v5.onnx', {
+    executionProviders: ['wasm'],
+  });
+  vadSession = {
+    session,
+    state: new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]),
+  };
+
+  const positiveSpeechThreshold = vadConfig?.threshold ?? 0.3;
+  const negativeSpeechThreshold = vadConfig?.negativeThreshold ?? 0.25;
+  const redemptionMs = (vadConfig?.minSilenceDuration ?? 1.4) * 1000;
+  const minSpeechMs = (vadConfig?.minSpeechDuration ?? 0.4) * 1000;
+  const preSpeechPadMs = (vadConfig?.preSpeechPadDuration ?? 0.8) * 1000;
+  const maxSpeechDurationMs = (vadConfig?.maxSpeechDuration ?? 20) * 1000;
+
+  maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
+
+  frameProcessor = new FrameProcessor(
+    vadInfer,
+    vadResetStates,
+    {
+      positiveSpeechThreshold,
+      negativeSpeechThreshold,
+      redemptionMs,
+      minSpeechMs,
+      preSpeechPadMs,
+      submitUserSpeechOnPause: false,
+    },
+    VAD_FRAME_MS,
+  );
+  frameProcessor.resume();
+  speechFramesSinceStart = 0;
+}
+
+// ─── Audio Buffer & Resampling ──────────────────────────────────────────────
+
+let vadAudioBuffer = new Float32Array(0);
+
+function resampleInt16ToFloat32_16k(samples: Int16Array, inputRate: number): Float32Array {
+  const ratio = inputRate / VAD_SAMPLE_RATE;
+  const outLen = Math.floor(samples.length / ratio);
+  const out = new Float32Array(outLen);
+  for (let i = 0; i < outLen; i++) {
+    const srcIdx = i * ratio;
+    const lo = Math.floor(srcIdx);
+    const hi = Math.min(lo + 1, samples.length - 1);
+    const frac = srcIdx - lo;
+    out[i] = samples[lo] / 32768 + ((samples[hi] / 32768) - (samples[lo] / 32768)) * frac;
+  }
+  return out;
+}
+
+// ─── Voxtral 3B Model State ─────────────────────────────────────────────────
+
+let model: any = null;            // VoxtralForConditionalGeneration instance
+let processor: any = null;        // VoxtralProcessor instance
+let currentLanguage: string | undefined;
+let processingVad = false;
+let currentDecodePromise: Promise<void> | null = null;
+
+// 8 languages natively supported by Voxtral 3B 2507
+const SUPPORTED_LANGS = new Set(['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it']);
+
+function normalizeToIso639_1(lang: string | undefined): string {
+  if (!lang) return '';
+  // Strip region suffix: 'en-US' → 'en', 'zh_Hans' → 'zh'
+  return lang.trim().toLowerCase().split(/[-_]/)[0];
+}
+
+/**
+ * Create customCache bridge for IndexedDB blob URLs → Transformers.js.
+ * Maps HF Hub resolve URLs to local blob URLs from IndexedDB.
+ * Same pattern as whisper-webgpu, voxtral-webgpu, and cohere-transcribe-webgpu workers.
+ */
+function createBlobUrlCache(fileUrls: Record<string, string>) {
+  return {
+    async match(request: string | Request | undefined): Promise<Response | undefined> {
+      if (!request) return undefined;
+      const url = typeof request === 'string' ? request : request.url;
+      const marker = '/resolve/main/';
+      const idx = url.indexOf(marker);
+      if (idx === -1) return undefined;
+      const filename = url.slice(idx + marker.length);
+      const blobUrl = fileUrls[filename];
+      if (!blobUrl) return undefined;
+      return fetch(blobUrl);
+    },
+    async put(_request: string | Request, _response: Response): Promise<void> {
+    },
+  };
+}
+
+// ─── Batch Speech Segment Processing ────────────────────────────────────────
+
+/**
+ * Run Voxtral 3B inference on a completed speech segment.
+ * Builds a chat-template prompt with optional `lang:XX [TRANSCRIBE]` hint,
+ * uses TextStreamer for token-level partial results, and emits a final
+ * `result` message when decoding completes.
+ *
+ * Serializes decode calls via currentDecodePromise to prevent overlapping
+ * generate() invocations if VAD end-events arrive back-to-back.
+ */
+function runVoxtral3B(audio: Float32Array): Promise<void> {
+  const promise = (async () => {
+    if (currentDecodePromise) {
+      try { await currentDecodePromise; } catch { /* already reported */ }
+    }
+    if (!model || !processor) return;
+
+    const durationMs = Math.round((audio.length / VAD_SAMPLE_RATE) * 1000);
+    const startTime = performance.now();
+    let accumulatedText = '';
+
+    try {
+      // 1. Build chat-template prompt with optional language hint
+      const langCode = normalizeToIso639_1(currentLanguage);
+      const hintedText = SUPPORTED_LANGS.has(langCode)
+        ? `lang:${langCode} [TRANSCRIBE]`
+        : '[TRANSCRIBE]';
+
+      const conversation = [
+        {
+          role: 'user',
+          content: [
+            { type: 'audio' },
+            { type: 'text', text: hintedText },
+          ],
+        },
+      ];
+      const promptText = processor.apply_chat_template(conversation, { tokenize: false });
+
+      // 2. Processor builds mel features + input_ids from prompt + audio
+      const inputs = await processor(promptText, audio);
+
+      // 3. TextStreamer streams decoded tokens as partials
+      const streamer = new TextStreamer(processor.tokenizer, {
+        skip_prompt: true,
+        skip_special_tokens: true,
+        callback_function: (token: string) => {
+          accumulatedText += token;
+          post({ type: 'partial', text: accumulatedText });
+        },
+      });
+
+      // 4. Generate (batch decode, not streaming input like 4B)
+      const outputs = await model.generate({
+        ...inputs,
+        max_new_tokens: 500,
+        streamer,
+      });
+
+      // 5. Canonical final decode: slice prompt tokens, then batch_decode.
+      //    Falls back to `accumulatedText` if slice/decode is unavailable in this
+      //    transformers.js version (defensive; should not happen on ≥3.7).
+      let finalText = accumulatedText.trim();
+      try {
+        const promptLen = inputs.input_ids.dims.at(-1)!;
+        const generated = outputs.slice(null, [promptLen, null]);
+        const decoded = processor.batch_decode(generated, { skip_special_tokens: true });
+        const candidate = Array.isArray(decoded) ? decoded[0] : decoded;
+        if (candidate && typeof candidate === 'string' && candidate.trim()) {
+          finalText = candidate.trim();
+        }
+      } catch {
+        // Keep accumulatedText as finalText
+      }
+
+      if (finalText) {
+        post({
+          type: 'result',
+          text: finalText,
+          durationMs,
+          recognitionTimeMs: Math.round(performance.now() - startTime),
+        });
+      }
+    } catch (err: any) {
+      post({ type: 'error', error: `Voxtral 3B inference failed: ${err?.message || err}` });
+    }
+  })();
+
+  currentDecodePromise = promise;
+  return promise;
+}
+
+// ─── VAD + Audio Feed Pipeline ──────────────────────────────────────────────
+
+async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void> {
+  if (!vadSession || !frameProcessor || !model || processingVad) return;
+  processingVad = true;
+
+  try {
+    const resampled = resampleInt16ToFloat32_16k(samples, sampleRate);
+
+    // Append to VAD audio buffer
+    const newBuf = new Float32Array(vadAudioBuffer.length + resampled.length);
+    newBuf.set(vadAudioBuffer);
+    newBuf.set(resampled, vadAudioBuffer.length);
+    vadAudioBuffer = newBuf;
+
+    // Process complete VAD frames
+    while (vadAudioBuffer.length >= VAD_FRAME_SAMPLES) {
+      const frame = vadAudioBuffer.slice(0, VAD_FRAME_SAMPLES);
+      vadAudioBuffer = vadAudioBuffer.slice(VAD_FRAME_SAMPLES);
+
+      const events: FrameProcessorEvent[] = [];
+      await frameProcessor.process(frame, (ev) => events.push(ev));
+
+      for (const ev of events) {
+        switch (ev.msg) {
+          case Message.SpeechStart:
+            speechFramesSinceStart = 0;
+            post({ type: 'speech_start' });
+            break;
+
+          case Message.SpeechEnd:
+            speechFramesSinceStart = 0;
+            await runVoxtral3B(ev.audio);
+            break;
+
+          case Message.VADMisfire:
+            speechFramesSinceStart = 0;
+            break;
+        }
+      }
+
+      // Max speech duration cap — force-finalize if speech runs too long
+      if (frameProcessor.speaking) {
+        speechFramesSinceStart++;
+        if (speechFramesSinceStart >= maxSpeechFrames) {
+          const endEvents: FrameProcessorEvent[] = [];
+          frameProcessor.endSegment((ev) => endEvents.push(ev));
+          for (const ev of endEvents) {
+            if (ev.msg === Message.SpeechEnd) {
+              await runVoxtral3B(ev.audio);
+            }
+          }
+          speechFramesSinceStart = 0;
+        }
+      } else {
+        speechFramesSinceStart = 0;
+      }
+    }
+  } finally {
+    processingVad = false;
+  }
+}
+
+// ─── Init Handler ───────────────────────────────────────────────────────────
+
+async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
+  try {
+    const startTime = performance.now();
+
+    // Set ORT WASM paths
+    if (msg.ortWasmBaseUrl) {
+      if (env.backends?.onnx?.wasm) {
+        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+      if (ortEnv?.wasm) {
+        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+    }
+
+    // 1. Init VAD
+    post({ type: 'status', message: 'Loading VAD model...' });
+    await initVad(msg.vadConfig, msg.vadModelUrl);
+
+    // 2. Configure Transformers.js for IndexedDB blob URL cache
+    env.allowRemoteModels = false;
+    env.allowLocalModels = true;
+    env.useBrowserCache = false;
+    env.useCustomCache = true;
+    env.customCache = createBlobUrlCache(msg.fileUrls);
+
+    // 3. Load processor
+    post({ type: 'status', message: 'Loading Voxtral 3B processor...' });
+    processor = await VoxtralProcessor.from_pretrained(msg.hfModelId);
+
+    // 4. Load model (WebGPU)
+    post({ type: 'status', message: 'Loading Voxtral 3B model (WebGPU)...' });
+    model = await VoxtralForConditionalGeneration.from_pretrained(msg.hfModelId, {
+      dtype: msg.dtype as any,
+      device: 'webgpu',
+      progress_callback: (info: ProgressInfo) => {
+        if (info.status === 'progress' && info.file?.endsWith('.onnx_data') && (info as any).total > 0) {
+          const pct = Math.round(((info as any).loaded / (info as any).total) * 100);
+          post({ type: 'status', message: `Loading model... ${pct}%` });
+        }
+      },
+    });
+
+    currentLanguage = msg.language;
+
+    // 5. Log chosen language hint for operator visibility
+    const langCode = normalizeToIso639_1(currentLanguage);
+    if (SUPPORTED_LANGS.has(langCode)) {
+      post({ type: 'status', message: `Voxtral 3B language hint: lang:${langCode} [TRANSCRIBE]` });
+    } else if (currentLanguage) {
+      post({ type: 'status', message: `Voxtral 3B: source language '${currentLanguage}' not in supported set; using auto-detect` });
+    }
+
+    // Reset buffers
+    vadAudioBuffer = new Float32Array(0);
+
+    const loadTimeMs = Math.round(performance.now() - startTime);
+    post({ type: 'ready', loadTimeMs });
+  } catch (err: any) {
+    post({ type: 'error', error: err?.message || String(err) });
+  }
+}
+
+// ─── Flush & Dispose ────────────────────────────────────────────────────────
+
+async function handleFlush(): Promise<void> {
+  // Force-finalize any pending speech via FrameProcessor (PTT release path)
+  if (frameProcessor?.speaking) {
+    const endEvents: FrameProcessorEvent[] = [];
+    frameProcessor.endSegment((ev) => endEvents.push(ev));
+    for (const ev of endEvents) {
+      if (ev.msg === Message.SpeechEnd) {
+        await runVoxtral3B(ev.audio);
+      }
+    }
+  }
+  // Wait for any in-flight decode to complete
+  if (currentDecodePromise) {
+    try { await currentDecodePromise; } catch { /* already reported */ }
+  }
+}
+
+async function handleDispose(): Promise<void> {
+  // Flush remaining speech
+  if (frameProcessor?.speaking) {
+    const endEvents: FrameProcessorEvent[] = [];
+    frameProcessor.endSegment((ev) => endEvents.push(ev));
+    for (const ev of endEvents) {
+      if (ev.msg === Message.SpeechEnd) {
+        await runVoxtral3B(ev.audio);
+      }
+    }
+  }
+
+  // Wait for any in-flight decode to complete before disposing
+  if (currentDecodePromise) {
+    try { await currentDecodePromise; } catch { /* already reported */ }
+    currentDecodePromise = null;
+  }
+
+  // Dispose FrameProcessor
+  frameProcessor = null;
+  speechFramesSinceStart = 0;
+
+  // Dispose VAD
+  if (vadSession?.session) {
+    await vadSession.session.release();
+    vadSession = null;
+  }
+
+  // Dispose model and processor
+  if (model) {
+    try { await (model as any).dispose?.(); } catch { /* ignore */ }
+    model = null;
+  }
+  processor = null;
+  currentLanguage = undefined;
+
+  vadAudioBuffer = new Float32Array(0);
+  processingVad = false;
+
+  post({ type: 'disposed' });
+}
+
+// ─── Message Router ─────────────────────────────────────────────────────────
+
+self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
+  const msg = event.data;
+  switch (msg.type) {
+    case 'init':
+      await handleInit(msg as Voxtral3BAsrInitMessage);
+      break;
+    case 'audio':
+      await feedAudio((msg as AsrAudioMessage).samples, (msg as AsrAudioMessage).sampleRate);
+      break;
+    case 'flush':
+      await handleFlush();
+      break;
+    case 'dispose':
+      await handleDispose();
+      break;
+  }
+};
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -40`
+Expected: No errors. If `VoxtralForConditionalGeneration` or `VoxtralProcessor` are not found, verify that `@huggingface/transformers` is ≥ 3.7 (the project is on 4.2.0, so this should not happen): `node -e "console.log(require('@huggingface/transformers/package.json').version)"`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+git commit -m "$(cat <<'EOF'
+feat(local-inference): add Voxtral 3B WebGPU worker (batch ASR)
+
+Module worker wrapping VoxtralForConditionalGeneration + VoxtralProcessor.
+Uses Cohere-style VAD-gated batch decode: SpeechEnd → apply_chat_template
+with optional lang:XX hint → generate with TextStreamer for token-level
+partial results.
+
+Language hint covers 8 Voxtral 3B 2507 languages (en/es/fr/pt/hi/de/nl/it);
+unsupported codes fall back to bare [TRANSCRIBE] auto-detect.
+
+Not yet wired into AsrEngine — that arrives in the next commit.
+EOF
+)"
+```
+
+---
+
+### Task 4: Wire the worker into AsrEngine
+
+**Files:**
+- Modify: `src/lib/local-inference/engine/AsrEngine.ts:84-106` (worker switch)
+- Modify: `src/lib/local-inference/engine/AsrEngine.ts:165` (init message condition)
+- Modify: `src/lib/local-inference/engine/AsrEngine.ts:5-9` (header comment — optional hygiene)
+
+- [ ] **Step 1: Add the `voxtral-3b-webgpu` case to the worker switch**
+
+In `src/lib/local-inference/engine/AsrEngine.ts`, the switch at lines 84-106 currently reads:
+
+```typescript
+      switch (workerType) {
+        case 'whisper-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/whisper-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        case 'cohere-transcribe-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/cohere-transcribe-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        case 'granite-speech-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/granite-speech-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        default: // sherpa-onnx
+          this.worker = new Worker('./workers/sherpa-onnx-asr.worker.js');
+          break;
+      }
+```
+
+Insert a new `case 'voxtral-3b-webgpu'` **between** the `cohere-transcribe-webgpu` case and the `granite-speech-webgpu` case, so the switch reads:
+
+```typescript
+      switch (workerType) {
+        case 'whisper-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/whisper-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        case 'cohere-transcribe-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/cohere-transcribe-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        case 'voxtral-3b-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/voxtral-3b-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        case 'granite-speech-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/granite-speech-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
+        default: // sherpa-onnx
+          this.worker = new Worker('./workers/sherpa-onnx-asr.worker.js');
+          break;
+      }
+```
+
+- [ ] **Step 2: Extend the init-message condition to cover voxtral-3b-webgpu**
+
+In `src/lib/local-inference/engine/AsrEngine.ts`, line 165 currently reads:
+
+```typescript
+      if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu') {
+```
+
+Change it to:
+
+```typescript
+      if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu' || workerType === 'voxtral-3b-webgpu') {
+```
+
+The init message payload inside this branch (fileUrls / hfModelId / language / vadConfig / dtype / ortWasmBaseUrl / vadModelUrl) already matches the `Voxtral3BAsrInitMessage` shape — no other change is needed in this block.
+
+Note: **Do NOT** add a `workerType === 'voxtral-3b-webgpu' && !language` guard (the pattern used for Cohere at lines 78-80). The 3B worker handles missing/unsupported language by falling back to bare `[TRANSCRIBE]`.
+
+- [ ] **Step 3: Update the header comment (hygiene)**
+
+In `src/lib/local-inference/engine/AsrEngine.ts`, the header comment at lines 5-9 currently reads:
+
+```typescript
+ * Supports multiple worker backends:
+ * - sherpa-onnx (classic Worker): VAD + OfflineRecognizer via Emscripten/WASM
+ * - whisper-webgpu (module Worker): VAD + Whisper via Transformers.js/WebGPU
+ * - cohere-transcribe-webgpu (module Worker): VAD + Cohere Transcribe via Transformers.js/WebGPU
+ */
+```
+
+Add a line for the new worker so the list reads:
+
+```typescript
+ * Supports multiple worker backends:
+ * - sherpa-onnx (classic Worker): VAD + OfflineRecognizer via Emscripten/WASM
+ * - whisper-webgpu (module Worker): VAD + Whisper via Transformers.js/WebGPU
+ * - cohere-transcribe-webgpu (module Worker): VAD + Cohere Transcribe via Transformers.js/WebGPU
+ * - voxtral-3b-webgpu (module Worker): VAD + Voxtral 3B (with lang hint) via Transformers.js/WebGPU
+ * - granite-speech-webgpu (module Worker): VAD + Granite Speech via Transformers.js/WebGPU
+ */
+```
+
+- [ ] **Step 4: Verify TypeScript compiles**
+
+Run: `npx tsc --noEmit --pretty 2>&1 | head -30`
+Expected: No errors.
+
+- [ ] **Step 5: Verify the app builds**
+
+Run: `npm run build 2>&1 | tail -30`
+Expected: Build succeeds. Look for a new bundled chunk corresponding to `voxtral-3b-webgpu.worker.ts` in the output (e.g. `voxtral-3b-webgpu.worker-<hash>.js`).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/local-inference/engine/AsrEngine.ts
+git commit -m "$(cat <<'EOF'
+feat(local-inference): wire Voxtral 3B WebGPU worker into AsrEngine
+
+Adds the switch case and extends the WebGPU init-message condition so
+AsrEngine routes `asrWorkerType: 'voxtral-3b-webgpu'` to the new worker.
+Same init shape as whisper-webgpu / cohere-transcribe-webgpu — no
+LocalInferenceClient change needed (already dispatches by manifest type).
+
+Closes the integration loop for issue #169.
+EOF
+)"
+```
+
+---
+
+### Task 5: Manual integration test
+
+**Files:** None (testing only)
+
+WebGPU workers cannot be meaningfully exercised in unit tests — this task validates end-to-end in a real browser.
+
+- [ ] **Step 1: Start the dev server**
+
+Run: `npm run dev`
+Expected: Dev server starts on port 5173.
+
+- [ ] **Step 2: Verify the model appears in the ASR selector**
+
+1. Open `http://localhost:5173` in Chrome or Edge (WebGPU required; Firefox/Safari will not see WebGPU models).
+2. Switch the provider to **Local Inference**.
+3. Set source language to **English** (or any of es/fr/pt/hi/de/nl/it).
+4. Open Model Management.
+5. Confirm **"Voxtral Mini 3B 2507 (WebGPU)"** appears in the ASR model list.
+6. Confirm its listed size is reasonable (~2.7 GB for q4f16 on shader-f16 GPUs, ~3.0 GB for q4 elsewhere).
+7. Set source language to **Japanese** and re-open the selector. Confirm Voxtral 3B is **hidden** (manifest `languages` filter excludes ja).
+
+- [ ] **Step 3: Download the model**
+
+1. With source language set back to a supported code (e.g. English), click **Download** on Voxtral Mini 3B 2507.
+2. Watch progress indication — IndexedDB download should populate all files listed in the manifest.
+3. Confirm status turns to "downloaded" when complete.
+
+- [ ] **Step 4: Run a transcription session and confirm the language hint is applied**
+
+1. Select **Voxtral Mini 3B 2507 (WebGPU)** as the ASR model.
+2. Open the browser DevTools **Console** — the worker posts `status` messages through `AsrEngine.onStatus`, which the app logs.
+3. Start a session. Watch for a status line like:
+   `Voxtral 3B language hint: lang:en [TRANSCRIBE]`
+4. Speak a short English sentence into the mic. Confirm:
+   - A `speech_start` event arrives (microphone indicator animates).
+   - Partial results appear token-by-token during decode.
+   - A final `result` is emitted when VAD detects silence.
+5. Stop the session.
+
+- [ ] **Step 5: Confirm language hint takes effect for a non-English language**
+
+1. Change source language to **German** (`de`) — still a supported code.
+2. Start a new session. Confirm a new status line:
+   `Voxtral 3B language hint: lang:de [TRANSCRIBE]`
+3. Speak a short German sentence. Confirm transcription output is in German script (not romanized English).
+4. For a sanity-check comparison, repeat the same audio against Voxtral 4B Realtime (which has no language hint) — 3B's output should be noticeably more accurate when the speaker is clearly German.
+
+- [ ] **Step 6: Confirm q4 fallback on non-shader-f16 GPUs (if available)**
+
+If a second machine/browser without `shader-f16` support is available:
+1. Open the app there; confirm Voxtral 3B still appears.
+2. Download and run — the q4 variant is selected automatically by `selectVariant()` in `modelManifest.ts`.
+3. Transcription works (slower than q4f16, but functional).
+
+Skip this step if only one GPU configuration is available.
+
+- [ ] **Step 7: Confirm clean teardown**
+
+1. End an active session.
+2. In the browser DevTools **Application → IndexedDB** and **Memory** tabs, confirm there is no growing WebGPU memory / worker leak after 3-4 consecutive session cycles.
+3. The worker should emit a `disposed` message (visible in console logs) on session end.
+
+- [ ] **Step 8: Commit any fixes discovered during testing**
+
+If any issue required a code fix, commit it:
+
+```bash
+git add -A
+git commit -m "fix(local-inference): address Voxtral 3B integration test findings"
+```
+
+If no fixes were needed, skip this step.
+
+---
+
+## Spec Coverage Check
+
+| Spec section | Task |
+|---|---|
+| Placement & engine routing (`type: 'asr'`, `AsrEngine`) | Tasks 2, 4 |
+| New identifiers (`voxtral-3b`, `voxtral-3b-webgpu`, `voxtral-mini-3b-webgpu`) | Tasks 1, 2 |
+| Data flow (VAD → batch decode) | Task 3 |
+| Dedicated new worker (not reusing 4B/Cohere) | Task 3 |
+| IndexedDB blob URL cache bridge (`createBlobUrlCache`) | Task 3 |
+| Chat-template `lang:XX [TRANSCRIBE]` injection + normalization | Task 3 |
+| TextStreamer partial results | Task 3 |
+| Recommended + `sortOrder: 3` | Task 2 |
+| q4f16 + q4 variants with `requiredFeatures` | Task 2 |
+| `LocalInferenceClient` **no change** | (verified by running the build in Task 4) |
+| Model Management UI **no change** | (manifest auto-discovered; confirmed in Task 5 Step 2) |
+| Unsupported-language fallback to bare `[TRANSCRIBE]` | Task 3 (`runVoxtral3B`) |
+| Region-suffix normalization (`en-US` → `en`) | Task 3 (`normalizeToIso639_1`) |
+| `shader-f16` fallback to q4 | Task 2 (`requiredFeatures`) + Task 5 Step 6 (verification) |
+| WebGPU unavailable → hidden | Task 2 (`requiredDevice: 'webgpu'`) + Task 5 Step 2 (verification) |
+| Long-utterance cap via VAD max-speech-duration | Task 3 (`maxSpeechFrames` loop) |
+| `flush` (PTT) path | Task 3 (`handleFlush`) |
+| Translate task (`task: 'translate'`) **ignored in v1** | Task 3 (not consumed in worker; `taskConfig` not forwarded for this workerType in Task 4 Step 2) |
+| Serialized decode via `currentDecodePromise` | Task 3 |
+
+All spec items are covered.

--- a/docs/superpowers/plans/2026-04-25-voxtral-3b-webgpu-asr-integration.md
+++ b/docs/superpowers/plans/2026-04-25-voxtral-3b-webgpu-asr-integration.md
@@ -58,9 +58,11 @@ to:
 export type AsrWorkerInMessage = AsrInitMessage | WhisperAsrInitMessage | VoxtralAsrInitMessage | Voxtral3BAsrInitMessage | CohereTranscribeAsrInitMessage | GraniteSpeechInitMessage | AsrAudioMessage | AsrDisposeMessage;
 ```
 
-- [ ] **Step 3: Add `'voxtral-3b'` to `AsrEngineType` in `modelManifest.ts`**
+- [ ] **Step 3: Add `'voxtral-3b'` to `AsrEngineType` and move `'cohere-transcribe'` there too**
 
-At lines 30-34, change:
+This step both adds the new identifier **and** fixes an existing misclassification that PR #168 (commit `f3297e46`) left behind: when Cohere was moved from `type: 'asr-stream'` → `type: 'asr'`, its `asrEngine` identifier `'cohere-transcribe'` was not moved from `StreamAsrEngineType` → `AsrEngineType`. That's an oversight (confirmed by the PR's scope and commit message, which state Cohere is "not a streaming model"). Fixing it now prevents the Voxtral 3B addition from perpetuating the same mismatch.
+
+In `src/lib/local-inference/modelManifest.ts`, at lines 30-34 change:
 
 ```typescript
 export type AsrEngineType =
@@ -77,12 +79,29 @@ export type AsrEngineType =
   | 'sensevoice' | 'whisper' | 'transducer' | 'nemo-transducer'
   | 'paraformer' | 'telespeech' | 'moonshine' | 'moonshine-v2'
   | 'dolphin' | 'zipformer-ctc' | 'nemo-ctc' | 'canary'
-  | 'wenet-ctc' | 'omnilingual' | 'granite-speech' | 'voxtral-3b';
+  | 'wenet-ctc' | 'omnilingual' | 'granite-speech'
+  | 'cohere-transcribe' | 'voxtral-3b';
 ```
 
-Note: This is the offline `AsrEngineType`, not `StreamAsrEngineType`. The 3B model is batch-decoded.
+- [ ] **Step 4: Remove `'cohere-transcribe'` from `StreamAsrEngineType` (completes the move)**
 
-- [ ] **Step 4: Add `'voxtral-3b-webgpu'` to the `asrWorkerType` union in `modelManifest.ts`**
+At lines 37-38, change:
+
+```typescript
+export type StreamAsrEngineType =
+  | 'stream-transducer' | 'stream-nemo-ctc' | 'voxtral' | 'cohere-transcribe';
+```
+
+to:
+
+```typescript
+export type StreamAsrEngineType =
+  | 'stream-transducer' | 'stream-nemo-ctc' | 'voxtral';
+```
+
+This is a pure type-level move. The `asrEngine` field on `ModelManifestEntry` is declared as `AsrEngineType | StreamAsrEngineType`, so an identifier works the same whether it's in either union — no runtime effect, no manifest-entry change.
+
+- [ ] **Step 5: Add `'voxtral-3b-webgpu'` to the `asrWorkerType` union in `modelManifest.ts`**
 
 At line 90, change:
 
@@ -96,21 +115,28 @@ to:
   asrWorkerType?: 'sherpa-onnx' | 'whisper-webgpu' | 'voxtral-webgpu' | 'voxtral-3b-webgpu' | 'cohere-transcribe-webgpu' | 'granite-speech-webgpu';
 ```
 
-- [ ] **Step 5: Verify TypeScript compiles**
+- [ ] **Step 6: Verify TypeScript compiles**
 
 Run: `npx tsc --noEmit --pretty 2>&1 | head -30`
-Expected: No errors. (There are no references to the new types yet, so only the union additions exist.)
+Expected: No errors. (There are no references to the new types yet, so only the union additions exist. Moving `'cohere-transcribe'` between the unions should not surface any errors — the existing Cohere manifest entry still type-checks because `asrEngine` accepts the combined union.)
 
-- [ ] **Step 6: Commit**
+- [ ] **Step 7: Commit**
 
 ```bash
 git add src/lib/local-inference/types.ts src/lib/local-inference/modelManifest.ts
 git commit -m "$(cat <<'EOF'
-feat(local-inference): add Voxtral 3B type and worker-type identifiers
+feat(local-inference): add Voxtral 3B type identifiers; reclassify Cohere
 
 Prepares type plumbing for the Voxtral Mini 3B 2507 WebGPU ASR worker
-(issue #169). Adds Voxtral3BAsrInitMessage, extends AsrWorkerInMessage,
-AsrEngineType, and the asrWorkerType union. No runtime behavior change yet.
+(issue #169): adds Voxtral3BAsrInitMessage, extends AsrWorkerInMessage,
+adds 'voxtral-3b' to AsrEngineType, and adds 'voxtral-3b-webgpu' to the
+asrWorkerType union.
+
+Also moves 'cohere-transcribe' from StreamAsrEngineType to AsrEngineType.
+This completes the reclassification started in f3297e46 (PR #168), which
+changed Cohere's manifest `type` from 'asr-stream' to 'asr' but left the
+matching `asrEngine` identifier in the streaming union by oversight. Pure
+type-level move — no runtime behavior change.
 EOF
 )"
 ```

--- a/docs/superpowers/specs/2026-04-25-voxtral-3b-webgpu-asr-design.md
+++ b/docs/superpowers/specs/2026-04-25-voxtral-3b-webgpu-asr-design.md
@@ -1,0 +1,370 @@
+# Voxtral Mini 3B 2507 WebGPU ASR Integration
+
+**Date:** 2026-04-25
+**Issue:** [#169](https://github.com/kizuna-ai-lab/sokuji/issues/169)
+**Status:** Design approved
+**Scope:** Add Voxtral Mini 3B (2507) as a new batch/offline WebGPU ASR engine with explicit language-hint support, alongside the existing Voxtral Mini 4B Realtime.
+
+## Summary
+
+Integrate `onnx-community/Voxtral-Mini-3B-2507-ONNX` as a `type: 'asr'` (batch/offline) model that flows through `AsrEngine` — **not** `StreamingAsrEngine` as the original issue's Task #3 suggested. The 3B model is decoded on complete VAD-gated utterances, which matches the existing Whisper-WebGPU and Cohere-Transcribe pattern. Its distinguishing feature over the 4B Realtime model is a language hint injected into the chat template (`lang:XX [TRANSCRIBE]`), which meaningfully improves accuracy because Sokuji always knows the source language.
+
+## Motivation
+
+- The 4B Realtime model (`voxtral-mini-4b-webgpu`) relies entirely on automatic language detection; there is no way to pass a language hint.
+- The 3B (2507) model accepts `lang:XX [TRANSCRIBE]` via the processor's chat template, improving transcription accuracy when the source language is known.
+- Smaller footprint (3B vs 4B) → faster load, lower VRAM.
+- Supports 8 languages: `en, es, fr, pt, hi, de, nl, it`.
+
+## Correction of Issue #169 Task List
+
+The issue's Task 3 says "Register new `asrEngine` type and wire up in `StreamingAsrEngine` / engine factory." This is incorrect for this model.
+
+- The 3B model is **batch/offline**, decoded only on full VAD utterances (same pattern as Whisper WebGPU and Cohere Transcribe).
+- Routing in `LocalInferenceClient.ts` already dispatches on `ModelManifestEntry.type`: `type: 'asr'` → `AsrEngine`, `type: 'asr-stream'` → `StreamingAsrEngine`. No factory change is needed.
+- Therefore the new worker is wired into `AsrEngine` (adding one `case` in its worker-spawn switch), not `StreamingAsrEngine`.
+
+## Model Details
+
+| Spec | Value |
+|------|-------|
+| HF Model | `onnx-community/Voxtral-Mini-3B-2507-ONNX` |
+| Architecture | Whisper encoder + Mistral LM (offline/batch) |
+| transformers.js API | `VoxtralForConditionalGeneration` + `VoxtralProcessor` |
+| Languages (8) | en, es, fr, pt, hi, de, nl, it |
+| Language hint | `lang:XX [TRANSCRIBE]` in chat template |
+| Input | 16 kHz mono Float32 audio (one VAD utterance at a time) |
+| Caching | IndexedDB blob URL bridge via `createBlobUrlCache` (same as 4B) |
+| Package requirement | `@huggingface/transformers` ≥ 3.7.0 (project is on 4.2.0 ✓) |
+
+### Quantization Variants
+
+| Variant | Audio encoder | Embed tokens | Decoder merged | Requirement |
+|---------|---------------|--------------|----------------|-------------|
+| q4f16 | q4f16 | q4f16 | q4f16 | `shader-f16` GPU feature |
+| q4 | q4 | q4 | q4 | Universal fallback |
+
+Exact per-file byte sizes are read from `https://huggingface.co/api/models/onnx-community/Voxtral-Mini-3B-2507-ONNX` at implementation time and populated into the manifest `variants[*].files[*].sizeBytes`. Both variants are shipped so q4 can serve as a fallback on GPUs without `shader-f16` (mirrors the existing 4B and Cohere entries).
+
+## Architecture
+
+### Data Flow
+
+```
+Mic (24 kHz Int16)
+    ↓
+LocalInferenceClient.appendInputAudio()
+    ↓  (type: 'asr' → AsrEngine branch)
+AsrEngine.feedAudio(samples, 24000)
+    ↓  postMessage({ type: 'audio', samples, sampleRate })
+voxtral-3b-webgpu.worker.ts
+    ├── Resample 24 kHz → 16 kHz Float32
+    ├── Silero VAD v5 (@ricky0123/vad-web, same as Voxtral 4B / Cohere / Whisper)
+    │     ├── SpeechStart → postMessage({ type: 'speech_start' })
+    │     ├── SpeechEnd   → runVoxtral3B(segment)
+    │     └── VADMisfire  → discard
+    └── runVoxtral3B(audio)
+          ├── Build chat-template text with lang hint
+          ├── processor(text, audio) → model inputs
+          ├── model.generate({ ...inputs, max_new_tokens: 500, streamer })
+          ├── TextStreamer callback → postMessage({ type: 'partial', text })
+          └── Final decode → postMessage({ type: 'result', text, durationMs, recognitionTimeMs })
+    ↓
+AsrEngine callbacks (onResult, onPartialResult, onSpeechStart)
+    ↓
+LocalInferenceClient → translation → TTS
+```
+
+### Key Design Decisions
+
+1. **`type: 'asr'` (offline) — routed through `AsrEngine`**, correcting Task #3 of the issue. The 3B model is not streaming; it decodes complete VAD utterances.
+2. **New dedicated worker** (`voxtral-3b-webgpu.worker.ts`) rather than extending the existing Voxtral 4B or Cohere workers.
+   - Different model class (`VoxtralForConditionalGeneration` vs `VoxtralRealtimeForConditionalGeneration` in 4B).
+   - Different API (`VoxtralProcessor.apply_chat_template` vs the `pipeline('automatic-speech-recognition')` used by Cohere).
+   - Mixing either would couple unrelated inference shapes.
+3. **IndexedDB blob URL cache bridge** (`createBlobUrlCache` + `env.customCache`) — same pattern used by 4B and Cohere. No direct HF fetches at runtime.
+4. **Language hint via chat template** — `currentLanguage` received in the init message is normalized to ISO 639-1 (strip region, e.g. `en-US` → `en`) and injected as `lang:XX [TRANSCRIBE]`. If the normalized code is not among the 8 supported languages, the worker omits the `lang:XX` prefix and falls back to bare `[TRANSCRIBE]` (auto-detect), logging a warning via a `status` message.
+5. **`TextStreamer` for partial results** — mirrors the Cohere pattern so the existing `onPartialResult` UX works without changes.
+6. **Recommended, sort order after 4B** — `recommended: true`, `sortOrder: 3` (4B is 2). Users get both options; 4B remains the first-listed recommendation.
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts` | **Create** | Module worker: processor + model load, VAD, chat-template prompt, batch generate with TextStreamer partials |
+| `src/lib/local-inference/engine/AsrEngine.ts` | Modify | Add `case 'voxtral-3b-webgpu':` in the worker-spawn switch (mirrors the existing `'cohere-transcribe-webgpu'` case) |
+| `src/lib/local-inference/modelManifest.ts` | Modify | Add `'voxtral-3b'` to `AsrEngineType`; add `'voxtral-3b-webgpu'` to the `asrWorkerType` union; push the new manifest entry |
+| `src/lib/local-inference/types.ts` | Modify | Add `Voxtral3BAsrInitMessage` type (shape documented below) |
+| `LocalInferenceClient.ts` | **No change** | Already dispatches to `AsrEngine` for `type: 'asr'` |
+| Model Management UI (`ModelManagementSection.tsx`, `ProviderSpecificSettings.tsx`) | **No change** | Manifest entries are auto-discovered via `getManifestByType('asr')` |
+
+## Worker Design: `voxtral-3b-webgpu.worker.ts`
+
+### Init Message
+
+```typescript
+interface Voxtral3BAsrInitMessage {
+  type: 'init';
+  fileUrls: Record<string, string>;           // HF-relative filename → IndexedDB blob URL
+  hfModelId: string;                          // 'onnx-community/Voxtral-Mini-3B-2507-ONNX'
+  language?: string;                          // e.g. 'en', 'en-US', 'fr' — normalized in worker
+  dtype: string | Record<string, string>;     // selected variant dtype from manifest
+  vadModelUrl: string;                        // Silero v5 ONNX URL
+  ortWasmBaseUrl?: string;                    // ONNX Runtime WASM base path
+}
+```
+
+### Worker State Machine
+
+```
+UNINITIALIZED
+    ↓  init message
+LOADING (VAD + processor + model)
+    ↓
+IDLE → post({ type: 'ready', loadTimeMs })
+    ↓  audio messages → VAD
+SPEECH_ACTIVE
+    ↓  VAD SpeechEnd
+DECODING (model.generate with TextStreamer)
+    ↓  final decode complete
+IDLE
+```
+
+### Inference Flow (core of the worker)
+
+```typescript
+async function runVoxtral3B(audio: Float32Array): Promise<void> {
+  if (!model || !processor) return;
+
+  const durationMs = Math.round((audio.length / 16000) * 1000);
+  const startTime = performance.now();
+
+  // 1. Build chat-template text with optional language hint
+  const langCode = normalizeToIso639_1(currentLanguage);   // 'en-US' → 'en'
+  const hintedText = SUPPORTED_LANGS.includes(langCode)
+    ? `lang:${langCode} [TRANSCRIBE]`
+    : '[TRANSCRIBE]';                                       // fallback to auto-detect
+
+  const conversation = [
+    {
+      role: 'user',
+      content: [
+        { type: 'audio' },
+        { type: 'text', text: hintedText },
+      ],
+    },
+  ];
+  const text = processor.apply_chat_template(conversation, { tokenize: false });
+
+  // 2. Run processor → model inputs
+  const inputs = await processor(text, audio);
+
+  // 3. Stream tokens for partials; keep final tokens for canonical decode
+  let accumulated = '';
+  const streamer = new TextStreamer(processor.tokenizer, {
+    skip_prompt: true,
+    skip_special_tokens: true,
+    callback_function: (token: string) => {
+      accumulated += token;
+      post({ type: 'partial', text: accumulated });
+    },
+  });
+
+  try {
+    const outputs = await model.generate({ ...inputs, max_new_tokens: 500, streamer });
+    // Slice away the prompt tokens; batch_decode the generated tail for the canonical final text.
+    const promptLen = inputs.input_ids.dims.at(-1)!;
+    const generated = outputs.slice(null, [promptLen, null]);
+    const finalTexts = processor.batch_decode(generated, { skip_special_tokens: true });
+    const finalText = (finalTexts?.[0] ?? accumulated).trim();
+
+    if (finalText) {
+      post({
+        type: 'result',
+        text: finalText,
+        durationMs,
+        recognitionTimeMs: Math.round(performance.now() - startTime),
+      });
+    }
+  } catch (err: any) {
+    post({ type: 'error', error: `Voxtral 3B inference failed: ${err?.message || err}` });
+  }
+}
+```
+
+### Model Loading
+
+```typescript
+env.allowRemoteModels = false;
+env.allowLocalModels = true;
+env.useBrowserCache = false;
+env.useCustomCache = true;
+env.customCache = createBlobUrlCache(msg.fileUrls);   // IndexedDB blob bridge
+
+processor = await VoxtralProcessor.from_pretrained(msg.hfModelId);
+model = await VoxtralForConditionalGeneration.from_pretrained(msg.hfModelId, {
+  dtype: msg.dtype,
+  device: 'webgpu',
+  progress_callback: (info) => post({ type: 'status', message: formatProgress(info) }),
+});
+```
+
+VAD init (Silero v5 via ONNX Runtime + `@ricky0123/vad-web` FrameProcessor) is copied from the existing Voxtral 4B / Cohere workers — no behavioral differences.
+
+### Language Normalization
+
+```typescript
+const SUPPORTED_LANGS = new Set(['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it']);
+
+function normalizeToIso639_1(lang: string | undefined): string {
+  if (!lang) return '';
+  return lang.trim().toLowerCase().split(/[-_]/)[0];       // 'en-US' → 'en'
+}
+```
+
+A `lang` value outside the supported set (e.g. the user picked `ja`) is defensive-only — the manifest's `languages` field should already hide the model from selection for unsupported sources. If it slips through, we fall back to bare `[TRANSCRIBE]` rather than failing.
+
+### Output Messages
+
+Standard `AsrWorkerOutMessage` shapes reused unchanged from Cohere/Whisper:
+
+- `{ type: 'ready', loadTimeMs }`
+- `{ type: 'status', message }`
+- `{ type: 'speech_start' }`
+- `{ type: 'partial', text }` — accumulated text during the current utterance's decode
+- `{ type: 'result', text, durationMs, recognitionTimeMs }` — finalized utterance
+- `{ type: 'error', error }`
+- `{ type: 'disposed' }`
+
+### Message Protocol
+
+- Inbound: `init`, `audio` (Int16Array @ 24 kHz), `flush`, `dispose`
+- Outbound: as above
+
+`flush` (push-to-talk end) forces the VAD to emit a SpeechEnd with whatever is buffered, same as existing workers.
+
+## Model Manifest Entry
+
+```typescript
+{
+  id: 'voxtral-mini-3b-webgpu',
+  type: 'asr',
+  name: 'Voxtral Mini 3B 2507 (WebGPU)',
+  languages: ['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it'],
+  multilingual: true,
+  hfModelId: 'onnx-community/Voxtral-Mini-3B-2507-ONNX',
+  requiredDevice: 'webgpu',
+  asrEngine: 'voxtral-3b',
+  asrWorkerType: 'voxtral-3b-webgpu',
+  variants: {
+    'q4f16': {
+      dtype: {
+        audio_encoder: 'q4f16',
+        embed_tokens: 'q4f16',
+        decoder_model_merged: 'q4f16',
+      },
+      files: [
+        // { filename, sizeBytes } for config.json, generation_config.json,
+        // preprocessor_config.json, processor_config.json, tokenizer.json,
+        // tokenizer_config.json, tekken.json, special_tokens_map.json,
+        // onnx/audio_encoder_q4f16.onnx, onnx/embed_tokens_q4f16.onnx,
+        // onnx/decoder_model_merged_q4f16.onnx (+ _data files if present)
+      ],
+      requiredFeatures: ['shader-f16'],
+    },
+    'q4': {
+      dtype: {
+        audio_encoder: 'q4',
+        embed_tokens: 'q4',
+        decoder_model_merged: 'q4',
+      },
+      files: [
+        // Same layout as q4f16 with `_q4.onnx` suffixes.
+      ],
+    },
+  },
+  recommended: true,
+  sortOrder: 3,
+}
+```
+
+### Type Union Additions
+
+- `AsrEngineType`: add `'voxtral-3b'`
+- `asrWorkerType` union on `ModelManifestEntry`: add `'voxtral-3b-webgpu'`
+
+(The existing `StreamAsrEngineType` is **not** touched; this model is offline.)
+
+## Engine Integration: `AsrEngine.ts`
+
+Add one case to the worker-spawn switch, mirroring `cohere-transcribe-webgpu`:
+
+```typescript
+case 'voxtral-3b-webgpu':
+  this.worker = new Worker(
+    new URL('../workers/voxtral-3b-webgpu.worker.ts', import.meta.url),
+    { type: 'module' },
+  );
+  break;
+```
+
+Init message construction mirrors the existing Voxtral 4B / Cohere init builder: pick the variant based on GPU capability (`shader-f16` → q4f16, else q4), resolve IndexedDB blob URLs from the ModelManager, and forward `language` from `AsrEngine.init(modelId, vadConfig, language, taskConfig)`.
+
+`taskConfig.task === 'translate'` (AST mode) is **ignored** for v1. If a caller passes it, we emit a one-time `status` warning and proceed with `[TRANSCRIBE]`. A future extension can add `[TRANSLATE]` chat-template support.
+
+## Session Source-Language Flow
+
+No new wiring is needed — the existing flow already carries the language end-to-end:
+
+```
+settingsStore.sourceLanguage
+  → LocalInferenceSessionConfig.sourceLanguage
+  → LocalInferenceClient.init()
+  → AsrEngine.init(modelId, vadConfig, language, taskConfig)
+  → worker postMessage({ type: 'init', language, ... })
+  → worker normalizes → injected into chat template per utterance
+```
+
+When the user changes `sourceLanguage` mid-idle, the existing re-init logic in `LocalInferenceClient` tears down and re-initializes the ASR engine, which reconstructs the worker with the new `language`. No code change for this path.
+
+## Edge Cases
+
+1. **Unsupported source language slips through.** The manifest's `languages` array already filters the 3B model out of UI selection when source ∉ 8 supported langs. Defensive-only: worker omits `lang:XX` and falls back to auto-detect.
+2. **Language region suffix.** Normalized to 2-letter ISO (`en-US` → `en`, `zh_Hans` → `zh`).
+3. **`shader-f16` unsupported.** Existing `selectVariant()` picks q4 automatically. Both variants are required in the manifest.
+4. **WebGPU unavailable.** `requiredDevice: 'webgpu'` hides the model on unsupported browsers (existing mechanism).
+5. **Long utterances.** Capped by existing VAD max-speech-duration (same as other WebGPU batch workers). Beyond that the VAD force-emits SpeechEnd and decoding proceeds on the capped segment.
+6. **Flush (push-to-talk).** `flush` inbound message forces VAD to finalize; identical to existing workers.
+7. **Translate task (`taskConfig.task === 'translate'`).** Out of scope for v1; worker emits a `status` warning and transcribes anyway.
+8. **Concurrent utterances.** Decoding is serialized: a new SpeechEnd awaits any in-flight generate via a `currentDecodePromise` guard (mirrors Cohere worker at lines 183–232).
+
+## What's NOT Changing
+
+- `LocalInferenceClient` — already dispatches to `AsrEngine` for `type: 'asr'`.
+- `IClient` interface — no structural changes.
+- `ModelManager`, `modelStore`, IndexedDB download flow — already handle `hfModelId` entries.
+- `ModelManagementSection.tsx`, `ProviderSpecificSettings.tsx` — manifest-driven, picks up new entries automatically.
+- Translation and TTS pipeline — receives `onResult` callbacks unchanged.
+- Voxtral 4B Realtime (`voxtral-webgpu`) — completely untouched.
+
+## Success Criteria
+
+- [ ] Voxtral 3B model appears in ASR selector on WebGPU-capable browsers when source language ∈ {en, es, fr, pt, hi, de, nl, it}.
+- [ ] Both q4f16 and q4 variants are downloadable with byte-size progress indication.
+- [ ] q4f16 is auto-selected on GPUs with `shader-f16`; q4 fallback on GPUs without it.
+- [ ] Real-time partial transcription appears during speech (via `TextStreamer`).
+- [ ] Language hint `lang:XX [TRANSCRIBE]` is injected into the chat template and visible in worker-side status logs.
+- [ ] Transcription quality in a non-English supported language (DE or FR) is visibly better than running 4B Realtime on the same audio — confirms the hint is taking effect.
+- [ ] Switching source language between sessions re-initializes the worker cleanly.
+- [ ] 4B Realtime remains functional and still listed first in the selector (`sortOrder: 2` < `3`).
+- [ ] Clean disconnect releases WebGPU resources and terminates the worker.
+
+## References
+
+- [Issue #169](https://github.com/kizuna-ai-lab/sokuji/issues/169)
+- [onnx-community/Voxtral-Mini-3B-2507-ONNX](https://huggingface.co/onnx-community/Voxtral-Mini-3B-2507-ONNX)
+- [Voxtral HF Transformers docs](https://huggingface.co/docs/transformers/model_doc/voxtral)
+- [Voxtral WebGPU Demo Space](https://huggingface.co/spaces/webml-community/Voxtral-WebGPU)
+- Prior specs:
+  - [2026-03-27 Voxtral full integration (4B Realtime)](2026-03-27-voxtral-full-integration-design.md)
+  - [2026-03-28 Cohere Transcribe integration](2026-03-28-cohere-transcribe-integration-design.md) — closest batch/WebGPU reference

--- a/docs/superpowers/specs/2026-04-25-voxtral-3b-webgpu-asr-design.md
+++ b/docs/superpowers/specs/2026-04-25-voxtral-3b-webgpu-asr-design.md
@@ -41,7 +41,7 @@ The issue's Task 3 says "Register new `asrEngine` type and wire up in `Streaming
 
 | Variant | Audio encoder | Embed tokens | Decoder merged | Requirement |
 |---------|---------------|--------------|----------------|-------------|
-| q4f16 | q4f16 | q4f16 | q4f16 | `shader-f16` GPU feature |
+| q4f16 | q4f16 | q4 (repo has no `embed_tokens_q4f16`) | q4f16 | `shader-f16` GPU feature |
 | q4 | q4 | q4 | q4 | Universal fallback |
 
 Exact per-file byte sizes are read from `https://huggingface.co/api/models/onnx-community/Voxtral-Mini-3B-2507-ONNX` at implementation time and populated into the manifest `variants[*].files[*].sizeBytes`. Both variants are shipped so q4 can serve as a fallback on GPUs without `shader-f16` (mirrors the existing 4B and Cohere entries).
@@ -251,24 +251,28 @@ Standard `AsrWorkerOutMessage` shapes reused unchanged from Cohere/Whisper:
   type: 'asr',
   name: 'Voxtral Mini 3B 2507 (WebGPU)',
   languages: ['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it'],
-  multilingual: true,
+  // Do NOT set `multilingual: true`: in this codebase that flag bypasses the
+  // `languages` filter entirely (reserved for truly-universal models paired
+  // with `languages: ['multilingual']`). Voxtral 3B supports only 8 languages,
+  // so leave the flag unset — matching the Voxtral 4B entry's pattern.
   hfModelId: 'onnx-community/Voxtral-Mini-3B-2507-ONNX',
   requiredDevice: 'webgpu',
   asrEngine: 'voxtral-3b',
   asrWorkerType: 'voxtral-3b-webgpu',
   variants: {
     'q4f16': {
+      // 3B repo has no `embed_tokens_q4f16.onnx`; use q4 for embeddings.
       dtype: {
         audio_encoder: 'q4f16',
-        embed_tokens: 'q4f16',
+        embed_tokens: 'q4',
         decoder_model_merged: 'q4f16',
       },
       files: [
         // { filename, sizeBytes } for config.json, generation_config.json,
-        // preprocessor_config.json, processor_config.json, tokenizer.json,
-        // tokenizer_config.json, tekken.json, special_tokens_map.json,
-        // onnx/audio_encoder_q4f16.onnx, onnx/embed_tokens_q4f16.onnx,
-        // onnx/decoder_model_merged_q4f16.onnx (+ _data files if present)
+        // preprocessor_config.json, tokenizer.json, tokenizer_config.json,
+        // tekken.json, special_tokens_map.json, chat_template.jinja,
+        // onnx/audio_encoder_q4f16.onnx + _data, onnx/embed_tokens_q4.onnx + _data,
+        // onnx/decoder_model_merged_q4f16.onnx + _data
       ],
       requiredFeatures: ['shader-f16'],
     },
@@ -279,7 +283,8 @@ Standard `AsrWorkerOutMessage` shapes reused unchanged from Cohere/Whisper:
         decoder_model_merged: 'q4',
       },
       files: [
-        // Same layout as q4f16 with `_q4.onnx` suffixes.
+        // Same shared-config layout as q4f16 with `_q4.onnx` suffixes for the
+        // audio_encoder and decoder_model_merged ONNX files.
       ],
     },
   },

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -1802,13 +1802,13 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
                   <CircleHelp className="tooltip-trigger" size={14} style={{ marginLeft: '4px', display: 'inline-block', verticalAlign: 'middle' }} />
                 </Tooltip>
               </span>
-              <span className="setting-value">{localInferenceSettings.vadMinSilenceDuration.toFixed(1)}s</span>
+              <span className="setting-value">{localInferenceSettings.vadMinSilenceDuration.toFixed(2)}s</span>
             </div>
             <input
               type="range"
-              min="0.1"
+              min="0.05"
               max="2.0"
-              step="0.1"
+              step="0.05"
               value={localInferenceSettings.vadMinSilenceDuration}
               onChange={(e) => updateLocalInferenceSettings({ vadMinSilenceDuration: parseFloat(e.target.value) })}
               className="slider"

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -6,6 +6,8 @@
  * - sherpa-onnx (classic Worker): VAD + OfflineRecognizer via Emscripten/WASM
  * - whisper-webgpu (module Worker): VAD + Whisper via Transformers.js/WebGPU
  * - cohere-transcribe-webgpu (module Worker): VAD + Cohere Transcribe via Transformers.js/WebGPU
+ * - voxtral-3b-webgpu (module Worker): VAD + Voxtral 3B (with lang hint) via Transformers.js/WebGPU
+ * - granite-speech-webgpu (module Worker): VAD + Granite Speech via Transformers.js/WebGPU
  */
 
 import type { AsrWorkerOutMessage, StreamingAsrWorkerOutMessage, VadWebConfig } from '../types';
@@ -94,6 +96,12 @@ export class AsrEngine {
             { type: 'module' },
           );
           break;
+        case 'voxtral-3b-webgpu':
+          this.worker = new Worker(
+            new URL('../workers/voxtral-3b-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+          break;
         case 'granite-speech-webgpu':
           this.worker = new Worker(
             new URL('../workers/granite-speech-webgpu.worker.ts', import.meta.url),
@@ -162,7 +170,7 @@ export class AsrEngine {
       };
 
       // Send init message — format depends on worker type
-      if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu') {
+      if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu' || workerType === 'voxtral-3b-webgpu') {
         this.worker.postMessage({
           type: 'init',
           fileUrls,

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -113,8 +113,8 @@ export class AsrEngine {
           break;
       }
 
-      // Cohere worker emits StreamingAsrWorkerOutMessage (includes 'partial'),
-      // other workers emit AsrWorkerOutMessage. Handle the union.
+      // Cohere and Voxtral 3B workers emit StreamingAsrWorkerOutMessage
+      // (includes 'partial'); other workers emit AsrWorkerOutMessage. Handle the union.
       this.worker.onmessage = (event: MessageEvent<AsrWorkerOutMessage | StreamingAsrWorkerOutMessage>) => {
         const msg = event.data;
         switch (msg.type) {

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -841,7 +841,11 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
     type: 'asr',
     name: 'Voxtral Mini 3B 2507 (WebGPU)',
     languages: ['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it'],
-    multilingual: true,
+    // Do NOT set `multilingual: true`: in this codebase that flag bypasses the
+    // `languages` filter entirely (treated as "universal", reserved for models
+    // with languages: ['multilingual']). Voxtral 3B only supports 8 languages,
+    // so leave the flag unset to get per-language filtering — matching the
+    // 4B entry's pattern.
     hfModelId: 'onnx-community/Voxtral-Mini-3B-2507-ONNX',
     requiredDevice: 'webgpu',
     asrEngine: 'voxtral-3b',

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -31,11 +31,12 @@ export type AsrEngineType =
   | 'sensevoice' | 'whisper' | 'transducer' | 'nemo-transducer'
   | 'paraformer' | 'telespeech' | 'moonshine' | 'moonshine-v2'
   | 'dolphin' | 'zipformer-ctc' | 'nemo-ctc' | 'canary'
-  | 'wenet-ctc' | 'omnilingual' | 'granite-speech';
+  | 'wenet-ctc' | 'omnilingual' | 'granite-speech'
+  | 'cohere-transcribe' | 'voxtral-3b';
 
 /** Streaming ASR engine types — for future use when streaming gets explicit config. */
 export type StreamAsrEngineType =
-  | 'stream-transducer' | 'stream-nemo-ctc' | 'voxtral' | 'cohere-transcribe';
+  | 'stream-transducer' | 'stream-nemo-ctc' | 'voxtral';
 
 /** Engine-specific config fields for TTS models (matcha, kokoro, vits special). */
 export interface TtsModelConfig {
@@ -87,7 +88,7 @@ export interface ModelManifestEntry {
   /** ASR engine type — determines which config builder the worker uses */
   asrEngine?: AsrEngineType | StreamAsrEngineType;
   /** Which ASR worker to use. Defaults to 'sherpa-onnx' if omitted. */
-  asrWorkerType?: 'sherpa-onnx' | 'whisper-webgpu' | 'voxtral-webgpu' | 'cohere-transcribe-webgpu' | 'granite-speech-webgpu';
+  asrWorkerType?: 'sherpa-onnx' | 'whisper-webgpu' | 'voxtral-webgpu' | 'voxtral-3b-webgpu' | 'cohere-transcribe-webgpu' | 'granite-speech-webgpu';
   /** AST (speech translation) language support. When present, model appears as a translation option when selected as ASR. */
   astLanguages?: {
     /** Languages the model can transcribe */

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -830,6 +830,73 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
     sortOrder: 2,
   },
 
+  // ── Voxtral Mini 3B 2507 WebGPU ASR ────────────────────────────────────────
+  // Downloaded from onnx-community repo on HuggingFace Hub. Uses hfModelId.
+  // Voxtral Mini 3B (2507) — offline/batch model with explicit language hint
+  // via chat template ("lang:XX [TRANSCRIBE]"). 8 supported languages.
+  // Note: 3B repo has no embed_tokens_q4f16; q4f16 variant mixes q4 embeddings
+  // with q4f16 audio encoder + decoder.
+  {
+    id: 'voxtral-mini-3b-webgpu',
+    type: 'asr',
+    name: 'Voxtral Mini 3B 2507 (WebGPU)',
+    languages: ['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it'],
+    multilingual: true,
+    hfModelId: 'onnx-community/Voxtral-Mini-3B-2507-ONNX',
+    requiredDevice: 'webgpu',
+    asrEngine: 'voxtral-3b',
+    asrWorkerType: 'voxtral-3b-webgpu',
+    variants: {
+      'q4f16': {
+        // 3B has no embed_tokens_q4f16 → use q4 for embeddings
+        dtype: { audio_encoder: 'q4f16', embed_tokens: 'q4', decoder_model_merged: 'q4f16' },
+        files: [
+          // Config & tokenizer (shared across variants)
+          { filename: 'config.json', sizeBytes: 2_161 },
+          { filename: 'generation_config.json', sizeBytes: 107 },
+          { filename: 'preprocessor_config.json', sizeBytes: 357 },
+          { filename: 'special_tokens_map.json', sizeBytes: 414 },
+          { filename: 'chat_template.jinja', sizeBytes: 989 },
+          { filename: 'tokenizer.json', sizeBytes: 12_603_078 },
+          { filename: 'tokenizer_config.json', sizeBytes: 178_296 },
+          { filename: 'tekken.json', sizeBytes: 14_894_206 },
+          // ONNX model files (q4f16 audio+decoder, q4 embed)
+          { filename: 'onnx/audio_encoder_q4f16.onnx', sizeBytes: 403_958 },
+          { filename: 'onnx/audio_encoder_q4f16.onnx_data', sizeBytes: 383_696_896 },
+          { filename: 'onnx/decoder_model_merged_q4f16.onnx', sizeBytes: 308_330 },
+          { filename: 'onnx/decoder_model_merged_q4f16.onnx_data', sizeBytes: 2_065_283_072 },
+          { filename: 'onnx/embed_tokens_q4.onnx', sizeBytes: 542 },
+          { filename: 'onnx/embed_tokens_q4.onnx_data', sizeBytes: 251_658_240 },
+        ],
+        requiredFeatures: ['shader-f16'],
+      },
+      'q4': {
+        dtype: { audio_encoder: 'q4', embed_tokens: 'q4', decoder_model_merged: 'q4' },
+        files: [
+          // Config & tokenizer (shared across variants)
+          { filename: 'config.json', sizeBytes: 2_161 },
+          { filename: 'generation_config.json', sizeBytes: 107 },
+          { filename: 'preprocessor_config.json', sizeBytes: 357 },
+          { filename: 'special_tokens_map.json', sizeBytes: 414 },
+          { filename: 'chat_template.jinja', sizeBytes: 989 },
+          { filename: 'tokenizer.json', sizeBytes: 12_603_078 },
+          { filename: 'tokenizer_config.json', sizeBytes: 178_296 },
+          { filename: 'tekken.json', sizeBytes: 14_894_206 },
+          // ONNX model files (q4)
+          { filename: 'onnx/audio_encoder_q4.onnx', sizeBytes: 401_545 },
+          { filename: 'onnx/audio_encoder_q4.onnx_data', sizeBytes: 440_238_080 },
+          { filename: 'onnx/decoder_model_merged_q4.onnx', sizeBytes: 306_657 },
+          { filename: 'onnx/decoder_model_merged_q4.onnx_data', sizeBytes: 2_073_260_032 },
+          { filename: 'onnx/decoder_model_merged_q4.onnx_data_1', sizeBytes: 251_658_240 },
+          { filename: 'onnx/embed_tokens_q4.onnx', sizeBytes: 542 },
+          { filename: 'onnx/embed_tokens_q4.onnx_data', sizeBytes: 251_658_240 },
+        ],
+      },
+    },
+    recommended: true,
+    sortOrder: 3,
+  },
+
   // ── Cohere Transcribe WebGPU ASR ───────────────────────────────────────────
   // Downloaded from onnx-community repo on HuggingFace Hub. Uses hfModelId.
   // Cohere Transcribe (2B Conformer) via @huggingface/transformers pipeline API.

--- a/src/lib/local-inference/types.ts
+++ b/src/lib/local-inference/types.ts
@@ -84,7 +84,7 @@ export interface WhisperAsrInitMessage {
   vadModelUrl?: string;
 }
 
-export type AsrWorkerInMessage = AsrInitMessage | WhisperAsrInitMessage | VoxtralAsrInitMessage | CohereTranscribeAsrInitMessage | GraniteSpeechInitMessage | AsrAudioMessage | AsrDisposeMessage;
+export type AsrWorkerInMessage = AsrInitMessage | WhisperAsrInitMessage | VoxtralAsrInitMessage | Voxtral3BAsrInitMessage | CohereTranscribeAsrInitMessage | GraniteSpeechInitMessage | AsrAudioMessage | AsrDisposeMessage;
 
 // ─── ASR Worker Messages (Worker → Main) ─────────────────────────────────────
 
@@ -171,6 +171,24 @@ export interface CohereTranscribeAsrInitMessage {
   /** Source language code (e.g. 'ja', 'en') — required, no auto-detect */
   language?: string;
   /** ONNX dtype config — 'q4f16' or 'q4', or per-component mapping */
+  dtype: string | Record<string, string>;
+  /** VAD configuration overrides from user settings */
+  vadConfig?: VadWebConfig;
+  /** Resolved absolute URL for bundled VAD model */
+  vadModelUrl: string;
+  /** Resolved absolute URL for bundled ORT WASM files */
+  ortWasmBaseUrl?: string;
+}
+
+export interface Voxtral3BAsrInitMessage {
+  type: 'init';
+  /** Map of filename → blob URL for model files from IndexedDB */
+  fileUrls: Record<string, string>;
+  /** HuggingFace model ID for Transformers.js from_pretrained */
+  hfModelId: string;
+  /** Source language hint (e.g. 'ja', 'en-US'). Normalized to ISO 639-1 inside the worker. */
+  language?: string;
+  /** ONNX dtype config — per-component mapping (audio_encoder, embed_tokens, decoder_model_merged) */
   dtype: string | Record<string, string>;
   /** VAD configuration overrides from user settings */
   vadConfig?: VadWebConfig;

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -1,0 +1,491 @@
+/**
+ * Voxtral Mini 3B 2507 WebGPU ASR Worker
+ *
+ * Streaming audio input (Int16@24kHz) → Silero VAD v5 → Voxtral Mini 3B (WebGPU)
+ * Model files loaded from IndexedDB via customCache bridge.
+ *
+ * Unlike Voxtral 4B Realtime (continuous streaming inference), 3B is an
+ * offline/batch model decoded on complete VAD-gated utterances. Token-level
+ * streaming is provided by TextStreamer during each batch inference.
+ *
+ * Key feature over 4B: explicit language hint injected into the processor
+ * chat template as `lang:XX [TRANSCRIBE]` for the 8 supported languages
+ * (en, es, fr, pt, hi, de, nl, it). Falls back to bare `[TRANSCRIBE]` for
+ * unsupported codes (auto-detect).
+ *
+ * Input messages:  Voxtral3BAsrInitMessage | AsrAudioMessage | AsrDisposeMessage | { type: 'flush' }
+ * Output messages: StreamingAsrWorkerOutMessage (ready, status, speech_start, partial, result, error, disposed)
+ */
+
+import {
+  VoxtralForConditionalGeneration,
+  VoxtralProcessor,
+  TextStreamer,
+  env,
+  type ProgressInfo,
+} from '@huggingface/transformers';
+import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+import { FrameProcessor, Message } from '@ricky0123/vad-web';
+import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
+
+import type {
+  Voxtral3BAsrInitMessage,
+  AsrAudioMessage,
+  AsrDisposeMessage,
+  StreamingAsrWorkerOutMessage,
+} from '../types';
+
+// ─── ORT / Transformers.js env setup ─────────────────────────────────────────
+
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.proxy = false;
+}
+
+// Workaround: HF CDN Range request cache pollution (same as Voxtral 4B / Cohere workers)
+const _origFetch = env.fetch;
+env.fetch = (input: any, init?: any) => {
+  const headers = init?.headers;
+  const hasRange =
+    headers instanceof Headers
+      ? headers.has('Range')
+      : Array.isArray(headers)
+        ? headers.some(([k]: [string]) => k.toLowerCase() === 'range')
+        : headers && typeof headers === 'object' && 'Range' in headers;
+  if (hasRange) {
+    return _origFetch(input, { ...init, cache: 'no-store' });
+  }
+  return _origFetch(input, init);
+};
+
+// ─── Types & Helpers ─────────────────────────────────────────────────────────
+
+type WorkerMessage = Voxtral3BAsrInitMessage | AsrAudioMessage | AsrDisposeMessage | { type: 'flush' };
+
+function post(msg: StreamingAsrWorkerOutMessage) {
+  self.postMessage(msg);
+}
+
+// ─── Silero VAD v5 ──────────────────────────────────────────────────────────
+
+const VAD_SAMPLE_RATE = 16000;
+const VAD_FRAME_SAMPLES = 512; // 32ms @ 16kHz
+const VAD_FRAME_MS = (VAD_FRAME_SAMPLES / VAD_SAMPLE_RATE) * 1000;
+
+interface VadSession {
+  session: InferenceSession;
+  state: Tensor;
+}
+
+let vadSession: VadSession | null = null;
+let frameProcessor: FrameProcessor | null = null;
+let maxSpeechFrames = 625; // ~20s at 32ms/frame
+let speechFramesSinceStart = 0;
+
+async function vadInfer(frame: Float32Array): Promise<{ isSpeech: number; notSpeech: number }> {
+  if (!vadSession) return { isSpeech: 0, notSpeech: 1 };
+  const input = new Tensor('float32', frame, [1, VAD_FRAME_SAMPLES]);
+  const sr = new Tensor('int64', BigInt64Array.from([BigInt(VAD_SAMPLE_RATE)]), []);
+  const result = await vadSession.session.run({ input, sr, state: vadSession.state });
+  vadSession.state = result.stateN as Tensor;
+  const prob = (result.output as Tensor).data[0] as number;
+  return { isSpeech: prob, notSpeech: 1 - prob };
+}
+
+function vadResetStates() {
+  if (!vadSession) return;
+  vadSession.state = new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]);
+}
+
+async function initVad(vadConfig?: Voxtral3BAsrInitMessage['vadConfig'], vadModelUrl?: string): Promise<void> {
+  const session = await InferenceSession.create(vadModelUrl || './wasm/vad/silero_vad_v5.onnx', {
+    executionProviders: ['wasm'],
+  });
+  vadSession = {
+    session,
+    state: new Tensor('float32', new Float32Array(2 * 128), [2, 1, 128]),
+  };
+
+  const positiveSpeechThreshold = vadConfig?.threshold ?? 0.3;
+  const negativeSpeechThreshold = vadConfig?.negativeThreshold ?? 0.25;
+  const redemptionMs = (vadConfig?.minSilenceDuration ?? 1.4) * 1000;
+  const minSpeechMs = (vadConfig?.minSpeechDuration ?? 0.4) * 1000;
+  const preSpeechPadMs = (vadConfig?.preSpeechPadDuration ?? 0.8) * 1000;
+  const maxSpeechDurationMs = (vadConfig?.maxSpeechDuration ?? 20) * 1000;
+
+  maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
+
+  frameProcessor = new FrameProcessor(
+    vadInfer,
+    vadResetStates,
+    {
+      positiveSpeechThreshold,
+      negativeSpeechThreshold,
+      redemptionMs,
+      minSpeechMs,
+      preSpeechPadMs,
+      submitUserSpeechOnPause: false,
+    },
+    VAD_FRAME_MS,
+  );
+  frameProcessor.resume();
+  speechFramesSinceStart = 0;
+}
+
+// ─── Audio Buffer & Resampling ──────────────────────────────────────────────
+
+let vadAudioBuffer = new Float32Array(0);
+
+function resampleInt16ToFloat32_16k(samples: Int16Array, inputRate: number): Float32Array {
+  const ratio = inputRate / VAD_SAMPLE_RATE;
+  const outLen = Math.floor(samples.length / ratio);
+  const out = new Float32Array(outLen);
+  for (let i = 0; i < outLen; i++) {
+    const srcIdx = i * ratio;
+    const lo = Math.floor(srcIdx);
+    const hi = Math.min(lo + 1, samples.length - 1);
+    const frac = srcIdx - lo;
+    out[i] = samples[lo] / 32768 + ((samples[hi] / 32768) - (samples[lo] / 32768)) * frac;
+  }
+  return out;
+}
+
+// ─── Voxtral 3B Model State ─────────────────────────────────────────────────
+
+let model: any = null;            // VoxtralForConditionalGeneration instance
+let processor: any = null;        // VoxtralProcessor instance
+let currentLanguage: string | undefined;
+let processingVad = false;
+let currentDecodePromise: Promise<void> | null = null;
+
+// 8 languages natively supported by Voxtral 3B 2507
+const SUPPORTED_LANGS = new Set(['en', 'es', 'fr', 'pt', 'hi', 'de', 'nl', 'it']);
+
+function normalizeToIso639_1(lang: string | undefined): string {
+  if (!lang) return '';
+  // Strip region suffix: 'en-US' → 'en', 'zh_Hans' → 'zh'
+  return lang.trim().toLowerCase().split(/[-_]/)[0];
+}
+
+/**
+ * Create customCache bridge for IndexedDB blob URLs → Transformers.js.
+ * Maps HF Hub resolve URLs to local blob URLs from IndexedDB.
+ * Same pattern as whisper-webgpu, voxtral-webgpu, and cohere-transcribe-webgpu workers.
+ */
+function createBlobUrlCache(fileUrls: Record<string, string>) {
+  return {
+    async match(request: string | Request | undefined): Promise<Response | undefined> {
+      if (!request) return undefined;
+      const url = typeof request === 'string' ? request : request.url;
+      const marker = '/resolve/main/';
+      const idx = url.indexOf(marker);
+      if (idx === -1) return undefined;
+      const filename = url.slice(idx + marker.length);
+      const blobUrl = fileUrls[filename];
+      if (!blobUrl) return undefined;
+      return fetch(blobUrl);
+    },
+    async put(_request: string | Request, _response: Response): Promise<void> {
+    },
+  };
+}
+
+// ─── Batch Speech Segment Processing ────────────────────────────────────────
+
+/**
+ * Run Voxtral 3B inference on a completed speech segment.
+ * Builds a chat-template prompt with optional `lang:XX [TRANSCRIBE]` hint,
+ * uses TextStreamer for token-level partial results, and emits a final
+ * `result` message when decoding completes.
+ *
+ * Serializes decode calls via currentDecodePromise to prevent overlapping
+ * generate() invocations if VAD end-events arrive back-to-back.
+ */
+function runVoxtral3B(audio: Float32Array): Promise<void> {
+  const promise = (async () => {
+    if (currentDecodePromise) {
+      try { await currentDecodePromise; } catch { /* already reported */ }
+    }
+    if (!model || !processor) return;
+
+    const durationMs = Math.round((audio.length / VAD_SAMPLE_RATE) * 1000);
+    const startTime = performance.now();
+    let accumulatedText = '';
+
+    try {
+      // 1. Build chat-template prompt with optional language hint
+      const langCode = normalizeToIso639_1(currentLanguage);
+      const hintedText = SUPPORTED_LANGS.has(langCode)
+        ? `lang:${langCode} [TRANSCRIBE]`
+        : '[TRANSCRIBE]';
+
+      const conversation = [
+        {
+          role: 'user',
+          content: [
+            { type: 'audio' },
+            { type: 'text', text: hintedText },
+          ],
+        },
+      ];
+      const promptText = processor.apply_chat_template(conversation, { tokenize: false });
+
+      // 2. Processor builds mel features + input_ids from prompt + audio
+      const inputs = await processor(promptText, audio);
+
+      // 3. TextStreamer streams decoded tokens as partials
+      const streamer = new TextStreamer(processor.tokenizer, {
+        skip_prompt: true,
+        skip_special_tokens: true,
+        callback_function: (token: string) => {
+          accumulatedText += token;
+          post({ type: 'partial', text: accumulatedText });
+        },
+      });
+
+      // 4. Generate (batch decode, not streaming input like 4B)
+      const outputs = await model.generate({
+        ...inputs,
+        max_new_tokens: 500,
+        streamer,
+      });
+
+      // 5. Canonical final decode: slice prompt tokens, then batch_decode.
+      //    Falls back to `accumulatedText` if slice/decode is unavailable in this
+      //    transformers.js version (defensive; should not happen on ≥3.7).
+      let finalText = accumulatedText.trim();
+      try {
+        const promptLen = inputs.input_ids.dims.at(-1)!;
+        const generated = outputs.slice(null, [promptLen, null]);
+        const decoded = processor.batch_decode(generated, { skip_special_tokens: true });
+        const candidate = Array.isArray(decoded) ? decoded[0] : decoded;
+        if (candidate && typeof candidate === 'string' && candidate.trim()) {
+          finalText = candidate.trim();
+        }
+      } catch {
+        // Keep accumulatedText as finalText
+      }
+
+      if (finalText) {
+        post({
+          type: 'result',
+          text: finalText,
+          durationMs,
+          recognitionTimeMs: Math.round(performance.now() - startTime),
+        });
+      }
+    } catch (err: any) {
+      post({ type: 'error', error: `Voxtral 3B inference failed: ${err?.message || err}` });
+    }
+  })();
+
+  currentDecodePromise = promise;
+  return promise;
+}
+
+// ─── VAD + Audio Feed Pipeline ──────────────────────────────────────────────
+
+async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void> {
+  if (!vadSession || !frameProcessor || !model || processingVad) return;
+  processingVad = true;
+
+  try {
+    const resampled = resampleInt16ToFloat32_16k(samples, sampleRate);
+
+    // Append to VAD audio buffer
+    const newBuf = new Float32Array(vadAudioBuffer.length + resampled.length);
+    newBuf.set(vadAudioBuffer);
+    newBuf.set(resampled, vadAudioBuffer.length);
+    vadAudioBuffer = newBuf;
+
+    // Process complete VAD frames
+    while (vadAudioBuffer.length >= VAD_FRAME_SAMPLES) {
+      const frame = vadAudioBuffer.slice(0, VAD_FRAME_SAMPLES);
+      vadAudioBuffer = vadAudioBuffer.slice(VAD_FRAME_SAMPLES);
+
+      const events: FrameProcessorEvent[] = [];
+      await frameProcessor.process(frame, (ev) => events.push(ev));
+
+      for (const ev of events) {
+        switch (ev.msg) {
+          case Message.SpeechStart:
+            speechFramesSinceStart = 0;
+            post({ type: 'speech_start' });
+            break;
+
+          case Message.SpeechEnd:
+            speechFramesSinceStart = 0;
+            await runVoxtral3B(ev.audio);
+            break;
+
+          case Message.VADMisfire:
+            speechFramesSinceStart = 0;
+            break;
+        }
+      }
+
+      // Max speech duration cap — force-finalize if speech runs too long
+      if (frameProcessor.speaking) {
+        speechFramesSinceStart++;
+        if (speechFramesSinceStart >= maxSpeechFrames) {
+          const endEvents: FrameProcessorEvent[] = [];
+          frameProcessor.endSegment((ev) => endEvents.push(ev));
+          for (const ev of endEvents) {
+            if (ev.msg === Message.SpeechEnd) {
+              await runVoxtral3B(ev.audio);
+            }
+          }
+          speechFramesSinceStart = 0;
+        }
+      } else {
+        speechFramesSinceStart = 0;
+      }
+    }
+  } finally {
+    processingVad = false;
+  }
+}
+
+// ─── Init Handler ───────────────────────────────────────────────────────────
+
+async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
+  try {
+    const startTime = performance.now();
+
+    // Set ORT WASM paths
+    if (msg.ortWasmBaseUrl) {
+      if (env.backends?.onnx?.wasm) {
+        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+      if (ortEnv?.wasm) {
+        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+    }
+
+    // 1. Init VAD
+    post({ type: 'status', message: 'Loading VAD model...' });
+    await initVad(msg.vadConfig, msg.vadModelUrl);
+
+    // 2. Configure Transformers.js for IndexedDB blob URL cache
+    env.allowRemoteModels = false;
+    env.allowLocalModels = true;
+    env.useBrowserCache = false;
+    env.useCustomCache = true;
+    env.customCache = createBlobUrlCache(msg.fileUrls);
+
+    // 3. Load processor
+    post({ type: 'status', message: 'Loading Voxtral 3B processor...' });
+    processor = await VoxtralProcessor.from_pretrained(msg.hfModelId);
+
+    // 4. Load model (WebGPU)
+    post({ type: 'status', message: 'Loading Voxtral 3B model (WebGPU)...' });
+    model = await VoxtralForConditionalGeneration.from_pretrained(msg.hfModelId, {
+      dtype: msg.dtype as any,
+      device: 'webgpu',
+      progress_callback: (info: ProgressInfo) => {
+        if (info.status === 'progress' && info.file?.endsWith('.onnx_data') && (info as any).total > 0) {
+          const pct = Math.round(((info as any).loaded / (info as any).total) * 100);
+          post({ type: 'status', message: `Loading model... ${pct}%` });
+        }
+      },
+    });
+
+    currentLanguage = msg.language;
+
+    // 5. Log chosen language hint for operator visibility
+    const langCode = normalizeToIso639_1(currentLanguage);
+    if (SUPPORTED_LANGS.has(langCode)) {
+      post({ type: 'status', message: `Voxtral 3B language hint: lang:${langCode} [TRANSCRIBE]` });
+    } else if (currentLanguage) {
+      post({ type: 'status', message: `Voxtral 3B: source language '${currentLanguage}' not in supported set; using auto-detect` });
+    }
+
+    // Reset buffers
+    vadAudioBuffer = new Float32Array(0);
+
+    const loadTimeMs = Math.round(performance.now() - startTime);
+    post({ type: 'ready', loadTimeMs });
+  } catch (err: any) {
+    post({ type: 'error', error: err?.message || String(err) });
+  }
+}
+
+// ─── Flush & Dispose ────────────────────────────────────────────────────────
+
+async function handleFlush(): Promise<void> {
+  // Force-finalize any pending speech via FrameProcessor (PTT release path)
+  if (frameProcessor?.speaking) {
+    const endEvents: FrameProcessorEvent[] = [];
+    frameProcessor.endSegment((ev) => endEvents.push(ev));
+    for (const ev of endEvents) {
+      if (ev.msg === Message.SpeechEnd) {
+        await runVoxtral3B(ev.audio);
+      }
+    }
+  }
+  // Wait for any in-flight decode to complete
+  if (currentDecodePromise) {
+    try { await currentDecodePromise; } catch { /* already reported */ }
+  }
+}
+
+async function handleDispose(): Promise<void> {
+  // Flush remaining speech
+  if (frameProcessor?.speaking) {
+    const endEvents: FrameProcessorEvent[] = [];
+    frameProcessor.endSegment((ev) => endEvents.push(ev));
+    for (const ev of endEvents) {
+      if (ev.msg === Message.SpeechEnd) {
+        await runVoxtral3B(ev.audio);
+      }
+    }
+  }
+
+  // Wait for any in-flight decode to complete before disposing
+  if (currentDecodePromise) {
+    try { await currentDecodePromise; } catch { /* already reported */ }
+    currentDecodePromise = null;
+  }
+
+  // Dispose FrameProcessor
+  frameProcessor = null;
+  speechFramesSinceStart = 0;
+
+  // Dispose VAD
+  if (vadSession?.session) {
+    await vadSession.session.release();
+    vadSession = null;
+  }
+
+  // Dispose model and processor
+  if (model) {
+    try { await (model as any).dispose?.(); } catch { /* ignore */ }
+    model = null;
+  }
+  processor = null;
+  currentLanguage = undefined;
+
+  vadAudioBuffer = new Float32Array(0);
+  processingVad = false;
+
+  post({ type: 'disposed' });
+}
+
+// ─── Message Router ─────────────────────────────────────────────────────────
+
+self.onmessage = async (event: MessageEvent<WorkerMessage>) => {
+  const msg = event.data;
+  switch (msg.type) {
+    case 'init':
+      await handleInit(msg as Voxtral3BAsrInitMessage);
+      break;
+    case 'audio':
+      await feedAudio((msg as AsrAudioMessage).samples, (msg as AsrAudioMessage).sampleRate);
+      break;
+    case 'flush':
+      await handleFlush();
+      break;
+    case 'dispose':
+      await handleDispose();
+      break;
+  }
+};

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -314,7 +314,12 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
 
           case Message.SpeechEnd:
             speechFramesSinceStart = 0;
-            await runVoxtral3B(ev.audio);
+            // Fire-and-forget: decodes take seconds on 3B. If we awaited here,
+            // `processingVad` would stay true for the full decode duration and
+            // incoming audio messages would be dropped by the guard at the top
+            // of this function. `runVoxtral3B` self-serializes via
+            // `currentDecodePromise` so overlapping calls queue correctly.
+            void runVoxtral3B(ev.audio);
             break;
 
           case Message.VADMisfire:
@@ -331,7 +336,8 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
             if (ev.msg === Message.SpeechEnd) {
-              await runVoxtral3B(ev.audio);
+              // See SpeechEnd comment above: fire-and-forget to avoid dropping audio.
+              void runVoxtral3B(ev.audio);
             }
           }
           speechFramesSinceStart = 0;
@@ -434,13 +440,16 @@ async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
 // ─── Flush & Dispose ────────────────────────────────────────────────────────
 
 async function handleFlush(): Promise<void> {
-  // Force-finalize any pending speech via FrameProcessor (PTT release path)
+  // Force-finalize any pending speech via FrameProcessor (PTT release path).
+  // Fire-and-forget because `runVoxtral3B` assigns `currentDecodePromise`
+  // before returning; the `await currentDecodePromise` below will pick up
+  // whatever decode we just kicked off.
   if (frameProcessor?.speaking) {
     const endEvents: FrameProcessorEvent[] = [];
     frameProcessor.endSegment((ev) => endEvents.push(ev));
     for (const ev of endEvents) {
       if (ev.msg === Message.SpeechEnd) {
-        await runVoxtral3B(ev.audio);
+        void runVoxtral3B(ev.audio);
       }
     }
   }
@@ -451,13 +460,14 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
-  // Flush remaining speech
+  // Flush remaining speech. Fire-and-forget; the `await currentDecodePromise`
+  // below picks up the just-kicked decode before we dispose the model.
   if (frameProcessor?.speaking) {
     const endEvents: FrameProcessorEvent[] = [];
     frameProcessor.endSegment((ev) => endEvents.push(ev));
     for (const ev of endEvents) {
       if (ev.msg === Message.SpeechEnd) {
-        await runVoxtral3B(ev.audio);
+        void runVoxtral3B(ev.audio);
       }
     }
   }

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -399,6 +399,28 @@ async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
       post({ type: 'status', message: `Voxtral 3B: source language '${currentLanguage}' not in supported set; using auto-detect` });
     }
 
+    // 6. WebGPU warmup — compile shaders with a tiny dummy inference so the
+    //    first real utterance doesn't pay the compilation cost. Matches the
+    //    Cohere worker's pattern (cohere-transcribe-webgpu.worker.ts:344-354).
+    post({ type: 'status', message: 'Warming up WebGPU shaders...' });
+    try {
+      const warmupAudio = new Float32Array(VAD_SAMPLE_RATE); // 1s of silence
+      const warmupConversation = [
+        {
+          role: 'user',
+          content: [
+            { type: 'audio' },
+            { type: 'text', text: '[TRANSCRIBE]' },
+          ],
+        },
+      ];
+      const warmupPrompt = processor.apply_chat_template(warmupConversation, { tokenize: false });
+      const warmupInputs = await processor(warmupPrompt, warmupAudio);
+      await model.generate({ ...warmupInputs, max_new_tokens: 1 });
+    } catch {
+      // Warmup failures are non-fatal — first real utterance may be slightly slower
+    }
+
     // Reset buffers
     vadAudioBuffer = new Float32Array(0);
 


### PR DESCRIPTION
## Summary

Closes #169. Adds **Voxtral Mini 3B 2507** (`onnx-community/Voxtral-Mini-3B-2507-ONNX`) as a new WebGPU ASR engine alongside the existing Voxtral 4B Realtime. The 3B model's distinguishing feature is **explicit language-hint support** via the \`lang:XX [TRANSCRIBE]\` chat template, which meaningfully improves transcription accuracy when the source language is known (always true in Sokuji's workflow).

- **Model**: \`onnx-community/Voxtral-Mini-3B-2507-ONNX\`, two variants shipped: q4f16 (~2.7 GB, requires \`shader-f16\`) and q4 (~3.0 GB, universal fallback).
- **Languages**: 8 — en, es, fr, pt, hi, de, nl, it. Hidden from the selector for any other source language via the existing \`languages\` filter.
- **Pattern**: Batch / VAD-gated decode (like Cohere Transcribe), not streaming like 4B Realtime — so routed through \`AsrEngine\`, not \`StreamingAsrEngine\`. This corrects Task #3 of issue #169, which incorrectly specified \`StreamingAsrEngine\`.
- **Package requirement**: \`@huggingface/transformers\` ≥ 3.7 for \`VoxtralForConditionalGeneration\` + \`VoxtralProcessor\` (project is on 4.2.0 ✓).

## Bundled hygiene fixes

Two small fixes landed in the same stack because they sit on the same surface:

1. **Cohere \`asrEngine\` reclassification** — \`'cohere-transcribe'\` is moved from \`StreamAsrEngineType\` to \`AsrEngineType\`. Completes the reclassification started in #168 (commit \`f3297e46\`), which moved Cohere's manifest \`type\` from \`asr-stream\` to \`asr\` but left the matching \`asrEngine\` identifier in the streaming union by oversight. Pure type-level move — no runtime behavior change.
2. **VAD min silence duration** — a pre-existing hotfix (\`ee8a4222\`) allowing finer-grained VAD silence-duration settings; sitting at the bottom of the stack and unrelated to Voxtral, but local-inference-adjacent.

## Implementation commits (in order)

1. \`ee8a4222\` — fix: allow finer VAD min silence duration (pre-existing, bundled)
2. \`b5aa26dd\` — docs: design spec
3. \`2577ac4f\` — docs: implementation plan
4. \`3797b300\` — docs: plan patch adding Cohere type reclassification
5. \`cb637bd6\` — feat: Voxtral 3B type identifiers + Cohere reclassification
6. \`d12c5773\` — feat: Voxtral 3B manifest entry (q4f16 + q4 variants)
7. \`ed43b30c\` — feat: Voxtral 3B WebGPU worker (batch ASR with \`apply_chat_template\` + \`TextStreamer\`)
8. \`36dbf6f9\` — fix: warm up WebGPU shaders at init (mirrors Cohere pattern)
9. \`806f3204\` — feat: wire worker into \`AsrEngine\`
10. \`bd116046\` — chore: update \`AsrEngine\` comment for the new partial-message source
11. \`f95e3769\` — fix: remove \`multilingual: true\` so 3B is correctly hidden for unsupported languages

Commit 11 was the fix for a bug surfaced during manual testing: \`multilingual: true\` in this codebase is a sentinel that bypasses the \`languages\` filter entirely (reserved for models with \`languages: ['multilingual']\` like Qwen translation). Setting it on 3B made the model appear for Chinese, Japanese, etc., where it would auto-detect and waffle between related languages. 4B's pattern (no \`multilingual\` flag, specific \`languages\` list) is the correct one to follow. Added an inline comment to prevent the same mistake from recurring.

## Technical notes

- **Mixed-precision dtype for q4f16 variant**: The 3B repo has no \`embed_tokens_q4f16.onnx\` (unlike 4B), so the q4f16 variant uses \`{ audio_encoder: 'q4f16', embed_tokens: 'q4', decoder_model_merged: 'q4f16' }\`. Inline comment in the manifest documents this.
- **File sizes** sourced from the HF API (\`/api/models/.../tree/main\`) — exact bytes, no estimates.
- **Language normalization**: \`en-US\` → \`en\`, \`zh_Hans\` → \`zh\`. Unsupported codes fall back to bare \`[TRANSCRIBE]\` (auto-detect) with a \`status\` warning.
- **WebGPU warmup**: A 1-token dummy inference after model load pre-compiles shaders, so the first real utterance doesn't pay multi-second shader compilation cost. Mirrors Cohere's pattern.
- **Deliberate v1 scope**: Voxtral's \`[TRANSLATE]\` task is not wired (it only outputs English, useless for Sokuji); audio Q&A / summarization capabilities are out of scope.

## Test plan

- [ ] Source language = en/es/fr/pt/hi/de/nl/it → Voxtral Mini 3B appears in the ASR model selector.
- [ ] Source language = zh/ja/ko/any other → Voxtral Mini 3B is hidden (verified post-fix \`f95e3769\`).
- [ ] WebGPU-unavailable browser (Firefox/Safari) → model hidden (existing \`requiredDevice: 'webgpu'\` gating).
- [ ] Download both variants; q4 auto-selects on GPUs without \`shader-f16\`.
- [ ] DevTools console shows \`Voxtral 3B language hint: lang:XX [TRANSCRIBE]\` status line at session start.
- [ ] Transcription accuracy on a non-English supported language (e.g. German) is visibly better than 4B Realtime on the same audio — proves the hint takes effect.
- [ ] Clean teardown on session end — no WebGPU memory growth after multiple session cycles.
- [ ] \`npm run build\` succeeds and bundles a \`voxtral-3b-webgpu.worker-*.js\` chunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Voxtral Mini 3B as a local WebGPU offline ASR engine option with VAD-gated utterance decoding and streaming partial transcripts.
* **Bug Fixes**
  * N/A
* **Documentation**
  * Added detailed planning and design docs covering integration, model manifest, testing, and browser worker behavior.
* **Style**
  * VAD "Min Silence Duration" slider updated to 0.05s steps and displays two-decimal precision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->