### PR TITLE
feat(subtitle): floating subtitle mode

### DIFF
--- a/docs/superpowers/specs/2026-05-10-subtitle-mode-manual-test.md
+++ b/docs/superpowers/specs/2026-05-10-subtitle-mode-manual-test.md
@@ -1,0 +1,74 @@
+# Subtitle Mode — Manual Test Plan
+
+Run on each target platform: macOS, Windows, Linux X11, Linux Wayland.
+
+Companion to `2026-05-10-subtitle-mode-design.md`.
+
+## A. Entering subtitle mode
+
+- [ ] 1. Subtitle button (Captions icon) is disabled before a session starts.
+- [ ] 2. After session start, button is clickable.
+- [ ] 3. Click → window transforms in place to a frameless translucent bar at the bottom-center of the screen on first use (~80% width × 200 px high).
+- [ ] 4. Custom title bar disappears in subtitle mode; subtitle bar appears.
+- [ ] 5. Background is translucent; desktop is visible behind it.
+- [ ] 6. Live conversation rows scroll into the subtitle area.
+
+## B. Floating bar interaction
+
+- [ ] 7. Drag the bar — window moves.
+- [ ] 8. Drag a window edge — window resizes (no visual handle, but cursor + drag work).
+- [ ] 9. Cursor leaves window for 1.5 s → bar fades out (opacity 0). Subtitle area stays.
+- [ ] 10. Cursor re-enters → bar fades back in.
+
+## C. Lock + always-on-top
+
+- [ ] 11. Click 🔒 (lock). Cursor on bar shows it's no longer draggable; window edges no longer resize.
+- [ ] 12. Click 🔒 again — both restored.
+- [ ] 13. With 📌 (pin) active, click on another app's window. Subtitle stays in front.
+- [ ] 14. Toggle 📌 off. Click another app — subtitle goes behind. (Linux Wayland may behave differently per compositor.)
+
+## D. Settings popover
+
+- [ ] 15. Click ⚙ — popover opens; click outside or press Escape — popover closes.
+- [ ] 16. Drag opacity slider — background opacity changes live.
+- [ ] 17. Click each background color preset — applies live.
+- [ ] 18. Source text color preset — speaker source-text rows update.
+- [ ] 19. Translation color preset — translation rows update.
+
+## E. Toolbar buttons
+
+- [ ] 20. Speaker DisplayMode cycles `Both → Src → Trans → Both`; subtitle stream filters accordingly.
+- [ ] 21. Participant DisplayMode appears only when system audio is connected; same cycle.
+- [ ] 22. Font − / Font + change subtitle font size; main panel font does NOT change.
+- [ ] 23. Compact toggle changes subtitle row layout; main panel layout unchanged.
+- [ ] 24. Export downloads a transcript file.
+- [ ] 25. Clear is currently a no-op in subtitle mode (deferred to a future store-level action). Verify the button doesn't crash but doesn't clear either.
+
+## F. Exit and error paths
+
+- [ ] 26. Click ✕ → window restores to prior size and position; main UI returns.
+- [ ] 27. Press ESC → same as ✕.
+- [ ] 28. While in subtitle mode, manually stop the session (kill network or wait for provider error) → "Session ended" placeholder appears with "Return to main window" button.
+- [ ] 29. Click "Return to main window" → exits subtitle mode.
+- [ ] 30. Quit the app, relaunch, start a session, enter subtitle mode → bounds + opacity match the last session.
+- [ ] 31. Enter subtitle mode on an external monitor, save bounds, disconnect the monitor, relaunch → bounds clamp to the primary display.
+
+## G. Custom TitleBar (normal mode)
+
+- [ ] 32. macOS traffic-light buttons render and work (close / minimize / zoom).
+- [ ] 33. Win/Linux: min, max, close buttons work; clicking close exits the app.
+- [ ] 34. Drag region works for moving the window in normal mode.
+
+## Known platform caveats
+
+- Linux Wayland: alwaysOnTop behavior depends on the compositor (KWin / Mutter / Sway). If the subtitle bar doesn't stay in front of other apps when 📌 is active, that's a Wayland-level limitation — not a sokuji bug.
+- Linux X11: transparency may not work on legacy desktop environments without compositing enabled.
+- macOS Stage Manager / Mission Control may treat the always-on-top window inconsistently across spaces.
+
+## Verifying the architectural invariant
+
+These checks confirm the items mirror chain (T16.5) is intact:
+
+- [ ] 35. Start a session, send a few translations, enter subtitle mode → subtitle area shows the same conversation rows that were in the main panel.
+- [ ] 36. While in subtitle mode, send more translations → subtitle area updates live.
+- [ ] 37. Exit subtitle mode → main panel shows all the rows that accumulated during subtitle mode.

--- a/docs/superpowers/specs/2026-05-10-subtitle-mode-manual-test.md
+++ b/docs/superpowers/specs/2026-05-10-subtitle-mode-manual-test.md
@@ -42,7 +42,7 @@ Companion to `2026-05-10-subtitle-mode-design.md`.
 - [ ] 22. Font − / Font + change subtitle font size; main panel font does NOT change.
 - [ ] 23. Compact toggle changes subtitle row layout; main panel layout unchanged.
 - [ ] 24. Export downloads a transcript file.
-- [ ] 25. Clear is currently a no-op in subtitle mode (deferred to a future store-level action). Verify the button doesn't crash but doesn't clear either.
+- [ ] 25. Clear empties the subtitle stream. Exit subtitle mode and confirm the main panel conversation is also empty (same action goes through `sessionStore.requestClearConversation` so both surfaces stay in sync).
 
 ## F. Exit and error paths
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -250,6 +250,11 @@ function createWindow() {
     height: 800,
     title: 'Sokuji',
     icon: iconPath,
+    frame: false,
+    transparent: true,
+    hasShadow: true,
+    backgroundColor: '#00000000',
+    titleBarStyle: process.platform === 'darwin' ? 'hiddenInset' : 'default',
     webPreferences: {
       nodeIntegration: false,
       contextIsolation: true,

--- a/electron/main.js
+++ b/electron/main.js
@@ -452,6 +452,19 @@ app.on('will-quit', cleanupAndExit);
 // IPC handler for app version
 ipcMain.handle('get-app-version', () => app.getVersion());
 
+// ---- Window controls for the custom title bar ----
+ipcMain.handle('window:minimize', () => {
+  if (mainWindow) mainWindow.minimize();
+});
+ipcMain.handle('window:maximize-toggle', () => {
+  if (!mainWindow) return;
+  if (mainWindow.isMaximized()) mainWindow.unmaximize();
+  else mainWindow.maximize();
+});
+ipcMain.handle('window:close', () => {
+  if (mainWindow) mainWindow.close();
+});
+
 // IPC handlers for audio functionality
 ipcMain.handle('check-audio-system', async () => {
   try {

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,7 @@
 const { app, BrowserWindow, ipcMain, Menu, dialog, shell, session, systemPreferences, desktopCapturer } = require('electron');
 const path = require('path');
 const { betterAuthAdapter } = require('./better-auth-adapter');
+const { setupSubtitleHandlers } = require('./subtitle-window.js');
 
 // Handle Squirrel events for Windows
 if (process.platform === 'win32') {
@@ -263,6 +264,8 @@ function createWindow() {
       webSecurity: !isDev
     }
   });
+
+  setupSubtitleHandlers(mainWindow);
 
   // Set custom User Agent for the window
   mainWindow.webContents.setUserAgent(customUserAgent);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -128,6 +128,10 @@ contextBridge.exposeInMainWorld(
         'update-download',
         'update-install',
         'get-app-version',
+        // Window control IPC for custom title bar
+        'window:minimize',
+        'window:maximize-toggle',
+        'window:close',
       ];
       if (validChannels.includes(channel)) {
         return ipcRenderer.invoke(channel, data);

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -60,6 +60,8 @@ const validReceiveChannels = [
   // Auto-update channels (main → renderer)
   'update-status',
   'update-progress',
+  // Subtitle window bounds change events
+  'subtitle:window-bounds-changed',
 ];
 
 // Expose protected methods that allow the renderer process to use
@@ -132,6 +134,12 @@ contextBridge.exposeInMainWorld(
         'window:minimize',
         'window:maximize-toggle',
         'window:close',
+        // Subtitle mode IPC
+        'subtitle:enter',
+        'subtitle:exit',
+        'subtitle:set-always-on-top',
+        'subtitle:set-locked',
+        'subtitle:get-screen-bounds',
       ];
       if (validChannels.includes(channel)) {
         return ipcRenderer.invoke(channel, data);

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -10,6 +10,23 @@ const { ipcMain, screen } = require('electron');
 // to settle before we accept user-driven resize/move events.
 const TRANSITION_BLACKOUT_MS = 600;
 
+// Module-scope state shared by the IPC handlers below. createWindow() may be
+// called more than once during an app's lifetime (notably on macOS, after
+// the user closes the window and clicks the dock icon — see
+// `app.on('activate')` in main.js). ipcMain.handle() throws on a second
+// registration of the same channel, so registering the handlers inside
+// setupSubtitleHandlers() — which runs per createWindow — would crash the
+// next time the window is recreated. We register the handlers once at
+// module load and have them resolve the *current* mainWindow at call time
+// via the activeWindow reference that setupSubtitleHandlers() updates.
+let activeWindow = null;
+let normalBoundsSnapshot = null;
+let transitionUntil = 0;
+
+const beginTransition = () => {
+  transitionUntil = Date.now() + TRANSITION_BLACKOUT_MS;
+};
+
 function clampToScreen(bounds, work) {
   const width = Math.min(bounds.width, work.width);
   const height = Math.min(bounds.height, work.height);
@@ -29,69 +46,78 @@ function defaultSubtitleBounds(work) {
   };
 }
 
+function getLiveWindow() {
+  return activeWindow && !activeWindow.isDestroyed() ? activeWindow : null;
+}
+
+ipcMain.handle('subtitle:get-screen-bounds', () => {
+  const display = screen.getPrimaryDisplay();
+  return display.workArea;
+});
+
+ipcMain.handle('subtitle:enter', (_event, payload) => {
+  const win = getLiveWindow();
+  if (!win) return { ok: false };
+  const work = screen.getPrimaryDisplay().workArea;
+  const requested = payload?.bounds ?? defaultSubtitleBounds(work);
+  const clamped = clampToScreen(requested, work);
+
+  normalBoundsSnapshot = win.getBounds();
+  beginTransition();
+  win.setBounds(clamped);
+  win.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), 'floating');
+  win.setResizable(!payload?.locked);
+  return { ok: true, bounds: clamped };
+});
+
+ipcMain.handle('subtitle:exit', (_event, payload) => {
+  const win = getLiveWindow();
+  if (!win) return { ok: false };
+  const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
+  beginTransition();
+  if (restore.x !== undefined && restore.y !== undefined) {
+    win.setBounds(restore);
+  } else {
+    const display = screen.getPrimaryDisplay().workArea;
+    win.setBounds({
+      x: display.x + Math.round((display.width - 1200) / 2),
+      y: display.y + Math.round((display.height - 800) / 2),
+      width: 1200,
+      height: 800,
+    });
+  }
+  win.setAlwaysOnTop(false);
+  win.setResizable(true);
+  normalBoundsSnapshot = null;
+  return { ok: true };
+});
+
+ipcMain.handle('subtitle:set-always-on-top', (_event, flag) => {
+  const win = getLiveWindow();
+  if (!win) return { ok: false };
+  win.setAlwaysOnTop(Boolean(flag), 'floating');
+  return { ok: true };
+});
+
+ipcMain.handle('subtitle:set-locked', (_event, locked) => {
+  const win = getLiveWindow();
+  if (!win) return { ok: false };
+  win.setResizable(!locked);
+  return { ok: true };
+});
+
 function setupSubtitleHandlers(mainWindow) {
-  let normalBoundsSnapshot = null;
-  let transitionUntil = 0;
+  // Rebind the active window. Resize/move listeners are per-window and need
+  // to be attached on every createWindow() call.
+  activeWindow = mainWindow;
+  // Reset snapshot/transition for the fresh window so a stale snapshot
+  // from a previous window can't leak in.
+  normalBoundsSnapshot = null;
+  transitionUntil = 0;
 
-  const beginTransition = () => {
-    transitionUntil = Date.now() + TRANSITION_BLACKOUT_MS;
-  };
-
-  ipcMain.handle('subtitle:get-screen-bounds', () => {
-    const display = screen.getPrimaryDisplay();
-    return display.workArea;
-  });
-
-  ipcMain.handle('subtitle:enter', (_event, payload) => {
-    if (mainWindow.isDestroyed()) return { ok: false };
-    const work = screen.getPrimaryDisplay().workArea;
-    const requested = payload?.bounds ?? defaultSubtitleBounds(work);
-    const clamped = clampToScreen(requested, work);
-
-    normalBoundsSnapshot = mainWindow.getBounds();
-    beginTransition();
-    mainWindow.setBounds(clamped);
-    mainWindow.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), 'floating');
-    mainWindow.setResizable(!payload?.locked);
-    return { ok: true, bounds: clamped };
-  });
-
-  ipcMain.handle('subtitle:exit', (_event, payload) => {
-    if (mainWindow.isDestroyed()) return { ok: false };
-    const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
-    beginTransition();
-    if (restore.x !== undefined && restore.y !== undefined) {
-      mainWindow.setBounds(restore);
-    } else {
-      const display = screen.getPrimaryDisplay().workArea;
-      mainWindow.setBounds({
-        x: display.x + Math.round((display.width - 1200) / 2),
-        y: display.y + Math.round((display.height - 800) / 2),
-        width: 1200,
-        height: 800,
-      });
-    }
-    mainWindow.setAlwaysOnTop(false);
-    mainWindow.setResizable(true);
-    normalBoundsSnapshot = null;
-    return { ok: true };
-  });
-
-  ipcMain.handle('subtitle:set-always-on-top', (_event, flag) => {
-    if (mainWindow.isDestroyed()) return { ok: false };
-    mainWindow.setAlwaysOnTop(Boolean(flag), 'floating');
-    return { ok: true };
-  });
-
-  ipcMain.handle('subtitle:set-locked', (_event, locked) => {
-    if (mainWindow.isDestroyed()) return { ok: false };
-    mainWindow.setResizable(!locked);
-    return { ok: true };
-  });
-
-  // Debounced bounds-changed broadcaster. Suppressed during transition windows
-  // so we don't capture intermediate WM-reported sizes as the user's
-  // intended bounds.
+  // Debounced bounds-changed broadcaster. Suppressed during transition
+  // windows so we don't capture intermediate WM-reported sizes as the
+  // user's intended bounds.
   let debounceTimer = null;
   const onChange = () => {
     if (Date.now() < transitionUntil) return;
@@ -108,6 +134,12 @@ function setupSubtitleHandlers(mainWindow) {
     if (debounceTimer) {
       clearTimeout(debounceTimer);
       debounceTimer = null;
+    }
+    // Drop the reference so handlers know there's no live window until the
+    // next createWindow() rebinds it.
+    if (activeWindow === mainWindow) {
+      activeWindow = null;
+      normalBoundsSnapshot = null;
     }
   });
 }

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -1,6 +1,15 @@
 // electron/subtitle-window.js
 const { ipcMain, screen } = require('electron');
 
+// Window managers (esp. on Linux/X11/Wayland) apply setBounds() asynchronously.
+// During the settling period, the resize event fires with intermediate values
+// and mainWindow.getBounds() can still report the pre-setBounds size for
+// hundreds of ms. If we forward those events to the renderer, the renderer
+// persists the stale bounds as "subtitle bounds", overwriting the true
+// subtitle dimensions. The TRANSITION_BLACKOUT_MS window gives the WM time
+// to settle before we accept user-driven resize/move events.
+const TRANSITION_BLACKOUT_MS = 600;
+
 function clampToScreen(bounds, work) {
   const width = Math.min(bounds.width, work.width);
   const height = Math.min(bounds.height, work.height);
@@ -22,6 +31,11 @@ function defaultSubtitleBounds(work) {
 
 function setupSubtitleHandlers(mainWindow) {
   let normalBoundsSnapshot = null;
+  let transitionUntil = 0;
+
+  const beginTransition = () => {
+    transitionUntil = Date.now() + TRANSITION_BLACKOUT_MS;
+  };
 
   ipcMain.handle('subtitle:get-screen-bounds', () => {
     const display = screen.getPrimaryDisplay();
@@ -35,6 +49,7 @@ function setupSubtitleHandlers(mainWindow) {
     const clamped = clampToScreen(requested, work);
 
     normalBoundsSnapshot = mainWindow.getBounds();
+    beginTransition();
     mainWindow.setBounds(clamped);
     mainWindow.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), 'floating');
     mainWindow.setResizable(!payload?.locked);
@@ -44,6 +59,7 @@ function setupSubtitleHandlers(mainWindow) {
   ipcMain.handle('subtitle:exit', (_event, payload) => {
     if (mainWindow.isDestroyed()) return { ok: false };
     const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
+    beginTransition();
     if (restore.x !== undefined && restore.y !== undefined) {
       mainWindow.setBounds(restore);
     } else {
@@ -73,12 +89,15 @@ function setupSubtitleHandlers(mainWindow) {
     return { ok: true };
   });
 
-  // Debounced bounds-changed broadcaster
+  // Debounced bounds-changed broadcaster. Suppressed during transition windows
+  // so we don't capture intermediate WM-reported sizes as the user's
+  // intended bounds.
   let debounceTimer = null;
   const onChange = () => {
+    if (Date.now() < transitionUntil) return;
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
-      if (!mainWindow.isDestroyed()) {
+      if (!mainWindow.isDestroyed() && Date.now() >= transitionUntil) {
         mainWindow.webContents.send('subtitle:window-bounds-changed', mainWindow.getBounds());
       }
     }, 200);

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -29,6 +29,7 @@ function setupSubtitleHandlers(mainWindow) {
   });
 
   ipcMain.handle('subtitle:enter', (_event, payload) => {
+    if (mainWindow.isDestroyed()) return { ok: false };
     const work = screen.getPrimaryDisplay().workArea;
     const requested = payload?.bounds ?? defaultSubtitleBounds(work);
     const clamped = clampToScreen(requested, work);
@@ -41,6 +42,7 @@ function setupSubtitleHandlers(mainWindow) {
   });
 
   ipcMain.handle('subtitle:exit', (_event, payload) => {
+    if (mainWindow.isDestroyed()) return { ok: false };
     const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
     if (restore.x !== undefined && restore.y !== undefined) {
       mainWindow.setBounds(restore);
@@ -60,11 +62,13 @@ function setupSubtitleHandlers(mainWindow) {
   });
 
   ipcMain.handle('subtitle:set-always-on-top', (_event, flag) => {
+    if (mainWindow.isDestroyed()) return { ok: false };
     mainWindow.setAlwaysOnTop(Boolean(flag), 'floating');
     return { ok: true };
   });
 
   ipcMain.handle('subtitle:set-locked', (_event, locked) => {
+    if (mainWindow.isDestroyed()) return { ok: false };
     mainWindow.setResizable(!locked);
     return { ok: true };
   });
@@ -81,6 +85,12 @@ function setupSubtitleHandlers(mainWindow) {
   };
   mainWindow.on('resize', onChange);
   mainWindow.on('move', onChange);
+  mainWindow.on('closed', () => {
+    if (debounceTimer) {
+      clearTimeout(debounceTimer);
+      debounceTimer = null;
+    }
+  });
 }
 
 module.exports = { setupSubtitleHandlers };

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -67,6 +67,9 @@ ipcMain.handle('subtitle:enter', (_event, payload) => {
   win.setBounds(clamped);
   win.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), 'floating');
   win.setResizable(!payload?.locked);
+  if (process.platform === 'darwin') {
+    win.setWindowButtonVisibility(false);
+  }
   return { ok: true, bounds: clamped };
 });
 
@@ -88,6 +91,9 @@ ipcMain.handle('subtitle:exit', (_event, payload) => {
   }
   win.setAlwaysOnTop(false);
   win.setResizable(true);
+  if (process.platform === 'darwin') {
+    win.setWindowButtonVisibility(true);
+  }
   normalBoundsSnapshot = null;
   return { ok: true };
 });

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -1,0 +1,86 @@
+// electron/subtitle-window.js
+const { ipcMain, screen } = require('electron');
+
+function clampToScreen(bounds, work) {
+  const width = Math.min(bounds.width, work.width);
+  const height = Math.min(bounds.height, work.height);
+  const x = Math.max(work.x, Math.min(bounds.x, work.x + work.width - width));
+  const y = Math.max(work.y, Math.min(bounds.y, work.y + work.height - height));
+  return { x, y, width, height };
+}
+
+function defaultSubtitleBounds(work) {
+  const width = Math.round(work.width * 0.8);
+  const height = 200;
+  return {
+    x: work.x + Math.round((work.width - width) / 2),
+    y: work.y + work.height - height - 80,
+    width,
+    height,
+  };
+}
+
+function setupSubtitleHandlers(mainWindow) {
+  let normalBoundsSnapshot = null;
+
+  ipcMain.handle('subtitle:get-screen-bounds', () => {
+    const display = screen.getPrimaryDisplay();
+    return display.workArea;
+  });
+
+  ipcMain.handle('subtitle:enter', (_event, payload) => {
+    const work = screen.getPrimaryDisplay().workArea;
+    const requested = payload?.bounds ?? defaultSubtitleBounds(work);
+    const clamped = clampToScreen(requested, work);
+
+    normalBoundsSnapshot = mainWindow.getBounds();
+    mainWindow.setBounds(clamped);
+    mainWindow.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), 'floating');
+    mainWindow.setResizable(!payload?.locked);
+    return { ok: true, bounds: clamped };
+  });
+
+  ipcMain.handle('subtitle:exit', (_event, payload) => {
+    const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
+    if (restore.x !== undefined && restore.y !== undefined) {
+      mainWindow.setBounds(restore);
+    } else {
+      const display = screen.getPrimaryDisplay().workArea;
+      mainWindow.setBounds({
+        x: display.x + Math.round((display.width - 1200) / 2),
+        y: display.y + Math.round((display.height - 800) / 2),
+        width: 1200,
+        height: 800,
+      });
+    }
+    mainWindow.setAlwaysOnTop(false);
+    mainWindow.setResizable(true);
+    normalBoundsSnapshot = null;
+    return { ok: true };
+  });
+
+  ipcMain.handle('subtitle:set-always-on-top', (_event, flag) => {
+    mainWindow.setAlwaysOnTop(Boolean(flag), 'floating');
+    return { ok: true };
+  });
+
+  ipcMain.handle('subtitle:set-locked', (_event, locked) => {
+    mainWindow.setResizable(!locked);
+    return { ok: true };
+  });
+
+  // Debounced bounds-changed broadcaster
+  let debounceTimer = null;
+  const onChange = () => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      if (!mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('subtitle:window-bounds-changed', mainWindow.getBounds());
+      }
+    }, 200);
+  };
+  mainWindow.on('resize', onChange);
+  mainWindow.on('move', onChange);
+}
+
+module.exports = { setupSubtitleHandlers };

--- a/src/App.scss
+++ b/src/App.scss
@@ -1,9 +1,12 @@
+html, body, #root, .App {
+  background: transparent;
+}
+
 .App {
   width: 100%;
   height: 100%;
   min-height: 0; /* Allow shrinking for nested scrolling */
   overflow: hidden;
-  background-color: #1e1e1e;
   color: white;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',

--- a/src/components/MainLayout/MainLayout.scss
+++ b/src/components/MainLayout/MainLayout.scss
@@ -71,62 +71,6 @@
     }
   }
   
-  .main-panel-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 20px;
-    background-color: #252525;
-    border-bottom: 1px solid #333;
-    
-    h1 {
-      margin: 0;
-      font-size: 18px;
-      font-weight: 500;
-      line-height: 32px;
-    }
-    
-    .header-controls {
-      display: flex;
-      align-items: center;
-      gap: 8px;
-      
-      
-      .settings-button,
-      .audio-button,
-      .logs-button {
-        display: flex;
-        align-items: center;
-        gap: 6px;
-        background: transparent;
-        border: 1px solid #555;
-        border-radius: 4px;
-        color: white;
-        padding: 6px 12px;
-        cursor: pointer;
-        font-size: 14px;
-        
-        &:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-        }
-        
-        &.active {
-          background-color: rgba(255, 255, 255, 0.2);
-          border-color: #10a37f;
-        }
-        
-        /* Hide text on small screens */
-        @media (max-width: 576px) {
-          padding: 6px;
-          
-          span {
-            display: none;
-          }
-        }
-      }
-    }
-  }
-  
   .main-panel-container {
     flex: 1;
     display: flex;

--- a/src/components/MainLayout/MainLayout.scss
+++ b/src/components/MainLayout/MainLayout.scss
@@ -4,7 +4,7 @@
   min-height: 0; /* Allow shrinking for nested scrolling */
   width: 100%;
   flex: 1; /* Take up available space from parent */
-  background-color: #1e1e1e;
+  background-color: #1e1e1e; /* opaque background so window body looks normal */
   color: white;
   overflow: hidden; /* Prevent overflow from causing scrollbars on the body */
   

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -5,6 +5,7 @@ import LogsPanel from '../LogsPanel/LogsPanel';
 import { Settings as SettingsComponent } from '../Settings';
 import Onboarding from '../Onboarding/Onboarding';
 import UserTypeSelection from '../UserTypeSelection/UserTypeSelection';
+import TitleBar from '../TitleBar/TitleBar';
 import { Terminal, Settings } from 'lucide-react';
 import './MainLayout.scss';
 import { useAnalytics } from '../../lib/analytics';
@@ -12,6 +13,7 @@ import { useProvider, useUIMode, useSetProvider, useSetUIMode, useSettingsNaviga
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../lib/auth/hooks';
 import { Provider } from '../../types/Provider';
+import { isElectron } from '../../utils/environment';
 
 type PanelName = 'settings' | 'audio' | 'logs' | 'main';
 
@@ -185,6 +187,8 @@ const MainLayout: React.FC = () => {
   }
 
   return (
+    <>
+    {isElectron() && <TitleBar />}
     <div className="main-layout">
       <div className={`main-content ${(showLogs || showSettings || showAudio) ? 'with-panel' : 'full-width'}`}>
         <header className="main-panel-header">
@@ -219,6 +223,7 @@ const MainLayout: React.FC = () => {
       )}
       <Onboarding />
     </div>
+    </>
   );
 };
 

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -9,7 +9,8 @@ import TitleBar from '../TitleBar/TitleBar';
 import { Terminal, Settings } from 'lucide-react';
 import './MainLayout.scss';
 import { useAnalytics } from '../../lib/analytics';
-import { useProvider, useUIMode, useSetProvider, useSetUIMode, useSettingsNavigationTarget } from '../../stores/settingsStore';
+import { useProvider, useUIMode, useSetProvider, useSetUIMode, useSettingsNavigationTarget, useSubtitleModeActive } from '../../stores/settingsStore';
+import SubtitleApp from '../Subtitle/SubtitleApp';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../lib/auth/hooks';
 import { Provider } from '../../types/Provider';
@@ -27,6 +28,7 @@ const MainLayout: React.FC = () => {
   const settingsNavigationTarget = useSettingsNavigationTarget();
   const { userTypeSelected, setUserType } = useOnboarding();
   const { isSignedIn } = useAuth();
+  const subtitleActive = useSubtitleModeActive();
   const [showLogs, setShowLogs] = useState(() => {
     return sessionStorage.getItem('panelState.showLogs') === 'true';
   });
@@ -188,8 +190,11 @@ const MainLayout: React.FC = () => {
 
   return (
     <>
-    {isElectron() && <TitleBar />}
-    <div className="main-layout">
+    {!subtitleActive && isElectron() && <TitleBar />}
+    <div
+      className="main-layout"
+      style={subtitleActive ? { display: 'none' } : undefined}
+    >
       <div className={`main-content ${(showLogs || showSettings || showAudio) ? 'with-panel' : 'full-width'}`}>
         <header className="main-panel-header">
           <h1>{t('app.title')}</h1>
@@ -223,6 +228,7 @@ const MainLayout: React.FC = () => {
       )}
       <Onboarding />
     </div>
+    {subtitleActive && <SubtitleApp />}
     </>
   );
 };

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -6,7 +6,6 @@ import { Settings as SettingsComponent } from '../Settings';
 import Onboarding from '../Onboarding/Onboarding';
 import UserTypeSelection from '../UserTypeSelection/UserTypeSelection';
 import TitleBar from '../TitleBar/TitleBar';
-import { Terminal, Settings } from 'lucide-react';
 import './MainLayout.scss';
 import { useAnalytics } from '../../lib/analytics';
 import { useProvider, useUIMode, useSetProvider, useSetUIMode, useSettingsNavigationTarget, useSubtitleModeActive } from '../../stores/settingsStore';
@@ -16,10 +15,9 @@ import { useAuth } from '../../lib/auth/hooks';
 import { Provider } from '../../types/Provider';
 import { isElectron } from '../../utils/environment';
 
-type PanelName = 'settings' | 'audio' | 'logs' | 'main';
+type PanelName = 'settings' | 'logs' | 'main';
 
 const MainLayout: React.FC = () => {
-  const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
   const provider = useProvider();
   const uiMode = useUIMode();
@@ -35,18 +33,15 @@ const MainLayout: React.FC = () => {
   const [showSettings, setShowSettings] = useState(() => {
     return sessionStorage.getItem('panelState.showSettings') === 'true';
   });
-  const [showAudio, setShowAudio] = useState(() => {
-    return sessionStorage.getItem('panelState.showAudio') === 'true';
-  });
 
-  
+
   // Track panel view times
   const panelOpenTimeRef = useRef<number | null>(null);
   const currentPanelRef = useRef<PanelName | null>(null);
-  
+
   // Track previous auth state to detect login
   const prevIsSignedInRef = useRef(isSignedIn);
-  
+
   // Helper function to track panel view events
   const trackPanelView = (panelName: PanelName | null) => {
     // Track closing of previous panel
@@ -57,7 +52,7 @@ const MainLayout: React.FC = () => {
         view_duration_ms: viewDuration
       });
     }
-    
+
     // Track opening of new panel
     if (panelName) {
       trackEvent('panel_viewed', {
@@ -76,23 +71,6 @@ const MainLayout: React.FC = () => {
   };
 
   // Modify toggle functions to ensure only one panel is displayed at a time
-  const toggleAudio = () => {
-    // If already shown, close it; otherwise open it and close other panels
-    if (showAudio) {
-      setShowAudio(false);
-      sessionStorage.setItem('panelState.showAudio', 'false');
-      trackPanelView(null);
-    } else {
-      setShowAudio(true);
-      setShowLogs(false);
-      setShowSettings(false);
-      sessionStorage.setItem('panelState.showAudio', 'true');
-      sessionStorage.setItem('panelState.showLogs', 'false');
-      sessionStorage.setItem('panelState.showSettings', 'false');
-      trackPanelView('audio');
-    }
-  };
-  
   const toggleLogs = () => {
     // If already shown, close it; otherwise open it and close other panels
     if (showLogs) {
@@ -101,15 +79,13 @@ const MainLayout: React.FC = () => {
       trackPanelView(null);
     } else {
       setShowLogs(true);
-      setShowAudio(false);
       setShowSettings(false);
       sessionStorage.setItem('panelState.showLogs', 'true');
-      sessionStorage.setItem('panelState.showAudio', 'false');
       sessionStorage.setItem('panelState.showSettings', 'false');
       trackPanelView('logs');
     }
   };
-  
+
   const toggleSettings = () => {
     // If already shown, close it; otherwise open it and close other panels
     if (showSettings) {
@@ -118,10 +94,8 @@ const MainLayout: React.FC = () => {
       trackPanelView(null);
     } else {
       setShowSettings(true);
-      setShowAudio(false);
       setShowLogs(false);
       sessionStorage.setItem('panelState.showSettings', 'true');
-      sessionStorage.setItem('panelState.showAudio', 'false');
       sessionStorage.setItem('panelState.showLogs', 'false');
       trackPanelView('settings');
     }
@@ -133,11 +107,9 @@ const MainLayout: React.FC = () => {
     if (settingsNavigationTarget) {
       // Open settings panel when navigation is requested
       setShowSettings(true);
-      setShowAudio(false);
       setShowLogs(false);
       // Save to sessionStorage when programmatically opening settings
       sessionStorage.setItem('panelState.showSettings', 'true');
-      sessionStorage.setItem('panelState.showAudio', 'false');
       sessionStorage.setItem('panelState.showLogs', 'false');
       trackPanelView('settings');
     }
@@ -148,10 +120,10 @@ const MainLayout: React.FC = () => {
     // Set UI mode based on user type
     const newMode = type === 'regular' ? 'basic' : 'advanced';
     setUIMode(newMode);
-    
+
     // Call the onboarding context to handle the selection
     setUserType(type);
-    
+
     trackEvent('user_type_applied', {
       user_type: type,
       ui_mode: newMode
@@ -166,7 +138,7 @@ const MainLayout: React.FC = () => {
       if (uiMode === 'basic' && provider !== Provider.KIZUNA_AI) {
         // User is in Basic Mode and not using KizunaAI, switch to KizunaAI
         setProvider(Provider.KIZUNA_AI);
-        
+
         // Track the auto-switch
         trackEvent('settings_modified', {
           setting_name: 'provider',
@@ -174,11 +146,11 @@ const MainLayout: React.FC = () => {
           old_value: provider,
           category: 'api'
         });
-        
+
         console.log('[MainLayout] Auto-switched to KizunaAI provider for Basic Mode user on login');
       }
     }
-    
+
     // Update the ref for next render
     prevIsSignedInRef.current = isSignedIn;
   }, [isSignedIn, uiMode, provider, setProvider, trackEvent]);
@@ -190,27 +162,19 @@ const MainLayout: React.FC = () => {
 
   return (
     <>
-    {!subtitleActive && isElectron() && <TitleBar />}
+    {!subtitleActive && isElectron() && (
+      <TitleBar
+        showSettings={showSettings}
+        showLogs={showLogs}
+        onToggleSettings={toggleSettings}
+        onToggleLogs={toggleLogs}
+      />
+    )}
     <div
       className="main-layout"
       style={subtitleActive ? { display: 'none' } : undefined}
     >
-      <div className={`main-content ${(showLogs || showSettings || showAudio) ? 'with-panel' : 'full-width'}`}>
-        <header className="main-panel-header">
-          <h1>{t('app.title')}</h1>
-          <div className="header-controls">
-<button className={`settings-button ${showSettings || showAudio ? 'active' : ''}`} onClick={toggleSettings}>
-              <Settings size={16} />
-              <span>{t('settings.title')}</span>
-            </button>
-            {uiMode === 'advanced' && (
-              <button className={`logs-button ${showLogs ? 'active' : ''}`} onClick={toggleLogs}>
-                <Terminal size={16} />
-                <span>{t('common.logs')}</span>
-              </button>
-            )}
-          </div>
-        </header>
+      <div className={`main-content ${(showLogs || showSettings) ? 'with-panel' : 'full-width'}`}>
         <div className="main-panel-container">
           <MainPanel />
         </div>

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -13,7 +13,6 @@ import SubtitleApp from '../Subtitle/SubtitleApp';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../lib/auth/hooks';
 import { Provider } from '../../types/Provider';
-import { isElectron } from '../../utils/environment';
 
 type PanelName = 'settings' | 'logs' | 'main';
 
@@ -162,7 +161,7 @@ const MainLayout: React.FC = () => {
 
   return (
     <>
-    {!subtitleActive && isElectron() && (
+    {!subtitleActive && (
       <TitleBar
         showSettings={showSettings}
         showLogs={showLogs}

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -111,12 +111,12 @@
   overflow-wrap: anywhere;
 
   &.src {
-    color: #9aa0a6;
+    color: var(--subtitle-source-color, #9aa0a6);
     font-style: italic;
   }
 
   &.tr {
-    color: #e8e8e8;
+    color: var(--subtitle-translation-color, #e8e8e8);
   }
 }
 

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -33,7 +33,7 @@ import {
   useCurrentTurnDetectionMode
 } from '../../stores/settingsStore';
 import useSettingsStore, { createParticipantLocalInferenceConfig } from '../../stores/settingsStore';
-import useSessionStore, { useSession, useIsReconnecting, useSetIsReconnecting } from '../../stores/sessionStore';
+import useSessionStore, { useSession, useIsReconnecting, useSetIsReconnecting, useSetItems as useSetStoreItems, useSetSystemAudioItems as useSetStoreSystemAudioItems } from '../../stores/sessionStore';
 import { useAudioContext, useNoiseSuppressionMode } from '../../stores/audioStore';
 import { useLogActions } from '../../stores/logStore';
 import type { RealtimeEvent } from '../../stores/logStore';
@@ -162,6 +162,10 @@ const MainPanel: React.FC<MainPanelProps> = () => {
 
   const isReconnecting = useIsReconnecting();
   const setIsReconnecting = useSetIsReconnecting();
+
+  // Store setters for mirroring local items state into sessionStore
+  const setStoreItems = useSetStoreItems();
+  const setStoreSystemAudioItems = useSetStoreSystemAudioItems();
 
   // Get log functions from store
   const { addRealtimeEvent } = useLogActions();
@@ -579,6 +583,16 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const disconnectInProgressRef = useRef<boolean>(false);
 
   const [systemAudioItems, setSystemAudioItems] = useState<ConversationItem[]>([]);
+
+  // Mirror items into sessionStore so SubtitleApp can read them
+  // after MainPanel unmounts (e.g. when entering subtitle mode).
+  useEffect(() => {
+    setStoreItems(items);
+  }, [items, setStoreItems]);
+
+  useEffect(() => {
+    setStoreSystemAudioItems(systemAudioItems);
+  }, [systemAudioItems, setStoreSystemAudioItems]);
 
   const clearConversation = useCallback(() => {
     // Cancel pending throttled update that would re-populate items

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -59,7 +59,6 @@ import DisplayModeButton from './DisplayModeButton';
 import ConversationRow from './ConversationRow';
 import { shouldShowItem } from './conversationFilter';
 import ExportButton from './ExportButton';
-import SubtitleEnterButton from '../Subtitle/SubtitleEnterButton';
 
 
 /**
@@ -2902,7 +2901,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         {/* Conversation toolbar */}
         {(isSessionActive || combinedItems.length > 0) && (
           <div className="conversation-toolbar">
-            <SubtitleEnterButton />
             <DisplayModeButton
               scope="speaker"
               value={speakerDisplayMode}

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -33,7 +33,7 @@ import {
   useCurrentTurnDetectionMode
 } from '../../stores/settingsStore';
 import useSettingsStore, { createParticipantLocalInferenceConfig } from '../../stores/settingsStore';
-import useSessionStore, { useSession, useIsReconnecting, useSetIsReconnecting, useSetItems as useSetStoreItems, useSetSystemAudioItems as useSetStoreSystemAudioItems } from '../../stores/sessionStore';
+import useSessionStore, { useSession, useIsReconnecting, useSetIsReconnecting, useSetItems as useSetStoreItems, useSetSystemAudioItems as useSetStoreSystemAudioItems, useClearConversationVersion, useRequestClearConversation } from '../../stores/sessionStore';
 import { useAudioContext, useNoiseSuppressionMode } from '../../stores/audioStore';
 import { useLogActions } from '../../stores/logStore';
 import type { RealtimeEvent } from '../../stores/logStore';
@@ -166,6 +166,8 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   // Store setters for mirroring local items state into sessionStore
   const setStoreItems = useSetStoreItems();
   const setStoreSystemAudioItems = useSetStoreSystemAudioItems();
+  const clearConversationVersion = useClearConversationVersion();
+  const requestClearConversation = useRequestClearConversation();
 
   // Get log functions from store
   const { addRealtimeEvent } = useLogActions();
@@ -607,6 +609,19 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     setItems([]);
     setSystemAudioItems([]);
   }, []);
+
+  // Watch for clear-conversation requests from anywhere in the app
+  // (e.g. the SubtitleBar's clear button) — sessionStore.requestClearConversation
+  // bumps a version counter and we run the local clearConversation logic
+  // when that counter changes. The initial value is recorded once so the
+  // first mount does not trigger a spurious clear.
+  const lastClearVersionRef = useRef(clearConversationVersion);
+  useEffect(() => {
+    if (clearConversationVersion !== lastClearVersionRef.current) {
+      lastClearVersionRef.current = clearConversationVersion;
+      clearConversation();
+    }
+  }, [clearConversationVersion, clearConversation]);
 
   // Snapshots the source/target language pair at the moment each conversation
   // item is first seen, keyed by item id. Without this, badges in the history
@@ -2962,7 +2977,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             />
             <button
               className="clear-conversation-btn"
-              onClick={clearConversation}
+              onClick={requestClearConversation}
               title={t('mainPanel.clearConversation', 'Clear conversation')}
               aria-label={t('mainPanel.clearConversation', 'Clear conversation')}
               type="button"

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2900,8 +2900,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       <UpdateDialog />
       <div className="main-panel">
         {/* Conversation toolbar */}
-        {combinedItems.length > 0 && (
+        {(isSessionActive || combinedItems.length > 0) && (
           <div className="conversation-toolbar">
+            <SubtitleEnterButton />
+            {combinedItems.length > 0 && (
+              <>
             <DisplayModeButton
               scope="speaker"
               value={speakerDisplayMode}
@@ -2914,7 +2917,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
                 onChange={setParticipantDisplayMode}
               />
             )}
-            <SubtitleEnterButton />
             <button
               className="font-size-btn"
               onClick={() => setConversationFontSize(Math.max(12, conversationFontSize - 2))}
@@ -2971,6 +2973,8 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             >
               <Trash2 size={14} />
             </button>
+              </>
+            )}
           </div>
         )}
         {/* Conversation Display */}

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -59,6 +59,7 @@ import DisplayModeButton from './DisplayModeButton';
 import ConversationRow from './ConversationRow';
 import { shouldShowItem } from './conversationFilter';
 import ExportButton from './ExportButton';
+import SubtitleEnterButton from '../Subtitle/SubtitleEnterButton';
 
 
 /**
@@ -2913,6 +2914,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
                 onChange={setParticipantDisplayMode}
               />
             )}
+            <SubtitleEnterButton />
             <button
               className="font-size-btn"
               onClick={() => setConversationFontSize(Math.max(12, conversationFontSize - 2))}

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2903,8 +2903,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         {(isSessionActive || combinedItems.length > 0) && (
           <div className="conversation-toolbar">
             <SubtitleEnterButton />
-            {combinedItems.length > 0 && (
-              <>
             <DisplayModeButton
               scope="speaker"
               value={speakerDisplayMode}
@@ -2973,8 +2971,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             >
               <Trash2 size={14} />
             </button>
-              </>
-            )}
           </div>
         )}
         {/* Conversation Display */}

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -7,14 +7,20 @@
   border-radius: 8px;
   overflow: hidden;
   color: var(--subtitle-source-color, #FFFFFF);
+  // Positioning context for the SubtitleBar, which floats above the
+  // subtitle area so the bar's footprint isn't permanently reserved.
+  position: relative;
 }
 
-.subtitle-ptt-hint {
+.subtitle-ptt-hint,
+.subtitle-session-ended {
   flex: 1;
   display: flex;
   align-items: center;
   justify-content: center;
   padding: 16px 24px;
+  gap: 12px;
+  flex-direction: column;
 
   p {
     margin: 0;

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -1,0 +1,10 @@
+// src/components/Subtitle/SubtitleApp.scss
+.subtitle-app {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+  border-radius: 8px;
+  overflow: hidden;
+  color: var(--subtitle-source-color, #FFFFFF);
+}

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -8,3 +8,18 @@
   overflow: hidden;
   color: var(--subtitle-source-color, #FFFFFF);
 }
+
+.subtitle-ptt-hint {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px 24px;
+
+  p {
+    margin: 0;
+    font-size: 16px;
+    color: rgba(255, 255, 255, 0.7);
+    letter-spacing: 0.3px;
+  }
+}

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -121,8 +121,7 @@ const SubtitleApp: React.FC = () => {
   // prevents the resize event triggered by exiting (setBounds(restore))
   // from being saved as subtitle bounds.
   useEffect(() => {
-    const electronApi = (window as any).electron;
-    if (!electronApi?.receive) return;
+    if (!window.electron?.receive) return;
     let debounce: ReturnType<typeof setTimeout> | null = null;
     const handler = (bounds: { x: number; y: number; width: number; height: number }) => {
       if (debounce) clearTimeout(debounce);
@@ -131,10 +130,10 @@ const SubtitleApp: React.FC = () => {
         void saveBounds(bounds);
       }, 500);
     };
-    electronApi.receive('subtitle:window-bounds-changed', handler);
+    window.electron.receive('subtitle:window-bounds-changed', handler);
     return () => {
       if (debounce) clearTimeout(debounce);
-      electronApi.removeListener?.('subtitle:window-bounds-changed', handler);
+      window.electron?.removeListener?.('subtitle:window-bounds-changed', handler);
     };
   }, [saveBounds]);
 

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -69,15 +69,35 @@ const SubtitleApp: React.FC = () => {
     () => getCurrentProviderSettings(),
     [getCurrentProviderSettings, provider],
   );
-  const sourceLanguage: string = (providerSettings as any)?.sourceLanguage ?? 'en';
-  const targetLanguage: string = (providerSettings as any)?.targetLanguage ?? 'zh';
+  // The provider-settings union doesn't guarantee these fields (a few
+  // members are text-only and never carry a language pair), so cast to a
+  // narrow shape that exposes only what we actually read.
+  const providerLanguages = providerSettings as { sourceLanguage?: string; targetLanguage?: string } | null | undefined;
+  const sourceLanguage: string = providerLanguages?.sourceLanguage ?? 'en';
+  const targetLanguage: string = providerLanguages?.targetLanguage ?? 'zh';
 
-  // Combine items with source tagging (mirrors MainPanel's logic, simplified)
-  const combinedItems = useMemo(() => {
-    const tagSpeaker = (item: ConversationItem) =>
-      ({ ...item, source: item.source ?? 'speaker', sourceLanguage, targetLanguage }) as any;
-    const tagParticipant = (item: ConversationItem) =>
-      ({ ...item, source: item.source ?? 'participant', sourceLanguage, targetLanguage }) as any;
+  // Combine items with source tagging (mirrors MainPanel's logic, simplified).
+  // Tagged items extend ConversationItem with the speaker/participant role and
+  // the snapshotted language pair so ConversationRow can render badges
+  // consistently after the languages change mid-conversation.
+  type TaggedItem = ConversationItem & {
+    source: 'speaker' | 'participant';
+    sourceLanguage: string;
+    targetLanguage: string;
+  };
+  const combinedItems = useMemo<TaggedItem[]>(() => {
+    const tagSpeaker = (item: ConversationItem): TaggedItem => ({
+      ...item,
+      source: item.source ?? 'speaker',
+      sourceLanguage,
+      targetLanguage,
+    });
+    const tagParticipant = (item: ConversationItem): TaggedItem => ({
+      ...item,
+      source: item.source ?? 'participant',
+      sourceLanguage,
+      targetLanguage,
+    });
     const all = [
       ...items.map(tagSpeaker),
       ...systemAudioItems.map(tagParticipant),
@@ -140,12 +160,14 @@ const SubtitleApp: React.FC = () => {
   // Detect whether participant has produced any items
   const participantHasAudio = systemAudioItems.length > 0;
 
-  // Build CSS variables for background
+  // Build CSS variables for background. The intersection with
+  // Record<string, string | number> lets us set CSS custom properties
+  // without TS rejecting non-camelCase keys.
   const bgAlpha = subtitle.bgOpacity / 100;
-  const rootStyle: React.CSSProperties = {
+  const rootStyle: React.CSSProperties & Record<string, string | number> = {
     background: hexToRgba(subtitle.bgColor, bgAlpha),
-    ['--bar-opacity' as any]: barVisible ? 1 : 0,
-    ['--bar-pointer-events' as any]: barVisible ? 'auto' : 'none',
+    '--bar-opacity': barVisible ? 1 : 0,
+    '--bar-pointer-events': barVisible ? 'auto' : 'none',
   };
 
   return (

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -1,5 +1,6 @@
 // src/components/Subtitle/SubtitleApp.tsx
 import React, { useEffect, useState, useRef, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 import SubtitleBar from './SubtitleBar';
 import SubtitleStream from './SubtitleStream';
 import SubtitleSessionEnded from './SubtitleSessionEnded';
@@ -12,6 +13,7 @@ import useSettingsStore, {
   useProvider,
   useGetCurrentProviderSettings,
   useLocalInferenceSettings,
+  useCurrentTurnDetectionMode,
 } from '../../stores/settingsStore';
 import {
   useIsSessionActive,
@@ -40,6 +42,7 @@ function hexToRgba(hex: string, alpha: number): string {
 }
 
 const SubtitleApp: React.FC = () => {
+  const { t } = useTranslation();
   const subtitle = useSubtitleSettings();
   const exitSubtitleMode = useExitSubtitleMode();
   const saveBounds = useSaveSubtitleWindowBounds();
@@ -52,6 +55,13 @@ const SubtitleApp: React.FC = () => {
   const localInferenceSettings = useLocalInferenceSettings();
   const isSessionActive = useIsSessionActive();
   const sessionStartTime = useSessionStartTime();
+  const turnDetectionMode = useCurrentTurnDetectionMode();
+  // Mirrors isPttLikeMode in MainPanel — modes that send audio only while
+  // the user holds Space.
+  const canHoldToSpeak =
+    turnDetectionMode === 'Push-to-Talk' ||
+    turnDetectionMode === 'Push-to-Translate' ||
+    turnDetectionMode === 'Disabled';
 
   const providerSettings = useMemo(
     () => getCurrentProviderSettings(),
@@ -162,17 +172,23 @@ const SubtitleApp: React.FC = () => {
         }}
       />
       {isSessionActive ? (
-        <SubtitleStream
-          items={combinedItems}
-          compact={subtitle.compactMode}
-          fontSize={subtitle.fontSize}
-          speakerMode={speakerMode}
-          participantMode={participantMode}
-          sourceLanguage={sourceLanguage}
-          targetLanguage={targetLanguage}
-          sourceTextColor={subtitle.sourceTextColor}
-          translationTextColor={subtitle.translationTextColor}
-        />
+        canHoldToSpeak && combinedItems.length === 0 ? (
+          <div className="subtitle-ptt-hint">
+            <p>{t('subtitle.pttHint', 'Press Space to speak')}</p>
+          </div>
+        ) : (
+          <SubtitleStream
+            items={combinedItems}
+            compact={subtitle.compactMode}
+            fontSize={subtitle.fontSize}
+            speakerMode={speakerMode}
+            participantMode={participantMode}
+            sourceLanguage={sourceLanguage}
+            targetLanguage={targetLanguage}
+            sourceTextColor={subtitle.sourceTextColor}
+            translationTextColor={subtitle.translationTextColor}
+          />
+        )
       ) : (
         <SubtitleSessionEnded onReturn={() => void exitSubtitleMode()} />
       )}

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState, useRef, useMemo } from 'react';
 import SubtitleBar from './SubtitleBar';
 import SubtitleStream from './SubtitleStream';
 import SubtitleSessionEnded from './SubtitleSessionEnded';
-import {
+import useSettingsStore, {
   useSubtitleSettings,
   useExitSubtitleMode,
   useSaveSubtitleWindowBounds,
@@ -103,14 +103,21 @@ const SubtitleApp: React.FC = () => {
     return () => window.removeEventListener('keydown', onKey);
   }, [exitSubtitleMode]);
 
-  // Bounds-changed listener (debounced 500 ms before persistence)
+  // Bounds-changed listener (debounced 500 ms before persistence).
+  // The main process emits this for any resize/move regardless of mode, so
+  // we double-guard: only persist while subtitle mode is still active. This
+  // prevents the resize event triggered by exiting (setBounds(restore))
+  // from being saved as subtitle bounds.
   useEffect(() => {
     const electronApi = (window as any).electron;
     if (!electronApi?.receive) return;
     let debounce: ReturnType<typeof setTimeout> | null = null;
     const handler = (bounds: { x: number; y: number; width: number; height: number }) => {
       if (debounce) clearTimeout(debounce);
-      debounce = setTimeout(() => void saveBounds(bounds), 500);
+      debounce = setTimeout(() => {
+        if (!useSettingsStore.getState().subtitleModeActive) return;
+        void saveBounds(bounds);
+      }, 500);
     };
     electronApi.receive('subtitle:window-bounds-changed', handler);
     return () => {

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -1,0 +1,176 @@
+// src/components/Subtitle/SubtitleApp.tsx
+import React, { useEffect, useState, useRef, useMemo } from 'react';
+import SubtitleBar from './SubtitleBar';
+import SubtitleStream from './SubtitleStream';
+import SubtitleSessionEnded from './SubtitleSessionEnded';
+import {
+  useSubtitleSettings,
+  useExitSubtitleMode,
+  useSaveSubtitleWindowBounds,
+  useSpeakerDisplayMode,
+  useParticipantDisplayMode,
+  useProvider,
+  useGetCurrentProviderSettings,
+  useLocalInferenceSettings,
+} from '../../stores/settingsStore';
+import {
+  useIsSessionActive,
+  useSessionStartTime,
+  useItems,
+  useSystemAudioItems,
+} from '../../stores/sessionStore';
+import type { ConversationItem } from '../../services/interfaces/IClient';
+import './SubtitleApp.scss';
+
+const AUTO_HIDE_MS = 1500;
+
+function languageCodeShort(longCode: string | undefined): string {
+  if (!longCode) return '?';
+  return longCode.slice(0, 2).toUpperCase();
+}
+
+function hexToRgba(hex: string, alpha: number): string {
+  const m = /^#?([a-fA-F0-9]{6})$/.exec(hex);
+  if (!m) return `rgba(0,0,0,${alpha})`;
+  const v = parseInt(m[1], 16);
+  const r = (v >> 16) & 0xff;
+  const g = (v >> 8) & 0xff;
+  const b = v & 0xff;
+  return `rgba(${r},${g},${b},${alpha})`;
+}
+
+const SubtitleApp: React.FC = () => {
+  const subtitle = useSubtitleSettings();
+  const exitSubtitleMode = useExitSubtitleMode();
+  const saveBounds = useSaveSubtitleWindowBounds();
+  const items = useItems();
+  const systemAudioItems = useSystemAudioItems();
+  const speakerMode = useSpeakerDisplayMode();
+  const participantMode = useParticipantDisplayMode();
+  const provider = useProvider();
+  const getCurrentProviderSettings = useGetCurrentProviderSettings();
+  const localInferenceSettings = useLocalInferenceSettings();
+  const isSessionActive = useIsSessionActive();
+  const sessionStartTime = useSessionStartTime();
+
+  const providerSettings = useMemo(
+    () => getCurrentProviderSettings(),
+    [getCurrentProviderSettings, provider],
+  );
+  const sourceLanguage: string = (providerSettings as any)?.sourceLanguage ?? 'en';
+  const targetLanguage: string = (providerSettings as any)?.targetLanguage ?? 'zh';
+
+  // Combine items with source tagging (mirrors MainPanel's logic, simplified)
+  const combinedItems = useMemo(() => {
+    const tagSpeaker = (item: ConversationItem) =>
+      ({ ...item, source: item.source ?? 'speaker', sourceLanguage, targetLanguage }) as any;
+    const tagParticipant = (item: ConversationItem) =>
+      ({ ...item, source: item.source ?? 'participant', sourceLanguage, targetLanguage }) as any;
+    const all = [
+      ...items.map(tagSpeaker),
+      ...systemAudioItems.map(tagParticipant),
+    ];
+    return all.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
+  }, [items, systemAudioItems, sourceLanguage, targetLanguage]);
+
+  // Session timer
+  const [now, setNow] = useState(Date.now());
+  useEffect(() => {
+    if (!isSessionActive) return;
+    const t = setInterval(() => setNow(Date.now()), 1000);
+    return () => clearInterval(t);
+  }, [isSessionActive]);
+  const elapsedMs = isSessionActive && sessionStartTime ? now - sessionStartTime : 0;
+
+  // Auto-hide bar
+  const [barVisible, setBarVisible] = useState(true);
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onMouseEnter = () => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    setBarVisible(true);
+  };
+  const onMouseLeave = () => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+    hideTimer.current = setTimeout(() => setBarVisible(false), AUTO_HIDE_MS);
+  };
+
+  // ESC to exit subtitle mode
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') void exitSubtitleMode();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [exitSubtitleMode]);
+
+  // Bounds-changed listener (debounced 500 ms before persistence)
+  useEffect(() => {
+    const electronApi = (window as any).electron;
+    if (!electronApi?.receive) return;
+    let debounce: ReturnType<typeof setTimeout> | null = null;
+    const handler = (bounds: { x: number; y: number; width: number; height: number }) => {
+      if (debounce) clearTimeout(debounce);
+      debounce = setTimeout(() => void saveBounds(bounds), 500);
+    };
+    electronApi.receive('subtitle:window-bounds-changed', handler);
+    return () => {
+      if (debounce) clearTimeout(debounce);
+      electronApi.removeListener?.('subtitle:window-bounds-changed', handler);
+    };
+  }, [saveBounds]);
+
+  // Detect whether participant has produced any items
+  const participantHasAudio = systemAudioItems.length > 0;
+
+  // Build CSS variables for background
+  const bgAlpha = subtitle.bgOpacity / 100;
+  const rootStyle: React.CSSProperties = {
+    background: hexToRgba(subtitle.bgColor, bgAlpha),
+    ['--bar-opacity' as any]: barVisible ? 1 : 0,
+  };
+
+  return (
+    <div
+      className="subtitle-app"
+      style={rootStyle}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+    >
+      <SubtitleBar
+        sessionElapsedMs={elapsedMs}
+        sourceLanguageCode={languageCodeShort(sourceLanguage)}
+        targetLanguageCode={languageCodeShort(targetLanguage)}
+        onClearConversation={() => {
+          // TODO(subtitle v2): wire to a store-level clearConversation action;
+          // currently a no-op because MainPanel owns the clear logic.
+        }}
+        participantHasAudio={participantHasAudio}
+        exportProps={{
+          combinedItems,
+          provider,
+          currentProviderSettings: providerSettings,
+          localInferenceSettings,
+          sourceLanguage,
+          targetLanguage,
+        }}
+      />
+      {isSessionActive ? (
+        <SubtitleStream
+          items={combinedItems}
+          compact={subtitle.compactMode}
+          fontSize={subtitle.fontSize}
+          speakerMode={speakerMode}
+          participantMode={participantMode}
+          sourceLanguage={sourceLanguage}
+          targetLanguage={targetLanguage}
+          sourceTextColor={subtitle.sourceTextColor}
+          translationTextColor={subtitle.translationTextColor}
+        />
+      ) : (
+        <SubtitleSessionEnded onReturn={() => void exitSubtitleMode()} />
+      )}
+    </div>
+  );
+};
+
+export default SubtitleApp;

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -144,6 +144,7 @@ const SubtitleApp: React.FC = () => {
   const rootStyle: React.CSSProperties = {
     background: hexToRgba(subtitle.bgColor, bgAlpha),
     ['--bar-opacity' as any]: barVisible ? 1 : 0,
+    ['--bar-pointer-events' as any]: barVisible ? 'auto' : 'none',
   };
 
   return (

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -20,6 +20,7 @@ import {
   useSessionStartTime,
   useItems,
   useSystemAudioItems,
+  useRequestClearConversation,
 } from '../../stores/sessionStore';
 import type { ConversationItem } from '../../services/interfaces/IClient';
 import './SubtitleApp.scss';
@@ -56,6 +57,7 @@ const SubtitleApp: React.FC = () => {
   const isSessionActive = useIsSessionActive();
   const sessionStartTime = useSessionStartTime();
   const turnDetectionMode = useCurrentTurnDetectionMode();
+  const requestClearConversation = useRequestClearConversation();
   // Mirrors isPttLikeMode in MainPanel — modes that send audio only while
   // the user holds Space.
   const canHoldToSpeak =
@@ -158,10 +160,7 @@ const SubtitleApp: React.FC = () => {
         sessionElapsedMs={elapsedMs}
         sourceLanguageCode={languageCodeShort(sourceLanguage)}
         targetLanguageCode={languageCodeShort(targetLanguage)}
-        onClearConversation={() => {
-          // TODO(subtitle v2): wire to a store-level clearConversation action;
-          // currently a no-op because MainPanel owns the clear logic.
-        }}
+        onClearConversation={requestClearConversation}
         participantHasAudio={participantHasAudio}
         exportProps={{
           combinedItems,

--- a/src/components/Subtitle/SubtitleBar.scss
+++ b/src/components/Subtitle/SubtitleBar.scss
@@ -1,5 +1,14 @@
 // src/components/Subtitle/SubtitleBar.scss
 .subtitle-bar {
+  // Float above the subtitle area instead of pinning to the top of the
+  // flex column. This frees up the 36 px the bar used to reserve so the
+  // subtitle text fills the whole window when the bar is auto-hidden.
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -12,6 +21,10 @@
   flex-shrink: 0;
   opacity: var(--bar-opacity, 1);
   transition: opacity 200ms ease-in-out;
+  // When the bar is fading out / hidden, let clicks pass through to the
+  // subtitle area underneath. SubtitleApp toggles --bar-pointer-events
+  // alongside --bar-opacity.
+  pointer-events: var(--bar-pointer-events, auto);
 
   &.locked {
     -webkit-app-region: no-drag;

--- a/src/components/Subtitle/SubtitleBar.scss
+++ b/src/components/Subtitle/SubtitleBar.scss
@@ -1,0 +1,81 @@
+// src/components/Subtitle/SubtitleBar.scss
+.subtitle-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 36px;
+  padding: 0 12px;
+  background: rgba(20, 20, 20, 0.95);
+  color: #e8e8e8;
+  -webkit-app-region: drag;
+  font-size: 12px;
+  flex-shrink: 0;
+  opacity: var(--bar-opacity, 1);
+  transition: opacity 200ms ease-in-out;
+
+  &.locked {
+    -webkit-app-region: no-drag;
+  }
+
+  .subtitle-bar__left,
+  .subtitle-bar__center,
+  .subtitle-bar__right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    -webkit-app-region: no-drag;
+  }
+
+  .subtitle-bar__logo {
+    font-weight: 600;
+    color: #10a37f;
+  }
+
+  .subtitle-bar__quota {
+    color: #9aa0a6;
+    font-size: 11px;
+  }
+
+  .subtitle-bar__timer {
+    font-family: monospace;
+    font-size: 13px;
+  }
+
+  .subtitle-bar__lang {
+    color: #c8c8c8;
+    font-weight: 500;
+  }
+
+  .subtitle-bar__btn {
+    background: transparent;
+    border: none;
+    color: #c8c8c8;
+    cursor: pointer;
+    padding: 4px;
+    border-radius: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    &.active {
+      color: #10a37f;
+      background: rgba(16, 163, 127, 0.15);
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
+  .subtitle-bar__divider {
+    width: 1px;
+    height: 18px;
+    background: #3a3a3a;
+    margin: 0 4px;
+  }
+}

--- a/src/components/Subtitle/SubtitleBar.scss
+++ b/src/components/Subtitle/SubtitleBar.scss
@@ -85,6 +85,25 @@
     }
   }
 
+  // Unify reused MainPanel buttons (DisplayModeButton, ExportButton) with
+  // our own .subtitle-bar__btn. Their own SCSS (color: #555) is tuned for
+  // MainPanel's lighter toolbar; on the subtitle bar's near-black bg it's
+  // nearly invisible. Scoping the override here keeps MainPanel untouched.
+  .display-mode-btn,
+  .export-btn {
+    color: #c8c8c8;
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.08);
+      color: #c8c8c8;
+    }
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+  }
+
   .subtitle-bar__divider {
     width: 1px;
     height: 18px;

--- a/src/components/Subtitle/SubtitleBar.scss
+++ b/src/components/Subtitle/SubtitleBar.scss
@@ -36,7 +36,10 @@
     display: flex;
     align-items: center;
     gap: 8px;
-    -webkit-app-region: no-drag;
+    // Non-interactive areas inside segments (logo, timer, lang label,
+    // dividers) stay in the drag region so the user can grab almost any
+    // visible part of the bar to move the window. Interactive elements
+    // below opt out individually with -webkit-app-region: no-drag.
   }
 
   .subtitle-bar__logo {
@@ -69,6 +72,7 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    -webkit-app-region: no-drag;
 
     &:hover {
       background: rgba(255, 255, 255, 0.08);
@@ -89,9 +93,12 @@
   // our own .subtitle-bar__btn. Their own SCSS (color: #555) is tuned for
   // MainPanel's lighter toolbar; on the subtitle bar's near-black bg it's
   // nearly invisible. Scoping the override here keeps MainPanel untouched.
+  // Both classes also opt out of the bar's drag region so clicks land
+  // on the button rather than starting a window-drag.
   .display-mode-btn,
   .export-btn {
     color: #c8c8c8;
+    -webkit-app-region: no-drag;
 
     &:hover:not(:disabled) {
       background: rgba(255, 255, 255, 0.08);

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -1,0 +1,187 @@
+// src/components/Subtitle/SubtitleBar.tsx
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown,
+  Pin, Lock, X, Settings, Trash2,
+} from 'lucide-react';
+import {
+  useFloating, useClick, useDismiss, useInteractions, offset, flip, FloatingPortal,
+} from '@floating-ui/react';
+import DisplayModeButton from '../MainPanel/DisplayModeButton';
+import ExportButton from '../MainPanel/ExportButton';
+import {
+  useSubtitleSettings,
+  useSetSubtitleFontSize,
+  useSetSubtitleCompactMode,
+  useToggleSubtitleAlwaysOnTop,
+  useToggleSubtitlePositionLocked,
+  useSpeakerDisplayMode,
+  useParticipantDisplayMode,
+  useSetSpeakerDisplayMode,
+  useSetParticipantDisplayMode,
+  useExitSubtitleMode,
+} from '../../stores/settingsStore';
+import SubtitleSettingsPopover from './SubtitleSettingsPopover';
+import './SubtitleBar.scss';
+
+interface Props {
+  sessionElapsedMs: number;
+  sourceLanguageCode: string;
+  targetLanguageCode: string;
+  onClearConversation: () => void;
+  participantHasAudio: boolean;
+  exportProps: React.ComponentProps<typeof ExportButton>;
+}
+
+function formatElapsed(ms: number): string {
+  const totalSec = Math.floor(ms / 1000);
+  const hh = String(Math.floor(totalSec / 3600)).padStart(2, '0');
+  const mm = String(Math.floor((totalSec % 3600) / 60)).padStart(2, '0');
+  const ss = String(totalSec % 60).padStart(2, '0');
+  return `${hh}:${mm}:${ss}`;
+}
+
+const SubtitleBar: React.FC<Props> = ({
+  sessionElapsedMs,
+  sourceLanguageCode,
+  targetLanguageCode,
+  onClearConversation,
+  participantHasAudio,
+  exportProps,
+}) => {
+  const { t } = useTranslation();
+  const subtitle = useSubtitleSettings();
+  const setFontSize = useSetSubtitleFontSize();
+  const setCompactMode = useSetSubtitleCompactMode();
+  const toggleAlwaysOnTop = useToggleSubtitleAlwaysOnTop();
+  const togglePositionLocked = useToggleSubtitlePositionLocked();
+  const speakerMode = useSpeakerDisplayMode();
+  const participantMode = useParticipantDisplayMode();
+  const setSpeakerMode = useSetSpeakerDisplayMode();
+  const setParticipantMode = useSetParticipantDisplayMode();
+  const exitSubtitleMode = useExitSubtitleMode();
+
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const { refs, floatingStyles, context } = useFloating({
+    open: popoverOpen,
+    onOpenChange: setPopoverOpen,
+    placement: 'bottom-end',
+    middleware: [offset(8), flip()],
+  });
+  const click = useClick(context);
+  const dismiss = useDismiss(context);
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+
+  return (
+    <div className={`subtitle-bar ${subtitle.positionLocked ? 'locked' : ''}`} role="toolbar">
+      <div className="subtitle-bar__left">
+        <span className="subtitle-bar__logo">Sokuji</span>
+        <span className="subtitle-bar__quota" />
+      </div>
+
+      <div className="subtitle-bar__center">
+        <span className="subtitle-bar__timer">{formatElapsed(sessionElapsedMs)}</span>
+        <span className="subtitle-bar__lang">
+          {sourceLanguageCode} → {targetLanguageCode}
+        </span>
+      </div>
+
+      <div className="subtitle-bar__right">
+        <DisplayModeButton scope="speaker" value={speakerMode} onChange={setSpeakerMode} />
+        {participantHasAudio && (
+          <DisplayModeButton scope="participant" value={participantMode} onChange={setParticipantMode} />
+        )}
+        <button
+          type="button"
+          className="subtitle-bar__btn"
+          onClick={() => setFontSize(subtitle.fontSize - 2)}
+          disabled={subtitle.fontSize <= 16}
+          title={t('subtitle.bar.fontDecrease', 'Decrease font size')}
+          aria-label={t('subtitle.bar.fontDecrease', 'Decrease font size')}
+        >
+          <AArrowDown size={14} />
+        </button>
+        <button
+          type="button"
+          className="subtitle-bar__btn"
+          onClick={() => setFontSize(subtitle.fontSize + 2)}
+          disabled={subtitle.fontSize >= 48}
+          title={t('subtitle.bar.fontIncrease', 'Increase font size')}
+          aria-label={t('subtitle.bar.fontIncrease', 'Increase font size')}
+        >
+          <AArrowUp size={14} />
+        </button>
+        <button
+          type="button"
+          className="subtitle-bar__btn"
+          onClick={() => setCompactMode(!subtitle.compactMode)}
+          title={subtitle.compactMode ? t('subtitle.bar.expand', 'Expanded view') : t('subtitle.bar.compact', 'Compact view')}
+          aria-label={subtitle.compactMode ? t('subtitle.bar.expand', 'Expanded view') : t('subtitle.bar.compact', 'Compact view')}
+        >
+          {subtitle.compactMode ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
+        </button>
+        <ExportButton {...exportProps} />
+        <button
+          type="button"
+          className="subtitle-bar__btn"
+          onClick={onClearConversation}
+          title={t('subtitle.bar.clear', 'Clear conversation')}
+          aria-label={t('subtitle.bar.clear', 'Clear conversation')}
+        >
+          <Trash2 size={14} />
+        </button>
+
+        <span className="subtitle-bar__divider" />
+
+        <button
+          type="button"
+          className="subtitle-bar__btn"
+          ref={refs.setReference}
+          {...getReferenceProps()}
+          title={t('subtitle.bar.settings', 'Subtitle settings')}
+          aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
+        >
+          <Settings size={14} />
+        </button>
+        <button
+          type="button"
+          className={`subtitle-bar__btn ${subtitle.alwaysOnTop ? 'active' : ''}`}
+          onClick={toggleAlwaysOnTop}
+          title={t('subtitle.bar.alwaysOnTop', 'Always on top')}
+          aria-label={t('subtitle.bar.alwaysOnTop', 'Always on top')}
+        >
+          <Pin size={14} />
+        </button>
+        <button
+          type="button"
+          className={`subtitle-bar__btn ${subtitle.positionLocked ? 'active' : ''}`}
+          onClick={togglePositionLocked}
+          title={t('subtitle.bar.lock', 'Lock position and size')}
+          aria-label={t('subtitle.bar.lock', 'Lock position and size')}
+        >
+          <Lock size={14} />
+        </button>
+        <button
+          type="button"
+          className="subtitle-bar__btn"
+          onClick={() => void exitSubtitleMode()}
+          title={t('subtitle.bar.exit', 'Exit subtitle mode')}
+          aria-label={t('subtitle.bar.exit', 'Exit subtitle mode')}
+        >
+          <X size={14} />
+        </button>
+      </div>
+
+      {popoverOpen && (
+        <FloatingPortal>
+          <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+            <SubtitleSettingsPopover />
+          </div>
+        </FloatingPortal>
+      )}
+    </div>
+  );
+};
+
+export default SubtitleBar;

--- a/src/components/Subtitle/SubtitleEnterButton.tsx
+++ b/src/components/Subtitle/SubtitleEnterButton.tsx
@@ -12,20 +12,22 @@ const SubtitleEnterButton: React.FC = () => {
 
   if (!isElectron()) return null;
 
+  const label = t('subtitle.enterButton.label', 'Subtitle');
+  const tooltip = isSessionActive
+    ? t('subtitle.enterButton.title', 'Enter subtitle mode')
+    : t('subtitle.enterButton.disabled', 'Start a session first');
+
   return (
     <button
       type="button"
-      className="font-size-btn"
+      className="title-bar__action"
       onClick={() => void enterSubtitleMode()}
       disabled={!isSessionActive}
-      title={
-        isSessionActive
-          ? t('subtitle.enterButton.title', 'Enter subtitle mode')
-          : t('subtitle.enterButton.disabled', 'Start a session first')
-      }
-      aria-label={t('subtitle.enterButton.title', 'Enter subtitle mode')}
+      title={tooltip}
+      aria-label={tooltip}
     >
       <Captions size={14} />
+      <span className="title-bar__action-label">{label}</span>
     </button>
   );
 };

--- a/src/components/Subtitle/SubtitleEnterButton.tsx
+++ b/src/components/Subtitle/SubtitleEnterButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { Captions } from 'lucide-react';
+import { useIsSessionActive } from '../../stores/sessionStore';
+import { useEnterSubtitleMode } from '../../stores/settingsStore';
+import { isElectron } from '../../utils/environment';
+
+const SubtitleEnterButton: React.FC = () => {
+  const { t } = useTranslation();
+  const enterSubtitleMode = useEnterSubtitleMode();
+  const isSessionActive = useIsSessionActive();
+
+  if (!isElectron()) return null;
+
+  return (
+    <button
+      type="button"
+      className="font-size-btn"
+      onClick={() => void enterSubtitleMode()}
+      disabled={!isSessionActive}
+      title={
+        isSessionActive
+          ? t('subtitle.enterButton.title', 'Enter subtitle mode')
+          : t('subtitle.enterButton.disabled', 'Start a session first')
+      }
+      aria-label={t('subtitle.enterButton.title', 'Enter subtitle mode')}
+    >
+      <Captions size={14} />
+    </button>
+  );
+};
+
+export default SubtitleEnterButton;

--- a/src/components/Subtitle/SubtitleSessionEnded.test.tsx
+++ b/src/components/Subtitle/SubtitleSessionEnded.test.tsx
@@ -1,0 +1,18 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import SubtitleSessionEnded from './SubtitleSessionEnded';
+
+describe('SubtitleSessionEnded', () => {
+  it('renders the ended message and a return button', () => {
+    render(<SubtitleSessionEnded onReturn={() => {}} />);
+    expect(screen.getByText(/session ended|会话已结束/i)).toBeTruthy();
+    expect(screen.getByRole('button')).toBeTruthy();
+  });
+
+  it('calls onReturn when the button is clicked', () => {
+    const onReturn = vi.fn();
+    render(<SubtitleSessionEnded onReturn={onReturn} />);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onReturn).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/Subtitle/SubtitleSessionEnded.tsx
+++ b/src/components/Subtitle/SubtitleSessionEnded.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+interface Props {
+  onReturn: () => void;
+}
+
+const SubtitleSessionEnded: React.FC<Props> = ({ onReturn }) => {
+  const { t } = useTranslation();
+  return (
+    <div className="subtitle-session-ended">
+      <p>{t('subtitle.sessionEnded', 'Session ended')}</p>
+      <button type="button" onClick={onReturn}>
+        {t('subtitle.backToMain', 'Return to main window')}
+      </button>
+    </div>
+  );
+};
+
+export default SubtitleSessionEnded;

--- a/src/components/Subtitle/SubtitleSettingsPopover.scss
+++ b/src/components/Subtitle/SubtitleSettingsPopover.scss
@@ -1,0 +1,42 @@
+.subtitle-settings-popover {
+  background: #1a1a1a;
+  color: #e8e8e8;
+  border: 1px solid #3a3a3a;
+  border-radius: 8px;
+  padding: 16px;
+  width: 280px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+
+  .field {
+    margin-bottom: 12px;
+
+    label {
+      display: block;
+      font-size: 12px;
+      margin-bottom: 6px;
+      color: #c8c8c8;
+    }
+
+    input[type="range"] {
+      width: 100%;
+    }
+
+    .palette {
+      display: flex;
+      gap: 6px;
+
+      .swatch {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid transparent;
+        cursor: pointer;
+        padding: 0;
+
+        &.selected {
+          border-color: #10a37f;
+        }
+      }
+    }
+  }
+}

--- a/src/components/Subtitle/SubtitleSettingsPopover.tsx
+++ b/src/components/Subtitle/SubtitleSettingsPopover.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useSubtitleSettings,
+  useSetSubtitleBgOpacity,
+  useSetSubtitleBgColor,
+  useSetSubtitleSourceTextColor,
+  useSetSubtitleTranslationTextColor,
+} from '../../stores/settingsStore';
+import './SubtitleSettingsPopover.scss';
+
+const BG_PRESETS = ['#000000', '#1a1a1a', '#0d2032', '#0f2419', '#FFFFFF', '#2a2a2a'];
+const SOURCE_PRESETS = ['#FFFFFF', '#E8E8E8', '#FFD27D', '#FFAA66', '#9aa0a6', '#FF6B6B'];
+const TRANSLATION_PRESETS = ['#6CC5FF', '#10a37f', '#FFFFFF', '#A8E6CF', '#FFB86C', '#BD93F9'];
+
+const SubtitleSettingsPopover: React.FC = () => {
+  const { t } = useTranslation();
+  const subtitle = useSubtitleSettings();
+  const setBgOpacity = useSetSubtitleBgOpacity();
+  const setBgColor = useSetSubtitleBgColor();
+  const setSourceColor = useSetSubtitleSourceTextColor();
+  const setTranslationColor = useSetSubtitleTranslationTextColor();
+
+  return (
+    <div className="subtitle-settings-popover" role="dialog">
+      <div className="field">
+        <label>{t('subtitle.settings.bgOpacity', 'Background opacity')} ({subtitle.bgOpacity}%)</label>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={subtitle.bgOpacity}
+          onChange={(e) => setBgOpacity(Number(e.target.value))}
+        />
+      </div>
+
+      <div className="field">
+        <label>{t('subtitle.settings.bgColor', 'Background color')}</label>
+        <div className="palette">
+          {BG_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              className={`swatch ${subtitle.bgColor === c ? 'selected' : ''}`}
+              style={{ background: c }}
+              onClick={() => setBgColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="field">
+        <label>{t('subtitle.settings.sourceColor', 'Source text color')}</label>
+        <div className="palette">
+          {SOURCE_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              className={`swatch ${subtitle.sourceTextColor === c ? 'selected' : ''}`}
+              style={{ background: c }}
+              onClick={() => setSourceColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="field">
+        <label>{t('subtitle.settings.translationColor', 'Translation color')}</label>
+        <div className="palette">
+          {TRANSLATION_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              className={`swatch ${subtitle.translationTextColor === c ? 'selected' : ''}`}
+              style={{ background: c }}
+              onClick={() => setTranslationColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SubtitleSettingsPopover;

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -1,0 +1,15 @@
+.subtitle-stream {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px 24px 16px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  scroll-behavior: smooth;
+
+  // Hide scrollbar; subtitle area should look clean
+  &::-webkit-scrollbar {
+    width: 0;
+    background: transparent;
+  }
+}

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -28,6 +28,12 @@
       flex-direction: column;
       justify-content: flex-end;
 
+      // Fade the top of the band so any partially-clipped character row
+      // melts into the background instead of getting cut in half. The
+      // fade height matches one line of text (line-height: 1.4em).
+      mask-image: linear-gradient(to bottom, transparent 0, black 1.4em, black 100%);
+      -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 1.4em, black 100%);
+
       p {
         margin: 0;
         line-height: 1.4;

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -12,4 +12,23 @@
     width: 0;
     background: transparent;
   }
+
+  // Compact mode: two flowing concatenated paragraphs.
+  .subtitle-stream__source,
+  .subtitle-stream__translation {
+    margin: 0;
+    line-height: 1.4;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+
+  .subtitle-stream__source {
+    color: var(--subtitle-source-color, #9aa0a6);
+    font-style: italic;
+    margin-bottom: 0.4em;
+  }
+
+  .subtitle-stream__translation {
+    color: var(--subtitle-translation-color, #e8e8e8);
+  }
 }

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -1,34 +1,66 @@
 .subtitle-stream {
   flex: 1;
-  overflow-y: auto;
+  min-height: 0;
   padding: 12px 24px 16px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-end;
   scroll-behavior: smooth;
 
-  // Hide scrollbar; subtitle area should look clean
   &::-webkit-scrollbar {
     width: 0;
     background: transparent;
   }
 
-  // Compact mode: two flowing concatenated paragraphs.
-  .subtitle-stream__source,
-  .subtitle-stream__translation {
-    margin: 0;
-    line-height: 1.4;
-    overflow-wrap: anywhere;
-    word-break: break-word;
+  // Compact mode: up to four equal-height bands (speaker source,
+  // speaker translation, participant source, participant translation).
+  // Each visible band gets flex:1 so they share the height evenly. Long
+  // content inside a band clips to the bottom — the newest text stays
+  // pinned to the band's bottom edge and the top is hidden by overflow.
+  &.compact {
+    overflow: hidden;
+    gap: 8px;
+
+    .subtitle-stream__line {
+      flex: 1 1 0;
+      min-height: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      justify-content: flex-end;
+
+      p {
+        margin: 0;
+        line-height: 1.4;
+        overflow-wrap: anywhere;
+        word-break: break-word;
+      }
+    }
+
+    .subtitle-stream__line--source p {
+      color: var(--subtitle-source-color, #9aa0a6);
+      font-style: italic;
+    }
+
+    .subtitle-stream__line--translation p {
+      color: var(--subtitle-translation-color, #e8e8e8);
+    }
+
+    // Subtle visual marker so users can tell speaker vs participant
+    // apart when both are on screen.
+    .subtitle-stream__line--participant {
+      padding-left: 6px;
+      border-left: 2px solid rgba(243, 156, 18, 0.6);
+    }
+    .subtitle-stream__line--speaker {
+      padding-left: 6px;
+      border-left: 2px solid rgba(16, 163, 127, 0.6);
+    }
   }
 
-  .subtitle-stream__source {
-    color: var(--subtitle-source-color, #9aa0a6);
-    font-style: italic;
-    margin-bottom: 0.4em;
-  }
-
-  .subtitle-stream__translation {
-    color: var(--subtitle-translation-color, #e8e8e8);
+  // Expanded mode: ConversationRow drives its own layout; we just provide
+  // the scroll container.
+  &.expanded {
+    overflow-y: auto;
+    justify-content: flex-end;
   }
 }

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -38,7 +38,6 @@
         margin: 0;
         line-height: 1.4;
         overflow-wrap: anywhere;
-        word-break: break-word;
       }
     }
 

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -91,6 +91,26 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
     expect(speakerSrc.textContent).toBe('hello world');
   });
 
+  it('routes error / system items into the translation bucket so they remain visible', () => {
+    const withError: any[] = [
+      ...items,
+      { id: 'e1', source: 'speaker', role: 'system', type: 'error', status: 'completed', formatted: { text: '[error] connection lost' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    const { container } = render(
+      <SubtitleStream
+        items={withError}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const speakerTr = container.querySelector('.subtitle-stream__line--speaker.subtitle-stream__line--translation p')!;
+    expect(speakerTr.textContent).toContain('[error] connection lost');
+  });
+
   it('applies fontSize and color CSS variables', () => {
     const { container } = render(
       <SubtitleStream

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -15,8 +15,8 @@ const items: any[] = [
   { id: '4', source: 'participant', role: 'assistant', type: 'message', status: 'completed', formatted: { text: 'goodbye' },  sourceLanguage: 'en', targetLanguage: 'zh' },
 ];
 
-describe('SubtitleStream', () => {
-  it('renders all 4 rows when both display modes are "both"', () => {
+describe('SubtitleStream — compact mode (flat two-line)', () => {
+  it('concatenates user items into the source line and assistant items into the translation line', () => {
     const { container } = render(
       <SubtitleStream
         items={items}
@@ -28,10 +28,13 @@ describe('SubtitleStream', () => {
         targetLanguage="zh"
       />,
     );
-    expect(container.querySelectorAll('.conversation-row').length).toBe(4);
+    const source = container.querySelector('.subtitle-stream__source')!;
+    const translation = container.querySelector('.subtitle-stream__translation')!;
+    expect(source.textContent).toBe('hello 再见');
+    expect(translation.textContent).toBe('你好 goodbye');
   });
 
-  it('hides participant assistant when participantMode is "source"', () => {
+  it('respects participantMode="source": drops participant assistant from translation line', () => {
     const { container } = render(
       <SubtitleStream
         items={items}
@@ -43,8 +46,9 @@ describe('SubtitleStream', () => {
         targetLanguage="zh"
       />,
     );
-    // 4 rows - 1 (participant assistant) = 3
-    expect(container.querySelectorAll('.conversation-row').length).toBe(3);
+    const translation = container.querySelector('.subtitle-stream__translation')!;
+    // participant assistant ('goodbye') hidden; only speaker assistant remains
+    expect(translation.textContent).toBe('你好');
   });
 
   it('applies fontSize and color CSS variables', () => {
@@ -65,5 +69,26 @@ describe('SubtitleStream', () => {
     expect(root.style.fontSize).toBe('36px');
     expect(root.style.getPropertyValue('--subtitle-source-color')).toBe('#FF0000');
     expect(root.style.getPropertyValue('--subtitle-translation-color')).toBe('#00FF00');
+    // Also propagates to the var ConversationRow reads in expanded mode
+    expect(root.style.getPropertyValue('--conversation-font-size')).toBe('36px');
+  });
+});
+
+describe('SubtitleStream — expanded mode (per-item rows)', () => {
+  it('renders one ConversationRow per visible item, no flat lines', () => {
+    const { container } = render(
+      <SubtitleStream
+        items={items}
+        compact={false}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelectorAll('.conversation-row').length).toBe(4);
+    expect(container.querySelector('.subtitle-stream__source')).toBeNull();
+    expect(container.querySelector('.subtitle-stream__translation')).toBeNull();
   });
 });

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import SubtitleStream from './SubtitleStream';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+const items: any[] = [
+  { id: '1', source: 'speaker',     role: 'user',      type: 'message', status: 'completed', formatted: { text: 'hello' },   sourceLanguage: 'en', targetLanguage: 'zh' },
+  { id: '2', source: 'speaker',     role: 'assistant', type: 'message', status: 'completed', formatted: { text: '你好' },     sourceLanguage: 'en', targetLanguage: 'zh' },
+  { id: '3', source: 'participant', role: 'user',      type: 'message', status: 'completed', formatted: { text: '再见' },    sourceLanguage: 'en', targetLanguage: 'zh' },
+  { id: '4', source: 'participant', role: 'assistant', type: 'message', status: 'completed', formatted: { text: 'goodbye' },  sourceLanguage: 'en', targetLanguage: 'zh' },
+];
+
+describe('SubtitleStream', () => {
+  it('renders all 4 rows when both display modes are "both"', () => {
+    const { container } = render(
+      <SubtitleStream
+        items={items}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelectorAll('.conversation-row').length).toBe(4);
+  });
+
+  it('hides participant assistant when participantMode is "source"', () => {
+    const { container } = render(
+      <SubtitleStream
+        items={items}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="source"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    // 4 rows - 1 (participant assistant) = 3
+    expect(container.querySelectorAll('.conversation-row').length).toBe(3);
+  });
+
+  it('applies fontSize and color CSS variables', () => {
+    const { container } = render(
+      <SubtitleStream
+        items={items}
+        compact
+        fontSize={36}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+        sourceTextColor="#FF0000"
+        translationTextColor="#00FF00"
+      />,
+    );
+    const root = container.querySelector('.subtitle-stream') as HTMLElement;
+    expect(root.style.fontSize).toBe('36px');
+    expect(root.style.getPropertyValue('--subtitle-source-color')).toBe('#FF0000');
+    expect(root.style.getPropertyValue('--subtitle-translation-color')).toBe('#00FF00');
+  });
+});

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -15,8 +15,8 @@ const items: any[] = [
   { id: '4', source: 'participant', role: 'assistant', type: 'message', status: 'completed', formatted: { text: 'goodbye' },  sourceLanguage: 'en', targetLanguage: 'zh' },
 ];
 
-describe('SubtitleStream — compact mode (flat two-line)', () => {
-  it('concatenates user items into the source line and assistant items into the translation line', () => {
+describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
+  it('renders four lines (speaker src/tr, participant src/tr) when all are present', () => {
     const { container } = render(
       <SubtitleStream
         items={items}
@@ -28,13 +28,15 @@ describe('SubtitleStream — compact mode (flat two-line)', () => {
         targetLanguage="zh"
       />,
     );
-    const source = container.querySelector('.subtitle-stream__source')!;
-    const translation = container.querySelector('.subtitle-stream__translation')!;
-    expect(source.textContent).toBe('hello 再见');
-    expect(translation.textContent).toBe('你好 goodbye');
+    const lines = container.querySelectorAll('.subtitle-stream__line');
+    expect(lines.length).toBe(4);
+    expect(container.querySelector('.subtitle-stream__line--speaker.subtitle-stream__line--source p')!.textContent).toBe('hello');
+    expect(container.querySelector('.subtitle-stream__line--speaker.subtitle-stream__line--translation p')!.textContent).toBe('你好');
+    expect(container.querySelector('.subtitle-stream__line--participant.subtitle-stream__line--source p')!.textContent).toBe('再见');
+    expect(container.querySelector('.subtitle-stream__line--participant.subtitle-stream__line--translation p')!.textContent).toBe('goodbye');
   });
 
-  it('respects participantMode="source": drops participant assistant from translation line', () => {
+  it('drops the participant-translation line when participantMode is "source"', () => {
     const { container } = render(
       <SubtitleStream
         items={items}
@@ -46,9 +48,47 @@ describe('SubtitleStream — compact mode (flat two-line)', () => {
         targetLanguage="zh"
       />,
     );
-    const translation = container.querySelector('.subtitle-stream__translation')!;
-    // participant assistant ('goodbye') hidden; only speaker assistant remains
-    expect(translation.textContent).toBe('你好');
+    const lines = container.querySelectorAll('.subtitle-stream__line');
+    expect(lines.length).toBe(3);
+    expect(container.querySelector('.subtitle-stream__line--participant.subtitle-stream__line--translation')).toBeNull();
+  });
+
+  it('renders only speaker lines when there are no participant items', () => {
+    const speakerOnly = items.filter((i) => i.source === 'speaker');
+    const { container } = render(
+      <SubtitleStream
+        items={speakerOnly}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const lines = container.querySelectorAll('.subtitle-stream__line');
+    expect(lines.length).toBe(2);
+    expect(container.querySelector('.subtitle-stream__line--participant')).toBeNull();
+  });
+
+  it('concatenates multiple items in the same bucket (chronological order)', () => {
+    const many: any[] = [
+      ...items,
+      { id: '5', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'world' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    const { container } = render(
+      <SubtitleStream
+        items={many}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const speakerSrc = container.querySelector('.subtitle-stream__line--speaker.subtitle-stream__line--source p')!;
+    expect(speakerSrc.textContent).toBe('hello world');
   });
 
   it('applies fontSize and color CSS variables', () => {
@@ -69,13 +109,12 @@ describe('SubtitleStream — compact mode (flat two-line)', () => {
     expect(root.style.fontSize).toBe('36px');
     expect(root.style.getPropertyValue('--subtitle-source-color')).toBe('#FF0000');
     expect(root.style.getPropertyValue('--subtitle-translation-color')).toBe('#00FF00');
-    // Also propagates to the var ConversationRow reads in expanded mode
     expect(root.style.getPropertyValue('--conversation-font-size')).toBe('36px');
   });
 });
 
 describe('SubtitleStream — expanded mode (per-item rows)', () => {
-  it('renders one ConversationRow per visible item, no flat lines', () => {
+  it('renders one ConversationRow per visible item, no compact lines', () => {
     const { container } = render(
       <SubtitleStream
         items={items}
@@ -88,7 +127,6 @@ describe('SubtitleStream — expanded mode (per-item rows)', () => {
       />,
     );
     expect(container.querySelectorAll('.conversation-row').length).toBe(4);
-    expect(container.querySelector('.subtitle-stream__source')).toBeNull();
-    expect(container.querySelector('.subtitle-stream__translation')).toBeNull();
+    expect(container.querySelector('.subtitle-stream__line')).toBeNull();
   });
 });

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -16,6 +16,23 @@ interface Props {
   translationTextColor?: string;
 }
 
+function itemText(item: any): string {
+  return item?.formatted?.transcript || item?.formatted?.text || '';
+}
+
+/**
+ * Subtitle stream has two display modes driven by `compact`:
+ *
+ * - compact (default for subtitle mode) — renders the conversation as two
+ *   flowing lines: every visible role=user item concatenated into a single
+ *   source-language paragraph, and every visible role=assistant item
+ *   concatenated into a single translation paragraph. This is the classic
+ *   floating-subtitle look.
+ *
+ * - expanded — falls back to per-item bubbles via ConversationRow with its
+ *   full layout (avatar, role label, language badge), suitable for users
+ *   who want to read the conversation as a log rather than a stream.
+ */
 const SubtitleStream: React.FC<Props> = ({
   items,
   compact,
@@ -32,34 +49,63 @@ const SubtitleStream: React.FC<Props> = ({
     [items, speakerMode, participantMode],
   );
 
+  const { sourceText, translationText } = useMemo(() => {
+    const sourceParts: string[] = [];
+    const translationParts: string[] = [];
+    for (const item of filtered) {
+      const text = itemText(item).trim();
+      if (!text) continue;
+      if (item.role === 'user') sourceParts.push(text);
+      else if (item.role === 'assistant') translationParts.push(text);
+    }
+    return {
+      sourceText: sourceParts.join(' '),
+      translationText: translationParts.join(' '),
+    };
+  }, [filtered]);
+
   const endRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
     if (endRef.current && typeof endRef.current.scrollIntoView === 'function') {
       endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }
-  }, [filtered.length]);
+  }, [compact, sourceText.length, translationText.length, filtered.length]);
 
+  // Apply fontSize to both our flat-line styles and the CSS var that
+  // ConversationRow reads in expanded mode.
   const style: React.CSSProperties & Record<string, string> = {
     fontSize: `${fontSize}px`,
+    '--conversation-font-size': `${fontSize}px`,
   };
   if (sourceTextColor) style['--subtitle-source-color'] = sourceTextColor;
   if (translationTextColor) style['--subtitle-translation-color'] = translationTextColor;
 
   return (
     <div className="subtitle-stream" style={style}>
-      {filtered.map((item, i) => (
-        <ConversationRow
-          key={item.id}
-          item={item}
-          prevItem={filtered[i - 1] ?? null}
-          compact={compact}
-          sourceLanguage={sourceLanguage}
-          targetLanguage={targetLanguage}
-          isPlaying={false}
-          highlightedChars={0}
-          canPlay={false}
-        />
-      ))}
+      {compact ? (
+        <>
+          {sourceText && (
+            <p className="subtitle-stream__source">{sourceText}</p>
+          )}
+          {translationText && (
+            <p className="subtitle-stream__translation">{translationText}</p>
+          )}
+        </>
+      ) : (
+        filtered.map((item, i) => (
+          <ConversationRow
+            key={item.id}
+            item={item}
+            prevItem={filtered[i - 1] ?? null}
+            compact={false}
+            sourceLanguage={sourceLanguage}
+            targetLanguage={targetLanguage}
+            isPlaying={false}
+            highlightedChars={0}
+            canPlay={false}
+          />
+        ))
+      )}
       <div ref={endRef} />
     </div>
   );

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -1,0 +1,68 @@
+import React, { useEffect, useRef, useMemo } from 'react';
+import ConversationRow from '../MainPanel/ConversationRow';
+import { shouldShowItem } from '../MainPanel/conversationFilter';
+import type { DisplayMode } from '../../stores/settingsStore';
+import './SubtitleStream.scss';
+
+interface Props {
+  items: any[];
+  compact: boolean;
+  fontSize: number;
+  speakerMode: DisplayMode;
+  participantMode: DisplayMode;
+  sourceLanguage: string;
+  targetLanguage: string;
+  sourceTextColor?: string;
+  translationTextColor?: string;
+}
+
+const SubtitleStream: React.FC<Props> = ({
+  items,
+  compact,
+  fontSize,
+  speakerMode,
+  participantMode,
+  sourceLanguage,
+  targetLanguage,
+  sourceTextColor,
+  translationTextColor,
+}) => {
+  const filtered = useMemo(
+    () => items.filter((item) => shouldShowItem(item, speakerMode, participantMode)),
+    [items, speakerMode, participantMode],
+  );
+
+  const endRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (endRef.current && typeof endRef.current.scrollIntoView === 'function') {
+      endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
+    }
+  }, [filtered.length]);
+
+  const style: React.CSSProperties & Record<string, string> = {
+    fontSize: `${fontSize}px`,
+  };
+  if (sourceTextColor) style['--subtitle-source-color'] = sourceTextColor;
+  if (translationTextColor) style['--subtitle-translation-color'] = translationTextColor;
+
+  return (
+    <div className="subtitle-stream" style={style}>
+      {filtered.map((item, i) => (
+        <ConversationRow
+          key={item.id}
+          item={item}
+          prevItem={filtered[i - 1] ?? null}
+          compact={compact}
+          sourceLanguage={sourceLanguage}
+          targetLanguage={targetLanguage}
+          isPlaying={false}
+          highlightedChars={0}
+          canPlay={false}
+        />
+      ))}
+      <div ref={endRef} />
+    </div>
+  );
+};
+
+export default SubtitleStream;

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -20,18 +20,29 @@ function itemText(item: any): string {
   return item?.formatted?.transcript || item?.formatted?.text || '';
 }
 
+type LineKind = 'source' | 'translation';
+type LineSource = 'speaker' | 'participant';
+interface SubtitleLine {
+  id: string;
+  kind: LineKind;
+  source: LineSource;
+  text: string;
+}
+
 /**
  * Subtitle stream has two display modes driven by `compact`:
  *
- * - compact (default for subtitle mode) — renders the conversation as two
- *   flowing lines: every visible role=user item concatenated into a single
- *   source-language paragraph, and every visible role=assistant item
- *   concatenated into a single translation paragraph. This is the classic
- *   floating-subtitle look.
+ * - compact (default) — renders up to four flowing lines: speaker source,
+ *   speaker translation, participant source, participant translation. Each
+ *   line concatenates every visible item of its category in chronological
+ *   order. Empty lines (no items, or hidden by displayMode) are dropped.
+ *   All visible lines share the available height equally; when a single
+ *   line's text is longer than its band it clips to the bottom so the
+ *   newest text stays visible without pushing other lines off-screen.
  *
- * - expanded — falls back to per-item bubbles via ConversationRow with its
- *   full layout (avatar, role label, language badge), suitable for users
- *   who want to read the conversation as a log rather than a stream.
+ * - expanded — falls back to per-item ConversationRow with its full layout
+ *   (avatar, role label, language badge), suitable for users who want to
+ *   read the conversation as a log rather than a subtitle stream.
  */
 const SubtitleStream: React.FC<Props> = ({
   items,
@@ -49,19 +60,36 @@ const SubtitleStream: React.FC<Props> = ({
     [items, speakerMode, participantMode],
   );
 
-  const { sourceText, translationText } = useMemo(() => {
-    const sourceParts: string[] = [];
-    const translationParts: string[] = [];
+  const lines = useMemo<SubtitleLine[]>(() => {
+    const buckets: Record<string, string[]> = {
+      'speaker-source': [],
+      'speaker-translation': [],
+      'participant-source': [],
+      'participant-translation': [],
+    };
     for (const item of filtered) {
       const text = itemText(item).trim();
       if (!text) continue;
-      if (item.role === 'user') sourceParts.push(text);
-      else if (item.role === 'assistant') translationParts.push(text);
+      const source: LineSource = item.source === 'participant' ? 'participant' : 'speaker';
+      const kind: LineKind | null =
+        item.role === 'user' ? 'source' : item.role === 'assistant' ? 'translation' : null;
+      if (!kind) continue;
+      buckets[`${source}-${kind}`].push(text);
     }
-    return {
-      sourceText: sourceParts.join(' '),
-      translationText: translationParts.join(' '),
-    };
+    const order: Array<{ source: LineSource; kind: LineKind }> = [
+      { source: 'speaker', kind: 'source' },
+      { source: 'speaker', kind: 'translation' },
+      { source: 'participant', kind: 'source' },
+      { source: 'participant', kind: 'translation' },
+    ];
+    return order
+      .map(({ source, kind }) => ({
+        id: `${source}-${kind}`,
+        source,
+        kind,
+        text: buckets[`${source}-${kind}`].join(' '),
+      }))
+      .filter((l) => l.text.length > 0);
   }, [filtered]);
 
   const endRef = useRef<HTMLDivElement | null>(null);
@@ -69,7 +97,7 @@ const SubtitleStream: React.FC<Props> = ({
     if (endRef.current && typeof endRef.current.scrollIntoView === 'function') {
       endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
     }
-  }, [compact, sourceText.length, translationText.length, filtered.length]);
+  }, [compact, lines, filtered.length]);
 
   // Apply fontSize to both our flat-line styles and the CSS var that
   // ConversationRow reads in expanded mode.
@@ -81,31 +109,29 @@ const SubtitleStream: React.FC<Props> = ({
   if (translationTextColor) style['--subtitle-translation-color'] = translationTextColor;
 
   return (
-    <div className="subtitle-stream" style={style}>
-      {compact ? (
-        <>
-          {sourceText && (
-            <p className="subtitle-stream__source">{sourceText}</p>
-          )}
-          {translationText && (
-            <p className="subtitle-stream__translation">{translationText}</p>
-          )}
-        </>
-      ) : (
-        filtered.map((item, i) => (
-          <ConversationRow
-            key={item.id}
-            item={item}
-            prevItem={filtered[i - 1] ?? null}
-            compact={false}
-            sourceLanguage={sourceLanguage}
-            targetLanguage={targetLanguage}
-            isPlaying={false}
-            highlightedChars={0}
-            canPlay={false}
-          />
-        ))
-      )}
+    <div className={`subtitle-stream ${compact ? 'compact' : 'expanded'}`} style={style}>
+      {compact
+        ? lines.map((line) => (
+            <div
+              key={line.id}
+              className={`subtitle-stream__line subtitle-stream__line--${line.kind} subtitle-stream__line--${line.source}`}
+            >
+              <p>{line.text}</p>
+            </div>
+          ))
+        : filtered.map((item, i) => (
+            <ConversationRow
+              key={item.id}
+              item={item}
+              prevItem={filtered[i - 1] ?? null}
+              compact={false}
+              sourceLanguage={sourceLanguage}
+              targetLanguage={targetLanguage}
+              isPlaying={false}
+              highlightedChars={0}
+              canPlay={false}
+            />
+          ))}
       <div ref={endRef} />
     </div>
   );

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -20,6 +20,13 @@ function itemText(item: any): string {
   return item?.formatted?.transcript || item?.formatted?.text || '';
 }
 
+// Cap how much text any one compact band concatenates. The band only
+// shows the tail anyway (overflow clipped to bottom), so processing the
+// full conversation history on every streaming update wastes CPU as
+// the session grows. ~2000 chars is well past what any visible band
+// could display at typical font sizes; older content drops cleanly.
+const BUCKET_MAX_CHARS = 2000;
+
 type LineKind = 'source' | 'translation';
 type LineSource = 'speaker' | 'participant';
 interface SubtitleLine {
@@ -34,11 +41,10 @@ interface SubtitleLine {
  *
  * - compact (default) — renders up to four flowing lines: speaker source,
  *   speaker translation, participant source, participant translation. Each
- *   line concatenates every visible item of its category in chronological
- *   order. Empty lines (no items, or hidden by displayMode) are dropped.
- *   All visible lines share the available height equally; when a single
- *   line's text is longer than its band it clips to the bottom so the
- *   newest text stays visible without pushing other lines off-screen.
+ *   line concatenates the most recent visible items of its category up to
+ *   BUCKET_MAX_CHARS. Empty lines are dropped. All visible lines share
+ *   the available height equally; when a line is longer than its band the
+ *   band clips to the bottom so the newest text stays pinned.
  *
  * - expanded — falls back to per-item ConversationRow with its full layout
  *   (avatar, role label, language badge), suitable for users who want to
@@ -67,15 +73,34 @@ const SubtitleStream: React.FC<Props> = ({
       'participant-source': [],
       'participant-translation': [],
     };
-    for (const item of filtered) {
+    const bucketLen: Record<string, number> = {
+      'speaker-source': 0,
+      'speaker-translation': 0,
+      'participant-source': 0,
+      'participant-translation': 0,
+    };
+
+    // Walk items newest-first, prepending each item's text to its bucket
+    // until that bucket reaches BUCKET_MAX_CHARS. Older items beyond the
+    // cap are dropped — the band only shows the tail anyway. shouldShowItem
+    // lets error/system rows pass; route them to the translation bucket of
+    // whichever side produced them so they remain visible.
+    for (let i = filtered.length - 1; i >= 0; i--) {
+      const item = filtered[i];
       const text = itemText(item).trim();
       if (!text) continue;
-      const source: LineSource = item.source === 'participant' ? 'participant' : 'speaker';
-      const kind: LineKind | null =
-        item.role === 'user' ? 'source' : item.role === 'assistant' ? 'translation' : null;
-      if (!kind) continue;
-      buckets[`${source}-${kind}`].push(text);
+      const side: LineSource = item.source === 'participant' ? 'participant' : 'speaker';
+      let kind: LineKind;
+      if (item.role === 'user') kind = 'source';
+      else if (item.role === 'assistant') kind = 'translation';
+      else if (item.type === 'error' || item.role === 'system') kind = 'translation';
+      else continue;
+      const key = `${side}-${kind}`;
+      if (bucketLen[key] >= BUCKET_MAX_CHARS) continue;
+      buckets[key].unshift(text);
+      bucketLen[key] += text.length + 1; // +1 for the joining space
     }
+
     const order: Array<{ source: LineSource; kind: LineKind }> = [
       { source: 'speaker', kind: 'source' },
       { source: 'speaker', kind: 'translation' },
@@ -92,12 +117,18 @@ const SubtitleStream: React.FC<Props> = ({
       .filter((l) => l.text.length > 0);
   }, [filtered]);
 
+  // Stick to bottom only in expanded mode, where ConversationRow rows pile
+  // up in a scrollable column and need to follow the latest content. In
+  // compact mode each band is a fixed flex slot with internal overflow:
+  // hidden, so the parent never scrolls and scrollIntoView is a no-op
+  // (and `behavior: 'smooth'` would just add jitter during streaming).
   const endRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
+    if (compact) return;
     if (endRef.current && typeof endRef.current.scrollIntoView === 'function') {
-      endRef.current.scrollIntoView({ behavior: 'smooth', block: 'end' });
+      endRef.current.scrollIntoView({ behavior: 'auto', block: 'end' });
     }
-  }, [compact, lines, filtered.length]);
+  }, [compact, filtered.length]);
 
   // Apply fontSize to both our flat-line styles and the CSS var that
   // ConversationRow reads in expanded mode.

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -20,7 +20,17 @@
 
   &.platform-other {
     padding-left: 12px;
-    padding-right: 0;
+    // Default right padding inset for environments without native window
+    // controls (e.g. the Chrome extension's side panel, whose rounded
+    // top-right corner would otherwise clip the rightmost action button).
+    padding-right: 12px;
+
+    // When Electron Win/Linux mounts its in-app min/max/close buttons at
+    // the very right edge, revert to flush — those buttons want to hug
+    // the corner the same way the system window controls would.
+    &.has-window-controls {
+      padding-right: 0;
+    }
   }
 }
 

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -1,6 +1,6 @@
 // src/components/TitleBar/TitleBar.scss
 .title-bar {
-  height: 30px;
+  height: 36px;
   display: flex;
   align-items: center;
   background: #1a1a1a;
@@ -8,6 +8,7 @@
   -webkit-app-region: drag;
   user-select: none;
   flex-shrink: 0;
+  gap: 12px;
 
   &.platform-darwin {
     // On macOS we use titleBarStyle: 'hiddenInset' so the OS draws traffic-
@@ -15,13 +16,11 @@
     // clear of them.
     padding-left: 78px;
     padding-right: 8px;
-    justify-content: flex-start;
   }
 
   &.platform-other {
     padding-left: 12px;
     padding-right: 0;
-    justify-content: space-between;
   }
 }
 
@@ -29,16 +28,60 @@
   font-size: 12px;
   font-weight: 500;
   letter-spacing: 0.3px;
+  flex-shrink: 0;
+}
+
+.title-bar__actions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-left: auto;
+  -webkit-app-region: no-drag;
+}
+
+.title-bar__action {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 26px;
+  padding: 0 10px;
+  background: transparent;
+  color: #c8c8c8;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+  line-height: 1;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &.is-active {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: #10a37f;
+    color: #fff;
+  }
+}
+
+.title-bar__action-label {
+  font-size: 12px;
+
+  // Hide labels on narrow windows; icon + tooltip remain
+  @media (max-width: 576px) {
+    display: none;
+  }
 }
 
 .title-bar__buttons {
   display: flex;
   -webkit-app-region: no-drag;
+  margin-left: 4px;
 }
 
 .title-bar__btn {
   width: 46px;
-  height: 30px;
+  height: 36px;
   border: none;
   background: transparent;
   color: #c8c8c8;

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -53,7 +53,7 @@
   font-size: 12px;
   line-height: 1;
 
-  &:hover {
+  &:hover:not(:disabled) {
     background: rgba(255, 255, 255, 0.08);
   }
 
@@ -61,6 +61,11 @@
     background: rgba(255, 255, 255, 0.12);
     border-color: #10a37f;
     color: #fff;
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
   }
 }
 

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -1,0 +1,59 @@
+// src/components/TitleBar/TitleBar.scss
+.title-bar {
+  height: 30px;
+  display: flex;
+  align-items: center;
+  background: #1a1a1a;
+  color: #e8e8e8;
+  -webkit-app-region: drag;
+  user-select: none;
+  flex-shrink: 0;
+
+  &.platform-darwin {
+    // On macOS we use titleBarStyle: 'hiddenInset' so the OS draws traffic-
+    // light buttons on the left. We just need padding to keep our content
+    // clear of them.
+    padding-left: 78px;
+    padding-right: 8px;
+    justify-content: flex-start;
+  }
+
+  &.platform-other {
+    padding-left: 12px;
+    padding-right: 0;
+    justify-content: space-between;
+  }
+}
+
+.title-bar__title {
+  font-size: 12px;
+  font-weight: 500;
+  letter-spacing: 0.3px;
+}
+
+.title-bar__buttons {
+  display: flex;
+  -webkit-app-region: no-drag;
+}
+
+.title-bar__btn {
+  width: 46px;
+  height: 30px;
+  border: none;
+  background: transparent;
+  color: #c8c8c8;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 14px;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+
+  &.title-bar__close:hover {
+    background: #c0392b;
+    color: #fff;
+  }
+}

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -1,0 +1,65 @@
+// src/components/TitleBar/TitleBar.tsx
+import React, { useCallback } from 'react';
+import { Minus, Square, X } from 'lucide-react';
+import './TitleBar.scss';
+
+const isMac = typeof process !== 'undefined' && process.platform === 'darwin';
+
+const TitleBar: React.FC = () => {
+  const minimize = useCallback(() => {
+    void window.electron?.invoke('window:minimize');
+  }, []);
+  const maximizeToggle = useCallback(() => {
+    void window.electron?.invoke('window:maximize-toggle');
+  }, []);
+  const close = useCallback(() => {
+    void window.electron?.invoke('window:close');
+  }, []);
+
+  if (isMac) {
+    // macOS: traffic-light buttons drawn by the OS via titleBarStyle: 'hiddenInset'.
+    // We just render a thin draggable area with the title.
+    return (
+      <div className="title-bar platform-darwin" role="banner">
+        <span className="title-bar__title">Sokuji</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="title-bar platform-other" role="banner">
+      <span className="title-bar__title">Sokuji</span>
+      <div className="title-bar__buttons">
+        <button
+          type="button"
+          className="title-bar__btn title-bar__minimize"
+          aria-label="Minimize"
+          onClick={minimize}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          <Minus size={14} />
+        </button>
+        <button
+          type="button"
+          className="title-bar__btn title-bar__maximize"
+          aria-label="Maximize"
+          onClick={maximizeToggle}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          <Square size={12} />
+        </button>
+        <button
+          type="button"
+          className="title-bar__btn title-bar__close"
+          aria-label="Close"
+          onClick={close}
+          onDoubleClick={(e) => e.stopPropagation()}
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default TitleBar;

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -48,7 +48,10 @@ const TitleBar: React.FC<TitleBarProps> = ({
   const platformClass = isElectron() && isMacOS() ? 'platform-darwin' : 'platform-other';
 
   return (
-    <div className={`title-bar ${platformClass}`} role="banner">
+    <div
+      className={`title-bar ${platformClass}${showInAppWindowControls ? ' has-window-controls' : ''}`}
+      role="banner"
+    >
       <span className="title-bar__title">Sokuji</span>
       <div className="title-bar__actions">
         <SubtitleEnterButton />

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -1,10 +1,25 @@
 // src/components/TitleBar/TitleBar.tsx
 import React, { useCallback } from 'react';
-import { Minus, Square, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { Minus, Square, X, Settings, Terminal } from 'lucide-react';
 import { isMacOS } from '../../utils/environment';
 import './TitleBar.scss';
 
-const TitleBar: React.FC = () => {
+interface TitleBarProps {
+  showSettings: boolean;
+  showLogs: boolean;
+  onToggleSettings: () => void;
+  onToggleLogs: () => void;
+}
+
+const TitleBar: React.FC<TitleBarProps> = ({
+  showSettings,
+  showLogs,
+  onToggleSettings,
+  onToggleLogs,
+}) => {
+  const { t } = useTranslation();
+
   const minimize = useCallback(() => {
     void window.electron?.invoke('window:minimize');
   }, []);
@@ -15,12 +30,41 @@ const TitleBar: React.FC = () => {
     void window.electron?.invoke('window:close');
   }, []);
 
+  const settingsLabel = t('settings.title', 'Settings');
+  const logsLabel = t('common.logs', 'Logs');
+
+  const actions = (
+    <div className="title-bar__actions">
+      <button
+        type="button"
+        className={`title-bar__action ${showSettings ? 'is-active' : ''}`}
+        onClick={onToggleSettings}
+        title={settingsLabel}
+        aria-label={settingsLabel}
+      >
+        <Settings size={14} />
+        <span className="title-bar__action-label">{settingsLabel}</span>
+      </button>
+      <button
+        type="button"
+        className={`title-bar__action ${showLogs ? 'is-active' : ''}`}
+        onClick={onToggleLogs}
+        title={logsLabel}
+        aria-label={logsLabel}
+      >
+        <Terminal size={14} />
+        <span className="title-bar__action-label">{logsLabel}</span>
+      </button>
+    </div>
+  );
+
   if (isMacOS()) {
     // macOS: traffic-light buttons drawn by the OS via titleBarStyle: 'hiddenInset'.
-    // We just render a thin draggable area with the title.
+    // Title on the left, action buttons pushed to the right.
     return (
       <div className="title-bar platform-darwin" role="banner">
         <span className="title-bar__title">Sokuji</span>
+        {actions}
       </div>
     );
   }
@@ -28,6 +72,7 @@ const TitleBar: React.FC = () => {
   return (
     <div className="title-bar platform-other" role="banner">
       <span className="title-bar__title">Sokuji</span>
+      {actions}
       <div className="title-bar__buttons">
         <button
           type="button"

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -3,6 +3,7 @@ import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Minus, Square, X, Settings, Terminal } from 'lucide-react';
 import { isMacOS } from '../../utils/environment';
+import SubtitleEnterButton from '../Subtitle/SubtitleEnterButton';
 import './TitleBar.scss';
 
 interface TitleBarProps {
@@ -55,6 +56,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
         <Terminal size={14} />
         <span className="title-bar__action-label">{logsLabel}</span>
       </button>
+      <SubtitleEnterButton />
     </div>
   );
 

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -36,6 +36,7 @@ const TitleBar: React.FC<TitleBarProps> = ({
 
   const actions = (
     <div className="title-bar__actions">
+      <SubtitleEnterButton />
       <button
         type="button"
         className={`title-bar__action ${showSettings ? 'is-active' : ''}`}
@@ -56,7 +57,6 @@ const TitleBar: React.FC<TitleBarProps> = ({
         <Terminal size={14} />
         <span className="title-bar__action-label">{logsLabel}</span>
       </button>
-      <SubtitleEnterButton />
     </div>
   );
 

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -2,7 +2,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Minus, Square, X, Settings, Terminal } from 'lucide-react';
-import { isMacOS } from '../../utils/environment';
+import { isElectron, isMacOS } from '../../utils/environment';
 import SubtitleEnterButton from '../Subtitle/SubtitleEnterButton';
 import './TitleBar.scss';
 
@@ -33,77 +33,80 @@ const TitleBar: React.FC<TitleBarProps> = ({
 
   const settingsLabel = t('settings.title', 'Settings');
   const logsLabel = t('common.logs', 'Logs');
+  const minimizeLabel = t('titleBar.minimize', 'Minimize');
+  const maximizeLabel = t('titleBar.maximize', 'Maximize');
+  const closeLabel = t('titleBar.close', 'Close');
 
-  const actions = (
-    <div className="title-bar__actions">
-      <SubtitleEnterButton />
-      <button
-        type="button"
-        className={`title-bar__action ${showSettings ? 'is-active' : ''}`}
-        onClick={onToggleSettings}
-        title={settingsLabel}
-        aria-label={settingsLabel}
-      >
-        <Settings size={14} />
-        <span className="title-bar__action-label">{settingsLabel}</span>
-      </button>
-      <button
-        type="button"
-        className={`title-bar__action ${showLogs ? 'is-active' : ''}`}
-        onClick={onToggleLogs}
-        title={logsLabel}
-        aria-label={logsLabel}
-      >
-        <Terminal size={14} />
-        <span className="title-bar__action-label">{logsLabel}</span>
-      </button>
-    </div>
-  );
-
-  if (isMacOS()) {
-    // macOS: traffic-light buttons drawn by the OS via titleBarStyle: 'hiddenInset'.
-    // Title on the left, action buttons pushed to the right.
-    return (
-      <div className="title-bar platform-darwin" role="banner">
-        <span className="title-bar__title">Sokuji</span>
-        {actions}
-      </div>
-    );
-  }
+  // Only Electron Win/Linux render the in-app min/max/close buttons. On
+  // macOS the OS draws traffic-light buttons (titleBarStyle: hiddenInset),
+  // and the browser extension lives inside the browser chrome which already
+  // provides window controls.
+  const showInAppWindowControls = isElectron() && !isMacOS();
+  // macOS-specific left padding (to clear the OS traffic-light area) only
+  // applies inside Electron on macOS — the extension's macOS context has
+  // no traffic-light cutout.
+  const platformClass = isElectron() && isMacOS() ? 'platform-darwin' : 'platform-other';
 
   return (
-    <div className="title-bar platform-other" role="banner">
+    <div className={`title-bar ${platformClass}`} role="banner">
       <span className="title-bar__title">Sokuji</span>
-      {actions}
-      <div className="title-bar__buttons">
+      <div className="title-bar__actions">
+        <SubtitleEnterButton />
         <button
           type="button"
-          className="title-bar__btn title-bar__minimize"
-          aria-label="Minimize"
-          onClick={minimize}
-          onDoubleClick={(e) => e.stopPropagation()}
+          className={`title-bar__action ${showSettings ? 'is-active' : ''}`}
+          onClick={onToggleSettings}
+          title={settingsLabel}
+          aria-label={settingsLabel}
         >
-          <Minus size={14} />
+          <Settings size={14} />
+          <span className="title-bar__action-label">{settingsLabel}</span>
         </button>
         <button
           type="button"
-          className="title-bar__btn title-bar__maximize"
-          aria-label="Maximize"
-          onClick={maximizeToggle}
-          onDoubleClick={(e) => e.stopPropagation()}
+          className={`title-bar__action ${showLogs ? 'is-active' : ''}`}
+          onClick={onToggleLogs}
+          title={logsLabel}
+          aria-label={logsLabel}
         >
-          <Square size={12} />
-        </button>
-        <button
-          type="button"
-          className="title-bar__btn title-bar__close"
-          aria-label="Close"
-          onClick={close}
-          onDoubleClick={(e) => e.stopPropagation()}
-        >
-          <X size={14} />
+          <Terminal size={14} />
+          <span className="title-bar__action-label">{logsLabel}</span>
         </button>
       </div>
+      {showInAppWindowControls && (
+        <div className="title-bar__buttons">
+          <button
+            type="button"
+            className="title-bar__btn title-bar__minimize"
+            aria-label={minimizeLabel}
+            title={minimizeLabel}
+            onClick={minimize}
+            onDoubleClick={(e) => e.stopPropagation()}
+          >
+            <Minus size={14} />
+          </button>
+          <button
+            type="button"
+            className="title-bar__btn title-bar__maximize"
+            aria-label={maximizeLabel}
+            title={maximizeLabel}
+            onClick={maximizeToggle}
+            onDoubleClick={(e) => e.stopPropagation()}
+          >
+            <Square size={12} />
+          </button>
+          <button
+            type="button"
+            className="title-bar__btn title-bar__close"
+            aria-label={closeLabel}
+            title={closeLabel}
+            onClick={close}
+            onDoubleClick={(e) => e.stopPropagation()}
+          >
+            <X size={14} />
+          </button>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -54,7 +54,10 @@ const TitleBar: React.FC<TitleBarProps> = ({
         <SubtitleEnterButton />
         <button
           type="button"
-          className={`title-bar__action ${showSettings ? 'is-active' : ''}`}
+          // Keep the legacy `settings-button` class so onboarding's
+          // `.settings-button` step target keeps matching after the
+          // button moved from main-panel-header into the TitleBar.
+          className={`title-bar__action settings-button ${showSettings ? 'is-active' : ''}`}
           onClick={onToggleSettings}
           title={settingsLabel}
           aria-label={settingsLabel}
@@ -64,7 +67,9 @@ const TitleBar: React.FC<TitleBarProps> = ({
         </button>
         <button
           type="button"
-          className={`title-bar__action ${showLogs ? 'is-active' : ''}`}
+          // Keep the legacy `logs-button` class for the same reason as
+          // settings-button above — preserves any selector consumers.
+          className={`title-bar__action logs-button ${showLogs ? 'is-active' : ''}`}
           onClick={onToggleLogs}
           title={logsLabel}
           aria-label={logsLabel}

--- a/src/components/TitleBar/TitleBar.tsx
+++ b/src/components/TitleBar/TitleBar.tsx
@@ -1,9 +1,8 @@
 // src/components/TitleBar/TitleBar.tsx
 import React, { useCallback } from 'react';
 import { Minus, Square, X } from 'lucide-react';
+import { isMacOS } from '../../utils/environment';
 import './TitleBar.scss';
-
-const isMac = typeof process !== 'undefined' && process.platform === 'darwin';
 
 const TitleBar: React.FC = () => {
   const minimize = useCallback(() => {
@@ -16,7 +15,7 @@ const TitleBar: React.FC = () => {
     void window.electron?.invoke('window:close');
   }, []);
 
-  if (isMac) {
+  if (isMacOS()) {
     // macOS: traffic-light buttons drawn by the OS via titleBarStyle: 'hiddenInset'.
     // We just render a thin draggable area with the title.
     return (

--- a/src/contexts/OnboardingContext.tsx
+++ b/src/contexts/OnboardingContext.tsx
@@ -4,6 +4,7 @@ import { useAnalytics } from '../lib/analytics';
 import useSettingsStore, { useProvider } from '../stores/settingsStore';
 import { ProviderConfigFactory } from '../services/providers/ProviderConfigFactory';
 import { Provider } from '../types/Provider';
+import { isKizunaAIEnabled } from '../utils/environment';
 
 export interface OnboardingStep {
   target: string;
@@ -45,8 +46,14 @@ const ONBOARDING_STORAGE_KEY = 'sokuji_onboarding_completed';
 const USER_TYPE_STORAGE_KEY = 'sokuji_user_type';
 const ONBOARDING_VERSION = '1.1.0';
 
-// Basic mode onboarding steps - simplified for regular users
-const createBasicOnboardingSteps = (t: any): OnboardingStep[] => [
+// Basic mode onboarding steps - simplified for regular users.
+// The account step targets #user-account-section, which AccountSection only
+// renders when isKizunaAIEnabled() — the browser-extension build (and any
+// build with VITE_ENABLE_KIZUNA_AI=false) omits that section, so the step
+// would land on a missing element and Joyride would skip ahead silently.
+// Filter it out at construction time instead so the step list matches reality.
+const createBasicOnboardingSteps = (t: any): OnboardingStep[] => {
+  const allSteps: (OnboardingStep | null)[] = [
   {
     target: 'body',
     content: t('onboarding.basic.steps.welcome.content', 'Welcome to Sokuji! This simple guide will help you start using real-time translation in just a few steps.'),
@@ -65,12 +72,12 @@ const createBasicOnboardingSteps = (t: any): OnboardingStep[] => [
     title: t('onboarding.basic.steps.settings.title', 'Step 1: Open Settings'),
     placement: 'bottom',
   },
-  {
+  isKizunaAIEnabled() ? {
     target: '#user-account-section',
     content: t('onboarding.basic.steps.account.content', 'Sign in to use Sokuji\'s built-in translation service, or choose another provider and enter your own API key.'),
     title: t('onboarding.basic.steps.account.title', 'Step 2: User Account'),
     placement: 'left',
-  },
+  } : null,
   {
     target: '#languages-section',
     content: t('onboarding.basic.steps.languages.content', 'Select your source language (what you speak) and target language (what you want the other party to hear).'),
@@ -114,7 +121,9 @@ const createBasicOnboardingSteps = (t: any): OnboardingStep[] => [
     placement: 'center',
     disableBeacon: true,
   }
-];
+  ];
+  return allSteps.filter((s): s is OnboardingStep => s !== null);
+};
 
 // Advanced mode onboarding steps - detailed for experienced users
 // Steps are filtered based on current provider capabilities to avoid targeting non-existent DOM elements

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -830,5 +830,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "انتهت الجلسة",
+    "backToMain": "العودة إلى النافذة الرئيسية",
+    "enterButton": {
+      "title": "تفعيل وضع الترجمة",
+      "disabled": "ابدأ جلسة أولاً",
+      "label": "ترجمة"
+    },
+    "bar": {
+      "fontDecrease": "تصغير الخط",
+      "fontIncrease": "تكبير الخط",
+      "expand": "عرض موسع",
+      "compact": "عرض مضغوط",
+      "clear": "مسح المحادثة",
+      "settings": "إعدادات الترجمة",
+      "alwaysOnTop": "دائمًا في المقدمة",
+      "lock": "قفل الموضع والحجم",
+      "exit": "الخروج من وضع الترجمة"
+    },
+    "settings": {
+      "bgOpacity": "شفافية الخلفية",
+      "bgColor": "لون الخلفية",
+      "sourceColor": "لون النص الأصلي",
+      "translationColor": "لون الترجمة"
+    },
+    "pttHint": "اضغط مفتاح المسافة للتحدث"
+  },
+  "titleBar": {
+    "minimize": "تصغير",
+    "maximize": "تكبير",
+    "close": "إغلاق"
   }
 }

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -836,5 +836,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "সেশন শেষ হয়েছে",
+    "backToMain": "মূল উইন্ডোতে ফিরুন",
+    "enterButton": {
+      "title": "সাবটাইটেল মোডে যান",
+      "disabled": "প্রথমে সেশন শুরু করুন",
+      "label": "সাবটাইটেল"
+    },
+    "bar": {
+      "fontDecrease": "ফন্ট ছোট করুন",
+      "fontIncrease": "ফন্ট বড় করুন",
+      "expand": "বিস্তৃত ভিউ",
+      "compact": "সংক্ষিপ্ত ভিউ",
+      "clear": "কথোপকথন মুছুন",
+      "settings": "সাবটাইটেল সেটিংস",
+      "alwaysOnTop": "সর্বদা উপরে",
+      "lock": "অবস্থান এবং আকার লক করুন",
+      "exit": "সাবটাইটেল মোড থেকে বের হোন"
+    },
+    "settings": {
+      "bgOpacity": "পটভূমির অস্বচ্ছতা",
+      "bgColor": "পটভূমির রঙ",
+      "sourceColor": "মূল টেক্সটের রঙ",
+      "translationColor": "অনুবাদের রঙ"
+    },
+    "pttHint": "কথা বলতে Space চাপুন"
+  },
+  "titleBar": {
+    "minimize": "ছোট করুন",
+    "maximize": "বড় করুন",
+    "close": "বন্ধ করুন"
   }
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -843,7 +843,7 @@
       "fontIncrease": "Schrift vergrößern",
       "expand": "Erweiterte Ansicht",
       "compact": "Kompakte Ansicht",
-      "clear": "Konversation löschen",
+      "clear": "Unterhaltung löschen",
       "settings": "Untertitel-Einstellungen",
       "alwaysOnTop": "Immer im Vordergrund",
       "lock": "Position und Größe sperren",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -829,5 +829,37 @@
     "downloadDeb": ".deb herunterladen",
     "linuxMigrateTitle": "Neue Version v{{version}} verfügbar",
     "linuxMigrateBody": "Automatische Updates sind mit AppImage verfügbar. Wähle ein Format, um v{{version}} herunterzuladen."
+  },
+  "subtitle": {
+    "sessionEnded": "Sitzung beendet",
+    "backToMain": "Zurück zum Hauptfenster",
+    "enterButton": {
+      "title": "Untertitel-Modus aktivieren",
+      "disabled": "Sitzung zuerst starten",
+      "label": "Untertitel"
+    },
+    "bar": {
+      "fontDecrease": "Schrift verkleinern",
+      "fontIncrease": "Schrift vergrößern",
+      "expand": "Erweiterte Ansicht",
+      "compact": "Kompakte Ansicht",
+      "clear": "Konversation löschen",
+      "settings": "Untertitel-Einstellungen",
+      "alwaysOnTop": "Immer im Vordergrund",
+      "lock": "Position und Größe sperren",
+      "exit": "Untertitel-Modus beenden"
+    },
+    "settings": {
+      "bgOpacity": "Hintergrund-Transparenz",
+      "bgColor": "Hintergrundfarbe",
+      "sourceColor": "Quelltextfarbe",
+      "translationColor": "Übersetzungsfarbe"
+    },
+    "pttHint": "Leertaste zum Sprechen halten"
+  },
+  "titleBar": {
+    "minimize": "Minimieren",
+    "maximize": "Maximieren",
+    "close": "Schließen"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -877,7 +877,8 @@
     "backToMain": "Return to main window",
     "enterButton": {
       "title": "Enter subtitle mode",
-      "disabled": "Start a session first"
+      "disabled": "Start a session first",
+      "label": "Subtitle"
     },
     "bar": {
       "fontDecrease": "Decrease font size",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -871,5 +871,30 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Session ended",
+    "backToMain": "Return to main window",
+    "enterButton": {
+      "title": "Enter subtitle mode",
+      "disabled": "Start a session first"
+    },
+    "bar": {
+      "fontDecrease": "Decrease font size",
+      "fontIncrease": "Increase font size",
+      "expand": "Expanded view",
+      "compact": "Compact view",
+      "clear": "Clear conversation",
+      "settings": "Subtitle settings",
+      "alwaysOnTop": "Always on top",
+      "lock": "Lock position and size",
+      "exit": "Exit subtitle mode"
+    },
+    "settings": {
+      "bgOpacity": "Background opacity",
+      "bgColor": "Background color",
+      "sourceColor": "Source text color",
+      "translationColor": "Translation color"
+    }
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -896,6 +896,7 @@
       "bgColor": "Background color",
       "sourceColor": "Source text color",
       "translationColor": "Translation color"
-    }
+    },
+    "pttHint": "Press Space to speak"
   }
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -898,5 +898,10 @@
       "translationColor": "Translation color"
     },
     "pttHint": "Press Space to speak"
+  },
+  "titleBar": {
+    "minimize": "Minimize",
+    "maximize": "Maximize",
+    "close": "Close"
   }
 }

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -829,5 +829,37 @@
     "downloadDeb": "Descargar .deb",
     "linuxMigrateTitle": "Nueva versión v{{version}} disponible",
     "linuxMigrateBody": "Las actualizaciones automáticas están disponibles con AppImage. Elige un formato para descargar v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sesión finalizada",
+    "backToMain": "Volver a la ventana principal",
+    "enterButton": {
+      "title": "Entrar en modo subtítulos",
+      "disabled": "Inicia una sesión primero",
+      "label": "Subtítulos"
+    },
+    "bar": {
+      "fontDecrease": "Reducir tamaño de fuente",
+      "fontIncrease": "Aumentar tamaño de fuente",
+      "expand": "Vista expandida",
+      "compact": "Vista compacta",
+      "clear": "Limpiar conversación",
+      "settings": "Ajustes de subtítulos",
+      "alwaysOnTop": "Siempre visible",
+      "lock": "Bloquear posición y tamaño",
+      "exit": "Salir del modo subtítulos"
+    },
+    "settings": {
+      "bgOpacity": "Opacidad del fondo",
+      "bgColor": "Color de fondo",
+      "sourceColor": "Color del texto original",
+      "translationColor": "Color de la traducción"
+    },
+    "pttHint": "Pulsa Espacio para hablar"
+  },
+  "titleBar": {
+    "minimize": "Minimizar",
+    "maximize": "Maximizar",
+    "close": "Cerrar"
   }
 }

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -836,5 +836,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "جلسه پایان یافت",
+    "backToMain": "بازگشت به پنجره اصلی",
+    "enterButton": {
+      "title": "ورود به حالت زیرنویس",
+      "disabled": "ابتدا یک جلسه شروع کنید",
+      "label": "زیرنویس"
+    },
+    "bar": {
+      "fontDecrease": "کوچک کردن فونت",
+      "fontIncrease": "بزرگ کردن فونت",
+      "expand": "نمای گسترده",
+      "compact": "نمای فشرده",
+      "clear": "پاک کردن گفت‌وگو",
+      "settings": "تنظیمات زیرنویس",
+      "alwaysOnTop": "همیشه در بالا",
+      "lock": "قفل موقعیت و اندازه",
+      "exit": "خروج از حالت زیرنویس"
+    },
+    "settings": {
+      "bgOpacity": "شفافیت پس‌زمینه",
+      "bgColor": "رنگ پس‌زمینه",
+      "sourceColor": "رنگ متن اصلی",
+      "translationColor": "رنگ ترجمه"
+    },
+    "pttHint": "برای صحبت، Space را نگه دارید"
+  },
+  "titleBar": {
+    "minimize": "کوچک کردن",
+    "maximize": "بزرگ کردن",
+    "close": "بستن"
   }
 }

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -802,7 +802,7 @@
       "compact": "Kompakti näkymä",
       "clear": "Tyhjennä keskustelu",
       "settings": "Tekstitysasetukset",
-      "alwaysOnTop": "Aina päällä",
+      "alwaysOnTop": "Aina päällimmäisenä",
       "lock": "Lukitse sijainti ja koko",
       "exit": "Poistu tekstitystilasta"
     },

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -786,5 +786,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Istunto päättyi",
+    "backToMain": "Palaa pääikkunaan",
+    "enterButton": {
+      "title": "Ota tekstitystila käyttöön",
+      "disabled": "Aloita istunto ensin",
+      "label": "Tekstitys"
+    },
+    "bar": {
+      "fontDecrease": "Pienennä fonttia",
+      "fontIncrease": "Suurenna fonttia",
+      "expand": "Laaja näkymä",
+      "compact": "Kompakti näkymä",
+      "clear": "Tyhjennä keskustelu",
+      "settings": "Tekstitysasetukset",
+      "alwaysOnTop": "Aina päällä",
+      "lock": "Lukitse sijainti ja koko",
+      "exit": "Poistu tekstitystilasta"
+    },
+    "settings": {
+      "bgOpacity": "Taustan läpinäkyvyys",
+      "bgColor": "Taustaväri",
+      "sourceColor": "Lähdetekstin väri",
+      "translationColor": "Käännöksen väri"
+    },
+    "pttHint": "Paina välilyöntiä puhuaksesi"
+  },
+  "titleBar": {
+    "minimize": "Pienennä",
+    "maximize": "Suurenna",
+    "close": "Sulje"
   }
 }

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -786,5 +786,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Tapos na ang session",
+    "backToMain": "Bumalik sa pangunahing window",
+    "enterButton": {
+      "title": "Pumasok sa subtitle mode",
+      "disabled": "Magsimula muna ng session",
+      "label": "Subtitle"
+    },
+    "bar": {
+      "fontDecrease": "Bawasan ang laki ng font",
+      "fontIncrease": "Lakihan ang laki ng font",
+      "expand": "Pinalawak na view",
+      "compact": "Compact na view",
+      "clear": "Burahin ang usapan",
+      "settings": "Mga setting ng subtitle",
+      "alwaysOnTop": "Laging nasa ibabaw",
+      "lock": "I-lock ang posisyon at sukat",
+      "exit": "Lumabas sa subtitle mode"
+    },
+    "settings": {
+      "bgOpacity": "Opacity ng background",
+      "bgColor": "Kulay ng background",
+      "sourceColor": "Kulay ng orihinal na teksto",
+      "translationColor": "Kulay ng salin"
+    },
+    "pttHint": "Pindutin ang Space upang magsalita"
+  },
+  "titleBar": {
+    "minimize": "I-minimize",
+    "maximize": "I-maximize",
+    "close": "Isara"
   }
 }

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -829,5 +829,37 @@
     "downloadDeb": "Télécharger .deb",
     "linuxMigrateTitle": "Nouvelle version v{{version}} disponible",
     "linuxMigrateBody": "Les mises à jour automatiques sont disponibles avec AppImage. Choisissez un format pour télécharger v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Session terminée",
+    "backToMain": "Retour à la fenêtre principale",
+    "enterButton": {
+      "title": "Activer le mode sous-titres",
+      "disabled": "Démarrez d’abord une session",
+      "label": "Sous-titres"
+    },
+    "bar": {
+      "fontDecrease": "Réduire la taille du texte",
+      "fontIncrease": "Augmenter la taille du texte",
+      "expand": "Vue développée",
+      "compact": "Vue compacte",
+      "clear": "Effacer la conversation",
+      "settings": "Paramètres des sous-titres",
+      "alwaysOnTop": "Toujours au premier plan",
+      "lock": "Verrouiller la position et la taille",
+      "exit": "Quitter le mode sous-titres"
+    },
+    "settings": {
+      "bgOpacity": "Opacité du fond",
+      "bgColor": "Couleur du fond",
+      "sourceColor": "Couleur du texte source",
+      "translationColor": "Couleur de la traduction"
+    },
+    "pttHint": "Appuyez sur Espace pour parler"
+  },
+  "titleBar": {
+    "minimize": "Réduire",
+    "maximize": "Agrandir",
+    "close": "Fermer"
   }
 }

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -834,5 +834,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "ההפעלה הסתיימה",
+    "backToMain": "חזרה לחלון הראשי",
+    "enterButton": {
+      "title": "הפעלת מצב כתוביות",
+      "disabled": "התחל הפעלה תחילה",
+      "label": "כתוביות"
+    },
+    "bar": {
+      "fontDecrease": "הקטנת גופן",
+      "fontIncrease": "הגדלת גופן",
+      "expand": "תצוגה מורחבת",
+      "compact": "תצוגה מצומצמת",
+      "clear": "ניקוי שיחה",
+      "settings": "הגדרות כתוביות",
+      "alwaysOnTop": "תמיד למעלה",
+      "lock": "נעילת מיקום וגודל",
+      "exit": "יציאה ממצב כתוביות"
+    },
+    "settings": {
+      "bgOpacity": "אטימות רקע",
+      "bgColor": "צבע רקע",
+      "sourceColor": "צבע טקסט מקור",
+      "translationColor": "צבע תרגום"
+    },
+    "pttHint": "לחץ על רווח כדי לדבר"
+  },
+  "titleBar": {
+    "minimize": "מזעור",
+    "maximize": "הגדלה",
+    "close": "סגירה"
   }
 }

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -780,5 +780,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "सत्र समाप्त हुआ",
+    "backToMain": "मुख्य विंडो पर लौटें",
+    "enterButton": {
+      "title": "सबटाइटल मोड शुरू करें",
+      "disabled": "पहले सत्र शुरू करें",
+      "label": "सबटाइटल"
+    },
+    "bar": {
+      "fontDecrease": "फ़ॉन्ट छोटा करें",
+      "fontIncrease": "फ़ॉन्ट बड़ा करें",
+      "expand": "विस्तृत दृश्य",
+      "compact": "कॉम्पैक्ट दृश्य",
+      "clear": "बातचीत साफ़ करें",
+      "settings": "सबटाइटल सेटिंग्स",
+      "alwaysOnTop": "हमेशा सबसे ऊपर",
+      "lock": "स्थिति और आकार लॉक करें",
+      "exit": "सबटाइटल मोड से बाहर निकलें"
+    },
+    "settings": {
+      "bgOpacity": "पृष्ठभूमि अस्पष्टता",
+      "bgColor": "पृष्ठभूमि रंग",
+      "sourceColor": "मूल पाठ रंग",
+      "translationColor": "अनुवाद रंग"
+    },
+    "pttHint": "बोलने के लिए स्पेस दबाएँ"
+  },
+  "titleBar": {
+    "minimize": "छोटा करें",
+    "maximize": "बड़ा करें",
+    "close": "बंद करें"
   }
 }

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -828,5 +828,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sesi berakhir",
+    "backToMain": "Kembali ke jendela utama",
+    "enterButton": {
+      "title": "Masuk mode subtitle",
+      "disabled": "Mulai sesi terlebih dahulu",
+      "label": "Subtitle"
+    },
+    "bar": {
+      "fontDecrease": "Perkecil font",
+      "fontIncrease": "Perbesar font",
+      "expand": "Tampilan diperluas",
+      "compact": "Tampilan ringkas",
+      "clear": "Hapus percakapan",
+      "settings": "Pengaturan subtitle",
+      "alwaysOnTop": "Selalu di atas",
+      "lock": "Kunci posisi dan ukuran",
+      "exit": "Keluar mode subtitle"
+    },
+    "settings": {
+      "bgOpacity": "Opasitas latar",
+      "bgColor": "Warna latar",
+      "sourceColor": "Warna teks asli",
+      "translationColor": "Warna terjemahan"
+    },
+    "pttHint": "Tekan Spasi untuk berbicara"
+  },
+  "titleBar": {
+    "minimize": "Minimalkan",
+    "maximize": "Maksimalkan",
+    "close": "Tutup"
   }
 }

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -828,5 +828,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sessione terminata",
+    "backToMain": "Torna alla finestra principale",
+    "enterButton": {
+      "title": "Attiva modalità sottotitoli",
+      "disabled": "Avvia prima una sessione",
+      "label": "Sottotitoli"
+    },
+    "bar": {
+      "fontDecrease": "Riduci dimensione carattere",
+      "fontIncrease": "Aumenta dimensione carattere",
+      "expand": "Vista espansa",
+      "compact": "Vista compatta",
+      "clear": "Cancella conversazione",
+      "settings": "Impostazioni sottotitoli",
+      "alwaysOnTop": "Sempre in primo piano",
+      "lock": "Blocca posizione e dimensioni",
+      "exit": "Esci dalla modalità sottotitoli"
+    },
+    "settings": {
+      "bgOpacity": "Opacità dello sfondo",
+      "bgColor": "Colore dello sfondo",
+      "sourceColor": "Colore testo originale",
+      "translationColor": "Colore traduzione"
+    },
+    "pttHint": "Premi Spazio per parlare"
+  },
+  "titleBar": {
+    "minimize": "Riduci a icona",
+    "maximize": "Ingrandisci",
+    "close": "Chiudi"
   }
 }

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -840,5 +840,37 @@
     "downloadDeb": ".deb をダウンロード",
     "linuxMigrateTitle": "新しいバージョン v{{version}} が利用できます",
     "linuxMigrateBody": "AppImage 形式なら自動更新を利用できます。v{{version}} をダウンロードする形式を選択してください。"
+  },
+  "subtitle": {
+    "sessionEnded": "セッションが終了しました",
+    "backToMain": "メイン画面に戻る",
+    "enterButton": {
+      "title": "字幕モードを開始",
+      "disabled": "先にセッションを開始してください",
+      "label": "字幕"
+    },
+    "bar": {
+      "fontDecrease": "文字を小さく",
+      "fontIncrease": "文字を大きく",
+      "expand": "展開表示",
+      "compact": "コンパクト表示",
+      "clear": "会話をクリア",
+      "settings": "字幕設定",
+      "alwaysOnTop": "最前面に固定",
+      "lock": "位置とサイズをロック",
+      "exit": "字幕モードを終了"
+    },
+    "settings": {
+      "bgOpacity": "背景の透明度",
+      "bgColor": "背景色",
+      "sourceColor": "原文の色",
+      "translationColor": "訳文の色"
+    },
+    "pttHint": "スペースキーを押して話す"
+  },
+  "titleBar": {
+    "minimize": "最小化",
+    "maximize": "最大化",
+    "close": "閉じる"
   }
 }

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -828,5 +828,37 @@
     "downloadDeb": ".deb 다운로드",
     "linuxMigrateTitle": "새 버전 v{{version}} 사용 가능",
     "linuxMigrateBody": "AppImage 형식에서 자동 업데이트가 지원됩니다. v{{version}} 다운로드 형식을 선택하세요."
+  },
+  "subtitle": {
+    "sessionEnded": "세션이 종료되었습니다",
+    "backToMain": "메인 창으로 돌아가기",
+    "enterButton": {
+      "title": "자막 모드 시작",
+      "disabled": "먼저 세션을 시작하세요",
+      "label": "자막"
+    },
+    "bar": {
+      "fontDecrease": "글자 크기 축소",
+      "fontIncrease": "글자 크기 확대",
+      "expand": "확장 보기",
+      "compact": "간략 보기",
+      "clear": "대화 지우기",
+      "settings": "자막 설정",
+      "alwaysOnTop": "항상 위",
+      "lock": "위치 및 크기 잠금",
+      "exit": "자막 모드 종료"
+    },
+    "settings": {
+      "bgOpacity": "배경 투명도",
+      "bgColor": "배경색",
+      "sourceColor": "원문 색상",
+      "translationColor": "번역 색상"
+    },
+    "pttHint": "스페이스바를 눌러 말하세요"
+  },
+  "titleBar": {
+    "minimize": "최소화",
+    "maximize": "최대화",
+    "close": "닫기"
   }
 }

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -827,5 +827,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sesi berakhir",
+    "backToMain": "Kembali ke tetingkap utama",
+    "enterButton": {
+      "title": "Masuk mod sari kata",
+      "disabled": "Mulakan sesi dahulu",
+      "label": "Sari kata"
+    },
+    "bar": {
+      "fontDecrease": "Kecilkan fon",
+      "fontIncrease": "Besarkan fon",
+      "expand": "Paparan dipanjangkan",
+      "compact": "Paparan padat",
+      "clear": "Kosongkan perbualan",
+      "settings": "Tetapan sari kata",
+      "alwaysOnTop": "Sentiasa di atas",
+      "lock": "Kunci kedudukan dan saiz",
+      "exit": "Keluar mod sari kata"
+    },
+    "settings": {
+      "bgOpacity": "Kelegapan latar",
+      "bgColor": "Warna latar",
+      "sourceColor": "Warna teks sumber",
+      "translationColor": "Warna terjemahan"
+    },
+    "pttHint": "Tekan Bar Ruang untuk bercakap"
+  },
+  "titleBar": {
+    "minimize": "Minimumkan",
+    "maximize": "Maksimumkan",
+    "close": "Tutup"
   }
 }

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -828,5 +828,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sessie beëindigd",
+    "backToMain": "Terug naar hoofdvenster",
+    "enterButton": {
+      "title": "Ondertitelmodus inschakelen",
+      "disabled": "Start eerst een sessie",
+      "label": "Ondertiteling"
+    },
+    "bar": {
+      "fontDecrease": "Lettergrootte verkleinen",
+      "fontIncrease": "Lettergrootte vergroten",
+      "expand": "Uitgebreide weergave",
+      "compact": "Compacte weergave",
+      "clear": "Conversatie wissen",
+      "settings": "Ondertitelinstellingen",
+      "alwaysOnTop": "Altijd op voorgrond",
+      "lock": "Positie en grootte vergrendelen",
+      "exit": "Ondertitelmodus afsluiten"
+    },
+    "settings": {
+      "bgOpacity": "Achtergrondtransparantie",
+      "bgColor": "Achtergrondkleur",
+      "sourceColor": "Kleur brontekst",
+      "translationColor": "Vertaalkleur"
+    },
+    "pttHint": "Druk op Spatie om te spreken"
+  },
+  "titleBar": {
+    "minimize": "Minimaliseren",
+    "maximize": "Maximaliseren",
+    "close": "Sluiten"
   }
 }

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -827,5 +827,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sesja zakończona",
+    "backToMain": "Powrót do okna głównego",
+    "enterButton": {
+      "title": "Włącz tryb napisów",
+      "disabled": "Najpierw uruchom sesję",
+      "label": "Napisy"
+    },
+    "bar": {
+      "fontDecrease": "Zmniejsz czcionkę",
+      "fontIncrease": "Powiększ czcionkę",
+      "expand": "Widok rozszerzony",
+      "compact": "Widok kompaktowy",
+      "clear": "Wyczyść rozmowę",
+      "settings": "Ustawienia napisów",
+      "alwaysOnTop": "Zawsze na wierzchu",
+      "lock": "Zablokuj pozycję i rozmiar",
+      "exit": "Wyjdź z trybu napisów"
+    },
+    "settings": {
+      "bgOpacity": "Przezroczystość tła",
+      "bgColor": "Kolor tła",
+      "sourceColor": "Kolor tekstu źródłowego",
+      "translationColor": "Kolor tłumaczenia"
+    },
+    "pttHint": "Naciśnij spację, aby mówić"
+  },
+  "titleBar": {
+    "minimize": "Minimalizuj",
+    "maximize": "Maksymalizuj",
+    "close": "Zamknij"
   }
 }

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -828,5 +828,37 @@
     "downloadDeb": "Baixar .deb",
     "linuxMigrateTitle": "Nova versão v{{version}} disponível",
     "linuxMigrateBody": "Atualizações automáticas estão disponíveis no AppImage. Escolha um formato para baixar v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sessão encerrada",
+    "backToMain": "Voltar à janela principal",
+    "enterButton": {
+      "title": "Ativar modo de legendas",
+      "disabled": "Inicie uma sessão primeiro",
+      "label": "Legendas"
+    },
+    "bar": {
+      "fontDecrease": "Diminuir tamanho da fonte",
+      "fontIncrease": "Aumentar tamanho da fonte",
+      "expand": "Visualização expandida",
+      "compact": "Visualização compacta",
+      "clear": "Limpar conversa",
+      "settings": "Configurações de legendas",
+      "alwaysOnTop": "Sempre no topo",
+      "lock": "Bloquear posição e tamanho",
+      "exit": "Sair do modo de legendas"
+    },
+    "settings": {
+      "bgOpacity": "Opacidade do fundo",
+      "bgColor": "Cor do fundo",
+      "sourceColor": "Cor do texto original",
+      "translationColor": "Cor da tradução"
+    },
+    "pttHint": "Pressione Espaço para falar"
+  },
+  "titleBar": {
+    "minimize": "Minimizar",
+    "maximize": "Maximizar",
+    "close": "Fechar"
   }
 }

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -831,5 +831,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sessão terminada",
+    "backToMain": "Voltar à janela principal",
+    "enterButton": {
+      "title": "Ativar modo de legendas",
+      "disabled": "Inicie uma sessão primeiro",
+      "label": "Legendas"
+    },
+    "bar": {
+      "fontDecrease": "Diminuir tamanho da letra",
+      "fontIncrease": "Aumentar tamanho da letra",
+      "expand": "Vista expandida",
+      "compact": "Vista compacta",
+      "clear": "Limpar conversa",
+      "settings": "Definições de legendas",
+      "alwaysOnTop": "Sempre por cima",
+      "lock": "Bloquear posição e tamanho",
+      "exit": "Sair do modo de legendas"
+    },
+    "settings": {
+      "bgOpacity": "Opacidade do fundo",
+      "bgColor": "Cor do fundo",
+      "sourceColor": "Cor do texto original",
+      "translationColor": "Cor da tradução"
+    },
+    "pttHint": "Prima Espaço para falar"
+  },
+  "titleBar": {
+    "minimize": "Minimizar",
+    "maximize": "Maximizar",
+    "close": "Fechar"
   }
 }

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -835,5 +835,37 @@
     "downloadDeb": "Скачать .deb",
     "linuxMigrateTitle": "Доступна новая версия v{{version}}",
     "linuxMigrateBody": "Автоматические обновления доступны в формате AppImage. Выберите формат для скачивания v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Сессия завершена",
+    "backToMain": "Вернуться в главное окно",
+    "enterButton": {
+      "title": "Включить режим субтитров",
+      "disabled": "Сначала запустите сессию",
+      "label": "Субтитры"
+    },
+    "bar": {
+      "fontDecrease": "Уменьшить шрифт",
+      "fontIncrease": "Увеличить шрифт",
+      "expand": "Развернутый вид",
+      "compact": "Компактный вид",
+      "clear": "Очистить разговор",
+      "settings": "Настройки субтитров",
+      "alwaysOnTop": "Поверх всех окон",
+      "lock": "Зафиксировать позицию и размер",
+      "exit": "Выйти из режима субтитров"
+    },
+    "settings": {
+      "bgOpacity": "Прозрачность фона",
+      "bgColor": "Цвет фона",
+      "sourceColor": "Цвет исходного текста",
+      "translationColor": "Цвет перевода"
+    },
+    "pttHint": "Удерживайте пробел для речи"
+  },
+  "titleBar": {
+    "minimize": "Свернуть",
+    "maximize": "Развернуть",
+    "close": "Закрыть"
   }
 }

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -784,5 +784,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Sessionen avslutad",
+    "backToMain": "Tillbaka till huvudfönstret",
+    "enterButton": {
+      "title": "Aktivera undertextläge",
+      "disabled": "Starta en session först",
+      "label": "Undertexter"
+    },
+    "bar": {
+      "fontDecrease": "Minska textstorlek",
+      "fontIncrease": "Öka textstorlek",
+      "expand": "Utökad vy",
+      "compact": "Kompakt vy",
+      "clear": "Rensa konversation",
+      "settings": "Undertextinställningar",
+      "alwaysOnTop": "Alltid överst",
+      "lock": "Lås position och storlek",
+      "exit": "Avsluta undertextläge"
+    },
+    "settings": {
+      "bgOpacity": "Bakgrundsopacitet",
+      "bgColor": "Bakgrundsfärg",
+      "sourceColor": "Källtextfärg",
+      "translationColor": "Översättningsfärg"
+    },
+    "pttHint": "Tryck på mellanslag för att tala"
+  },
+  "titleBar": {
+    "minimize": "Minimera",
+    "maximize": "Maximera",
+    "close": "Stäng"
   }
 }

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -761,5 +761,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "அமர்வு முடிந்தது",
+    "backToMain": "முதன்மை சாளரத்திற்குத் திரும்பு",
+    "enterButton": {
+      "title": "துணைத்தலைப்பு பயன்முறையில் நுழைக",
+      "disabled": "முதலில் ஒரு அமர்வைத் தொடங்கவும்",
+      "label": "துணைத்தலைப்பு"
+    },
+    "bar": {
+      "fontDecrease": "எழுத்தளவைக் குறை",
+      "fontIncrease": "எழுத்தளவை அதிகரி",
+      "expand": "விரிவாக்கப்பட்ட காட்சி",
+      "compact": "சுருக்கமான காட்சி",
+      "clear": "உரையாடலை அழி",
+      "settings": "துணைத்தலைப்பு அமைப்புகள்",
+      "alwaysOnTop": "எப்போதும் மேலே",
+      "lock": "இருப்பிடம் மற்றும் அளவைப் பூட்டு",
+      "exit": "துணைத்தலைப்பு பயன்முறையிலிருந்து வெளியேறு"
+    },
+    "settings": {
+      "bgOpacity": "பின்னணி ஒளிபுகாமை",
+      "bgColor": "பின்னணி நிறம்",
+      "sourceColor": "மூல உரை நிறம்",
+      "translationColor": "மொழிபெயர்ப்பு நிறம்"
+    },
+    "pttHint": "பேச Space அழுத்தவும்"
+  },
+  "titleBar": {
+    "minimize": "சிறிதாக்கு",
+    "maximize": "பெரிதாக்கு",
+    "close": "மூடு"
   }
 }

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -743,5 +743,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "సెషన్ ముగిసింది",
+    "backToMain": "ప్రధాన విండోకి తిరిగి వెళ్ళు",
+    "enterButton": {
+      "title": "సబ్‌టైటిల్ మోడ్‌లోకి ప్రవేశించు",
+      "disabled": "ముందుగా సెషన్ ప్రారంభించండి",
+      "label": "సబ్‌టైటిల్"
+    },
+    "bar": {
+      "fontDecrease": "ఫాంట్ తగ్గించు",
+      "fontIncrease": "ఫాంట్ పెంచు",
+      "expand": "విస్తరించిన వీక్షణ",
+      "compact": "కాంపాక్ట్ వీక్షణ",
+      "clear": "సంభాషణను తొలగించు",
+      "settings": "సబ్‌టైటిల్ సెట్టింగ్‌లు",
+      "alwaysOnTop": "ఎల్లప్పుడూ పైన",
+      "lock": "స్థానం మరియు పరిమాణం లాక్ చేయి",
+      "exit": "సబ్‌టైటిల్ మోడ్‌ నుండి బయటకు"
+    },
+    "settings": {
+      "bgOpacity": "నేపథ్యం పారదర్శకత",
+      "bgColor": "నేపథ్యం రంగు",
+      "sourceColor": "మూల వచనం రంగు",
+      "translationColor": "అనువాదం రంగు"
+    },
+    "pttHint": "మాట్లాడడానికి Space నొక్కండి"
+  },
+  "titleBar": {
+    "minimize": "చిన్నదిచేయి",
+    "maximize": "పెద్దదిచేయి",
+    "close": "మూసివేయి"
   }
 }

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -750,5 +750,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "เซสชันสิ้นสุดแล้ว",
+    "backToMain": "กลับสู่หน้าต่างหลัก",
+    "enterButton": {
+      "title": "เข้าสู่โหมดคำบรรยาย",
+      "disabled": "เริ่มเซสชันก่อน",
+      "label": "คำบรรยาย"
+    },
+    "bar": {
+      "fontDecrease": "ลดขนาดตัวอักษร",
+      "fontIncrease": "เพิ่มขนาดตัวอักษร",
+      "expand": "มุมมองแบบขยาย",
+      "compact": "มุมมองแบบกะทัดรัด",
+      "clear": "ล้างบทสนทนา",
+      "settings": "ตั้งค่าคำบรรยาย",
+      "alwaysOnTop": "อยู่บนสุดเสมอ",
+      "lock": "ล็อกตำแหน่งและขนาด",
+      "exit": "ออกจากโหมดคำบรรยาย"
+    },
+    "settings": {
+      "bgOpacity": "ความโปร่งใสของพื้นหลัง",
+      "bgColor": "สีพื้นหลัง",
+      "sourceColor": "สีข้อความต้นฉบับ",
+      "translationColor": "สีคำแปล"
+    },
+    "pttHint": "กด Space ค้างเพื่อพูด"
+  },
+  "titleBar": {
+    "minimize": "ย่อ",
+    "maximize": "ขยาย",
+    "close": "ปิด"
   }
 }

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -786,5 +786,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Oturum sona erdi",
+    "backToMain": "Ana pencereye dön",
+    "enterButton": {
+      "title": "Altyazı moduna geç",
+      "disabled": "Önce bir oturum başlatın",
+      "label": "Altyazı"
+    },
+    "bar": {
+      "fontDecrease": "Yazı tipini küçült",
+      "fontIncrease": "Yazı tipini büyüt",
+      "expand": "Genişletilmiş görünüm",
+      "compact": "Kompakt görünüm",
+      "clear": "Sohbeti temizle",
+      "settings": "Altyazı ayarları",
+      "alwaysOnTop": "Her zaman üstte",
+      "lock": "Konum ve boyutu kilitle",
+      "exit": "Altyazı modundan çık"
+    },
+    "settings": {
+      "bgOpacity": "Arka plan opaklığı",
+      "bgColor": "Arka plan rengi",
+      "sourceColor": "Kaynak metin rengi",
+      "translationColor": "Çeviri rengi"
+    },
+    "pttHint": "Konuşmak için Boşluk tuşuna basın"
+  },
+  "titleBar": {
+    "minimize": "Küçült",
+    "maximize": "Büyüt",
+    "close": "Kapat"
   }
 }

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -748,5 +748,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Сеанс завершено",
+    "backToMain": "Повернутися до головного вікна",
+    "enterButton": {
+      "title": "Увімкнути режим субтитрів",
+      "disabled": "Спочатку запустіть сеанс",
+      "label": "Субтитри"
+    },
+    "bar": {
+      "fontDecrease": "Зменшити шрифт",
+      "fontIncrease": "Збільшити шрифт",
+      "expand": "Розгорнутий вигляд",
+      "compact": "Компактний вигляд",
+      "clear": "Очистити розмову",
+      "settings": "Налаштування субтитрів",
+      "alwaysOnTop": "Поверх усіх вікон",
+      "lock": "Закріпити позицію та розмір",
+      "exit": "Вийти з режиму субтитрів"
+    },
+    "settings": {
+      "bgOpacity": "Прозорість тла",
+      "bgColor": "Колір тла",
+      "sourceColor": "Колір вихідного тексту",
+      "translationColor": "Колір перекладу"
+    },
+    "pttHint": "Натисніть пробіл, щоб говорити"
+  },
+  "titleBar": {
+    "minimize": "Згорнути",
+    "maximize": "Розгорнути",
+    "close": "Закрити"
   }
 }

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -779,5 +779,37 @@
     "downloadDeb": "Download .deb",
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
+  },
+  "subtitle": {
+    "sessionEnded": "Phiên đã kết thúc",
+    "backToMain": "Quay lại cửa sổ chính",
+    "enterButton": {
+      "title": "Bật chế độ phụ đề",
+      "disabled": "Hãy bắt đầu phiên trước",
+      "label": "Phụ đề"
+    },
+    "bar": {
+      "fontDecrease": "Giảm cỡ chữ",
+      "fontIncrease": "Tăng cỡ chữ",
+      "expand": "Chế độ mở rộng",
+      "compact": "Chế độ thu gọn",
+      "clear": "Xóa cuộc trò chuyện",
+      "settings": "Cài đặt phụ đề",
+      "alwaysOnTop": "Luôn trên cùng",
+      "lock": "Khóa vị trí và kích thước",
+      "exit": "Thoát chế độ phụ đề"
+    },
+    "settings": {
+      "bgOpacity": "Độ trong suốt nền",
+      "bgColor": "Màu nền",
+      "sourceColor": "Màu văn bản gốc",
+      "translationColor": "Màu bản dịch"
+    },
+    "pttHint": "Nhấn Phím cách để nói"
+  },
+  "titleBar": {
+    "minimize": "Thu nhỏ",
+    "maximize": "Phóng to",
+    "close": "Đóng"
   }
 }

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -840,5 +840,37 @@
   },
   "connectionStatus": {
     "reconnecting": "重新连接中..."
+  },
+  "subtitle": {
+    "sessionEnded": "会话已结束",
+    "backToMain": "返回主窗口",
+    "enterButton": {
+      "title": "进入字幕模式",
+      "disabled": "请先启动会话",
+      "label": "字幕"
+    },
+    "bar": {
+      "fontDecrease": "减小字号",
+      "fontIncrease": "增大字号",
+      "expand": "展开视图",
+      "compact": "紧凑视图",
+      "clear": "清空对话",
+      "settings": "字幕设置",
+      "alwaysOnTop": "置顶",
+      "lock": "锁定位置和尺寸",
+      "exit": "退出字幕模式"
+    },
+    "settings": {
+      "bgOpacity": "背景透明度",
+      "bgColor": "背景颜色",
+      "sourceColor": "源文颜色",
+      "translationColor": "译文颜色"
+    },
+    "pttHint": "按住空格说话"
+  },
+  "titleBar": {
+    "minimize": "最小化",
+    "maximize": "最大化",
+    "close": "关闭"
   }
 }

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -863,7 +863,7 @@
     "settings": {
       "bgOpacity": "背景透明度",
       "bgColor": "背景颜色",
-      "sourceColor": "源文颜色",
+      "sourceColor": "原文颜色",
       "translationColor": "译文颜色"
     },
     "pttHint": "按住空格说话"

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -798,5 +798,37 @@
     "downloadDeb": "下載 .deb",
     "linuxMigrateTitle": "有新版本 v{{version}}",
     "linuxMigrateBody": "AppImage 格式支援自動更新。選擇一種格式下載 v{{version}}。"
+  },
+  "subtitle": {
+    "sessionEnded": "對話已結束",
+    "backToMain": "返回主視窗",
+    "enterButton": {
+      "title": "進入字幕模式",
+      "disabled": "請先啟動對話",
+      "label": "字幕"
+    },
+    "bar": {
+      "fontDecrease": "縮小字級",
+      "fontIncrease": "放大字級",
+      "expand": "展開檢視",
+      "compact": "緊湊檢視",
+      "clear": "清除對話",
+      "settings": "字幕設定",
+      "alwaysOnTop": "視窗置頂",
+      "lock": "鎖定位置與大小",
+      "exit": "退出字幕模式"
+    },
+    "settings": {
+      "bgOpacity": "背景透明度",
+      "bgColor": "背景顏色",
+      "sourceColor": "原文顏色",
+      "translationColor": "譯文顏色"
+    },
+    "pttHint": "按住空白鍵說話"
+  },
+  "titleBar": {
+    "minimize": "最小化",
+    "maximize": "最大化",
+    "close": "關閉"
   }
 }

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
 import { useMemo } from 'react';
+import type { ConversationItem } from '../services/interfaces/IClient';
 
 interface SessionStore {
   // State
@@ -9,6 +10,8 @@ interface SessionStore {
   sessionStartTime: number | null;
   translationCount: number;
   isReconnecting: boolean;
+  items: ConversationItem[];
+  systemAudioItems: ConversationItem[];
 
   // Actions
   setIsSessionActive: (active: boolean) => void;
@@ -17,6 +20,8 @@ interface SessionStore {
   setTranslationCount: (count: number) => void;
   incrementTranslationCount: () => void;
   setIsReconnecting: (reconnecting: boolean) => void;
+  setItems: (items: ConversationItem[]) => void;
+  setSystemAudioItems: (items: ConversationItem[]) => void;
   
   // Compound actions
   startSession: (sessionId: string) => void;
@@ -32,6 +37,8 @@ const useSessionStore = create<SessionStore>()(
     sessionStartTime: null,
     translationCount: 0,
     isReconnecting: false,
+    items: [],
+    systemAudioItems: [],
 
     // Basic setters
     setIsSessionActive: (active) => set({ isSessionActive: active }),
@@ -39,7 +46,9 @@ const useSessionStore = create<SessionStore>()(
     setSessionStartTime: (time) => set({ sessionStartTime: time }),
     setTranslationCount: (count) => set({ translationCount: count }),
     setIsReconnecting: (reconnecting) => set({ isReconnecting: reconnecting }),
-    
+    setItems: (items) => set({ items }),
+    setSystemAudioItems: (systemAudioItems) => set({ systemAudioItems }),
+
     // Increment translation count
     incrementTranslationCount: () => set((state) => ({ 
       translationCount: state.translationCount + 1 
@@ -59,6 +68,8 @@ const useSessionStore = create<SessionStore>()(
       sessionId: null,
       sessionStartTime: null,
       isReconnecting: false,
+      items: [],
+      systemAudioItems: [],
       // Keep translation count for reference
     }),
 
@@ -69,6 +80,8 @@ const useSessionStore = create<SessionStore>()(
       sessionStartTime: null,
       translationCount: 0,
       isReconnecting: false,
+      items: [],
+      systemAudioItems: [],
     }),
   }))
 );
@@ -90,6 +103,10 @@ export const useSetIsReconnecting = () => useSessionStore((state) => state.setIs
 export const useStartSession = () => useSessionStore((state) => state.startSession);
 export const useEndSession = () => useSessionStore((state) => state.endSession);
 export const useResetSession = () => useSessionStore((state) => state.resetSession);
+export const useItems = () => useSessionStore((state) => state.items);
+export const useSystemAudioItems = () => useSessionStore((state) => state.systemAudioItems);
+export const useSetItems = () => useSessionStore((state) => state.setItems);
+export const useSetSystemAudioItems = () => useSessionStore((state) => state.setSystemAudioItems);
 
 // Export actions - use individual hooks and memoize to prevent recreating objects
 export const useSessionActions = () => {

--- a/src/stores/sessionStore.ts
+++ b/src/stores/sessionStore.ts
@@ -12,6 +12,11 @@ interface SessionStore {
   isReconnecting: boolean;
   items: ConversationItem[];
   systemAudioItems: ConversationItem[];
+  // Monotonic counter — every call to requestClearConversation bumps it.
+  // MainPanel watches this version and runs its local clearConversation
+  // routine when it changes, so any consumer (subtitle bar, main toolbar)
+  // can trigger a clear without holding a direct reference to MainPanel.
+  clearConversationVersion: number;
 
   // Actions
   setIsSessionActive: (active: boolean) => void;
@@ -22,7 +27,8 @@ interface SessionStore {
   setIsReconnecting: (reconnecting: boolean) => void;
   setItems: (items: ConversationItem[]) => void;
   setSystemAudioItems: (items: ConversationItem[]) => void;
-  
+  requestClearConversation: () => void;
+
   // Compound actions
   startSession: (sessionId: string) => void;
   endSession: () => void;
@@ -39,6 +45,7 @@ const useSessionStore = create<SessionStore>()(
     isReconnecting: false,
     items: [],
     systemAudioItems: [],
+    clearConversationVersion: 0,
 
     // Basic setters
     setIsSessionActive: (active) => set({ isSessionActive: active }),
@@ -48,6 +55,9 @@ const useSessionStore = create<SessionStore>()(
     setIsReconnecting: (reconnecting) => set({ isReconnecting: reconnecting }),
     setItems: (items) => set({ items }),
     setSystemAudioItems: (systemAudioItems) => set({ systemAudioItems }),
+    requestClearConversation: () => set((state) => ({
+      clearConversationVersion: state.clearConversationVersion + 1,
+    })),
 
     // Increment translation count
     incrementTranslationCount: () => set((state) => ({ 
@@ -107,6 +117,8 @@ export const useItems = () => useSessionStore((state) => state.items);
 export const useSystemAudioItems = () => useSessionStore((state) => state.systemAudioItems);
 export const useSetItems = () => useSessionStore((state) => state.setItems);
 export const useSetSystemAudioItems = () => useSessionStore((state) => state.setSystemAudioItems);
+export const useClearConversationVersion = () => useSessionStore((state) => state.clearConversationVersion);
+export const useRequestClearConversation = () => useSessionStore((state) => state.requestClearConversation);
 
 // Export actions - use individual hooks and memoize to prevent recreating objects
 export const useSessionActions = () => {

--- a/src/stores/settingsStore.subtitle.test.ts
+++ b/src/stores/settingsStore.subtitle.test.ts
@@ -10,6 +10,34 @@ vi.mock('../services/ServiceFactory', () => ({
   },
 }));
 
+// Pretend we're running inside Electron so the IPC-guarded actions
+// (enterSubtitleMode, exit*, toggle*) follow their real-environment paths.
+vi.mock('../utils/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/environment')>();
+  return {
+    ...actual,
+    isElectron: () => true,
+  };
+});
+
+// Provide a window.electron stub so the IPC-guarded actions can run.
+// The renderer code only calls invoke() — return resolved promises with
+// the shape each handler is expected to deliver.
+beforeEach(() => {
+  (window as any).electron = {
+    invoke: vi.fn(async (channel: string) => {
+      if (channel === 'subtitle:enter') {
+        return { ok: true, bounds: { x: 0, y: 0, width: 800, height: 200 } };
+      }
+      return { ok: true };
+    }),
+    receive: () => {},
+    removeListener: () => {},
+    removeAllListeners: () => {},
+    send: () => {},
+  };
+});
+
 // Import after mocking
 const { default: useSettingsStore } = await import('./settingsStore');
 const { default: useSessionStore } = await import('./sessionStore');

--- a/src/stores/settingsStore.subtitle.test.ts
+++ b/src/stores/settingsStore.subtitle.test.ts
@@ -1,0 +1,60 @@
+// src/stores/settingsStore.subtitle.test.ts
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: async (_k: string, d: any) => d,
+      setSetting: async () => undefined,
+    }),
+  },
+}));
+
+// Import after mocking
+const { default: useSettingsStore } = await import('./settingsStore');
+const { default: useSessionStore } = await import('./sessionStore');
+
+describe('settingsStore subtitle actions', () => {
+  beforeEach(() => {
+    useSettingsStore.setState({ subtitleModeActive: false });
+  });
+
+  it('enterSubtitleMode is a no-op when session is not active', async () => {
+    useSessionStore.setState({ isSessionActive: false } as any);
+    await useSettingsStore.getState().enterSubtitleMode();
+    expect(useSettingsStore.getState().subtitleModeActive).toBe(false);
+  });
+
+  it('enterSubtitleMode sets the flag when session is active', async () => {
+    useSessionStore.setState({ isSessionActive: true } as any);
+    await useSettingsStore.getState().enterSubtitleMode();
+    expect(useSettingsStore.getState().subtitleModeActive).toBe(true);
+  });
+
+  it('enterSubtitleMode is idempotent', async () => {
+    useSessionStore.setState({ isSessionActive: true } as any);
+    await useSettingsStore.getState().enterSubtitleMode();
+    await useSettingsStore.getState().enterSubtitleMode();
+    expect(useSettingsStore.getState().subtitleModeActive).toBe(true);
+  });
+
+  it('exitSubtitleMode resets the flag', async () => {
+    useSettingsStore.setState({ subtitleModeActive: true });
+    await useSettingsStore.getState().exitSubtitleMode();
+    expect(useSettingsStore.getState().subtitleModeActive).toBe(false);
+  });
+
+  it('setSubtitleFontSize clamps to 16-48', async () => {
+    await useSettingsStore.getState().setSubtitleFontSize(8);
+    expect(useSettingsStore.getState().subtitle.fontSize).toBe(16);
+    await useSettingsStore.getState().setSubtitleFontSize(100);
+    expect(useSettingsStore.getState().subtitle.fontSize).toBe(48);
+  });
+
+  it('setSubtitleBgOpacity clamps to 0-100', async () => {
+    await useSettingsStore.getState().setSubtitleBgOpacity(-5);
+    expect(useSettingsStore.getState().subtitle.bgOpacity).toBe(0);
+    await useSettingsStore.getState().setSubtitleBgOpacity(150);
+    expect(useSettingsStore.getState().subtitle.bgOpacity).toBe(100);
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -458,6 +458,15 @@ interface SettingsStore {
   setConversationCompactMode: (compact: boolean) => Promise<void>;
   setSpeakerDisplayMode: (mode: DisplayMode) => Promise<void>;
   setParticipantDisplayMode: (mode: DisplayMode) => Promise<void>;
+  setSubtitleFontSize: (n: number) => Promise<void>;
+  setSubtitleCompactMode: (b: boolean) => Promise<void>;
+  setSubtitleBgOpacity: (n: number) => Promise<void>;
+  setSubtitleBgColor: (s: string) => Promise<void>;
+  setSubtitleSourceTextColor: (s: string) => Promise<void>;
+  setSubtitleTranslationTextColor: (s: string) => Promise<void>;
+  toggleSubtitleAlwaysOnTop: () => Promise<void>;
+  toggleSubtitlePositionLocked: () => Promise<void>;
+  saveSubtitleWindowBounds: (b: SubtitleWindowBounds) => Promise<void>;
   setSystemInstructions: (instructions: string) => void;
   setTemplateSystemInstructions: (instructions: string) => void;
   setUseTemplateMode: (useTemplate: boolean) => void;
@@ -966,6 +975,116 @@ const useSettingsStore = create<SettingsStore>()(
       } catch (error) {
         console.error('[SettingsStore] Error persisting participantDisplayMode setting:', error);
         set({participantDisplayMode: previous});
+      }
+    },
+
+    setSubtitleFontSize: async (fontSize) => {
+      const clamped = Math.max(16, Math.min(48, Math.round(fontSize)));
+      const previous = get().subtitle.fontSize;
+      set((state) => ({ subtitle: { ...state.subtitle, fontSize: clamped } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.fontSize', clamped);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.fontSize:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, fontSize: previous } }));
+      }
+    },
+
+    setSubtitleCompactMode: async (compactMode) => {
+      const previous = get().subtitle.compactMode;
+      set((state) => ({ subtitle: { ...state.subtitle, compactMode } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.compactMode', compactMode);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.compactMode:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, compactMode: previous } }));
+      }
+    },
+
+    setSubtitleBgOpacity: async (n) => {
+      const clamped = Math.max(0, Math.min(100, Math.round(n)));
+      const previous = get().subtitle.bgOpacity;
+      set((state) => ({ subtitle: { ...state.subtitle, bgOpacity: clamped } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.bgOpacity', clamped);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.bgOpacity:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, bgOpacity: previous } }));
+      }
+    },
+
+    setSubtitleBgColor: async (s) => {
+      const previous = get().subtitle.bgColor;
+      set((state) => ({ subtitle: { ...state.subtitle, bgColor: s } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.bgColor', s);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.bgColor:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, bgColor: previous } }));
+      }
+    },
+
+    setSubtitleSourceTextColor: async (s) => {
+      const previous = get().subtitle.sourceTextColor;
+      set((state) => ({ subtitle: { ...state.subtitle, sourceTextColor: s } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.sourceTextColor', s);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.sourceTextColor:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, sourceTextColor: previous } }));
+      }
+    },
+
+    setSubtitleTranslationTextColor: async (s) => {
+      const previous = get().subtitle.translationTextColor;
+      set((state) => ({ subtitle: { ...state.subtitle, translationTextColor: s } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.translationTextColor', s);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.translationTextColor:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, translationTextColor: previous } }));
+      }
+    },
+
+    toggleSubtitleAlwaysOnTop: async () => {
+      const next = !get().subtitle.alwaysOnTop;
+      set((state) => ({ subtitle: { ...state.subtitle, alwaysOnTop: next } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.alwaysOnTop', next);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.alwaysOnTop:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, alwaysOnTop: !next } }));
+      }
+    },
+
+    toggleSubtitlePositionLocked: async () => {
+      const next = !get().subtitle.positionLocked;
+      set((state) => ({ subtitle: { ...state.subtitle, positionLocked: next } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.positionLocked', next);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.positionLocked:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, positionLocked: !next } }));
+      }
+    },
+
+    saveSubtitleWindowBounds: async (b) => {
+      const previous = get().subtitle.windowBounds;
+      set((state) => ({ subtitle: { ...state.subtitle, windowBounds: b } }));
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.subtitle.windowBounds', b);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting subtitle.windowBounds:', error);
+        set((state) => ({ subtitle: { ...state.subtitle, windowBounds: previous } }));
       }
     },
 
@@ -1691,6 +1810,17 @@ export const useConversationFontSize = () => useSettingsStore((state) => state.c
 export const useConversationCompactMode = () => useSettingsStore((state) => state.conversationCompactMode);
 export const useSpeakerDisplayMode = () => useSettingsStore((state) => state.speakerDisplayMode);
 export const useParticipantDisplayMode = () => useSettingsStore((state) => state.participantDisplayMode);
+export const useSubtitleSettings = () => useSettingsStore((state) => state.subtitle);
+export const useSubtitleModeActive = () => useSettingsStore((state) => state.subtitleModeActive);
+export const useSetSubtitleFontSize = () => useSettingsStore((state) => state.setSubtitleFontSize);
+export const useSetSubtitleCompactMode = () => useSettingsStore((state) => state.setSubtitleCompactMode);
+export const useSetSubtitleBgOpacity = () => useSettingsStore((state) => state.setSubtitleBgOpacity);
+export const useSetSubtitleBgColor = () => useSettingsStore((state) => state.setSubtitleBgColor);
+export const useSetSubtitleSourceTextColor = () => useSettingsStore((state) => state.setSubtitleSourceTextColor);
+export const useSetSubtitleTranslationTextColor = () => useSettingsStore((state) => state.setSubtitleTranslationTextColor);
+export const useToggleSubtitleAlwaysOnTop = () => useSettingsStore((state) => state.toggleSubtitleAlwaysOnTop);
+export const useToggleSubtitlePositionLocked = () => useSettingsStore((state) => state.toggleSubtitlePositionLocked);
+export const useSaveSubtitleWindowBounds = () => useSettingsStore((state) => state.saveSubtitleWindowBounds);
 export const useSystemInstructions = () => useSettingsStore((state) => state.systemInstructions);
 export const useTemplateSystemInstructions = () => useSettingsStore((state) => state.templateSystemInstructions);
 export const useUseTemplateMode = () => useSettingsStore((state) => state.useTemplateMode);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1,6 +1,7 @@
 import {create} from 'zustand';
 import {subscribeWithSelector} from 'zustand/middleware';
 import {ServiceFactory} from '../services/ServiceFactory';
+import {isElectron} from '../utils/environment';
 import {ProviderConfigFactory} from '../services/providers/ProviderConfigFactory';
 import {ProviderConfig} from '../services/providers/ProviderConfig';
 import {
@@ -1059,12 +1060,16 @@ const useSettingsStore = create<SettingsStore>()(
       const next = !get().subtitle.alwaysOnTop;
       set((state) => ({ subtitle: { ...state.subtitle, alwaysOnTop: next } }));
       try {
+        // Apply the live window change FIRST. If the IPC throws (e.g. main
+        // process is unreachable), we want to bail before writing the new
+        // value to disk — otherwise the next launch hydrates an
+        // un-applied state. Inside the try so any throw routes through
+        // the rollback in catch.
+        if (get().subtitleModeActive) {
+          await window.electron?.invoke('subtitle:set-always-on-top', next);
+        }
         const service = ServiceFactory.getSettingsService();
         await service.setSetting('settings.common.subtitle.alwaysOnTop', next);
-        if (get().subtitleModeActive) {
-          const electronApi = (window as any).electron;
-          await electronApi?.invoke('subtitle:set-always-on-top', next);
-        }
       } catch (error) {
         console.error('[SettingsStore] toggleSubtitleAlwaysOnTop failed:', error);
         set((state) => ({ subtitle: { ...state.subtitle, alwaysOnTop: !next } }));
@@ -1075,12 +1080,12 @@ const useSettingsStore = create<SettingsStore>()(
       const next = !get().subtitle.positionLocked;
       set((state) => ({ subtitle: { ...state.subtitle, positionLocked: next } }));
       try {
+        // IPC first, then persist (see toggleSubtitleAlwaysOnTop above).
+        if (get().subtitleModeActive) {
+          await window.electron?.invoke('subtitle:set-locked', next);
+        }
         const service = ServiceFactory.getSettingsService();
         await service.setSetting('settings.common.subtitle.positionLocked', next);
-        if (get().subtitleModeActive) {
-          const electronApi = (window as any).electron;
-          await electronApi?.invoke('subtitle:set-locked', next);
-        }
       } catch (error) {
         console.error('[SettingsStore] toggleSubtitlePositionLocked failed:', error);
         set((state) => ({ subtitle: { ...state.subtitle, positionLocked: !next } }));
@@ -1101,6 +1106,15 @@ const useSettingsStore = create<SettingsStore>()(
 
     enterSubtitleMode: async () => {
       if (get().subtitleModeActive) return;
+      // Subtitle mode is Electron-only — entering it without the IPC
+      // bridge would hide the main UI and mount SubtitleApp over a
+      // BrowserWindow that was never resized into the floating bar.
+      // Guard at the action level so a stray call (test, web/extension
+      // build, missing preload) can't put the app into a broken state.
+      if (!isElectron() || !window.electron?.invoke) {
+        console.warn('[SettingsStore] enterSubtitleMode ignored — not running in Electron');
+        return;
+      }
       const sessionActive = useSessionStore.getState().isSessionActive;
       if (!sessionActive) {
         console.warn('[SettingsStore] enterSubtitleMode ignored — no active session');
@@ -1117,19 +1131,16 @@ const useSettingsStore = create<SettingsStore>()(
         ? persisted
         : undefined;
       try {
-        const electronApi = (window as any).electron;
-        if (electronApi?.invoke) {
-          const result = await electronApi.invoke('subtitle:enter', {
-            bounds: requestedBounds,
-            alwaysOnTop: subtitle.alwaysOnTop,
-            locked: subtitle.positionLocked,
-          });
-          if (result?.bounds) {
-            // Persist clamped bounds so next launch uses corrected values
-            set((state) => ({ subtitle: { ...state.subtitle, windowBounds: result.bounds } }));
-            const service = ServiceFactory.getSettingsService();
-            await service.setSetting('settings.common.subtitle.windowBounds', result.bounds);
-          }
+        const result = await window.electron.invoke('subtitle:enter', {
+          bounds: requestedBounds,
+          alwaysOnTop: subtitle.alwaysOnTop,
+          locked: subtitle.positionLocked,
+        });
+        if (result?.bounds) {
+          // Persist clamped bounds so next launch uses corrected values
+          set((state) => ({ subtitle: { ...state.subtitle, windowBounds: result.bounds } }));
+          const service = ServiceFactory.getSettingsService();
+          await service.setSetting('settings.common.subtitle.windowBounds', result.bounds);
         }
         set({ subtitleModeActive: true });
       } catch (error) {
@@ -1140,9 +1151,8 @@ const useSettingsStore = create<SettingsStore>()(
     exitSubtitleMode: async () => {
       if (!get().subtitleModeActive) return;
       try {
-        const electronApi = (window as any).electron;
-        if (electronApi?.invoke) {
-          await electronApi.invoke('subtitle:exit', {});
+        if (isElectron() && window.electron?.invoke) {
+          await window.electron.invoke('subtitle:exit', {});
         }
       } catch (error) {
         console.error('[SettingsStore] exitSubtitleMode IPC failed:', error);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1061,8 +1061,12 @@ const useSettingsStore = create<SettingsStore>()(
       try {
         const service = ServiceFactory.getSettingsService();
         await service.setSetting('settings.common.subtitle.alwaysOnTop', next);
+        if (get().subtitleModeActive) {
+          const electronApi = (window as any).electron;
+          await electronApi?.invoke('subtitle:set-always-on-top', next);
+        }
       } catch (error) {
-        console.error('[SettingsStore] Error persisting subtitle.alwaysOnTop:', error);
+        console.error('[SettingsStore] toggleSubtitleAlwaysOnTop failed:', error);
         set((state) => ({ subtitle: { ...state.subtitle, alwaysOnTop: !next } }));
       }
     },
@@ -1073,8 +1077,12 @@ const useSettingsStore = create<SettingsStore>()(
       try {
         const service = ServiceFactory.getSettingsService();
         await service.setSetting('settings.common.subtitle.positionLocked', next);
+        if (get().subtitleModeActive) {
+          const electronApi = (window as any).electron;
+          await electronApi?.invoke('subtitle:set-locked', next);
+        }
       } catch (error) {
-        console.error('[SettingsStore] Error persisting subtitle.positionLocked:', error);
+        console.error('[SettingsStore] toggleSubtitlePositionLocked failed:', error);
         set((state) => ({ subtitle: { ...state.subtitle, positionLocked: !next } }));
       }
     },
@@ -1092,22 +1100,46 @@ const useSettingsStore = create<SettingsStore>()(
     },
 
     enterSubtitleMode: async () => {
-      // Idempotent: bail if already active
       if (get().subtitleModeActive) return;
-      // Require an active session
       const sessionActive = useSessionStore.getState().isSessionActive;
       if (!sessionActive) {
         console.warn('[SettingsStore] enterSubtitleMode ignored — no active session');
         return;
       }
-      set({ subtitleModeActive: true });
-      // IPC call to Electron main is added in Task 11; until then this is a no-op.
+      const subtitle = get().subtitle;
+      try {
+        const electronApi = (window as any).electron;
+        if (electronApi?.invoke) {
+          const result = await electronApi.invoke('subtitle:enter', {
+            bounds: subtitle.windowBounds ?? undefined,
+            alwaysOnTop: subtitle.alwaysOnTop,
+            locked: subtitle.positionLocked,
+          });
+          if (result?.bounds) {
+            // Persist clamped bounds so next launch uses corrected values
+            set((state) => ({ subtitle: { ...state.subtitle, windowBounds: result.bounds } }));
+            const service = ServiceFactory.getSettingsService();
+            await service.setSetting('settings.common.subtitle.windowBounds', result.bounds);
+          }
+        }
+        set({ subtitleModeActive: true });
+      } catch (error) {
+        console.error('[SettingsStore] enterSubtitleMode IPC failed:', error);
+      }
     },
 
     exitSubtitleMode: async () => {
       if (!get().subtitleModeActive) return;
-      set({ subtitleModeActive: false });
-      // IPC call to Electron main is added in Task 11; until then this is a no-op.
+      try {
+        const electronApi = (window as any).electron;
+        if (electronApi?.invoke) {
+          await electronApi.invoke('subtitle:exit', {});
+        }
+      } catch (error) {
+        console.error('[SettingsStore] exitSubtitleMode IPC failed:', error);
+      } finally {
+        set({ subtitleModeActive: false });
+      }
     },
 
     // === Provider Settings Actions ===

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1107,11 +1107,20 @@ const useSettingsStore = create<SettingsStore>()(
         return;
       }
       const subtitle = get().subtitle;
+      // Auto-recover: ignore persisted bounds that don't look like a subtitle
+      // bar (height >> what we'd ever set). Earlier builds had a Linux WM
+      // race that could persist main-window-sized bounds; this lets affected
+      // users transition without manual cleanup.
+      const SUBTITLE_PLAUSIBLE_MAX_HEIGHT = 400;
+      const persisted = subtitle.windowBounds;
+      const requestedBounds = persisted && persisted.height <= SUBTITLE_PLAUSIBLE_MAX_HEIGHT
+        ? persisted
+        : undefined;
       try {
         const electronApi = (window as any).electron;
         if (electronApi?.invoke) {
           const result = await electronApi.invoke('subtitle:enter', {
-            bounds: subtitle.windowBounds ?? undefined,
+            bounds: requestedBounds,
             alwaysOnTop: subtitle.alwaysOnTop,
             locked: subtitle.positionLocked,
           });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1442,6 +1442,42 @@ const useSettingsStore = create<SettingsStore>()(
         const conversationCompactMode = await service.getSetting('settings.common.conversationCompactMode', defaultCommonSettings.conversationCompactMode);
         const speakerDisplayMode = await service.getSetting<DisplayMode>('settings.common.speakerDisplayMode', defaultCommonSettings.speakerDisplayMode);
         const participantDisplayMode = await service.getSetting<DisplayMode>('settings.common.participantDisplayMode', defaultCommonSettings.participantDisplayMode);
+        const subtitleFontSize = await service.getSetting<number>(
+          'settings.common.subtitle.fontSize',
+          defaultCommonSettings.subtitle.fontSize,
+        );
+        const subtitleCompactMode = await service.getSetting<boolean>(
+          'settings.common.subtitle.compactMode',
+          defaultCommonSettings.subtitle.compactMode,
+        );
+        const subtitleBgOpacity = await service.getSetting<number>(
+          'settings.common.subtitle.bgOpacity',
+          defaultCommonSettings.subtitle.bgOpacity,
+        );
+        const subtitleBgColor = await service.getSetting<string>(
+          'settings.common.subtitle.bgColor',
+          defaultCommonSettings.subtitle.bgColor,
+        );
+        const subtitleSourceTextColor = await service.getSetting<string>(
+          'settings.common.subtitle.sourceTextColor',
+          defaultCommonSettings.subtitle.sourceTextColor,
+        );
+        const subtitleTranslationTextColor = await service.getSetting<string>(
+          'settings.common.subtitle.translationTextColor',
+          defaultCommonSettings.subtitle.translationTextColor,
+        );
+        const subtitleAlwaysOnTop = await service.getSetting<boolean>(
+          'settings.common.subtitle.alwaysOnTop',
+          defaultCommonSettings.subtitle.alwaysOnTop,
+        );
+        const subtitlePositionLocked = await service.getSetting<boolean>(
+          'settings.common.subtitle.positionLocked',
+          defaultCommonSettings.subtitle.positionLocked,
+        );
+        const subtitleWindowBounds = await service.getSetting<SubtitleWindowBounds | null>(
+          'settings.common.subtitle.windowBounds',
+          defaultCommonSettings.subtitle.windowBounds,
+        );
 
         // Validate provider availability
         const validProvider = ProviderConfigFactory.isProviderSupported(provider) ? provider : Provider.OPENAI;
@@ -1480,6 +1516,17 @@ const useSettingsStore = create<SettingsStore>()(
           conversationCompactMode,
           speakerDisplayMode,
           participantDisplayMode,
+          subtitle: {
+            fontSize: subtitleFontSize,
+            compactMode: subtitleCompactMode,
+            bgOpacity: subtitleBgOpacity,
+            bgColor: subtitleBgColor,
+            sourceTextColor: subtitleSourceTextColor,
+            translationTextColor: subtitleTranslationTextColor,
+            alwaysOnTop: subtitleAlwaysOnTop,
+            positionLocked: subtitlePositionLocked,
+            windowBounds: subtitleWindowBounds,
+          },
           openai,
           gemini,
           openaiCompatible,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -28,6 +28,27 @@ import i18n from '../locales';
 // Conversation display mode — which half of a bilingual utterance to show
 export type DisplayMode = 'source' | 'translation' | 'both';
 
+// Subtitle (floating-bar) mode settings — Electron-only feature.
+// Persisted under settings.common.subtitle.*
+export interface SubtitleWindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface SubtitleSettings {
+  fontSize: number;            // 16-48, clamped on set
+  compactMode: boolean;
+  bgOpacity: number;           // 0-100
+  bgColor: string;             // hex
+  sourceTextColor: string;     // hex
+  translationTextColor: string;// hex
+  alwaysOnTop: boolean;
+  positionLocked: boolean;
+  windowBounds: SubtitleWindowBounds | null;
+}
+
 // Common Settings
 export interface CommonSettings {
   provider: ProviderType;
@@ -42,6 +63,7 @@ export interface CommonSettings {
   conversationCompactMode: boolean;
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
+  subtitle: SubtitleSettings;
 }
 
 // Transport type for OpenAI Realtime API
@@ -243,6 +265,17 @@ const defaultCommonSettings: CommonSettings = {
   participantSystemInstructions: '',
   speakerDisplayMode: 'both',
   participantDisplayMode: 'both',
+  subtitle: {
+    fontSize: 24,
+    compactMode: true,
+    bgOpacity: 70,
+    bgColor: '#000000',
+    sourceTextColor: '#FFFFFF',
+    translationTextColor: '#6CC5FF',
+    alwaysOnTop: true,
+    positionLocked: false,
+    windowBounds: null,
+  },
 };
 
 const defaultOpenAICompatibleSettingsBase: OpenAICompatibleSettingsBase = {
@@ -410,6 +443,10 @@ interface SettingsStore {
   // Conversation display mode filters
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
+
+  // Subtitle mode settings and runtime flag
+  subtitle: SubtitleSettings;
+  subtitleModeActive: boolean;
 
   // === Actions ===
   // Common settings actions
@@ -788,6 +825,7 @@ const useSettingsStore = create<SettingsStore>()(
     settingsNavigationTarget: null,
 
     settingsLoaded: false,
+    subtitleModeActive: false,
 
     // === Common Settings Actions ===
     setProvider: async (provider) => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -18,6 +18,7 @@ import {
 import { getTtsModelsForLanguage, getManifestEntry, getTranslationModel, estimateModelMemoryByDevice } from '../lib/local-inference/modelManifest';
 import { buildDefaultLocalPrompt } from '../lib/local-inference/prompts';
 import { useModelStore, type ParticipantModelStatus } from './modelStore';
+import useSessionStore from './sessionStore';
 import {ApiKeyValidationResult} from '../services/interfaces/ISettingsService';
 import {Provider, ProviderType} from '../types/Provider';
 import {ClientOperations} from '../services/ClientOperations';
@@ -467,6 +468,8 @@ interface SettingsStore {
   toggleSubtitleAlwaysOnTop: () => Promise<void>;
   toggleSubtitlePositionLocked: () => Promise<void>;
   saveSubtitleWindowBounds: (b: SubtitleWindowBounds) => Promise<void>;
+  enterSubtitleMode: () => Promise<void>;
+  exitSubtitleMode: () => Promise<void>;
   setSystemInstructions: (instructions: string) => void;
   setTemplateSystemInstructions: (instructions: string) => void;
   setUseTemplateMode: (useTemplate: boolean) => void;
@@ -1086,6 +1089,25 @@ const useSettingsStore = create<SettingsStore>()(
         console.error('[SettingsStore] Error persisting subtitle.windowBounds:', error);
         set((state) => ({ subtitle: { ...state.subtitle, windowBounds: previous } }));
       }
+    },
+
+    enterSubtitleMode: async () => {
+      // Idempotent: bail if already active
+      if (get().subtitleModeActive) return;
+      // Require an active session
+      const sessionActive = useSessionStore.getState().isSessionActive;
+      if (!sessionActive) {
+        console.warn('[SettingsStore] enterSubtitleMode ignored — no active session');
+        return;
+      }
+      set({ subtitleModeActive: true });
+      // IPC call to Electron main is added in Task 11; until then this is a no-op.
+    },
+
+    exitSubtitleMode: async () => {
+      if (!get().subtitleModeActive) return;
+      set({ subtitleModeActive: false });
+      // IPC call to Electron main is added in Task 11; until then this is a no-op.
     },
 
     // === Provider Settings Actions ===
@@ -1821,6 +1843,8 @@ export const useSetSubtitleTranslationTextColor = () => useSettingsStore((state)
 export const useToggleSubtitleAlwaysOnTop = () => useSettingsStore((state) => state.toggleSubtitleAlwaysOnTop);
 export const useToggleSubtitlePositionLocked = () => useSettingsStore((state) => state.toggleSubtitlePositionLocked);
 export const useSaveSubtitleWindowBounds = () => useSettingsStore((state) => state.saveSubtitleWindowBounds);
+export const useEnterSubtitleMode = () => useSettingsStore((state) => state.enterSubtitleMode);
+export const useExitSubtitleMode = () => useSettingsStore((state) => state.exitSubtitleMode);
 export const useSystemInstructions = () => useSettingsStore((state) => state.systemInstructions);
 export const useTemplateSystemInstructions = () => useSettingsStore((state) => state.templateSystemInstructions);
 export const useUseTemplateMode = () => useSettingsStore((state) => state.useTemplateMode);

--- a/src/utils/clampToScreen.test.ts
+++ b/src/utils/clampToScreen.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { clampToScreen } from './clampToScreen';
+
+describe('clampToScreen', () => {
+  const work = { x: 0, y: 0, width: 1920, height: 1080 };
+
+  it('returns the same bounds when fully inside', () => {
+    const b = { x: 100, y: 100, width: 800, height: 200 };
+    expect(clampToScreen(b, work)).toEqual(b);
+  });
+
+  it('clamps a window pushed off the right edge back inside', () => {
+    const b = { x: 1500, y: 100, width: 800, height: 200 };
+    expect(clampToScreen(b, work)).toEqual({ x: 1120, y: 100, width: 800, height: 200 });
+  });
+
+  it('clamps a window pushed off the bottom edge back inside', () => {
+    const b = { x: 100, y: 1000, width: 800, height: 200 };
+    expect(clampToScreen(b, work)).toEqual({ x: 100, y: 880, width: 800, height: 200 });
+  });
+
+  it('clamps a window with negative origin to (workArea.x, workArea.y)', () => {
+    const b = { x: -50, y: -50, width: 800, height: 200 };
+    expect(clampToScreen(b, work)).toEqual({ x: 0, y: 0, width: 800, height: 200 });
+  });
+
+  it('shrinks a window that is wider than the work area', () => {
+    const b = { x: 0, y: 0, width: 3000, height: 200 };
+    expect(clampToScreen(b, work)).toEqual({ x: 0, y: 0, width: 1920, height: 200 });
+  });
+
+  it('respects a non-zero work area origin (e.g. taskbar offset)', () => {
+    const offsetWork = { x: 0, y: 40, width: 1920, height: 1040 };
+    const b = { x: 100, y: 0, width: 800, height: 200 };
+    expect(clampToScreen(b, offsetWork)).toEqual({ x: 100, y: 40, width: 800, height: 200 });
+  });
+});

--- a/src/utils/clampToScreen.ts
+++ b/src/utils/clampToScreen.ts
@@ -1,0 +1,16 @@
+export interface Bounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface WorkArea extends Bounds {}
+
+export function clampToScreen(bounds: Bounds, work: WorkArea): Bounds {
+  const width = Math.min(bounds.width, work.width);
+  const height = Math.min(bounds.height, work.height);
+  const x = Math.max(work.x, Math.min(bounds.x, work.x + work.width - width));
+  const y = Math.max(work.y, Math.min(bounds.y, work.y + work.height - height));
+  return { x, y, width, height };
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -103,6 +103,7 @@ export default defineConfig(({ command, mode }) => {
             'windows-audio-utils': 'electron/windows-audio-utils.js',
             'vb-cable-installer': 'electron/vb-cable-installer.js',
             'squirrel-events': 'electron/squirrel-events.js',
+            'subtitle-window': 'electron/subtitle-window.js',
             'update-manager': 'electron/update-manager.js'
           },
           onstart(args) {


### PR DESCRIPTION
## Summary

Implements the floating subtitle mode requested in [discussion #118](https://github.com/kizuna-ai-lab/sokuji/discussions/118). The Electron main window can switch in place between its normal frameless-with-custom-titlebar layout and a translucent, always-on-top floating bar that shows the live bilingual translation across the bottom of the screen. Same `BrowserWindow` instance throughout — no extra processes, no separate window to keep in sync.

Spec: `docs/superpowers/specs/2026-05-10-subtitle-mode-design.md`
Plan: `docs/superpowers/plans/2026-05-10-subtitle-mode.md`
Manual test plan: `docs/superpowers/specs/2026-05-10-subtitle-mode-manual-test.md`

## What's new

- **Subtitle button in the TitleBar** — always visible (disabled until a session is active), clicks switch the window in place to a bottom-centered floating bar (default 80% width × 200 px, position/size persisted across launches).
- **Subtitle bar** — three-segment auto-hiding bar floating above the subtitle area (`position: absolute`), so the bar's footprint isn't permanently reserved; left has Sokuji logo + quota slot, center has session timer + language pair, right has the same conversation-toolbar actions (DisplayMode × 2, font −/+, compact toggle, Export, Clear) plus subtitle-specific Settings / Pin / Lock / Exit. All right-segment buttons share one visual style.
- **Compact (default) subtitle render** — up to four equal-height bands (speaker source, speaker translation, participant source, participant translation), each concatenating its visible items into one flowing line, content clipped to bottom with a top fade-mask so overflow doesn't chop characters mid-glyph.
- **Expanded subtitle render** — falls back to per-item ConversationRow for users who want a conversation-log view.
- **Settings popover** — opacity slider + bg / source / translation color palettes, persisted under `settings.common.subtitle.*`.
- **PTT hint** — when a session is active in Push-to-Talk / Push-to-Translate mode and no items have arrived yet, the subtitle area shows \"Press Space to speak\" so users know they need to hold a key (space-bar listener was already global; the hint just exposes it).
- **Session-ended placeholder** — graceful state when a session drops mid-subtitle, with a \"Return to main window\" button.
- **Clear-conversation wiring** — sessionStore gets a `clearConversationVersion` counter; both the SubtitleBar trash icon and the MainPanel trash icon dispatch through it so MainPanel's existing clear logic runs regardless of which surface triggered it.

## Refactors riding along

- Main window switched to `frame: false, transparent: true` with a custom 36 px `TitleBar` (Sokuji + Subtitle / Settings / Logs actions + min/max/close), required by Windows for transparent windows and chosen on every platform for visual consistency.
- `items` and `systemAudioItems` are mirrored from MainPanel local state into sessionStore so SubtitleApp can read them when MainPanel is hidden (display:none in subtitle mode — kept mounted so its useEffect-driven mirror keeps firing).
- The unused `showAudio` panel state in MainLayout (state + toggle + sessionStorage, never bound to any UI) is removed alongside the TitleBar consolidation.

## Test plan

- [x] `npm run test` — 265 passing (added Vitest coverage for `clampToScreen`, subtitleStore actions, `SubtitleStream` compact/expanded modes, `SubtitleSessionEnded`).
- [ ] Manual cross-platform run of `docs/superpowers/specs/2026-05-10-subtitle-mode-manual-test.md` on macOS, Windows, Linux X11, Linux Wayland (entering / interacting / lock+pin / settings / toolbar reuse / exit / error paths / custom TitleBar).
- [x] Verify state isolation: subtitleFontSize / subtitleCompactMode don't affect MainPanel font/compact, DisplayMode is shared as designed.
- [x] Verify the items-mirror chain by entering subtitle mode mid-conversation and watching new translations stream in live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Subtitle mode: floating subtitle window with toolbar (font size, compact/expanded view, export/clear, always‑on‑top, lock/restore, exit), settings for background opacity and text colors, auto‑hide bar, PTT hint, and platform-aware title bar/entry control; main UI hides while active.
  * Conversation mirroring and cross‑app clear so subtitles reflect the main conversation.

* **Tests**
  * Unit tests for subtitle UI and window‑bounds/clamping logic.

* **Documentation**
  * Added manual test plan for subtitle mode across macOS, Windows, and Linux.

* **Localization**
  * Added subtitle and titleBar translations for many locales.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/225)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->