### PR TITLE
feat(display): more color options for subtitle and conversation panel (#231)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-conversation-font-size-cap.md
+++ b/docs/superpowers/plans/2026-05-14-conversation-font-size-cap.md
@@ -1,0 +1,428 @@
+# Conversation Font-Size Cap — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Raise the maximum conversation font size in MainPanel from 28 → 64 px and in Subtitle mode from 48 → 64 px so Sokuji is readable from the back of a classroom-projected screen, without changing defaults or adding new UI.
+
+**Architecture:** Two independent Zustand stores own the two font-size knobs (`settingsStore.conversationFontSize` and `subtitleStore.fontSize`). Subtitle already clamps via `FONT_SIZE_MIN / FONT_SIZE_MAX` constants — settingsStore does not, so we add the same pattern there. Existing +/- stepper UI in `MainPanel.tsx` and `SubtitleBar.tsx` automatically picks up the new bounds via the constants. CSS already uses a relative `line-height: 1.4` so nothing in styles needs to change.
+
+**Tech Stack:** TypeScript, React, Zustand (`subscribeWithSelector`), Vitest.
+
+**Spec:** [docs/superpowers/specs/2026-05-14-conversation-font-size-cap-design.md](../specs/2026-05-14-conversation-font-size-cap-design.md)
+
+---
+
+## File Map
+
+- **Modify** `src/stores/settingsStore.ts` — export `CONVERSATION_FONT_SIZE_MIN` / `CONVERSATION_FONT_SIZE_MAX`, clamp in `setConversationFontSize`, clamp on load (line 1460).
+- **Modify** `src/stores/settingsStore.test.ts` — add 3 clamp tests for `setConversationFontSize`.
+- **Modify** `src/components/MainPanel/MainPanel.tsx` — import the new constants, replace literals `12` / `28` at lines 2936-2937, 2946-2947.
+- **Modify** `src/stores/subtitleStore.ts` — change `FONT_SIZE_MAX` from `48` → `64` (line 65).
+- **Modify** `src/stores/subtitleStore.test.ts` — update the existing `'clamps fontSize to [12, 48]'` test to assert the new upper bound (lines 31, 35).
+
+No new files, no SCSS changes, no extension-side changes (extension shares `src/components` via vite alias).
+
+---
+
+## Task 1: Add MIN/MAX constants and clamping to settingsStore
+
+**Files:**
+- Modify: `src/stores/settingsStore.ts:43-50` (add constants near the `CommonSettings` interface), `src/stores/settingsStore.ts:901-911` (clamp in setter), `src/stores/settingsStore.ts:1460` (clamp on load)
+- Test: `src/stores/settingsStore.test.ts` (append a new `describe` block)
+
+- [ ] **Step 1: Write the failing tests**
+
+The existing test file deliberately imports the store dynamically *after* `vi.mock` has been wired (line 28: `const { default: useSettingsStore } = await import('./settingsStore');`). Static imports of any symbol from `./settingsStore` would evaluate the module before the mocks register, so we destructure the new constants from the same dynamic import.
+
+Replace line 28 of `src/stores/settingsStore.test.ts`:
+
+```ts
+const { default: useSettingsStore } = await import('./settingsStore');
+```
+
+with:
+
+```ts
+const {
+  default: useSettingsStore,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+} = await import('./settingsStore');
+```
+
+Then append this `describe` block inside `describe('settingsStore', …)`, before its closing `});`:
+
+```ts
+describe('conversationFontSize clamping', () => {
+  it('exports MIN=12 and MAX=64 constants', () => {
+    expect(CONVERSATION_FONT_SIZE_MIN).toBe(12);
+    expect(CONVERSATION_FONT_SIZE_MAX).toBe(64);
+  });
+
+  it('clamps values below MIN', async () => {
+    await useSettingsStore.getState().setConversationFontSize(5);
+    expect(useSettingsStore.getState().conversationFontSize).toBe(
+      CONVERSATION_FONT_SIZE_MIN,
+    );
+  });
+
+  it('clamps values above MAX', async () => {
+    await useSettingsStore.getState().setConversationFontSize(200);
+    expect(useSettingsStore.getState().conversationFontSize).toBe(
+      CONVERSATION_FONT_SIZE_MAX,
+    );
+  });
+
+  it('passes through in-range values', async () => {
+    await useSettingsStore.getState().setConversationFontSize(20);
+    expect(useSettingsStore.getState().conversationFontSize).toBe(20);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/stores/settingsStore.test.ts --run`
+
+Expected: 4 failures. The "exports MIN=12 and MAX=64" test fails at the `import` (constants not exported); the three clamp tests fail because the setter currently writes raw input.
+
+- [ ] **Step 3: Add the constants**
+
+In `src/stores/settingsStore.ts`, locate the `CommonSettings` interface (line 34) and the `defaultCommonSettings` const (line 187). Add the two constants between them, right above `defaultCommonSettings`:
+
+```ts
+export const CONVERSATION_FONT_SIZE_MIN = 12;
+export const CONVERSATION_FONT_SIZE_MAX = 64;
+
+const clampConversationFontSize = (n: number): number =>
+  Math.max(
+    CONVERSATION_FONT_SIZE_MIN,
+    Math.min(CONVERSATION_FONT_SIZE_MAX, Math.round(n)),
+  );
+```
+
+(Pattern mirrors `subtitleStore.ts:64-71`. Keep the helper file-local since it's only consumed in two places below.)
+
+- [ ] **Step 4: Clamp in the setter**
+
+Replace the body of `setConversationFontSize` at `src/stores/settingsStore.ts:901-911`. Current code:
+
+```ts
+    setConversationFontSize: async (conversationFontSize) => {
+      const previous = get().conversationFontSize;
+      set({conversationFontSize});
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.conversationFontSize', conversationFontSize);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting conversationFontSize setting:', error);
+        set({conversationFontSize: previous});
+      }
+    },
+```
+
+New code:
+
+```ts
+    setConversationFontSize: async (conversationFontSize) => {
+      const clamped = clampConversationFontSize(conversationFontSize);
+      const previous = get().conversationFontSize;
+      set({conversationFontSize: clamped});
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.conversationFontSize', clamped);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting conversationFontSize setting:', error);
+        set({conversationFontSize: previous});
+      }
+    },
+```
+
+- [ ] **Step 5: Clamp on load**
+
+Modify `src/stores/settingsStore.ts:1460` so any out-of-range stored value gets corrected on load. Current line:
+
+```ts
+        const conversationFontSize = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
+```
+
+New (split for clarity):
+
+```ts
+        const conversationFontSizeRaw = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
+        const conversationFontSize = clampConversationFontSize(conversationFontSizeRaw);
+```
+
+The downstream `set({…, conversationFontSize, …})` at line 1499 picks up the clamped local automatically — no other change required there.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `npm run test -- src/stores/settingsStore.test.ts --run`
+
+Expected: all 4 new tests pass; existing tests in the file continue to pass.
+
+- [ ] **Step 7: Type-check**
+
+Run: `npx tsc --noEmit`
+
+Expected: clean (no new errors).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/stores/settingsStore.ts src/stores/settingsStore.test.ts
+git commit -m "feat(ui): clamp conversation font size to [12, 64] in store
+
+Adds CONVERSATION_FONT_SIZE_MIN/MAX exports and clamps both the setter
+and the persisted value on load. Mirrors the pattern already used by
+subtitleStore. Refs #230."
+```
+
+---
+
+## Task 2: Wire MainPanel buttons to the new constants
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.tsx` (import + lines 2936-2937, 2946-2947)
+
+This task widens the user-visible cap from 28 → 64 by replacing hard-coded literals with the constants exported in Task 1.
+
+- [ ] **Step 1: Update the imports**
+
+Find the existing import from `../../stores/settingsStore` in `src/components/MainPanel/MainPanel.tsx` (search for `useConversationFontSize`). Add `CONVERSATION_FONT_SIZE_MIN` and `CONVERSATION_FONT_SIZE_MAX` to that import. For example, if the current import is:
+
+```ts
+import {
+  useConversationFontSize,
+  useSetConversationFontSize,
+  // …other imports…
+} from '../../stores/settingsStore';
+```
+
+Make it:
+
+```ts
+import {
+  useConversationFontSize,
+  useSetConversationFontSize,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+  // …other imports…
+} from '../../stores/settingsStore';
+```
+
+(If the existing import is a single-line form, expand it to multi-line; preserve all other named imports.)
+
+- [ ] **Step 2: Replace the literals**
+
+At `src/components/MainPanel/MainPanel.tsx:2934-2953`, replace the four occurrences of `12` and `28` with the imported constants. Current code:
+
+```tsx
+            <button
+              className="font-size-btn"
+              onClick={() => setConversationFontSize(Math.max(12, conversationFontSize - 2))}
+              disabled={conversationFontSize <= 12}
+              title={t('mainPanel.decreaseFontSize', 'Decrease font size')}
+              aria-label={t('mainPanel.decreaseFontSize', 'Decrease font size')}
+              type="button"
+            >
+              <AArrowDown size={14} />
+            </button>
+            <button
+              className="font-size-btn"
+              onClick={() => setConversationFontSize(Math.min(28, conversationFontSize + 2))}
+              disabled={conversationFontSize >= 28}
+              title={t('mainPanel.increaseFontSize', 'Increase font size')}
+              aria-label={t('mainPanel.increaseFontSize', 'Increase font size')}
+              type="button"
+            >
+              <AArrowUp size={14} />
+            </button>
+```
+
+New code:
+
+```tsx
+            <button
+              className="font-size-btn"
+              onClick={() => setConversationFontSize(Math.max(CONVERSATION_FONT_SIZE_MIN, conversationFontSize - 2))}
+              disabled={conversationFontSize <= CONVERSATION_FONT_SIZE_MIN}
+              title={t('mainPanel.decreaseFontSize', 'Decrease font size')}
+              aria-label={t('mainPanel.decreaseFontSize', 'Decrease font size')}
+              type="button"
+            >
+              <AArrowDown size={14} />
+            </button>
+            <button
+              className="font-size-btn"
+              onClick={() => setConversationFontSize(Math.min(CONVERSATION_FONT_SIZE_MAX, conversationFontSize + 2))}
+              disabled={conversationFontSize >= CONVERSATION_FONT_SIZE_MAX}
+              title={t('mainPanel.increaseFontSize', 'Increase font size')}
+              aria-label={t('mainPanel.increaseFontSize', 'Increase font size')}
+              type="button"
+            >
+              <AArrowUp size={14} />
+            </button>
+```
+
+- [ ] **Step 3: Type-check**
+
+Run: `npx tsc --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 4: Run the existing test suite**
+
+Run: `npm run test -- --run`
+
+Expected: all tests pass. (No new test added here — behavior is exercised by the store tests in Task 1; the buttons simply forward to the clamped setter.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.tsx
+git commit -m "feat(ui): raise MainPanel font-size cap to 64 px
+
+Replaces hard-coded 12/28 button bounds with the new
+CONVERSATION_FONT_SIZE_MIN/MAX constants from settingsStore so the
+conversation can be set up to 64 px for classroom projection. Default
+stays 14. Closes part of #230."
+```
+
+---
+
+## Task 3: Raise subtitle font-size cap to 64
+
+**Files:**
+- Modify: `src/stores/subtitleStore.ts:65` (constant change)
+- Modify: `src/stores/subtitleStore.test.ts:31, 35` (description + assertion)
+
+- [ ] **Step 1: Update the failing test first**
+
+In `src/stores/subtitleStore.test.ts`, change lines 31-38. Current code:
+
+```ts
+  it('clamps fontSize to [12, 48]', async () => {
+    await useSubtitleStore.getState().setFontSize(8);
+    expect(useSubtitleStore.getState().fontSize).toBe(12);
+    await useSubtitleStore.getState().setFontSize(99);
+    expect(useSubtitleStore.getState().fontSize).toBe(48);
+    await useSubtitleStore.getState().setFontSize(28);
+    expect(useSubtitleStore.getState().fontSize).toBe(28);
+  });
+```
+
+New code:
+
+```ts
+  it('clamps fontSize to [12, 64]', async () => {
+    await useSubtitleStore.getState().setFontSize(8);
+    expect(useSubtitleStore.getState().fontSize).toBe(12);
+    await useSubtitleStore.getState().setFontSize(99);
+    expect(useSubtitleStore.getState().fontSize).toBe(64);
+    await useSubtitleStore.getState().setFontSize(28);
+    expect(useSubtitleStore.getState().fontSize).toBe(28);
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/stores/subtitleStore.test.ts --run`
+
+Expected: the `'clamps fontSize to [12, 64]'` test fails — the second assertion sees `48` (current cap) instead of `64`. Other tests in the file continue to pass.
+
+- [ ] **Step 3: Bump the constant**
+
+In `src/stores/subtitleStore.ts:65`, change:
+
+```ts
+export const FONT_SIZE_MAX = 48;
+```
+
+to:
+
+```ts
+export const FONT_SIZE_MAX = 64;
+```
+
+No other change in this file. The clamp at line 95 and the bounds reads in `SubtitleBar.tsx:122-133` already pull from `FONT_SIZE_MAX`, so they update automatically.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/stores/subtitleStore.test.ts --run`
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Type-check**
+
+Run: `npx tsc --noEmit`
+
+Expected: clean.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/stores/subtitleStore.ts src/stores/subtitleStore.test.ts
+git commit -m "feat(subtitle): raise font-size cap to 64 px
+
+Brings subtitle mode's max in line with the new MainPanel cap so larger
+projection setups have headroom. Default stays 24. Closes #230."
+```
+
+---
+
+## Task 4: Manual verification
+
+No code changes. Run through the spec's manual test plan and record results in the PR.
+
+- [ ] **Step 1: Run the full automated suite once more**
+
+Run: `npm run test -- --run`
+
+Expected: all green.
+
+- [ ] **Step 2: Electron — MainPanel**
+
+Run: `npm run electron:dev`
+
+Verify on both Basic and Advanced UI mode (toggle in Settings):
+
+  1. Start a session, send / receive a few messages.
+  2. Click `A↑` in the conversation toolbar repeatedly. Value should reach 64 and the button becomes disabled.
+  3. Click `A↓` repeatedly. Value should reach 12 and the button becomes disabled.
+  4. At 64 px:
+     - Bubbles wrap; no horizontal overflow.
+     - Conversation scrolls correctly.
+     - Conversation toolbar (above) and footer (below) remain unaffected.
+     - Karaoke-highlighted bubbles render correctly.
+  5. Reload the app — chosen size persists.
+
+- [ ] **Step 3: Electron — Subtitle mode**
+
+From the same Electron session, open the floating subtitle window:
+
+  1. Click the `+` button in the SubtitleBar repeatedly. Value should reach 64; button becomes disabled.
+  2. At 64 px, original + translated text both render without clipping; SubtitleBar controls remain usable.
+  3. Close & reopen the subtitle window — chosen size persists.
+
+- [ ] **Step 4: Browser extension — both surfaces**
+
+Build and load the extension (per project README), then in the side panel and the on-page subtitle overlay, repeat the equivalent of Steps 2-3 in a Chromium browser.
+
+- [ ] **Step 5: Out-of-range storage check (optional but recommended)**
+
+In Electron DevTools (or extension storage), set `settings.common.conversationFontSize` to `200`, reload. Verify the value clamps to 64 in the UI on next load. Repeat for `subtitle.fontSize`.
+
+- [ ] **Step 6: Open the PR**
+
+Once verification is clean, push the worktree branch and open a PR referencing #230. Use the spec and this plan as supporting documents in the PR body. Include a screenshot of the conversation at 64 px.
+
+---
+
+## Notes for the implementer
+
+- **No SCSS edits**: `.message-content` already uses `line-height: 1.4` (relative). Padding and `max-width` stay in px and remain proportionate at 64 px.
+- **No extension-side edits**: `extension/vite.config.ts` aliases `@components` to `../src/components`, so MainPanel and SubtitleBar are shared.
+- **No i18n edits**: button `title` / `aria-label` already say "Increase / Decrease font size" — agnostic to the cap value.
+- **Defaults unchanged**: MainPanel stays at 14 px, subtitle stays at 24 px.
+- **Step size unchanged**: ±2 on both surfaces. 12 → 64 in steps of 2 is 26 clicks; acceptable since users typically set once and the value persists.

--- a/docs/superpowers/plans/2026-05-14-more-color-options.md
+++ b/docs/superpowers/plans/2026-05-14-more-color-options.md
@@ -1,0 +1,2009 @@
+# More Color Options Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship issue #231 — give Sokuji's subtitle and conversation panel each their own independent color settings (with three new dark color presets and a "+" custom-color picker), accessible from each surface's own ⚙ entry point.
+
+**Architecture:** Extract conversation display fields (`fontSize`, `compactMode`, plus three new color fields) from `settingsStore` into a dedicated `conversationDisplayStore` mirroring the v0.26 `subtitleStore` extraction. Rename `SubtitleSettingsPopover` to `DisplaySettingsPopover` and relocate to `src/components/Display/`; the popover takes a `source: 'subtitle' | 'conversation'` prop and is rendered through two thin store-binding wrappers (rules-of-hooks compliant). MainPanel's `conversation-toolbar` gains a new ⚙ button that opens the popover bound to conversation settings. Color CSS variables for the conversation panel use a new `--conversation-*` namespace, separate from the existing `--subtitle-*` used by the subtitle surface.
+
+**Tech Stack:** React 18 + TypeScript, Zustand (with `subscribeWithSelector` middleware), `@floating-ui/react`, `lucide-react`, `react-i18next`, Vitest + `@testing-library/react` for tests, SCSS for styling.
+
+**Spec:** [`docs/superpowers/specs/2026-05-14-more-color-options-design.md`](../specs/2026-05-14-more-color-options-design.md)
+
+---
+
+## File Structure
+
+**New files:**
+- `src/stores/conversationDisplayStore.ts` — new store: `fontSize`, `compactMode`, `bgColor`, `sourceTextColor`, `translationTextColor`, with namespaced persistence under `settings.common.conversationDisplay.*`.
+- `src/stores/conversationDisplayStore.test.ts` — defaults, clamping, persistence, hydration, no-old-key-read assertion.
+- `src/components/Display/DisplaySettingsPopover.tsx` — relocated + renamed popover, with `source` prop and split internal structure (Inner + two store-binding wrappers + `ColorRow` subcomponent).
+- `src/components/Display/DisplaySettingsPopover.scss` — relocated + renamed styles; adds `.swatch.custom` styling.
+- `src/components/Display/DisplaySettingsPopover.test.tsx` — per-source rendering, preset/setter wiring, "+" chip + debounce, highlight rules.
+
+**Modified files:**
+- `src/stores/settingsStore.ts` — remove `conversationFontSize` / `conversationCompactMode` fields, defaults, action interface entries, action implementations, hydration reads, and selector/action hook exports; remove `CONVERSATION_FONT_SIZE_MIN` / `CONVERSATION_FONT_SIZE_MAX` and `clampConversationFontSize`.
+- `src/stores/settingsStore.test.ts` — remove the `conversationFontSize clamping` describe block and its constant imports.
+- `src/routes/Home.tsx` — call `useConversationDisplayStore.getState().hydrate()` alongside `useSubtitleStore.getState().hydrate()`.
+- `src/components/Subtitle/SubtitleBar.tsx` — change popover import path and pass `source="subtitle"`.
+- `src/components/MainPanel/MainPanel.tsx` — switch the four conversation hook imports to come from `conversationDisplayStore`; add new ⚙ button + `<DisplaySettingsPopover source="conversation" />` to `conversation-toolbar`; set the three `--conversation-*` CSS custom properties on `.main-panel-wrapper`.
+- `src/components/MainPanel/MainPanel.scss` — `.conversation-display` gets `background: var(--conversation-bg-color, #1f1f1f)`; remove the dead `.message-bubble.user` / `.assistant` / `.participant-source.*` rules and the `.message-bubble.assistant .karaoke-played` override.
+- `src/components/MainPanel/ConversationRow.scss` — change `.row-body.playing` from translucent green bg to translation-color box-shadow ring; rename two existing CSS variable references from `--subtitle-source-color` / `--subtitle-translation-color` to `--conversation-source-color` / `--conversation-translation-color`.
+- `src/locales/en/translation.json` — relabel `subtitle.settings.bgColor/sourceColor/translationColor` and add `subtitle.settings.customColor` + `mainPanel.displaySettings` keys.
+
+**Deleted files:**
+- `src/components/Subtitle/SubtitleSettingsPopover.tsx`
+- `src/components/Subtitle/SubtitleSettingsPopover.scss`
+
+---
+
+## Task 1: Create `conversationDisplayStore` (TDD)
+
+**Files:**
+- Create: `src/stores/conversationDisplayStore.ts`
+- Test: `src/stores/conversationDisplayStore.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `src/stores/conversationDisplayStore.test.ts` with the full content below:
+
+```ts
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  useConversationDisplayStore,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+  useConversationDisplayFontSize,
+  useConversationDisplayBgColor,
+} from './conversationDisplayStore';
+
+const mockSetSetting = vi.fn(async () => ({ success: true }));
+const mockGetSetting = vi.fn(async (_key: string, def: unknown) => def);
+
+vi.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+    }),
+  },
+}));
+
+describe('conversationDisplayStore', () => {
+  beforeEach(() => {
+    mockSetSetting.mockClear();
+    mockGetSetting.mockClear();
+    useConversationDisplayStore.setState({
+      fontSize: 14,
+      compactMode: false,
+      bgColor: '#1f1f1f',
+      sourceTextColor: '#9aa0a6',
+      translationTextColor: '#e8e8e8',
+    });
+  });
+
+  it('exports CONVERSATION_FONT_SIZE_MIN=12 and CONVERSATION_FONT_SIZE_MAX=64', () => {
+    expect(CONVERSATION_FONT_SIZE_MIN).toBe(12);
+    expect(CONVERSATION_FONT_SIZE_MAX).toBe(64);
+  });
+
+  it('has the documented defaults', () => {
+    const s = useConversationDisplayStore.getState();
+    expect(s.fontSize).toBe(14);
+    expect(s.compactMode).toBe(false);
+    expect(s.bgColor).toBe('#1f1f1f');
+    expect(s.sourceTextColor).toBe('#9aa0a6');
+    expect(s.translationTextColor).toBe('#e8e8e8');
+  });
+
+  it('clamps setFontSize to [12, 64]', async () => {
+    await useConversationDisplayStore.getState().setFontSize(8);
+    expect(useConversationDisplayStore.getState().fontSize).toBe(12);
+    await useConversationDisplayStore.getState().setFontSize(99);
+    expect(useConversationDisplayStore.getState().fontSize).toBe(64);
+    await useConversationDisplayStore.getState().setFontSize(28);
+    expect(useConversationDisplayStore.getState().fontSize).toBe(28);
+  });
+
+  it('persists each setter under the conversationDisplay namespace', async () => {
+    await useConversationDisplayStore.getState().setBgColor('#FFFFFF');
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.bgColor',
+      '#FFFFFF',
+    );
+    await useConversationDisplayStore.getState().setSourceTextColor('#000000');
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.sourceTextColor',
+      '#000000',
+    );
+    await useConversationDisplayStore.getState().setTranslationTextColor('#003B6F');
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.translationTextColor',
+      '#003B6F',
+    );
+    await useConversationDisplayStore.getState().setFontSize(20);
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.fontSize',
+      20,
+    );
+    await useConversationDisplayStore.getState().setCompactMode(true);
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.compactMode',
+      true,
+    );
+  });
+
+  it('hydrate reads only from settings.common.conversationDisplay.* keys', async () => {
+    await useConversationDisplayStore.getState().hydrate();
+    const calls = mockGetSetting.mock.calls.map((c) => c[0] as string);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const key of calls) {
+      expect(key.startsWith('settings.common.conversationDisplay.')).toBe(true);
+    }
+    // Defaults applied since the mock returns the supplied default
+    const s = useConversationDisplayStore.getState();
+    expect(s.fontSize).toBe(14);
+    expect(s.bgColor).toBe('#1f1f1f');
+  });
+
+  it('hydrate does NOT read the old conversationFontSize / conversationCompactMode keys', async () => {
+    await useConversationDisplayStore.getState().hydrate();
+    const calls = mockGetSetting.mock.calls.map((c) => c[0] as string);
+    expect(calls).not.toContain('settings.common.conversationFontSize');
+    expect(calls).not.toContain('settings.common.conversationCompactMode');
+  });
+
+  it('selector hooks exist', () => {
+    expect(typeof useConversationDisplayFontSize).toBe('function');
+    expect(typeof useConversationDisplayBgColor).toBe('function');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test and verify it fails**
+
+Run: `npm run test -- src/stores/conversationDisplayStore.test.ts`
+Expected: FAIL with "Cannot find module './conversationDisplayStore'"
+
+- [ ] **Step 3: Create the store**
+
+Create `src/stores/conversationDisplayStore.ts` with the full content below:
+
+```ts
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import { useShallow } from 'zustand/shallow';
+import { ServiceFactory } from '../services/ServiceFactory';
+
+interface ConversationDisplayState {
+  // Typography
+  fontSize: number;            // clamped [CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX]
+  compactMode: boolean;
+  // Colors (hex)
+  bgColor: string;
+  sourceTextColor: string;
+  translationTextColor: string;
+
+  // Actions (async because persistence is async — matches subtitleStore)
+  setFontSize: (n: number) => Promise<void>;
+  setCompactMode: (b: boolean) => Promise<void>;
+  setBgColor: (s: string) => Promise<void>;
+  setSourceTextColor: (s: string) => Promise<void>;
+  setTranslationTextColor: (s: string) => Promise<void>;
+
+  // Hydration (called once at app boot from src/routes/Home.tsx)
+  hydrate: () => Promise<void>;
+}
+
+const DEFAULTS = {
+  fontSize: 14,
+  compactMode: false,
+  bgColor: '#1f1f1f',
+  sourceTextColor: '#9aa0a6',
+  translationTextColor: '#e8e8e8',
+};
+
+export const CONVERSATION_FONT_SIZE_MIN = 12;
+export const CONVERSATION_FONT_SIZE_MAX = 64;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+const KEY = (suffix: string) => `settings.common.conversationDisplay.${suffix}`;
+
+async function persist(
+  keySuffix: string,
+  value: unknown,
+  fieldNameForLog: string,
+): Promise<{ ok: boolean }> {
+  try {
+    await ServiceFactory.getSettingsService().setSetting(KEY(keySuffix), value);
+    return { ok: true };
+  } catch (error) {
+    console.error(`[ConversationDisplayStore] Error persisting ${fieldNameForLog}:`, error);
+    return { ok: false };
+  }
+}
+
+export const useConversationDisplayStore = create<ConversationDisplayState>()(
+  subscribeWithSelector((set, get) => ({
+    ...DEFAULTS,
+
+    setFontSize: async (n) => {
+      const clamped = clamp(Math.round(n), CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX);
+      const previous = get().fontSize;
+      set({ fontSize: clamped });
+      const { ok } = await persist('fontSize', clamped, 'fontSize');
+      if (!ok) set({ fontSize: previous });
+    },
+    setCompactMode: async (b) => {
+      const previous = get().compactMode;
+      set({ compactMode: b });
+      const { ok } = await persist('compactMode', b, 'compactMode');
+      if (!ok) set({ compactMode: previous });
+    },
+    setBgColor: async (s) => {
+      const previous = get().bgColor;
+      set({ bgColor: s });
+      const { ok } = await persist('bgColor', s, 'bgColor');
+      if (!ok) set({ bgColor: previous });
+    },
+    setSourceTextColor: async (s) => {
+      const previous = get().sourceTextColor;
+      set({ sourceTextColor: s });
+      const { ok } = await persist('sourceTextColor', s, 'sourceTextColor');
+      if (!ok) set({ sourceTextColor: previous });
+    },
+    setTranslationTextColor: async (s) => {
+      const previous = get().translationTextColor;
+      set({ translationTextColor: s });
+      const { ok } = await persist('translationTextColor', s, 'translationTextColor');
+      if (!ok) set({ translationTextColor: previous });
+    },
+
+    hydrate: async () => {
+      const svc = ServiceFactory.getSettingsService();
+      const [fontSize, compactMode, bgColor, sourceTextColor, translationTextColor] =
+        await Promise.all([
+          svc.getSetting(KEY('fontSize'), DEFAULTS.fontSize),
+          svc.getSetting(KEY('compactMode'), DEFAULTS.compactMode),
+          svc.getSetting(KEY('bgColor'), DEFAULTS.bgColor),
+          svc.getSetting(KEY('sourceTextColor'), DEFAULTS.sourceTextColor),
+          svc.getSetting(KEY('translationTextColor'), DEFAULTS.translationTextColor),
+        ]);
+      set({
+        fontSize: clamp(Math.round(fontSize), CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX),
+        compactMode,
+        bgColor,
+        sourceTextColor,
+        translationTextColor,
+      });
+    },
+  })),
+);
+
+// ──────────── Selector hooks ────────────
+export const useConversationDisplayFontSize = () => useConversationDisplayStore((s) => s.fontSize);
+export const useConversationDisplayCompactMode = () => useConversationDisplayStore((s) => s.compactMode);
+export const useConversationDisplayBgColor = () => useConversationDisplayStore((s) => s.bgColor);
+export const useConversationDisplaySourceTextColor = () => useConversationDisplayStore((s) => s.sourceTextColor);
+export const useConversationDisplayTranslationTextColor = () => useConversationDisplayStore((s) => s.translationTextColor);
+
+export const useConversationDisplaySettings = () =>
+  useConversationDisplayStore(
+    useShallow((s) => ({
+      fontSize: s.fontSize,
+      compactMode: s.compactMode,
+      bgColor: s.bgColor,
+      sourceTextColor: s.sourceTextColor,
+      translationTextColor: s.translationTextColor,
+    })),
+  );
+
+// ──────────── Action hooks ────────────
+export const useSetConversationDisplayFontSize = () => useConversationDisplayStore((s) => s.setFontSize);
+export const useSetConversationDisplayCompactMode = () => useConversationDisplayStore((s) => s.setCompactMode);
+export const useSetConversationDisplayBgColor = () => useConversationDisplayStore((s) => s.setBgColor);
+export const useSetConversationDisplaySourceTextColor = () => useConversationDisplayStore((s) => s.setSourceTextColor);
+export const useSetConversationDisplayTranslationTextColor = () => useConversationDisplayStore((s) => s.setTranslationTextColor);
+```
+
+- [ ] **Step 4: Run the test and verify it passes**
+
+Run: `npm run test -- src/stores/conversationDisplayStore.test.ts`
+Expected: PASS — all 7 test cases pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stores/conversationDisplayStore.ts src/stores/conversationDisplayStore.test.ts
+git commit -m "feat(stores): add conversationDisplayStore for MainPanel display settings
+
+Mirrors subtitleStore: holds fontSize, compactMode, and three new color
+fields, persisted under settings.common.conversationDisplay.*. No
+migration from the old settingsStore.conversationFontSize keys; spec
+explicitly accepts the one-time reset.
+
+Refs #231"
+```
+
+---
+
+## Task 2: Wire `conversationDisplayStore.hydrate()` into app boot
+
+**Files:**
+- Modify: `src/routes/Home.tsx:15-26`
+
+- [ ] **Step 1: Read the current hydration block**
+
+Run: `grep -n "useSubtitleStore\|loadSettings\|hydrate" src/routes/Home.tsx | head -10`
+Expected: Find the `Promise.all([loadSettings(), useSubtitleStore.getState().hydrate()])` block.
+
+- [ ] **Step 2: Add the new hydrate call**
+
+Edit `src/routes/Home.tsx`. Find the import block at the top of the file (the one importing `useSubtitleStore`) and add the new store import:
+
+```tsx
+import { useSubtitleStore } from '../stores/subtitleStore';
+import { useConversationDisplayStore } from '../stores/conversationDisplayStore';
+```
+
+Then update the Promise.all to include the new hydrate. Find:
+
+```tsx
+    Promise.all([
+      loadSettings(),
+      useSubtitleStore.getState().hydrate(),
+    ]).catch((err) => {
+      console.warn('[Home] Settings/subtitle hydration error:', err);
+    });
+```
+
+Replace with:
+
+```tsx
+    Promise.all([
+      loadSettings(),
+      useSubtitleStore.getState().hydrate(),
+      useConversationDisplayStore.getState().hydrate(),
+    ]).catch((err) => {
+      console.warn('[Home] Settings/subtitle/conversationDisplay hydration error:', err);
+    });
+```
+
+- [ ] **Step 3: Run the test suite to confirm nothing broke**
+
+Run: `npm run test -- src/routes`
+Expected: PASS (or no tests for this route — that's also fine; absence of test failure proves the import resolves).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/routes/Home.tsx
+git commit -m "feat(home): hydrate conversationDisplayStore at app boot
+
+Wires the new store's hydrate() alongside settingsStore and
+subtitleStore so MainPanel's persisted display settings are restored
+before the panel renders.
+
+Refs #231"
+```
+
+---
+
+## Task 3: Update English locale strings
+
+**Files:**
+- Modify: `src/locales/en/translation.json`
+
+- [ ] **Step 1: Locate the current `subtitle.settings` block**
+
+Run: `grep -n "bgOpacity\|bgColor\|sourceColor\|translationColor" src/locales/en/translation.json`
+Expected: Four lines reading the four current label strings inside the `subtitle.settings` object.
+
+- [ ] **Step 2: Edit the block**
+
+Find this block in `src/locales/en/translation.json`:
+
+```json
+    "settings": {
+      "bgOpacity": "Background opacity",
+      "bgColor": "Background color",
+      "sourceColor": "Source text color",
+      "translationColor": "Translation color"
+    },
+```
+
+Replace with:
+
+```json
+    "settings": {
+      "bgOpacity": "Background opacity",
+      "bgColor": "Display background",
+      "sourceColor": "Source text",
+      "translationColor": "Translation text",
+      "customColor": "Custom color"
+    },
+```
+
+- [ ] **Step 3: Add the `mainPanel.displaySettings` key**
+
+Run: `grep -n "decreaseFontSize\|increaseFontSize\|compactView" src/locales/en/translation.json | head -5`
+Expected: Lines for the existing MainPanel toolbar tooltips.
+
+Find the cluster of `mainPanel.*` font-size and view keys (next to `decreaseFontSize`). Add a new key alongside them, e.g. after `"compactView"`:
+
+```json
+      "displaySettings": "Display settings",
+```
+
+- [ ] **Step 4: Validate JSON parses**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('src/locales/en/translation.json'))"`
+Expected: No output (silent success). Any parse error means a misplaced comma or brace; fix.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/locales/en/translation.json
+git commit -m "i18n(en): rename color labels and add custom-color/displaySettings keys
+
+- subtitle.settings.bgColor: 'Background color' -> 'Display background'
+- subtitle.settings.sourceColor: 'Source text color' -> 'Source text'
+- subtitle.settings.translationColor: 'Translation color' -> 'Translation text'
+- new subtitle.settings.customColor: 'Custom color' (for the '+' chip aria-label)
+- new mainPanel.displaySettings: 'Display settings' (for the new MainPanel cog button)
+
+Other locales fall back to these via the t(key, fallback) defaults; per-locale
+translations land separately.
+
+Refs #231"
+```
+
+---
+
+## Task 4: Switch MainPanel to use `conversationDisplayStore` for fontSize and compactMode
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.tsx:25-30, 129-132` (and any other reference)
+
+- [ ] **Step 1: Read current import block**
+
+Run: `sed -n '20,35p' src/components/MainPanel/MainPanel.tsx`
+Expected: Imports including `useConversationFontSize`, `useSetConversationFontSize`, `CONVERSATION_FONT_SIZE_MIN`, `CONVERSATION_FONT_SIZE_MAX`, `useConversationCompactMode`, `useSetConversationCompactMode` from `../../stores/settingsStore`.
+
+- [ ] **Step 2: Update the import block**
+
+Edit `src/components/MainPanel/MainPanel.tsx`. Find the existing settingsStore import block that contains the conversation hooks (lines ~22-40 area) and **remove these specific entries** from it:
+
+```ts
+  useConversationFontSize,
+  useSetConversationFontSize,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+  useConversationCompactMode,
+  useSetConversationCompactMode,
+```
+
+Then add a new import block immediately after the settingsStore import:
+
+```ts
+import {
+  useConversationDisplayFontSize,
+  useSetConversationDisplayFontSize,
+  useConversationDisplayCompactMode,
+  useSetConversationDisplayCompactMode,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+} from '../../stores/conversationDisplayStore';
+```
+
+- [ ] **Step 3: Update the in-component hook calls**
+
+Find lines around 129-132 in `src/components/MainPanel/MainPanel.tsx`:
+
+```tsx
+  const conversationFontSize = useConversationFontSize();
+  const setConversationFontSize = useSetConversationFontSize();
+  const conversationCompactMode = useConversationCompactMode();
+  const setConversationCompactMode = useSetConversationCompactMode();
+```
+
+Replace with:
+
+```tsx
+  const conversationFontSize = useConversationDisplayFontSize();
+  const setConversationFontSize = useSetConversationDisplayFontSize();
+  const conversationCompactMode = useConversationDisplayCompactMode();
+  const setConversationCompactMode = useSetConversationDisplayCompactMode();
+```
+
+The local variable names stay the same so no other in-body references need to change.
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `npm run test -- src/components/MainPanel`
+Expected: PASS. If a test fails due to missing settingsStore hook, the test mocks need the new store path; resolve by mocking `../../stores/conversationDisplayStore` instead.
+
+- [ ] **Step 5: Type check**
+
+Run: `npx tsc --noEmit -p .`
+Expected: No errors related to MainPanel imports. (Other unrelated errors in the repo, if any, are out of scope.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.tsx
+git commit -m "feat(mainpanel): read fontSize/compactMode from conversationDisplayStore
+
+Switches MainPanel's four conversation display hooks to point at the
+new store. settingsStore still owns these fields at this commit; the
+removal happens in the next commit (sequenced this way so each commit
+keeps the suite green).
+
+Refs #231"
+```
+
+---
+
+## Task 5: Remove conversation display fields from `settingsStore`
+
+**Files:**
+- Modify: `src/stores/settingsStore.ts` (multiple locations: lines 43-44, 187-195, 203-204, 418-421, 436-437, 912-934, 1472-1474, 1512-1513, 1676-1677, 1730-1731)
+- Modify: `src/stores/settingsStore.test.ts` (the `conversationFontSize clamping` describe block + imports)
+
+- [ ] **Step 1: Remove the type interface entries**
+
+Edit `src/stores/settingsStore.ts`. Find this block (around lines 43-44):
+
+```ts
+  conversationFontSize: number;
+  conversationCompactMode: boolean;
+```
+
+Delete both lines.
+
+Find the duplicate in the actions interface (around lines 418-421):
+
+```ts
+  // Conversation font size
+  conversationFontSize: number;
+
+  // Conversation compact mode — hide chat chrome (avatars, names, timestamps, badges, play button) in the conversation panel
+  conversationCompactMode: boolean;
+```
+
+Delete all four lines (including the comments and blank line).
+
+Find (around lines 436-437):
+
+```ts
+  setConversationFontSize: (size: number) => void;
+  setConversationCompactMode: (compact: boolean) => Promise<void>;
+```
+
+Delete both lines.
+
+- [ ] **Step 2: Remove constants and helper**
+
+Find (around lines 187-195):
+
+```ts
+// ==================== Font Size Constants ====================
+
+export const CONVERSATION_FONT_SIZE_MIN = 12;
+export const CONVERSATION_FONT_SIZE_MAX = 64;
+
+const clampConversationFontSize = (n: number): number =>
+  Math.max(
+    CONVERSATION_FONT_SIZE_MIN,
+    Math.min(CONVERSATION_FONT_SIZE_MAX, Math.round(n)),
+  );
+```
+
+Delete the entire block (heading comment, two `export const`, and the `clampConversationFontSize` function).
+
+- [ ] **Step 3: Remove the default values**
+
+Find (around lines 203-204):
+
+```ts
+  conversationFontSize: 14,
+  conversationCompactMode: false,
+```
+
+Delete both lines.
+
+- [ ] **Step 4: Remove the action implementations**
+
+Find (around lines 912-934, the two consecutive `setConversationFontSize` and `setConversationCompactMode` async function blocks). Delete the entire block:
+
+```ts
+    setConversationFontSize: async (conversationFontSize) => {
+      const clamped = clampConversationFontSize(conversationFontSize);
+      const previous = get().conversationFontSize;
+      set({conversationFontSize: clamped});
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.conversationFontSize', clamped);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting conversationFontSize setting:', error);
+        set({conversationFontSize: previous});
+      }
+    },
+
+    setConversationCompactMode: async (conversationCompactMode) => {
+      const previous = get().conversationCompactMode;
+      set({conversationCompactMode});
+      try {
+        const service = ServiceFactory.getSettingsService();
+        await service.setSetting('settings.common.conversationCompactMode', conversationCompactMode);
+      } catch (error) {
+        console.error('[SettingsStore] Error persisting conversationCompactMode setting:', error);
+        set({conversationCompactMode: previous});
+      }
+    },
+```
+
+- [ ] **Step 5: Remove hydration reads and setState entries**
+
+Find (around lines 1472-1474):
+
+```ts
+        const conversationFontSizeRaw = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
+        const conversationFontSize = clampConversationFontSize(conversationFontSizeRaw);
+        const conversationCompactMode = await service.getSetting('settings.common.conversationCompactMode', defaultCommonSettings.conversationCompactMode);
+```
+
+Delete all three lines.
+
+Find (around lines 1512-1513) the `conversationFontSize,` and `conversationCompactMode,` entries inside the `set({ ... })` call within `loadSettings`. Delete both lines.
+
+- [ ] **Step 6: Remove selector and action hook exports**
+
+Find (around lines 1676-1677):
+
+```ts
+export const useConversationFontSize = () => useSettingsStore((state) => state.conversationFontSize);
+export const useConversationCompactMode = () => useSettingsStore((state) => state.conversationCompactMode);
+```
+
+Delete both lines.
+
+Find (around lines 1730-1731):
+
+```ts
+export const useSetConversationFontSize = () => useSettingsStore((state) => state.setConversationFontSize);
+export const useSetConversationCompactMode = () => useSettingsStore((state) => state.setConversationCompactMode);
+```
+
+Delete both lines.
+
+- [ ] **Step 7: Update settingsStore.test.ts — remove the conversationFontSize describe block**
+
+Edit `src/stores/settingsStore.test.ts`. Find the `describe('conversationFontSize clamping', ...)` block (around line 319). Delete the entire describe block (likely 25-40 lines including its `it` cases).
+
+Then remove these unused imports at the top of the file:
+
+```ts
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+```
+
+- [ ] **Step 8: Run the full test suite to confirm nothing else broke**
+
+Run: `npm run test`
+Expected: PASS. If any failure references `conversationFontSize` or `useConversationFontSize`, that file still references the deleted symbols; locate and fix (most likely a test fixture or mock).
+
+- [ ] **Step 9: Type check**
+
+Run: `npx tsc --noEmit -p .`
+Expected: No errors referencing the removed symbols. If `useConversationFontSize` is referenced anywhere outside `MainPanel.tsx` (already updated in Task 4), update those import sites too.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/stores/settingsStore.ts src/stores/settingsStore.test.ts
+git commit -m "refactor(settings): remove conversationFontSize/CompactMode (moved to conversationDisplayStore)
+
+Removes the two fields, their defaults, action interface entries,
+async actions, hydration reads, selector/action hook exports, and
+the test describe block. The fields now live in conversationDisplayStore
+(see prior commit). The old persistence keys (settings.common.conversationFontSize
+and ...conversationCompactMode) are abandoned, not migrated.
+
+Refs #231"
+```
+
+---
+
+## Task 6: Move and rename popover file (no-behavior-change move)
+
+**Files:**
+- Delete: `src/components/Subtitle/SubtitleSettingsPopover.tsx`
+- Delete: `src/components/Subtitle/SubtitleSettingsPopover.scss`
+- Create: `src/components/Display/DisplaySettingsPopover.tsx` (initial copy of old file with name change + `source` prop hardcoded to `'subtitle'`)
+- Create: `src/components/Display/DisplaySettingsPopover.scss` (copy of old SCSS, root class renamed)
+- Modify: `src/components/Subtitle/SubtitleBar.tsx:27, 205` (popover import path + JSX)
+
+- [ ] **Step 1: Make the new directory**
+
+Run: `mkdir -p src/components/Display`
+Expected: No output. Directory now exists.
+
+- [ ] **Step 2: Use git mv to preserve history**
+
+Run:
+```bash
+git mv src/components/Subtitle/SubtitleSettingsPopover.tsx src/components/Display/DisplaySettingsPopover.tsx
+git mv src/components/Subtitle/SubtitleSettingsPopover.scss src/components/Display/DisplaySettingsPopover.scss
+```
+Expected: No output. `git status` shows two renames.
+
+- [ ] **Step 3: Update the new SCSS file's root class**
+
+Edit `src/components/Display/DisplaySettingsPopover.scss`. Replace the root selector:
+
+```scss
+.subtitle-settings-popover {
+```
+
+With:
+
+```scss
+.display-settings-popover {
+```
+
+That's the only SCSS change in this task; the rest of the styles stay.
+
+- [ ] **Step 4: Update the new TSX file — class name, import path, and add `source` prop**
+
+Edit `src/components/Display/DisplaySettingsPopover.tsx`. Replace the entire file content with:
+
+```tsx
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  useSubtitleSettings,
+  useSetSubtitleBgOpacity,
+  useSetSubtitleBgColor,
+  useSetSubtitleSourceTextColor,
+  useSetSubtitleTranslationTextColor,
+} from '../../stores/subtitleStore';
+import './DisplaySettingsPopover.scss';
+
+const BG_PRESETS = ['#000000', '#1a1a1a', '#0d2032', '#0f2419', '#FFFFFF', '#2a2a2a'];
+const SOURCE_PRESETS = ['#FFFFFF', '#E8E8E8', '#FFD27D', '#FFAA66', '#9aa0a6', '#FF6B6B'];
+const TRANSLATION_PRESETS = ['#6CC5FF', '#10a37f', '#FFFFFF', '#A8E6CF', '#FFB86C', '#BD93F9'];
+
+export interface DisplaySettingsPopoverProps {
+  source: 'subtitle' | 'conversation';
+}
+
+const DisplaySettingsPopover: React.FC<DisplaySettingsPopoverProps> = ({ source }) => {
+  const { t } = useTranslation();
+  const subtitle = useSubtitleSettings();
+  const setBgOpacity = useSetSubtitleBgOpacity();
+  const setBgColor = useSetSubtitleBgColor();
+  const setSourceColor = useSetSubtitleSourceTextColor();
+  const setTranslationColor = useSetSubtitleTranslationTextColor();
+
+  // Task 7 will add the source='conversation' branch; today this file
+  // still serves only the subtitle path.
+  if (source !== 'subtitle') {
+    return <div className="display-settings-popover" role="dialog" />;
+  }
+
+  return (
+    <div className="display-settings-popover" role="dialog">
+      <div className="field">
+        <label>{t('subtitle.settings.bgOpacity', 'Background opacity')} ({subtitle.bgOpacity}%)</label>
+        <input
+          type="range"
+          min={0}
+          max={100}
+          step={1}
+          value={subtitle.bgOpacity}
+          onChange={(e) => setBgOpacity(Number(e.target.value))}
+        />
+      </div>
+
+      <div className="field">
+        <label>{t('subtitle.settings.bgColor', 'Display background')}</label>
+        <div className="palette">
+          {BG_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              className={`swatch ${subtitle.bgColor === c ? 'selected' : ''}`}
+              style={{ background: c }}
+              onClick={() => setBgColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="field">
+        <label>{t('subtitle.settings.sourceColor', 'Source text')}</label>
+        <div className="palette">
+          {SOURCE_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              className={`swatch ${subtitle.sourceTextColor === c ? 'selected' : ''}`}
+              style={{ background: c }}
+              onClick={() => setSourceColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+
+      <div className="field">
+        <label>{t('subtitle.settings.translationColor', 'Translation text')}</label>
+        <div className="palette">
+          {TRANSLATION_PRESETS.map((c) => (
+            <button
+              key={c}
+              type="button"
+              aria-label={c}
+              className={`swatch ${subtitle.translationTextColor === c ? 'selected' : ''}`}
+              style={{ background: c }}
+              onClick={() => setTranslationColor(c)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DisplaySettingsPopover;
+```
+
+Note: this is a transitional file. Task 7 will fully refactor the component into Inner + two wrappers + ColorRow. For this task we only:
+- Renamed the component to `DisplaySettingsPopover`.
+- Added a `source` prop (subtitle path works; conversation path renders empty as a stub).
+- Updated label fallbacks to the new English strings.
+- Renamed the root CSS class.
+
+- [ ] **Step 5: Update SubtitleBar.tsx import and usage**
+
+Edit `src/components/Subtitle/SubtitleBar.tsx`. Find:
+
+```tsx
+import SubtitleSettingsPopover from './SubtitleSettingsPopover';
+```
+
+Replace with:
+
+```tsx
+import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
+```
+
+Then find (around line 205):
+
+```tsx
+            <SubtitleSettingsPopover />
+```
+
+Replace with:
+
+```tsx
+            <DisplaySettingsPopover source="subtitle" />
+```
+
+- [ ] **Step 6: Run the test suite**
+
+Run: `npm run test`
+Expected: PASS. The subtitle popover behavior is preserved — only the file path and component name changed.
+
+- [ ] **Step 7: Type check**
+
+Run: `npx tsc --noEmit -p .`
+Expected: No errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/Display/ src/components/Subtitle/SubtitleBar.tsx
+# (the deletes are tracked via git mv)
+git commit -m "refactor(popover): rename SubtitleSettingsPopover -> DisplaySettingsPopover and relocate
+
+Pure rename + path change + 'source' prop scaffold. The conversation
+branch is a no-op stub; the next commit fills it in. The renamed
+labels (Background color -> Display background, etc.) ride along since
+they're trivial.
+
+Refs #231"
+```
+
+---
+
+## Task 7: Refactor popover into source-aware structure (Inner + wrappers + ColorRow)
+
+**Files:**
+- Modify: `src/components/Display/DisplaySettingsPopover.tsx` (full rewrite)
+
+This task introduces the conversation-bound rendering path, the rules-of-hooks-compliant wrapper structure, the new dark color presets, and the "+" custom-color chip with debounced picker. It is a large change but ships as one task because the structure does not work in pieces.
+
+- [ ] **Step 1: Replace `DisplaySettingsPopover.tsx` content**
+
+Edit `src/components/Display/DisplaySettingsPopover.tsx` and replace the full content with:
+
+```tsx
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
+import {
+  useSubtitleBgOpacity,
+  useSubtitleBgColor,
+  useSubtitleSourceTextColor,
+  useSubtitleTranslationTextColor,
+  useSetSubtitleBgOpacity,
+  useSetSubtitleBgColor,
+  useSetSubtitleSourceTextColor,
+  useSetSubtitleTranslationTextColor,
+} from '../../stores/subtitleStore';
+import {
+  useConversationDisplayBgColor,
+  useConversationDisplaySourceTextColor,
+  useConversationDisplayTranslationTextColor,
+  useSetConversationDisplayBgColor,
+  useSetConversationDisplaySourceTextColor,
+  useSetConversationDisplayTranslationTextColor,
+} from '../../stores/conversationDisplayStore';
+import './DisplaySettingsPopover.scss';
+
+const BG_PRESETS = ['#000000', '#1a1a1a', '#0d2032', '#0f2419', '#FFFFFF', '#2a2a2a'];
+const SOURCE_PRESETS = [
+  '#FFFFFF', '#E8E8E8', '#FFD27D', '#FFAA66', '#9aa0a6', '#FF6B6B',
+  '#000000', '#003B6F', '#1B5E20',
+];
+const TRANSLATION_PRESETS = [
+  '#6CC5FF', '#10a37f', '#FFFFFF', '#A8E6CF', '#FFB86C', '#BD93F9',
+  '#000000', '#003B6F', '#7B1FA2',
+];
+
+const PICKER_DEBOUNCE_MS = 150;
+
+type Source = 'subtitle' | 'conversation';
+
+export interface DisplaySettingsPopoverProps {
+  source: Source;
+}
+
+interface InnerBindings {
+  bgOpacity: number | undefined;
+  bgColor: string;
+  sourceTextColor: string;
+  translationTextColor: string;
+  setBgOpacity: ((n: number) => Promise<void>) | undefined;
+  setBgColor: (s: string) => Promise<void>;
+  setSourceTextColor: (s: string) => Promise<void>;
+  setTranslationTextColor: (s: string) => Promise<void>;
+}
+
+const DisplaySettingsPopover: React.FC<DisplaySettingsPopoverProps> = ({ source }) =>
+  source === 'subtitle' ? <SubtitleBoundPopover /> : <ConversationBoundPopover />;
+
+export default DisplaySettingsPopover;
+
+// ──────────── Source-bound wrappers ────────────
+// Each wrapper subscribes ONLY to its own store. This keeps the rules
+// of hooks satisfied: hooks are always called in the same order within
+// a given wrapper component.
+
+const SubtitleBoundPopover: React.FC = () => {
+  const bindings: InnerBindings = {
+    bgOpacity: useSubtitleBgOpacity(),
+    bgColor: useSubtitleBgColor(),
+    sourceTextColor: useSubtitleSourceTextColor(),
+    translationTextColor: useSubtitleTranslationTextColor(),
+    setBgOpacity: useSetSubtitleBgOpacity(),
+    setBgColor: useSetSubtitleBgColor(),
+    setSourceTextColor: useSetSubtitleSourceTextColor(),
+    setTranslationTextColor: useSetSubtitleTranslationTextColor(),
+  };
+  return <DisplaySettingsPopoverInner bindings={bindings} />;
+};
+
+const ConversationBoundPopover: React.FC = () => {
+  const bindings: InnerBindings = {
+    bgOpacity: undefined,
+    bgColor: useConversationDisplayBgColor(),
+    sourceTextColor: useConversationDisplaySourceTextColor(),
+    translationTextColor: useConversationDisplayTranslationTextColor(),
+    setBgOpacity: undefined,
+    setBgColor: useSetConversationDisplayBgColor(),
+    setSourceTextColor: useSetConversationDisplaySourceTextColor(),
+    setTranslationTextColor: useSetConversationDisplayTranslationTextColor(),
+  };
+  return <DisplaySettingsPopoverInner bindings={bindings} />;
+};
+
+// ──────────── Pure presentational inner ────────────
+
+const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bindings }) => {
+  const { t } = useTranslation();
+  const includeOpacity =
+    bindings.bgOpacity !== undefined && bindings.setBgOpacity !== undefined;
+
+  return (
+    <div className="display-settings-popover" role="dialog">
+      {includeOpacity && (
+        <div className="field">
+          <label>
+            {t('subtitle.settings.bgOpacity', 'Background opacity')} ({bindings.bgOpacity}%)
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={bindings.bgOpacity}
+            onChange={(e) => bindings.setBgOpacity!(Number(e.target.value))}
+          />
+        </div>
+      )}
+
+      <ColorRow
+        labelKey="subtitle.settings.bgColor"
+        labelDefault="Display background"
+        presets={BG_PRESETS}
+        value={bindings.bgColor}
+        onChange={bindings.setBgColor}
+      />
+      <ColorRow
+        labelKey="subtitle.settings.sourceColor"
+        labelDefault="Source text"
+        presets={SOURCE_PRESETS}
+        value={bindings.sourceTextColor}
+        onChange={bindings.setSourceTextColor}
+      />
+      <ColorRow
+        labelKey="subtitle.settings.translationColor"
+        labelDefault="Translation text"
+        presets={TRANSLATION_PRESETS}
+        value={bindings.translationTextColor}
+        onChange={bindings.setTranslationTextColor}
+      />
+    </div>
+  );
+};
+
+// ──────────── Reusable row with presets + custom chip ────────────
+
+interface ColorRowProps {
+  labelKey: string;
+  labelDefault: string;
+  presets: readonly string[];
+  value: string;
+  onChange: (s: string) => Promise<void>;
+}
+
+const ColorRow: React.FC<ColorRowProps> = ({
+  labelKey,
+  labelDefault,
+  presets,
+  value,
+  onChange,
+}) => {
+  const { t } = useTranslation();
+  const valueLower = value.toLowerCase();
+  const isCustom = !presets.some((p) => p.toLowerCase() === valueLower);
+
+  // Debounce the high-frequency change events emitted while the user
+  // drags inside the OS color picker.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onPickerChange = useCallback(
+    (next: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onChange(next);
+      }, PICKER_DEBOUNCE_MS);
+    },
+    [onChange],
+  );
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  return (
+    <div className="field">
+      <label>{t(labelKey, labelDefault)}</label>
+      <div className="palette">
+        {presets.map((c) => (
+          <button
+            key={c}
+            type="button"
+            aria-label={c}
+            className={`swatch ${valueLower === c.toLowerCase() ? 'selected' : ''}`}
+            style={{ background: c }}
+            onClick={() => onChange(c)}
+          />
+        ))}
+        <label
+          className={`swatch custom ${isCustom ? 'selected' : ''}`}
+          style={{ background: value }}
+          title={t('subtitle.settings.customColor', 'Custom color')}
+          aria-label={t('subtitle.settings.customColor', 'Custom color')}
+        >
+          <Plus size={10} />
+          <input
+            type="color"
+            value={value}
+            onChange={(e) => onPickerChange(e.target.value)}
+          />
+        </label>
+      </div>
+    </div>
+  );
+};
+```
+
+- [ ] **Step 2: Run tests to confirm subtitle path still works**
+
+Run: `npm run test`
+Expected: PASS. The subtitle popover behavior is functionally unchanged from the user's perspective — just newly factored. (No popover-specific tests exist yet; they land in Task 9.)
+
+- [ ] **Step 3: Type check**
+
+Run: `npx tsc --noEmit -p .`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Display/DisplaySettingsPopover.tsx
+git commit -m "feat(popover): split into source wrappers, add dark presets and '+' picker
+
+- DisplaySettingsPopover dispatches by source prop to one of two
+  wrappers (SubtitleBoundPopover, ConversationBoundPopover) that each
+  call only their own store's hooks (rules of hooks satisfied).
+- Inner presentational component takes resolved bindings as props.
+- ColorRow subcomponent renders the chip palette plus a '+' custom
+  chip with a hidden <input type=color>, debounced 150ms.
+- Source/translation rows gain three dark presets each:
+    SOURCE: #000000, #003B6F, #1B5E20
+    TRANSLATION: #000000, #003B6F, #7B1FA2
+- Conversation source path now reads/writes conversationDisplayStore.
+
+Refs #231"
+```
+
+---
+
+## Task 8: Update DisplaySettingsPopover SCSS for `.swatch.custom`
+
+**Files:**
+- Modify: `src/components/Display/DisplaySettingsPopover.scss`
+
+- [ ] **Step 1: Replace the file content**
+
+Edit `src/components/Display/DisplaySettingsPopover.scss`. Replace the full content with:
+
+```scss
+.display-settings-popover {
+  background: #1a1a1a;
+  color: #e8e8e8;
+  border: 1px solid #3a3a3a;
+  border-radius: 8px;
+  padding: 16px;
+  width: 280px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+
+  .field {
+    margin-bottom: 12px;
+
+    label {
+      display: block;
+      font-size: 12px;
+      margin-bottom: 6px;
+      color: #c8c8c8;
+    }
+
+    input[type="range"] {
+      width: 100%;
+    }
+
+    .palette {
+      display: flex;
+      gap: 6px;
+      flex-wrap: wrap;
+
+      .swatch {
+        width: 20px;
+        height: 20px;
+        border-radius: 50%;
+        border: 2px solid transparent;
+        cursor: pointer;
+        padding: 0;
+        position: relative;
+
+        &.selected {
+          border-color: #10a37f;
+        }
+
+        // Custom-color chip: a <label> wrapping a hidden <input type="color">.
+        // The chip's background reflects the current chosen color so it
+        // doubles as a "current value" indicator. The Plus icon is rendered
+        // in white with a thin dark outline so it stays legible regardless
+        // of the chip background.
+        &.custom {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          color: #fff;
+          filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.9));
+
+          input[type="color"] {
+            position: absolute;
+            inset: 0;
+            opacity: 0;
+            cursor: pointer;
+            border: none;
+            padding: 0;
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Manual visual sanity check**
+
+Run: `npm run dev`
+Expected: Dev server starts on port 5173. Open the app, enter subtitle mode, click the ⚙ icon. Expected popover layout: opacity slider on top (subtitle source), then three rows of color chips. Each row ends in a circular "+" chip showing the current color with a small white plus glyph. Clicking the "+" opens the OS color picker. (Stop the dev server with Ctrl-C after a quick check.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Display/DisplaySettingsPopover.scss
+git commit -m "style(popover): add .swatch.custom for the '+' custom-color chip
+
+Circular chip backed by current value; hidden <input type=color>
+covers the chip footprint so any click opens the OS picker. Plus
+icon rendered white with a thin drop-shadow for legibility on any
+chip background.
+
+Refs #231"
+```
+
+---
+
+## Task 9: Add `DisplaySettingsPopover` tests
+
+**Files:**
+- Create: `src/components/Display/DisplaySettingsPopover.test.tsx`
+
+- [ ] **Step 1: Write the test file**
+
+Create `src/components/Display/DisplaySettingsPopover.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import DisplaySettingsPopover from './DisplaySettingsPopover';
+import { useSubtitleStore } from '../../stores/subtitleStore';
+import { useConversationDisplayStore } from '../../stores/conversationDisplayStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock('../../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: vi.fn(async (_key: string, def: unknown) => def),
+      setSetting: vi.fn(async () => ({ success: true })),
+    }),
+  },
+}));
+
+describe('DisplaySettingsPopover', () => {
+  beforeEach(() => {
+    // Reset both stores to known starting state
+    useSubtitleStore.setState({
+      bgColor: '#000000',
+      sourceTextColor: '#FFFFFF',
+      translationTextColor: '#6CC5FF',
+      bgOpacity: 80,
+    } as Partial<ReturnType<typeof useSubtitleStore.getState>> as never);
+    useConversationDisplayStore.setState({
+      bgColor: '#1f1f1f',
+      sourceTextColor: '#9aa0a6',
+      translationTextColor: '#e8e8e8',
+    } as Partial<ReturnType<typeof useConversationDisplayStore.getState>> as never);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders opacity slider when source=subtitle', () => {
+    const { container } = render(<DisplaySettingsPopover source="subtitle" />);
+    expect(container.querySelector('input[type="range"]')).not.toBeNull();
+  });
+
+  it('does NOT render opacity slider when source=conversation', () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    expect(container.querySelector('input[type="range"]')).toBeNull();
+  });
+
+  it('clicking a preset chip in subtitle mode updates only subtitleStore', async () => {
+    const { container } = render(<DisplaySettingsPopover source="subtitle" />);
+    const whiteChip = container.querySelector(
+      'button.swatch[aria-label="#FFFFFF"]',
+    ) as HTMLButtonElement;
+    expect(whiteChip).not.toBeNull();
+    await act(async () => { fireEvent.click(whiteChip); });
+    expect(useSubtitleStore.getState().bgColor).toBe('#FFFFFF');
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#1f1f1f');
+  });
+
+  it('clicking a preset chip in conversation mode updates only conversationDisplayStore', async () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    const whiteChip = container.querySelector(
+      'button.swatch[aria-label="#FFFFFF"]',
+    ) as HTMLButtonElement;
+    await act(async () => { fireEvent.click(whiteChip); });
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#FFFFFF');
+    expect(useSubtitleStore.getState().bgColor).toBe('#000000');
+  });
+
+  it('clicking the new dark source-text preset updates the source color', async () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    // The new "#1B5E20" deep-forest chip is in the SOURCE row only.
+    const allChips = container.querySelectorAll('button.swatch[aria-label="#1B5E20"]');
+    expect(allChips.length).toBe(1);
+    await act(async () => { fireEvent.click(allChips[0] as HTMLButtonElement); });
+    expect(useConversationDisplayStore.getState().sourceTextColor).toBe('#1B5E20');
+  });
+
+  it('preset chip is selected when current value matches', () => {
+    useConversationDisplayStore.setState({ bgColor: '#000000' } as never);
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    const blackChip = container.querySelector('button.swatch[aria-label="#000000"]');
+    expect(blackChip?.classList.contains('selected')).toBe(true);
+    const customChip = container.querySelector('label.swatch.custom');
+    expect(customChip?.classList.contains('selected')).toBe(false);
+  });
+
+  it('"+" chip is selected when current value is not in the row presets', () => {
+    useConversationDisplayStore.setState({ bgColor: '#abcdef' } as never);
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    // BG row's custom chip
+    const customChips = container.querySelectorAll('label.swatch.custom');
+    expect(customChips.length).toBe(3);
+    expect(customChips[0].classList.contains('selected')).toBe(true);
+  });
+
+  it('debounces "+" chip color picker changes by ~150ms (only last value applied)', async () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    // The first custom chip's hidden input is the BG row's picker.
+    const colorInput = container.querySelector(
+      'label.swatch.custom input[type="color"]',
+    ) as HTMLInputElement;
+    expect(colorInput).not.toBeNull();
+
+    fireEvent.change(colorInput, { target: { value: '#aaaaaa' } });
+    fireEvent.change(colorInput, { target: { value: '#bbbbbb' } });
+    fireEvent.change(colorInput, { target: { value: '#cccccc' } });
+
+    // Before debounce window: setter NOT called yet
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#1f1f1f');
+
+    // Advance past the 150ms debounce
+    await act(async () => { vi.advanceTimersByTime(160); });
+
+    // After debounce: only the LAST value applied
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#cccccc');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test file**
+
+Run: `npm run test -- src/components/Display/DisplaySettingsPopover.test.tsx`
+Expected: PASS — all 8 cases pass. If a case fails:
+- "rendered opacity slider when source=conversation" — verify the inner component's `includeOpacity` check is `bindings.bgOpacity !== undefined && bindings.setBgOpacity !== undefined`.
+- preset chip click test fails with no setter call — verify `onClick={() => onChange(c)}` is on the chip button.
+- debounce test fails — verify `useFakeTimers` is called before render, and `act(async)` is used for `advanceTimersByTime`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Display/DisplaySettingsPopover.test.tsx
+git commit -m "test(popover): cover both source variants, presets, custom chip, debounce
+
+8 cases: opacity-slider visibility per source, preset clicks scoped to
+the right store, new dark preset added to source row, preset/custom
+highlight rules, debounced custom-color picker keeps only the last
+value of a rapid sequence.
+
+Refs #231"
+```
+
+---
+
+## Task 10: Add ⚙ button + popover to MainPanel `conversation-toolbar`
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.tsx` (imports near line 1-90; new state near line 130; new JSX near line 2980, after the existing clear button)
+
+- [ ] **Step 1: Verify the @floating-ui imports already exist**
+
+Run: `grep -n "@floating-ui/react\|FloatingPortal\|useFloating" src/components/MainPanel/MainPanel.tsx | head -5`
+Expected: One or more matches. If MainPanel doesn't import these yet, also add the import in the next step.
+
+- [ ] **Step 2: Add new imports**
+
+Edit `src/components/MainPanel/MainPanel.tsx`. Find the `lucide-react` import block. Add `Settings` to the existing destructured imports if not present. Example:
+
+```tsx
+import { /* ... existing icons ..., */ Settings } from 'lucide-react';
+```
+
+Find the `@floating-ui/react` import. If it doesn't exist, add at the top alongside other lib imports:
+
+```tsx
+import {
+  useFloating, useClick, useDismiss, useInteractions, offset, flip, FloatingPortal,
+} from '@floating-ui/react';
+```
+
+If it does exist, ensure the destructure includes all these names; add any missing.
+
+Add the popover import below the other component imports:
+
+```tsx
+import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
+```
+
+- [ ] **Step 3: Add popover state at the top of the component body**
+
+Find the existing `useState` calls at the top of the MainPanel component body (around lines 126-200). Add this block in the same area, after the other state initialisations:
+
+```tsx
+  // Display settings popover (conversation-toolbar ⚙)
+  const [displayPopoverOpen, setDisplayPopoverOpen] = useState(false);
+  const displayPopoverFloating = useFloating({
+    open: displayPopoverOpen,
+    onOpenChange: setDisplayPopoverOpen,
+    placement: 'bottom-end',
+    middleware: [offset(8), flip()],
+  });
+  const displayPopoverInteractions = useInteractions([
+    useClick(displayPopoverFloating.context),
+    useDismiss(displayPopoverFloating.context),
+  ]);
+```
+
+(Naming the bundles `displayPopover*` keeps them obviously associated and doesn't collide with any existing local names.)
+
+- [ ] **Step 4: Add the ⚙ button to `conversation-toolbar`**
+
+Find the `<div className="conversation-toolbar">` JSX block (around line 2923). Locate the existing `clear-conversation-btn` (around line 2986). Add a new button **before** the clear button:
+
+```tsx
+            <button
+              className="font-size-btn"
+              ref={displayPopoverFloating.refs.setReference}
+              {...displayPopoverInteractions.getReferenceProps()}
+              title={t('mainPanel.displaySettings', 'Display settings')}
+              aria-label={t('mainPanel.displaySettings', 'Display settings')}
+              type="button"
+            >
+              <Settings size={14} />
+            </button>
+```
+
+Reusing the `font-size-btn` class keeps the visual style identical to the other toolbar icon buttons; introducing a new class is unnecessary.
+
+- [ ] **Step 5: Add the FloatingPortal popover**
+
+Immediately after the closing `</div>` of `conversation-toolbar` (around line 2995), add the popover render:
+
+```tsx
+            {displayPopoverOpen && (
+              <FloatingPortal>
+                <div
+                  ref={displayPopoverFloating.refs.setFloating}
+                  style={displayPopoverFloating.floatingStyles}
+                  {...displayPopoverInteractions.getFloatingProps()}
+                >
+                  <DisplaySettingsPopover source="conversation" />
+                </div>
+              </FloatingPortal>
+            )}
+```
+
+- [ ] **Step 6: Run the test suite**
+
+Run: `npm run test`
+Expected: PASS. The new button and popover JSX shouldn't break any existing tests; if a snapshot test exists for MainPanel and fails, update the snapshot (the change is intentional).
+
+- [ ] **Step 7: Type check**
+
+Run: `npx tsc --noEmit -p .`
+Expected: No errors.
+
+- [ ] **Step 8: Manual visual sanity check**
+
+Run: `npm run dev`
+Expected: Open the app, start a session (or load a previous conversation if items exist), confirm a new ⚙ button appears at the right end of the conversation toolbar (just before the trash icon). Click it — the same popover from subtitle mode opens, but **without** the opacity slider. Click any color preset; the conversation panel updates while the subtitle window (if visible) does not. Stop the dev server with Ctrl-C.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.tsx
+git commit -m "feat(mainpanel): add ⚙ display-settings entry on conversation-toolbar
+
+New cog button at the end of the toolbar (before clear). Opens
+DisplaySettingsPopover bound to source='conversation' via @floating-ui.
+Hidden when there are no items / no session, same gating as the rest
+of the toolbar.
+
+Refs #231"
+```
+
+---
+
+## Task 11: Apply `--conversation-*` CSS variables on `.main-panel-wrapper`
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.tsx` (imports near top; hooks near line 130; root JSX near line 2917)
+
+- [ ] **Step 1: Add the new selector hooks to imports**
+
+Edit `src/components/MainPanel/MainPanel.tsx`. Find the `conversationDisplayStore` import added in Task 4 and add the three color selector hooks:
+
+```tsx
+import {
+  useConversationDisplayFontSize,
+  useSetConversationDisplayFontSize,
+  useConversationDisplayCompactMode,
+  useSetConversationDisplayCompactMode,
+  useConversationDisplayBgColor,
+  useConversationDisplaySourceTextColor,
+  useConversationDisplayTranslationTextColor,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+} from '../../stores/conversationDisplayStore';
+```
+
+- [ ] **Step 2: Read the three color values in the component body**
+
+Find the four conversation hook calls added in Task 4 (around line 129-132 area). Add three more lines after them:
+
+```tsx
+  const conversationBgColor = useConversationDisplayBgColor();
+  const conversationSourceTextColor = useConversationDisplaySourceTextColor();
+  const conversationTranslationTextColor = useConversationDisplayTranslationTextColor();
+```
+
+- [ ] **Step 3: Set the CSS variables on `.main-panel-wrapper`**
+
+Find the root JSX element of MainPanel (around line 2917):
+
+```tsx
+    <div className="main-panel-wrapper">
+```
+
+Replace with:
+
+```tsx
+    <div
+      className="main-panel-wrapper"
+      style={{
+        '--conversation-bg-color': conversationBgColor,
+        '--conversation-source-color': conversationSourceTextColor,
+        '--conversation-translation-color': conversationTranslationTextColor,
+      } as React.CSSProperties}
+    >
+```
+
+- [ ] **Step 4: Run the test suite**
+
+Run: `npm run test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.tsx
+git commit -m "feat(mainpanel): expose conversation color CSS variables on wrapper
+
+Sets --conversation-bg-color, --conversation-source-color, and
+--conversation-translation-color from the conversationDisplayStore on
+.main-panel-wrapper so .conversation-display and ConversationRow
+descendants can consume them.
+
+Refs #231"
+```
+
+---
+
+## Task 12: Update MainPanel.scss — `.conversation-display` background + dead-code cleanup
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.scss` (lines ~24, 127-180, 244-247)
+
+- [ ] **Step 1: Add background to `.conversation-display`**
+
+Edit `src/components/MainPanel/MainPanel.scss`. Find:
+
+```scss
+.conversation-display {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 0 12px 12px;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  position: relative;
+```
+
+Add this line directly after `position: relative;` and before the `&::-webkit-scrollbar` block:
+
+```scss
+  background: var(--conversation-bg-color, #1f1f1f);
+```
+
+- [ ] **Step 2: Remove the dead `.message-bubble.user` block**
+
+Find this block (around line 127):
+
+```scss
+  &.user {
+    align-self: flex-end;
+    background: #2a2a2a;
+    margin-left: auto;
+    border-bottom-right-radius: 4px;
+
+    &.playing {
+      background: #353535;
+      box-shadow: 0 0 10px rgba(16, 163, 127, 0.3);
+    }
+  }
+```
+
+Delete the entire block including the trailing blank line.
+
+- [ ] **Step 3: Remove the dead `.message-bubble.assistant` block**
+
+Find this block (around line 140):
+
+```scss
+  &.assistant {
+    align-self: flex-start;
+    background: #10a37f;
+    margin-right: auto;
+    border-bottom-left-radius: 4px;
+
+    &.playing {
+      background: #12b88f;
+      box-shadow: 0 0 10px rgba(16, 163, 127, 0.5);
+    }
+  }
+```
+
+Delete the entire block including the trailing blank line.
+
+- [ ] **Step 4: Remove the dead `.message-bubble.participant-source` block**
+
+Find this block (around line 165):
+
+```scss
+  // ── Participant source (orange) ──
+
+  &.participant-source {
+    border-left: 3px solid #f39c12;
+
+    &.user {
+      background: rgba(243, 156, 18, 0.15);
+      &.playing { background: rgba(243, 156, 18, 0.25); box-shadow: 0 0 10px rgba(243, 156, 18, 0.3); }
+    }
+
+    &.assistant {
+      background: #e67e22;
+      &.playing { background: #f39c12; box-shadow: 0 0 10px rgba(243, 156, 18, 0.5); }
+    }
+  }
+```
+
+Delete the entire block, including the `// ── Participant source (orange) ──` heading comment line and the trailing blank line.
+
+- [ ] **Step 5: Remove the `.message-bubble.assistant .karaoke-played` override**
+
+Find (around line 244):
+
+```scss
+// Assistant bubble (green bg) → white highlight
+.message-bubble.assistant .karaoke-played {
+  color: #fff;
+  text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
+}
+```
+
+Delete the entire block including the heading comment.
+
+- [ ] **Step 6: Sanity-grep for stragglers**
+
+Run: `grep -n "message-bubble.user\|message-bubble.assistant\|message-bubble.participant-source\|\\.message-bubble \\.karaoke" src/components/MainPanel/MainPanel.scss`
+Expected: No output (all dead-code rules removed). If output remains, delete those rules too.
+
+- [ ] **Step 7: Build to confirm SCSS still compiles**
+
+Run: `npm run build`
+Expected: Build succeeds. If SCSS errors appear, the deletions left a dangling `}` or selector — re-read MainPanel.scss in the area you edited and fix balance.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.scss
+git commit -m "feat(mainpanel-scss): theme conversation-display bg; drop dead message-bubble rules
+
+- .conversation-display gets background: var(--conversation-bg-color, #1f1f1f)
+- removes .message-bubble.user/.assistant/.participant-source.user/.assistant
+  rules (and their .playing variants) plus the .message-bubble.assistant
+  .karaoke-played override; MainPanel.tsx hasn't rendered these classes
+  for conversation rows since the move to <ConversationRow>, so they
+  were dead.
+- .message-bubble.error and .message-bubble.system stay; those are
+  still rendered for error / tool-call rows.
+
+Refs #231"
+```
+
+---
+
+## Task 13: Update ConversationRow.scss — playing ring + CSS variable rename
+
+**Files:**
+- Modify: `src/components/MainPanel/ConversationRow.scss:60-78, 110-121`
+
+- [ ] **Step 1: Update `.row-body.playing` to use a translation-color ring**
+
+Edit `src/components/MainPanel/ConversationRow.scss`. Find this block (around lines 60-78):
+
+```scss
+.row-body {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 2px 0 2px 30px; // indent so the line aligns under the name, avatar reserves space
+  line-height: 1.4;
+  font-size: var(--conversation-font-size, 14px);
+  transition: background-color 0.3s ease;
+
+  .conversation-row.grouped & {
+    padding-left: 30px;
+  }
+
+  &.playing {
+    background: rgba(16, 163, 127, 0.1);
+    border-radius: 4px;
+  }
+}
+```
+
+Replace with:
+
+```scss
+.row-body {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  padding: 2px 0 2px 30px; // indent so the line aligns under the name, avatar reserves space
+  line-height: 1.4;
+  font-size: var(--conversation-font-size, 14px);
+  transition: box-shadow 0.15s ease, border-radius 0.15s ease;
+
+  .conversation-row.grouped & {
+    padding-left: 30px;
+  }
+
+  &.playing {
+    box-shadow: 0 0 0 1px var(--conversation-translation-color, #10a37f);
+    border-radius: 4px;
+  }
+}
+```
+
+The transition was animating `background-color` for the now-removed playing background; switching it to `box-shadow / border-radius` matches the new ring effect.
+
+- [ ] **Step 2: Rename two CSS variable references**
+
+Find (around lines 110-121):
+
+```scss
+.row-text {
+  overflow-wrap: anywhere;
+
+  &.src {
+    color: var(--subtitle-source-color, #9aa0a6);
+    font-style: italic;
+  }
+
+  &.tr {
+    color: var(--subtitle-translation-color, #e8e8e8);
+  }
+}
+```
+
+Replace with:
+
+```scss
+.row-text {
+  overflow-wrap: anywhere;
+
+  &.src {
+    color: var(--conversation-source-color, #9aa0a6);
+    font-style: italic;
+  }
+
+  &.tr {
+    color: var(--conversation-translation-color, #e8e8e8);
+  }
+}
+```
+
+- [ ] **Step 3: Sanity-grep for any remaining `--subtitle-*` references in MainPanel scope**
+
+Run: `grep -rn "subtitle-source-color\|subtitle-translation-color" src/components/MainPanel/`
+Expected: No output. (`--subtitle-*` names live only under `src/components/Subtitle/`.)
+
+- [ ] **Step 4: Build and run tests**
+
+Run: `npm run build && npm run test`
+Expected: Build succeeds; all tests pass.
+
+- [ ] **Step 5: Manual visual verification**
+
+Run: `npm run dev`
+Expected:
+1. Start a session, get some conversation rows.
+2. Click conversation toolbar's ⚙, choose a white background and black source/translation text. The conversation panel should turn white with black text.
+3. Click a row's play button — instead of a translucent green box, the row should be ringed by a 1-px line in the chosen translation color.
+4. Open subtitle mode, the subtitle window's colors should be unaffected by step 2's choice.
+
+Stop the dev server with Ctrl-C after the check.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MainPanel/ConversationRow.scss
+git commit -m "feat(conversation-row): theme via --conversation-* and use ring for playing state
+
+- .row-body.playing changes from translucent green bg to a 1px
+  box-shadow ring in --conversation-translation-color, which stays
+  visible against any background color the user picks.
+- .row-text.src / .tr now consume --conversation-source-color /
+  --conversation-translation-color instead of the previous --subtitle-*
+  names. ConversationRow only renders inside MainPanel, so this
+  rename has no other consumers.
+
+Refs #231"
+```
+
+---
+
+## Task 14: Final verification
+
+**Files:**
+- None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm run test`
+Expected: PASS for all suites. Note any new failures and resolve before proceeding.
+
+- [ ] **Step 2: Run type check**
+
+Run: `npx tsc --noEmit -p .`
+Expected: No errors. If errors reference any of the removed `useConversationFontSize` / `useConversationCompactMode` / `CONVERSATION_FONT_SIZE_*` from `settingsStore`, find and update the importing site.
+
+- [ ] **Step 3: Build the project**
+
+Run: `npm run build`
+Expected: Build succeeds. SCSS validation runs as part of the build.
+
+- [ ] **Step 4: Sanity grep for orphaned references**
+
+Run:
+```bash
+grep -rn "SubtitleSettingsPopover" src/ --include="*.tsx" --include="*.ts"
+grep -rn "useConversationFontSize\b\|useConversationCompactMode\b" src/ --include="*.tsx" --include="*.ts" | grep -v conversationDisplayStore | grep -v "\\.test\\."
+grep -rn "settings.common.conversationFontSize\|settings.common.conversationCompactMode" src/ --include="*.tsx" --include="*.ts"
+grep -rn "subtitle-source-color\|subtitle-translation-color" src/components/MainPanel/
+```
+Expected: All four greps produce **no output**.
+
+- [ ] **Step 5: Manual end-to-end smoke test**
+
+Run: `npm run dev`
+
+Verify in the browser:
+1. **Subtitle popover entry point**: enter subtitle mode → click ⚙ → confirm popover opens with opacity slider, three color rows (each with new presets visible at the end of source/translation rows), and a "+" custom-color chip at the end of every row.
+2. **Conversation popover entry point**: in MainPanel toolbar, click the new ⚙ → confirm popover opens **without** opacity slider; otherwise identical layout.
+3. **Independent stores**: pick black bg in subtitle popover; pick white bg in conversation popover. Confirm both surfaces show their own choice and neither is overwritten by the other.
+4. **Custom color**: click any "+" chip → OS color picker opens → pick a non-preset color → that color applies to the surface, the other "+" chip swatches keep showing the current value of their own field, and the previously highlighted preset chip is unhighlighted.
+5. **Reset behavior**: pick a custom color, restart the app (or close + reopen). The custom color persists.
+6. **Default reset of font size**: open the app on a profile that previously had `conversationFontSize !== 14`. Confirm font size shows 14 (the documented persistence reset). Adjust via toolbar buttons; confirm the new value persists across a restart (now stored under the new namespace).
+7. **Playing ring**: in MainPanel, click play on a row. Confirm the ring (1px translation-color) shows around the row body, not a translucent green background.
+
+Stop the dev server with Ctrl-C.
+
+- [ ] **Step 6: Final commit (if any straggler changes from Step 5 manual fixes)**
+
+```bash
+git status
+# If any files were touched in Step 5 fixes:
+git add -A
+git commit -m "chore(231): wrap-up fixes from manual smoke test
+
+[describe specific issues found and fixed]
+
+Refs #231"
+```
+
+If no fixes needed, skip this step.
+
+- [ ] **Step 7: Show the final log**
+
+Run: `git log --oneline main..HEAD`
+Expected: 12-13 commits, all prefixed with `feat(...)`, `refactor(...)`, `i18n(...)`, `test(...)`, `style(...)`, or `chore(...)`, ending with `Refs #231`.
+
+---
+
+## Spec Coverage Self-Review (run after all tasks done)
+
+Spec sections vs tasks (manual cross-check):
+
+- ✅ **Conversation popover entry point at conversation-toolbar ⚙** — Task 10
+- ✅ **Subtitle popover entry point at subtitle bar ⚙** — preserved by Task 6
+- ✅ **`source: 'subtitle' | 'conversation'` prop with two wrappers + Inner** — Task 7
+- ✅ **Opacity slider only when source=subtitle** — Task 7
+- ✅ **New dark presets on source row** (`#000000`, `#003B6F`, `#1B5E20`) — Task 7
+- ✅ **New dark presets on translation row** (`#000000`, `#003B6F`, `#7B1FA2`) — Task 7
+- ✅ **"+" custom-color chip on every row with debounced OS picker** — Tasks 7-8
+- ✅ **Highlight rules: preset chip when value matches; "+" chip when not** — Task 7 + tested in Task 9
+- ✅ **Updated label strings (Display background / Source text / Translation text)** — Tasks 3 (i18n) + 7 (fallbacks)
+- ✅ **`subtitle.settings.customColor` i18n key** — Task 3
+- ✅ **`mainPanel.displaySettings` i18n key** — Task 3
+- ✅ **MainPanel reads colors from `conversationDisplayStore`** — Task 11
+- ✅ **`.conversation-display` background follows `--conversation-bg-color`** — Task 12
+- ✅ **`.row-body.playing` becomes a 1px translation-color ring** — Task 13
+- ✅ **`--subtitle-*` → `--conversation-*` rename in ConversationRow.scss** — Task 13
+- ✅ **Dead code cleanup of `.message-bubble.user/.assistant/.participant-source`** — Task 12
+- ✅ **New `conversationDisplayStore` with all 5 fields** — Task 1
+- ✅ **`conversationFontSize` / `conversationCompactMode` removed from settingsStore** — Task 5
+- ✅ **No persistence migration; old keys abandoned** — Task 1 (test asserts no read of old keys), Task 5 (no rewrite logic)
+- ✅ **Subtitle store / window / overlay completely unchanged** — only Task 6 touches subtitle bar's import line
+- ✅ **`subtitleStore.bgColor` default unchanged at `#000000`** — verified by absence of any task touching `subtitleStore.ts`
+- ✅ **Boot-time hydration call** — Task 2
+- ✅ **Tests** — Task 1 (store), Task 9 (popover)
+- ⚠️ **Spec mentions a MainPanel test asserting the three `--conversation-*` CSS custom properties on the wrapper** — intentionally omitted from this plan. There is no existing `MainPanel.test.tsx` to extend (only `ConversationRow.test.tsx`, which renders below the wrapper). Adding a brand-new render test for MainPanel just to assert `style={{...}}` props is testing React itself; the manual smoke test in Task 14 step 5 verifies the user-visible behavior end-to-end (subtitle vs conversation independence, default reset, ring playing state). If a follow-up wants this assertion, the simplest landing is to add it to the existing `ConversationRow.test.tsx` after wrapping the row in a small test harness that mounts a `<div style="--conversation-bg-color: ..."></div>` parent.
+
+---
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-14-more-color-options.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-14-conversation-font-size-cap-design.md
+++ b/docs/superpowers/specs/2026-05-14-conversation-font-size-cap-design.md
@@ -22,13 +22,18 @@ The plumbing for adjustable font sizes already exists on both surfaces:
 **Subtitle mode** (Electron floating window + extension overlay):
 - Has its own +/- buttons in `SubtitleBar.tsx:122-133`.
 - Range `FONT_SIZE_MIN=12 → FONT_SIZE_MAX=48`, step 2, default 24, persisted via `subtitleStore`.
-- Already adequate for projection; no change needed.
+- Adequate for typical screens but still small for large classroom / hall projection.
 
-The single concrete gap blocking the classroom use case is that **MainPanel's cap of 28 px is too small for projection**.
+Both surfaces have a cap that is too low for classroom-scale projection. **MainPanel's 28 px is the more severe gap, but subtitle's 48 px also leaves headroom for larger projection setups.**
 
 ## Proposed change
 
-Raise MainPanel's font-size cap from **28 → 48 px**, matching subtitle mode's existing range. Keep the existing +/- stepper UI, default value, persistence, and CSS variable wiring. No new settings surface.
+Raise the font-size cap on **both** surfaces to **64 px**:
+
+- MainPanel: **28 → 64 px**
+- Subtitle mode: **48 → 64 px**
+
+Keep the existing +/- stepper UI, default values, persistence, and CSS variable wiring on both surfaces. No new settings surface.
 
 ## Detailed design
 
@@ -38,7 +43,7 @@ Raise MainPanel's font-size cap from **28 → 48 px**, matching subtitle mode's 
 
   ```ts
   export const CONVERSATION_FONT_SIZE_MIN = 12;
-  export const CONVERSATION_FONT_SIZE_MAX = 48;
+  export const CONVERSATION_FONT_SIZE_MAX = 64;
   ```
 
   (Mirrors the `FONT_SIZE_MIN` / `FONT_SIZE_MAX` exports from `subtitleStore.ts:64-65`.)
@@ -64,50 +69,59 @@ No SCSS change. `.message-content { font-size: var(--conversation-font-size, 14p
 
 No extension-specific change. `extension/vite.config.ts` aliases `@components` to `../src/components`, so the same MainPanel ships in both targets.
 
-### 5. Subtitle mode
+### 5. `src/stores/subtitleStore.ts`
 
-Untouched. Already 12-48.
+- Update `FONT_SIZE_MAX` from `48` → `64` (line 65). `FONT_SIZE_MIN`, default (24), and step (2) stay the same.
+- Existing clamp logic (`clamp(Math.round(n), FONT_SIZE_MIN, FONT_SIZE_MAX)` on both setter and load path) automatically picks up the new bound.
+- Update the existing test in `src/stores/subtitleStore.test.ts` that hardcodes 48: line 31 description (`'clamps fontSize to [12, 48]'` → `'[12, 64]'`) and line 35 assertion (`toBe(48)` → `toBe(64)`). The line 37 in-range assertion (28) is unaffected.
 
 ## Acceptance-criteria mapping
 
 | Criterion (from issue #230) | How met |
 | --- | --- |
-| User can pick a font size that is clearly readable from across a typical classroom | Cap rises 28 → 48 px (~70% larger maximum), matching subtitle-mode max |
-| Default size unchanged | Default stays at 14 |
-| Persists across sessions | Already wired through `settingsStore`; clamp on load preserves valid stored values |
-| Layout works at the largest setting — no clipping, no overlap with controls/footer, scrolling still behaves | Verified manually at the new max; `line-height: 1.4` scales with font; bubbles wrap; toolbar sits above conversation, unaffected |
-| Works in both Electron and browser extension | Shared MainPanel code via `@components` alias |
+| User can pick a font size that is clearly readable from across a typical classroom | MainPanel cap rises 28 → 64 px (~2.3× larger max); subtitle cap rises 48 → 64 px |
+| Defaults unchanged | MainPanel default stays at 14; subtitle default stays at 24 |
+| Persists across sessions | Already wired through `settingsStore` and `subtitleStore`; clamp on load preserves valid stored values |
+| Layout works at the largest setting — no clipping, no overlap with controls/footer, scrolling still behaves | Verified manually at 64 on both surfaces; `line-height: 1.4` scales with font; bubbles wrap; toolbars / bars sit above conversation, unaffected |
+| Works in both Electron and browser extension | Shared MainPanel and Subtitle code via `@components` alias |
 
 ## Automated tests
 
-Add to `src/stores/settingsStore.test.ts` (currently has no coverage for `conversationFontSize`):
+**`src/stores/settingsStore.test.ts`** (currently has no coverage for `conversationFontSize`):
 
 - `setConversationFontSize(5)` → state value is clamped to `CONVERSATION_FONT_SIZE_MIN` (12).
-- `setConversationFontSize(100)` → state value is clamped to `CONVERSATION_FONT_SIZE_MAX` (48).
+- `setConversationFontSize(100)` → state value is clamped to `CONVERSATION_FONT_SIZE_MAX` (64).
 - `setConversationFontSize(20)` → state value stays at 20 (in-range pass-through).
 
 Mirrors the existing pattern in `src/stores/subtitleStore.test.ts:31-37`.
 
+**`src/stores/subtitleStore.test.ts`**: update the existing `'clamps fontSize to [12, 48]'` test to assert the new upper bound of 64 (description string + line 35 `toBe(48)` → `toBe(64)`).
+
 ## Manual verification (test plan)
 
-Run on Electron and on the extension side panel, in both basic and advanced UI modes:
+**MainPanel** — run on Electron and on the extension side panel, in both basic and advanced UI modes:
 
 1. Start a session, send / receive a few messages.
-2. Click `A↑` repeatedly — value reaches 48 and stops; button becomes disabled.
+2. Click `A↑` repeatedly — value reaches 64 and stops; button becomes disabled.
 3. Click `A↓` repeatedly — value reaches 12 and stops; button becomes disabled.
-4. At 48 px, verify:
+4. At 64 px, verify:
    - Bubbles wrap; no horizontal overflow.
    - Conversation scrolls correctly when content exceeds the viewport.
    - The conversation toolbar above and the footer below are unaffected.
    - Karaoke-highlighted (currently-playing) bubbles still render correctly with the new size.
 5. Reload the app — the chosen size persists.
-6. Manually inject an out-of-range value (e.g., 200) into stored settings, reload — value gets clamped to 48.
+6. Manually inject an out-of-range value (e.g., 200) into stored settings, reload — value gets clamped to 64.
+
+**Subtitle mode** — run on Electron's floating subtitle window and the extension overlay:
+
+7. Open subtitle mode, click `+` repeatedly — value reaches 64 and stops; button becomes disabled.
+8. At 64 px, verify the subtitle window/overlay still renders the original + translated text without clipping or layout breakage; controls in the bar remain usable.
+9. Reload — chosen size persists.
 
 ## Out of scope
 
 - Adding a separate "Presentation / Projection" preset (existing +/- control already implements an S/M/L/XL stepper shape; raising the cap covers the classroom use case).
-- Bumping subtitle mode's max (already adequate at 48).
-- Asymmetric step sizing (e.g., step=4 above 28). Subtitle mode lives with step=2 across its full range; consistency wins.
+- Asymmetric step sizing (e.g., step=4 above 28). Step=2 across the full range matches subtitle mode's existing behavior; consistency wins. (12 → 64 in steps of 2 is 26 clicks but still acceptable, and users typically set once and persist.)
 - Per-bubble-type or per-language sizing.
 - Replacing the +/- stepper with a slider or numeric input.
 

--- a/docs/superpowers/specs/2026-05-14-conversation-font-size-cap-design.md
+++ b/docs/superpowers/specs/2026-05-14-conversation-font-size-cap-design.md
@@ -1,0 +1,117 @@
+# Conversation Font-Size Cap for Classroom Projection — Design
+
+**Issue**: [#230](https://github.com/kizuna-ai-lab/sokuji/issues/230) — _allow larger font sizes for original and translated text in subtitle/conversation view_
+**Date**: 2026-05-14
+**Status**: Draft
+
+## Problem
+
+Reported by **Ray Chow**, who runs Sokuji in a Youth Night School English learning group projected onto a large classroom screen. At the current maximum, students sitting farther from the screen cannot read the original speech and the translation.
+
+## Existing state
+
+The plumbing for adjustable font sizes already exists on both surfaces:
+
+**MainPanel** (used in both Electron and the browser extension, in basic and advanced UI modes):
+- Conversation toolbar already exposes `A↓ / A↑` font-size buttons (`src/components/MainPanel/MainPanel.tsx:2934-2953`).
+- Range hard-coded to **12 → 28 px**, step 2, default 14.
+- State persisted via `settingsStore.conversationFontSize` (`src/stores/settingsStore.ts` lines 43, 192, 901-911, 1460).
+- CSS variable `--conversation-font-size` is set on `.conversation-display` and consumed by `.message-content` in `MainPanel.scss:218` and `ConversationRow.scss:67`. Line-height is `1.4` (unitless), so spacing scales with font size.
+- Toolbar is shown whenever a session is active or there are existing messages; no `uiMode` gating.
+
+**Subtitle mode** (Electron floating window + extension overlay):
+- Has its own +/- buttons in `SubtitleBar.tsx:122-133`.
+- Range `FONT_SIZE_MIN=12 → FONT_SIZE_MAX=48`, step 2, default 24, persisted via `subtitleStore`.
+- Already adequate for projection; no change needed.
+
+The single concrete gap blocking the classroom use case is that **MainPanel's cap of 28 px is too small for projection**.
+
+## Proposed change
+
+Raise MainPanel's font-size cap from **28 → 48 px**, matching subtitle mode's existing range. Keep the existing +/- stepper UI, default value, persistence, and CSS variable wiring. No new settings surface.
+
+## Detailed design
+
+### 1. `src/stores/settingsStore.ts`
+
+- Export new constants alongside the existing common-settings shape:
+
+  ```ts
+  export const CONVERSATION_FONT_SIZE_MIN = 12;
+  export const CONVERSATION_FONT_SIZE_MAX = 48;
+  ```
+
+  (Mirrors the `FONT_SIZE_MIN` / `FONT_SIZE_MAX` exports from `subtitleStore.ts:64-65`.)
+
+- In `setConversationFontSize`, clamp the incoming value to `[MIN, MAX]` before writing to state and persisting. Today the setter writes whatever it is given.
+
+- In the load path (around line 1460, where `conversationFontSize` is read from settings storage), clamp the value as well so any stored out-of-range value gets corrected on next load. This protects users who already have a value stored from a future change.
+
+### 2. `src/components/MainPanel/MainPanel.tsx`
+
+- Import the two new constants from `settingsStore`.
+- Replace the literal `12` / `28` in the two button handlers (lines 2936-2937, 2946-2947) with `CONVERSATION_FONT_SIZE_MIN` / `CONVERSATION_FONT_SIZE_MAX`. The `disabled` state continues to derive from the same bounds.
+
+### 3. Styles
+
+No SCSS change. `.message-content { font-size: var(--conversation-font-size, 14px); line-height: 1.4; word-wrap: break-word; white-space: pre-wrap; }` already scales correctly:
+
+- `line-height: 1.4` is unitless, so it scales with the font.
+- Bubble paddings/max-widths stay in px and remain proportionate.
+- `word-wrap: break-word` and `.conversation-display`'s flex layout ensure long lines wrap rather than clip.
+
+### 4. Extension
+
+No extension-specific change. `extension/vite.config.ts` aliases `@components` to `../src/components`, so the same MainPanel ships in both targets.
+
+### 5. Subtitle mode
+
+Untouched. Already 12-48.
+
+## Acceptance-criteria mapping
+
+| Criterion (from issue #230) | How met |
+| --- | --- |
+| User can pick a font size that is clearly readable from across a typical classroom | Cap rises 28 → 48 px (~70% larger maximum), matching subtitle-mode max |
+| Default size unchanged | Default stays at 14 |
+| Persists across sessions | Already wired through `settingsStore`; clamp on load preserves valid stored values |
+| Layout works at the largest setting — no clipping, no overlap with controls/footer, scrolling still behaves | Verified manually at the new max; `line-height: 1.4` scales with font; bubbles wrap; toolbar sits above conversation, unaffected |
+| Works in both Electron and browser extension | Shared MainPanel code via `@components` alias |
+
+## Automated tests
+
+Add to `src/stores/settingsStore.test.ts` (currently has no coverage for `conversationFontSize`):
+
+- `setConversationFontSize(5)` → state value is clamped to `CONVERSATION_FONT_SIZE_MIN` (12).
+- `setConversationFontSize(100)` → state value is clamped to `CONVERSATION_FONT_SIZE_MAX` (48).
+- `setConversationFontSize(20)` → state value stays at 20 (in-range pass-through).
+
+Mirrors the existing pattern in `src/stores/subtitleStore.test.ts:31-37`.
+
+## Manual verification (test plan)
+
+Run on Electron and on the extension side panel, in both basic and advanced UI modes:
+
+1. Start a session, send / receive a few messages.
+2. Click `A↑` repeatedly — value reaches 48 and stops; button becomes disabled.
+3. Click `A↓` repeatedly — value reaches 12 and stops; button becomes disabled.
+4. At 48 px, verify:
+   - Bubbles wrap; no horizontal overflow.
+   - Conversation scrolls correctly when content exceeds the viewport.
+   - The conversation toolbar above and the footer below are unaffected.
+   - Karaoke-highlighted (currently-playing) bubbles still render correctly with the new size.
+5. Reload the app — the chosen size persists.
+6. Manually inject an out-of-range value (e.g., 200) into stored settings, reload — value gets clamped to 48.
+
+## Out of scope
+
+- Adding a separate "Presentation / Projection" preset (existing +/- control already implements an S/M/L/XL stepper shape; raising the cap covers the classroom use case).
+- Bumping subtitle mode's max (already adequate at 48).
+- Asymmetric step sizing (e.g., step=4 above 28). Subtitle mode lives with step=2 across its full range; consistency wins.
+- Per-bubble-type or per-language sizing.
+- Replacing the +/- stepper with a slider or numeric input.
+
+## Risks
+
+- **Visual regression at large sizes**: mitigated by manual verification step 4 above. Line-height is relative so spacing scales; bubbles are flex children that wrap.
+- **Stored value out of range** (forward / backward compatibility): mitigated by clamp-on-load.

--- a/docs/superpowers/specs/2026-05-14-more-color-options-design.md
+++ b/docs/superpowers/specs/2026-05-14-more-color-options-design.md
@@ -1,0 +1,182 @@
+# More Color Options for Subtitle and Conversation Panel — Design
+
+**Date**: 2026-05-14
+**Status**: Approved for implementation planning
+**Tracking issue**: [#231](https://github.com/kizuna-ai-lab/sokuji/issues/231)
+**Scope**: `SubtitleSettingsPopover`, `MainPanel`, `subtitleStore` defaults
+
+## Context
+
+Issue #231 ("add high-contrast subtitle themes") came from a classroom user (Ray Chow, Youth Night School English group) projecting Sokuji on a large screen under varying lighting. The user's original email asked for "more background and font color options" and listed four example combinations (white-on-black, black-on-white, dark-blue-on-light, larger high-contrast). The issue draft re-cast the request as a "theme presets" feature with a `presentation` preset that bundles colors with a larger font size.
+
+Re-reading the email against the existing UI confirms a simpler diagnosis: the subtitle settings popover already exposes background, source-text, and translation-text color chips, but the source/translation chip palettes contain only light and warm colors. The user can configure three of the four example combinations today; the fourth (white background with dark text) is unreachable because no chip palette includes a dark color. Larger font is tracked separately and is out of scope here.
+
+This spec therefore drops the "theme" abstraction. It adds the missing dark color chips, adds an "any color" picker as a final fallback, wires the existing color fields into the conversation panel (today they are observed only by the dedicated subtitle surface), and rewords the popover labels so the user sees that one setting now affects two surfaces.
+
+## Non-Goals
+
+- Theme presets (named combinations of colors stored as a single setting).
+- Saving named custom themes.
+- Per-side colors (different bubble color per speaker / participant).
+- Larger font sizes — tracked in the separate font-size issue.
+- An app-wide light theme for chrome (titlebar, sidebar, control footer, input section). Chrome and content are already physically separate surfaces; a dark chrome does not break a white content area, and no user has asked for it. Re-evaluate if a second projector user reports it.
+- Removing or restyling the subtitle background opacity slider (still meaningful for the floating subtitle window; not applied to the conversation panel).
+- Changing chip colors that are already present.
+
+## User-Visible Behavior
+
+### In the subtitle settings popover
+
+The ⚙ Settings popover on the subtitle bar gains:
+
+- **Three additional dark chips on the source-text row**: black (`#000000`), deep navy (`#003B6F`), deep forest (`#1B5E20`). These let the user configure readable source text against a white or light background.
+- **Three additional dark chips on the translation-text row**: black (`#000000`), deep navy (`#003B6F`), deep purple (`#7B1FA2`).
+- **A "+" custom-color chip at the end of every chip row** (background, source, translation). Clicking opens the operating system's native color picker. Any hex the user picks is saved to the same setting as the preset chips (`bgColor` / `sourceTextColor` / `translationTextColor`); there is no new "custom theme" concept.
+- **Updated labels** that no longer pretend the settings only affect the subtitle window:
+  - "Background opacity" → unchanged (still subtitle-window only — the conversation panel does not apply opacity).
+  - "Background color" → "Display background".
+  - "Source text color" → "Source text".
+  - "Translation color" → "Translation text".
+  - A small one-line caption at the top of the popover: "Applies to the subtitle window and the conversation panel."
+
+### Highlight rules in the popover
+
+- A preset chip is highlighted when its hex equals the current stored value.
+- The "+" chip is highlighted when the current stored value is **not** in the preset row (i.e., the user picked a custom color). The "+" chip's swatch background reflects the current stored value so the user always sees what color is active.
+
+### In the conversation panel (MainPanel)
+
+When the user changes any of the three color settings, the conversation panel updates immediately:
+
+- **Conversation content area background** follows `bgColor`.
+- **Original-language text** in conversation rows follows `sourceTextColor`.
+- **Translated text** in conversation rows follows `translationTextColor`.
+- **Currently-playing row** is indicated by a 1px ring in the translation-text color around the row body, instead of the existing translucent green background. The ring works against any background color; the translucent green stops being visible against translation-color backgrounds.
+
+The chrome (control footer, text input section, titlebar, sidebar) does **not** change color and stays on its existing dark tokens.
+
+The conversation panel does not apply the subtitle-window background opacity. It uses the chosen `bgColor` as a flat color.
+
+### Default value change
+
+The `subtitleStore` default `bgColor` changes from `#000000` (pure black) to `#1f1f1f` (the conversation panel's existing implicit dark color). Rationale and migration are in [Compatibility](#compatibility).
+
+## Implementation
+
+### File-level changes
+
+#### `src/components/Subtitle/SubtitleSettingsPopover.tsx`
+
+- Extend `SOURCE_PRESETS` with `'#000000', '#003B6F', '#1B5E20'`.
+- Extend `TRANSLATION_PRESETS` with `'#000000', '#003B6F', '#7B1FA2'`.
+- `BG_PRESETS` is unchanged — it already covers the email's three background examples (black, white, deep navy `#0d2032`).
+- Extract a `<ColorRow label preset value onChange />` subcomponent reused by all three rows. Each row renders the existing chips, then one extra "+" custom-color chip.
+- The "+" chip is a `<label>` containing a hidden `<input type="color">`. Clicking the chip triggers the OS color dialog. The chip's swatch background is the current `value` so it doubles as a "current color" indicator.
+- The `onChange` of `<input type="color">` is debounced ~150ms before calling the corresponding setter (raw `onChange` fires continuously while the user drags inside the OS picker — without debounce this would flood the persistence layer).
+- Wrap the popover body in a small caption row showing the new "Applies to the subtitle window and the conversation panel" string from i18n.
+- Update label translation keys per [i18n](#i18n).
+
+#### `src/components/Subtitle/SubtitleSettingsPopover.scss`
+
+- Add `.swatch.custom` style: same circular footprint as the other chips, hosts a hidden `<input type="color">` (`position: absolute; opacity: 0; pointer-events: none; width: 100%; height: 100%`), shows current color via inline `style={{ background: value }}`, and overlays a small `+` icon (e.g., a `::after` glyph or a Lucide `Plus` rendered at 10–12px).
+- Caption row style: small font, low-emphasis foreground.
+
+#### `src/components/MainPanel/MainPanel.tsx`
+
+- At the existing root `<div className="main-panel-wrapper">` element, add inline `style` setting three CSS custom properties from `useSubtitleSettings()`:
+
+  ```tsx
+  const subtitle = useSubtitleSettings();
+  // ...
+  <div
+    className="main-panel-wrapper"
+    style={{
+      '--subtitle-bg-color': subtitle.bgColor,
+      '--subtitle-source-color': subtitle.sourceTextColor,
+      '--subtitle-translation-color': subtitle.translationTextColor,
+    } as React.CSSProperties}
+  >
+  ```
+
+- This is the only change in this file. The rest of the wiring is in SCSS variable consumption.
+- Note on isolation: `SubtitleStream` already sets the same two text-color properties on its own subtree. Because that subtree only renders inside the floating subtitle window or the extension overlay iframe (separate DOM trees from the side-panel's MainPanel), the two scopes never overlap.
+
+#### `src/components/MainPanel/MainPanel.scss`
+
+Two functional edits and one cleanup:
+
+1. `.conversation-display` gets `background: var(--subtitle-bg-color, #1f1f1f);` — the conversation content area becomes themable.
+2. `.conversation-list .row-body.playing` (which currently has `background: rgba(16, 163, 127, 0.1)`) drops the background and gets `box-shadow: 0 0 0 1px var(--subtitle-translation-color, #10a37f); border-radius: 4px;` — playing-state indicator becomes a translation-color ring that survives any background.
+3. **Cleanup**: remove the `.message-bubble.user`, `.message-bubble.assistant`, `.message-bubble.user.playing`, `.message-bubble.assistant.playing`, `.message-bubble.participant-source.user`, `.message-bubble.participant-source.assistant` (and their `.playing` nested rules) blocks, plus the `.message-bubble.assistant .karaoke-played` override. These selectors are no longer rendered: `MainPanel.tsx` only emits `message-bubble error` and `message-bubble system` for the bubble class today; the conversation rows are rendered through `<ConversationRow>` instead. Removing them prevents future readers from inferring user/assistant visual differentiation that no longer exists.
+
+`.message-bubble.error`, `.message-bubble.system`, `.text-input-section`, `.control-footer`, and `.conversation-toolbar` are unchanged: error and system are status-semantic colors; the rest are chrome.
+
+#### `src/components/MainPanel/ConversationRow.scss`
+
+Unchanged. `.row-text.src` and `.row-text.tr` already consume `--subtitle-source-color` and `--subtitle-translation-color` via `var(...)` with sensible fallbacks. `.row-name`, `.row-role-dot`, `.lang-badge`, and `.row-avatar` keep their existing hard-coded colors — they are row chrome (timestamps, role dots, language badges, avatars) and are not part of the readable conversation content the user theming targets.
+
+#### `src/stores/subtitleStore.ts`
+
+Single change: `DEFAULTS.bgColor` from `'#000000'` to `'#1f1f1f'`. See [Compatibility](#compatibility).
+
+#### i18n
+
+Translation-key changes in `public/locales/*/translation.json` (English source first; other languages picked up via the existing fallback while translations land):
+
+- Update existing keys:
+  - `subtitle.settings.bgColor`: "Background color" → "Display background"
+  - `subtitle.settings.sourceColor`: "Source text color" → "Source text"
+  - `subtitle.settings.translationColor`: "Translation color" → "Translation text"
+- Add new keys:
+  - `subtitle.settings.appliesToBoth`: "Applies to the subtitle window and the conversation panel"
+  - `subtitle.settings.customColor`: "Custom color" (used as the "+" chip's `aria-label` and `title`)
+
+### Compatibility
+
+The `bgColor` default change has three user populations to consider:
+
+- **New users (no persisted `bgColor`)**: hydration falls through to the new default `#1f1f1f`. Subtitle window starts as `rgba(31,31,31, 0.8)` (deep grey at 80% opacity); MainPanel content area is `#1f1f1f`, identical to the current implicit dark. No regression.
+- **Users who used subtitle mode but never changed `bgColor`**: their persisted `bgColor` is `#000000`. Subtitle window stays as it was (pure black at 80% opacity). MainPanel content area becomes `#000000` instead of the current `#1f1f1f` — a small visual regression that is one click to revert (open subtitle popover → pick `#1f1f1f` from the BG row, which is already a preset). The release note will mention this.
+- **Users who changed `bgColor` to anything**: their choice is respected; subtitle window and MainPanel both use it.
+
+We do not run a hydration migration that rewrites persisted `#000000` to `#1f1f1f`. Distinguishing "user explicitly chose pure black" from "user was on the old default of pure black" is impossible without a flag, and rewriting the second silently overrides the first. The small regression for the second population is the lesser evil.
+
+The subtitle window's visual difference between pure-black-at-80%-opacity and dark-grey-at-80%-opacity is below typical perceptual threshold (about 5% lightness delta after compositing), so the new-user default does not look meaningfully different from the old default.
+
+### Persistence and port mirror
+
+No new persisted fields. No changes to `sessionPortMirror` (which mirrors session/conversation state from side panel to extension overlay; the overlay reads its own `subtitleStore` for color settings and is unaffected by this change).
+
+## Testing
+
+### Automated
+
+- New `src/components/Subtitle/SubtitleSettingsPopover.test.tsx` (about 60 lines):
+  - Clicking a preset chip calls the corresponding setter with the chip's hex.
+  - Clicking the "+" chip dispatches a `click` on the underlying hidden `<input type="color">`.
+  - Firing `change` events on the hidden input batches into a single setter call after the debounce window.
+  - When the current store value is in the preset row, the matching preset chip has the `selected` class and the "+" chip does not.
+  - When the current store value is not in the preset row, no preset chip is selected and the "+" chip is selected.
+- Extend the existing `subtitleStore` test to assert the new default `bgColor === '#1f1f1f'` and that hydration of a persisted `'#000000'` is preserved (no migration).
+- No new MainPanel test. Add one assertion to the existing MainPanel render test (or its closest analogue) confirming the wrapper element receives the three CSS custom properties matching the current store values.
+
+### Manual
+
+- In the Electron app: open the subtitle settings popover, click each preset chip, confirm both the floating subtitle window and the side-panel MainPanel update.
+- Click the "+" chip on each of the three rows; confirm the OS color picker opens and that picking a color updates the corresponding surface (debounce: dragging inside the picker should not stutter or flood logs).
+- Reproduce the four email examples (white background + black text, black background + white text, deep-blue background + white text; the "larger high-contrast" example confirms the colors part — font size is out of scope) and confirm both the subtitle window and the conversation panel render them correctly.
+- In Electron with the floating subtitle window pinned always-on-top, open the OS color picker from the popover; confirm the picker appears above the always-on-top window and is interactive.
+- In the browser extension, open the side-panel popover and the in-tab overlay's popover separately; confirm the OS color picker opens in both contexts (the overlay runs inside an iframe; verify there is no blocked-popup behavior).
+- In `uiMode === 'basic'` and `uiMode === 'advanced'`, visually inspect MainPanel after a theme change: the conversation content area changes background; control footer and text input section keep their existing dark colors.
+- Confirm no `.message-bubble.user` / `.assistant` / `.participant-source` rules survive in the built CSS (grep the build output) — sanity check for the SCSS cleanup.
+- Fresh-install on a new profile: confirm the subtitle window opens at `#1f1f1f` and the MainPanel matches.
+- Existing-install with persisted `bgColor === '#000000'`: confirm subtitle window opens at pure black and MainPanel content area is also pure black (the documented small regression). Pick `#1f1f1f` from the BG row and confirm it reverts.
+
+## Out of Scope / Future Follow-ups
+
+- **Saved named themes**: a future "+ Save current as theme" affordance can layer cleanly on top of this design without changing the underlying fields. Defer until at least one user reports cycling between configurations frequently.
+- **Per-side colors**: would require additional fields (`participantSourceTextColor`, etc.) and a matching popover row. Out of scope until requested.
+- **App-wide light chrome theme**: would require a full design-token pass across all chrome components. Out of scope until a second projector user reports chrome readability problems.
+- **Hex / named color text input**: the OS color picker covers this need.
+- **Larger font sizes**: tracked separately.
+- **Migration that rewrites persisted `#000000` to `#1f1f1f`**: deliberately avoided to preserve users' explicit choice of pure black.

--- a/docs/superpowers/specs/2026-05-14-more-color-options-design.md
+++ b/docs/superpowers/specs/2026-05-14-more-color-options-design.md
@@ -3,180 +3,308 @@
 **Date**: 2026-05-14
 **Status**: Approved for implementation planning
 **Tracking issue**: [#231](https://github.com/kizuna-ai-lab/sokuji/issues/231)
-**Scope**: `SubtitleSettingsPopover`, `MainPanel`, `subtitleStore` defaults
+**Related**: [#230 conversation font-size cap](2026-05-14-conversation-font-size-cap-design.md) — touches the same `conversationFontSize` field this spec moves out of `settingsStore`.
 
 ## Context
 
-Issue #231 ("add high-contrast subtitle themes") came from a classroom user (Ray Chow, Youth Night School English group) projecting Sokuji on a large screen under varying lighting. The user's original email asked for "more background and font color options" and listed four example combinations (white-on-black, black-on-white, dark-blue-on-light, larger high-contrast). The issue draft re-cast the request as a "theme presets" feature with a `presentation` preset that bundles colors with a larger font size.
+Issue #231 ("add high-contrast subtitle themes") came from a classroom user (Ray Chow, Youth Night School English group) projecting Sokuji on a large screen under varying lighting. The original email asked for "more background and font color options" and listed four example combinations (white-on-black, black-on-white, dark-blue-on-light, larger high-contrast). The issue draft re-cast the request as a "theme presets" feature with a `presentation` preset that bundles colors with a larger font size.
 
-Re-reading the email against the existing UI confirms a simpler diagnosis: the subtitle settings popover already exposes background, source-text, and translation-text color chips, but the source/translation chip palettes contain only light and warm colors. The user can configure three of the four example combinations today; the fourth (white background with dark text) is unreachable because no chip palette includes a dark color. Larger font is tracked separately and is out of scope here.
+Re-reading the email against the existing UI confirms a simpler diagnosis: the subtitle settings popover already exposes background, source-text, and translation-text color chips, but the source/translation chip palettes contain only light and warm colors. The user can configure three of the four example combinations today; the fourth (white background with dark text) is unreachable because no chip palette includes a dark color. Larger font is tracked separately in [#230](2026-05-14-conversation-font-size-cap-design.md) and is out of scope here.
 
-This spec therefore drops the "theme" abstraction. It adds the missing dark color chips, adds an "any color" picker as a final fallback, wires the existing color fields into the conversation panel (today they are observed only by the dedicated subtitle surface), and rewords the popover labels so the user sees that one setting now affects two surfaces.
+This spec drops the "theme" abstraction. It adds the missing dark color chips, adds an "any color" picker as a final fallback, and brings color options to the conversation panel as well — but as **independent settings** from the subtitle window's, not a shared one. Subtitle mode and the conversation panel each get their own colors, their own popover entry point, their own store, and their own persistence keys. They do not influence each other.
+
+The conversation panel currently has no display-settings store of its own; `conversationFontSize` and `conversationCompactMode` live in `settingsStore` mixed in with auth, provider keys, and UI mode. As part of this work, those two fields plus the new color fields are extracted into a dedicated `conversationDisplayStore`, mirroring the v0.26 extraction of `subtitleStore` from `settingsStore`. This keeps `settingsStore` focused on cross-cutting concerns and lets the conversation panel evolve display settings independently.
 
 ## Non-Goals
 
 - Theme presets (named combinations of colors stored as a single setting).
 - Saving named custom themes.
 - Per-side colors (different bubble color per speaker / participant).
-- Larger font sizes — tracked in the separate font-size issue.
+- Larger font sizes — tracked in [#230](2026-05-14-conversation-font-size-cap-design.md).
 - An app-wide light theme for chrome (titlebar, sidebar, control footer, input section). Chrome and content are already physically separate surfaces; a dark chrome does not break a white content area, and no user has asked for it. Re-evaluate if a second projector user reports it.
 - Removing or restyling the subtitle background opacity slider (still meaningful for the floating subtitle window; not applied to the conversation panel).
-- Changing chip colors that are already present.
+- A single "apply theme to both surfaces" toggle. The two surfaces are configured independently by design — see [Context](#context).
+- Persistence migration for the existing `settings.common.conversationFontSize` and `settings.common.conversationCompactMode` keys. The new `conversationDisplayStore` uses a fresh key namespace; old persisted values are abandoned. See [Compatibility](#compatibility).
+- Renaming `subtitleStore` or its persistence keys.
 
 ## User-Visible Behavior
 
-### In the subtitle settings popover
+### Two entry points, one popover component
 
-The ⚙ Settings popover on the subtitle bar gains:
+The same color-and-display-settings popover is reachable from two places, each scoped to one surface's settings:
 
-- **Three additional dark chips on the source-text row**: black (`#000000`), deep navy (`#003B6F`), deep forest (`#1B5E20`). These let the user configure readable source text against a white or light background.
-- **Three additional dark chips on the translation-text row**: black (`#000000`), deep navy (`#003B6F`), deep purple (`#7B1FA2`).
-- **A "+" custom-color chip at the end of every chip row** (background, source, translation). Clicking opens the operating system's native color picker. Any hex the user picks is saved to the same setting as the preset chips (`bgColor` / `sourceTextColor` / `translationTextColor`); there is no new "custom theme" concept.
-- **Updated labels** that no longer pretend the settings only affect the subtitle window:
-  - "Background opacity" → unchanged (still subtitle-window only — the conversation panel does not apply opacity).
+- **Subtitle bar's ⚙ button** (existing) — opens the popover bound to subtitle settings. Changes here update the floating subtitle window (Electron) and the in-tab overlay (extension); they do **not** touch the conversation panel.
+- **Conversation toolbar's ⚙ button** (new, in `MainPanel`'s `conversation-toolbar`) — opens the same popover component bound to conversation-panel settings. Changes here update the side-panel `MainPanel` view; they do **not** touch the subtitle window.
+
+The popover is the same component (`<DisplaySettingsPopover source="subtitle" | "conversation" />`); the `source` prop selects which store it reads from and writes to, and which controls it renders.
+
+### Inside the popover
+
+- **Background opacity slider** — present only when `source === 'subtitle'`. The conversation panel does not apply opacity.
+- **Background color row** — three chips with current presets (`#000000`, `#1a1a1a`, `#0d2032`, `#0f2419`, `#FFFFFF`, `#2a2a2a`) plus a "+" custom-color chip.
+- **Source text color row** — current presets (`#FFFFFF`, `#E8E8E8`, `#FFD27D`, `#FFAA66`, `#9aa0a6`, `#FF6B6B`) plus three new dark presets (`#000000`, `#003B6F` deep navy, `#1B5E20` deep forest), plus a "+" custom-color chip.
+- **Translation text color row** — current presets (`#6CC5FF`, `#10a37f`, `#FFFFFF`, `#A8E6CF`, `#FFB86C`, `#BD93F9`) plus three new dark presets (`#000000`, `#003B6F`, `#7B1FA2` deep purple), plus a "+" custom-color chip.
+- **Labels** — neutralised so they read correctly from either entry point:
+  - "Background opacity" → unchanged.
   - "Background color" → "Display background".
   - "Source text color" → "Source text".
   - "Translation color" → "Translation text".
-  - A small one-line caption at the top of the popover: "Applies to the subtitle window and the conversation panel."
+  - No more cross-surface caption ("Applies to..."): the two entry points are now scoped to their own surface, so a caption claiming both would be wrong.
 
 ### Highlight rules in the popover
 
-- A preset chip is highlighted when its hex equals the current stored value.
-- The "+" chip is highlighted when the current stored value is **not** in the preset row (i.e., the user picked a custom color). The "+" chip's swatch background reflects the current stored value so the user always sees what color is active.
+- A preset chip is highlighted when its hex equals the current stored value for the active `source`.
+- The "+" chip is highlighted when the current stored value is **not** in the preset row. The "+" chip's swatch background reflects the current stored value so the user always sees what color is active.
+
+### "+" custom color chip behavior
+
+- Clicking the "+" chip opens the operating system's native color picker (`<input type="color">`).
+- Any hex the user picks is saved to the same setting as the preset chips (`bgColor` / `sourceTextColor` / `translationTextColor` on whichever store the popover is bound to).
+- There is no new "custom theme" concept; the picked color is just a value for the same field a preset chip would set.
 
 ### In the conversation panel (MainPanel)
 
-When the user changes any of the three color settings, the conversation panel updates immediately:
+When the user changes any of the three color settings via the conversation-toolbar popover, the conversation panel updates immediately:
 
-- **Conversation content area background** follows `bgColor`.
-- **Original-language text** in conversation rows follows `sourceTextColor`.
-- **Translated text** in conversation rows follows `translationTextColor`.
+- **Conversation content area background** follows `conversationDisplayStore.bgColor`.
+- **Original-language text** in conversation rows follows `conversationDisplayStore.sourceTextColor`.
+- **Translated text** in conversation rows follows `conversationDisplayStore.translationTextColor`.
 - **Currently-playing row** is indicated by a 1px ring in the translation-text color around the row body, instead of the existing translucent green background. The ring works against any background color; the translucent green stops being visible against translation-color backgrounds.
 
 The chrome (control footer, text input section, titlebar, sidebar) does **not** change color and stays on its existing dark tokens.
 
-The conversation panel does not apply the subtitle-window background opacity. It uses the chosen `bgColor` as a flat color.
+The conversation panel does not apply any opacity. It uses the chosen `bgColor` as a flat color.
 
-### Default value change
+### In subtitle mode
 
-The `subtitleStore` default `bgColor` changes from `#000000` (pure black) to `#1f1f1f` (the conversation panel's existing implicit dark color). Rationale and migration are in [Compatibility](#compatibility).
+Subtitle window behavior is unchanged from today's implementation, except that the popover is now the renamed `<DisplaySettingsPopover source="subtitle" />` instead of `<SubtitleSettingsPopover />`. The user sees the same chips (now with the additional dark presets and a "+" picker), the same opacity slider, and the same labels (re-worded as above).
 
 ## Implementation
 
 ### File-level changes
 
-#### `src/components/Subtitle/SubtitleSettingsPopover.tsx`
+#### New: `src/stores/conversationDisplayStore.ts`
 
-- Extend `SOURCE_PRESETS` with `'#000000', '#003B6F', '#1B5E20'`.
-- Extend `TRANSLATION_PRESETS` with `'#000000', '#003B6F', '#7B1FA2'`.
-- `BG_PRESETS` is unchanged — it already covers the email's three background examples (black, white, deep navy `#0d2032`).
-- Extract a `<ColorRow label preset value onChange />` subcomponent reused by all three rows. Each row renders the existing chips, then one extra "+" custom-color chip.
+Mirrors the structure of `src/stores/subtitleStore.ts`. Owns:
+
+- `fontSize: number` — clamped `[12, 64]`, default `14`. Moved from `settingsStore.conversationFontSize`.
+- `compactMode: boolean` — default `false`. Moved from `settingsStore.conversationCompactMode`.
+- `bgColor: string` — hex, default `'#1f1f1f'` (matches today's implicit MainPanel dark).
+- `sourceTextColor: string` — hex, default `'#9aa0a6'` (matches today's `ConversationRow.scss` fallback).
+- `translationTextColor: string` — hex, default `'#e8e8e8'` (matches today's `ConversationRow.scss` fallback).
+
+Async setters for each field, mirroring `subtitleStore`'s persist-and-rollback-on-error pattern. Persistence key namespace: `settings.common.conversationDisplay.*` (e.g., `settings.common.conversationDisplay.fontSize`, `settings.common.conversationDisplay.bgColor`).
+
+Selector hooks: `useConversationDisplayFontSize`, `useConversationDisplayCompactMode`, `useConversationDisplayBgColor`, `useConversationDisplaySourceTextColor`, `useConversationDisplayTranslationTextColor`, `useConversationDisplaySettings` (shallow snapshot).
+
+Action hooks: `useSetConversationDisplayFontSize`, `useSetConversationDisplayCompactMode`, `useSetConversationDisplayBgColor`, `useSetConversationDisplaySourceTextColor`, `useSetConversationDisplayTranslationTextColor`.
+
+Constants: `CONVERSATION_FONT_SIZE_MIN = 12`, `CONVERSATION_FONT_SIZE_MAX = 64` exported from this store (moved from `settingsStore`).
+
+`hydrate()` reads the new keys with defaults; **does not** read or migrate the old `settings.common.conversationFontSize` / `settings.common.conversationCompactMode` keys.
+
+#### Modified: `src/stores/settingsStore.ts`
+
+Remove:
+
+- The `conversationFontSize: number` and `conversationCompactMode: boolean` fields from the state interface.
+- Their entries in `defaultCommonSettings`.
+- The `setConversationFontSize` / `setConversationCompactMode` action implementations.
+- The `CONVERSATION_FONT_SIZE_MIN` / `CONVERSATION_FONT_SIZE_MAX` constants (moved to the new store).
+- The `clampConversationFontSize` helper (moved or inlined into the new store).
+- The hydration reads for `settings.common.conversationFontSize` / `settings.common.conversationCompactMode`.
+- Any selector or action hook re-exports for these fields.
+
+#### Modified: `src/stores/settingsStore.test.ts`
+
+Remove the `conversationFontSize clamping` describe block (lines 319+) and its imports of `CONVERSATION_FONT_SIZE_MIN` / `CONVERSATION_FONT_SIZE_MAX`. The clamping behavior moves to the new `conversationDisplayStore.test.ts` below.
+
+#### New: `src/stores/conversationDisplayStore.test.ts`
+
+Mirrors the structure of `src/stores/subtitleStore.test.ts` (assumed to follow the same pattern as `settingsStore.test.ts`). Covers:
+
+- Default values for all five fields.
+- `setFontSize` clamps to `[CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX]` and persists the clamped value.
+- Each color setter persists its value with the correct namespaced key.
+- `hydrate()` reads from the new `settings.common.conversationDisplay.*` keys with correct defaults when missing.
+- `hydrate()` ignores any persisted `settings.common.conversationFontSize` / `...conversationCompactMode` (the old keys) — sanity test that no migration happens.
+
+#### Renamed and relocated: `src/components/Subtitle/SubtitleSettingsPopover.tsx` → `src/components/Display/DisplaySettingsPopover.tsx`
+
+The new path lives in a new `src/components/Display/` directory (peer to `Subtitle/` and `MainPanel/`). The `.scss` companion is renamed and moved alongside.
+
+The component gains a `source: 'subtitle' | 'conversation'` prop:
+
+```tsx
+interface Props {
+  source: 'subtitle' | 'conversation';
+}
+```
+
+To respect React's rules of hooks (no conditional hook calls based on `source`), the popover is structured as a thin presentational `<DisplaySettingsPopoverInner>` that takes already-resolved bindings as props, plus two thin source-specific wrappers that read from their respective stores:
+
+```tsx
+// DisplaySettingsPopover.tsx — entry point dispatched by source prop
+export default function DisplaySettingsPopover({ source }: Props) {
+  return source === 'subtitle'
+    ? <SubtitleBoundPopover />
+    : <ConversationBoundPopover />;
+}
+
+function SubtitleBoundPopover() {
+  // Calls only subtitleStore hooks. Resolved bindings passed down.
+  const bgColor = useSubtitleBgColor();
+  // ... other subtitle hooks ...
+  return <DisplaySettingsPopoverInner
+    bindings={{ bgColor, /* ... */, includeOpacity: true }}
+  />;
+}
+
+function ConversationBoundPopover() {
+  // Calls only conversationDisplayStore hooks.
+  const bgColor = useConversationDisplayBgColor();
+  // ...
+  return <DisplaySettingsPopoverInner
+    bindings={{ bgColor, /* ... */, includeOpacity: false }}
+  />;
+}
+```
+
+Each wrapper subscribes only to its own store, so re-renders are scoped correctly. `<DisplaySettingsPopoverInner>` is the JSX that renders the rows and slider; it has no store dependencies.
+
+The popover then renders:
+
+- The "Background opacity" slider only when `bindings.includeOpacity === true`.
+- The three color rows, each as a reusable `<ColorRow label preset value onChange />` subcomponent. Each row renders the existing chips, then one extra "+" custom-color chip.
 - The "+" chip is a `<label>` containing a hidden `<input type="color">`. Clicking the chip triggers the OS color dialog. The chip's swatch background is the current `value` so it doubles as a "current color" indicator.
-- The `onChange` of `<input type="color">` is debounced ~150ms before calling the corresponding setter (raw `onChange` fires continuously while the user drags inside the OS picker — without debounce this would flood the persistence layer).
-- Wrap the popover body in a small caption row showing the new "Applies to the subtitle window and the conversation panel" string from i18n.
-- Update label translation keys per [i18n](#i18n).
+- The `onChange` of `<input type="color">` is debounced ~150ms before calling the corresponding setter (raw `onChange` fires continuously while the user drags inside the OS picker; without debounce this would flood the persistence layer).
 
-#### `src/components/Subtitle/SubtitleSettingsPopover.scss`
+Translation-key changes per [i18n](#i18n).
+
+#### Modified: `src/components/Display/DisplaySettingsPopover.scss`
+
+Migrated from the old SCSS (rename + path change), then:
 
 - Add `.swatch.custom` style: same circular footprint as the other chips, hosts a hidden `<input type="color">` (`position: absolute; opacity: 0; pointer-events: none; width: 100%; height: 100%`), shows current color via inline `style={{ background: value }}`, and overlays a small `+` icon (e.g., a `::after` glyph or a Lucide `Plus` rendered at 10–12px).
-- Caption row style: small font, low-emphasis foreground.
 
-#### `src/components/MainPanel/MainPanel.tsx`
+#### Modified: `src/components/Subtitle/SubtitleBar.tsx`
 
-- At the existing root `<div className="main-panel-wrapper">` element, add inline `style` setting three CSS custom properties from `useSubtitleSettings()`:
+Update the import path and component name for the popover:
 
-  ```tsx
-  const subtitle = useSubtitleSettings();
-  // ...
-  <div
-    className="main-panel-wrapper"
-    style={{
-      '--subtitle-bg-color': subtitle.bgColor,
-      '--subtitle-source-color': subtitle.sourceTextColor,
-      '--subtitle-translation-color': subtitle.translationTextColor,
-    } as React.CSSProperties}
-  >
-  ```
+- `import SubtitleSettingsPopover from './SubtitleSettingsPopover';` → `import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';`
+- `<SubtitleSettingsPopover />` → `<DisplaySettingsPopover source="subtitle" />` (in the `FloatingPortal` block at line ~205).
 
-- This is the only change in this file. The rest of the wiring is in SCSS variable consumption.
-- Note on isolation: `SubtitleStream` already sets the same two text-color properties on its own subtree. Because that subtree only renders inside the floating subtitle window or the extension overlay iframe (separate DOM trees from the side-panel's MainPanel), the two scopes never overlap.
+#### Modified: `src/components/MainPanel/MainPanel.tsx`
 
-#### `src/components/MainPanel/MainPanel.scss`
+Two distinct changes:
+
+1. **Replace `useSettingsStore` reads with `useConversationDisplayStore` reads** for the two moved fields. Search-and-replace targets:
+   - `useConversationFontSize()` → import from `conversationDisplayStore` instead of `settingsStore`.
+   - `useConversationCompactMode()` → same.
+   - `useSetConversationFontSize()` / `useSetConversationCompactMode()` → import from new store.
+   - `CONVERSATION_FONT_SIZE_MIN` / `CONVERSATION_FONT_SIZE_MAX` import path changes.
+2. **Add a ⚙ Settings button to `conversation-toolbar`** (the `<div className="conversation-toolbar">` block around line 2923). Place it after the existing compact-mode button. Wire it to a `useFloating` instance (mirroring `SubtitleBar`'s approach) and render `<DisplaySettingsPopover source="conversation" />` inside a `FloatingPortal` when open.
+3. **Apply CSS custom properties on the wrapper** for the conversation panel's color theming. At the existing root `<div className="main-panel-wrapper">`, add an inline `style` setting three CSS custom properties from `useConversationDisplaySettings()`:
+
+   ```tsx
+   const conversationDisplay = useConversationDisplaySettings();
+   // ...
+   <div
+     className="main-panel-wrapper"
+     style={{
+       '--conversation-bg-color': conversationDisplay.bgColor,
+       '--conversation-source-color': conversationDisplay.sourceTextColor,
+       '--conversation-translation-color': conversationDisplay.translationTextColor,
+     } as React.CSSProperties}
+   >
+   ```
+
+#### Modified: `src/components/MainPanel/MainPanel.scss`
 
 Two functional edits and one cleanup:
 
-1. `.conversation-display` gets `background: var(--subtitle-bg-color, #1f1f1f);` — the conversation content area becomes themable.
-2. `.conversation-list .row-body.playing` (which currently has `background: rgba(16, 163, 127, 0.1)`) drops the background and gets `box-shadow: 0 0 0 1px var(--subtitle-translation-color, #10a37f); border-radius: 4px;` — playing-state indicator becomes a translation-color ring that survives any background.
-3. **Cleanup**: remove the `.message-bubble.user`, `.message-bubble.assistant`, `.message-bubble.user.playing`, `.message-bubble.assistant.playing`, `.message-bubble.participant-source.user`, `.message-bubble.participant-source.assistant` (and their `.playing` nested rules) blocks, plus the `.message-bubble.assistant .karaoke-played` override. These selectors are no longer rendered: `MainPanel.tsx` only emits `message-bubble error` and `message-bubble system` for the bubble class today; the conversation rows are rendered through `<ConversationRow>` instead. Removing them prevents future readers from inferring user/assistant visual differentiation that no longer exists.
+1. `.conversation-display` gets `background: var(--conversation-bg-color, #1f1f1f);` — the conversation content area becomes themable from `conversationDisplayStore`.
+2. `.conversation-list .row-body.playing` (currently `background: rgba(16, 163, 127, 0.1)`) drops the background and gets `box-shadow: 0 0 0 1px var(--conversation-translation-color, #10a37f); border-radius: 4px;` — playing-state indicator becomes a translation-color ring that survives any background.
+3. **Cleanup**: remove the `.message-bubble.user`, `.message-bubble.assistant`, `.message-bubble.user.playing`, `.message-bubble.assistant.playing`, `.message-bubble.participant-source.user`, `.message-bubble.participant-source.assistant` (and their `.playing` nested rules) blocks, plus the `.message-bubble.assistant .karaoke-played` override. These selectors are no longer rendered: `MainPanel.tsx` only emits `message-bubble error` and `message-bubble system` for the bubble class today; conversation rows go through `<ConversationRow>`. Removing them prevents future readers from inferring user/assistant visual differentiation that no longer exists.
 
 `.message-bubble.error`, `.message-bubble.system`, `.text-input-section`, `.control-footer`, and `.conversation-toolbar` are unchanged: error and system are status-semantic colors; the rest are chrome.
 
-#### `src/components/MainPanel/ConversationRow.scss`
+#### Modified: `src/components/MainPanel/ConversationRow.scss`
 
-Unchanged. `.row-text.src` and `.row-text.tr` already consume `--subtitle-source-color` and `--subtitle-translation-color` via `var(...)` with sensible fallbacks. `.row-name`, `.row-role-dot`, `.lang-badge`, and `.row-avatar` keep their existing hard-coded colors — they are row chrome (timestamps, role dots, language badges, avatars) and are not part of the readable conversation content the user theming targets.
+The two existing `var(--subtitle-source-color, ...)` / `var(--subtitle-translation-color, ...)` references in `.row-text.src` (line 114) and `.row-text.tr` (line 119) are renamed to `var(--conversation-source-color, ...)` / `var(--conversation-translation-color, ...)`. `ConversationRow` is only rendered inside `MainPanel`, so this change has no other consumer to break.
 
-#### `src/stores/subtitleStore.ts`
+`.row-name`, `.row-role-dot`, `.lang-badge`, and `.row-avatar` keep their existing hard-coded colors — they are row chrome (timestamps, role dots, language badges, avatars) and are not part of the readable conversation content the user theming targets.
 
-Single change: `DEFAULTS.bgColor` from `'#000000'` to `'#1f1f1f'`. See [Compatibility](#compatibility).
+#### Unchanged: subtitle surface
+
+`SubtitleApp.tsx`, `SubtitleStream.tsx`, `SubtitleApp.scss`, and `SubtitleStream.scss` all keep their existing `--subtitle-bg-color` / `--subtitle-source-color` / `--subtitle-translation-color` CSS variable names and their existing `setProperty` calls reading from `subtitleStore`. The `subtitleStore` itself is unchanged: same fields, same defaults (including `bgColor: '#000000'`), same persistence keys.
 
 #### i18n
 
 Translation-key changes in `public/locales/*/translation.json` (English source first; other languages picked up via the existing fallback while translations land):
 
-- Update existing keys:
+- Update existing keys (label string changes; key names stay the same):
   - `subtitle.settings.bgColor`: "Background color" → "Display background"
   - `subtitle.settings.sourceColor`: "Source text color" → "Source text"
   - `subtitle.settings.translationColor`: "Translation color" → "Translation text"
-- Add new keys:
-  - `subtitle.settings.appliesToBoth`: "Applies to the subtitle window and the conversation panel"
+- Add new key:
   - `subtitle.settings.customColor`: "Custom color" (used as the "+" chip's `aria-label` and `title`)
+
+The `subtitle.settings.*` namespace is reused (not renamed to `display.settings.*`) to keep the diff small. The labels are display-neutral despite the namespace name; renaming the namespace would force every `t()` call site to update for no functional benefit.
 
 ### Compatibility
 
-The `bgColor` default change has three user populations to consider:
+This change has three compatibility considerations:
 
-- **New users (no persisted `bgColor`)**: hydration falls through to the new default `#1f1f1f`. Subtitle window starts as `rgba(31,31,31, 0.8)` (deep grey at 80% opacity); MainPanel content area is `#1f1f1f`, identical to the current implicit dark. No regression.
-- **Users who used subtitle mode but never changed `bgColor`**: their persisted `bgColor` is `#000000`. Subtitle window stays as it was (pure black at 80% opacity). MainPanel content area becomes `#000000` instead of the current `#1f1f1f` — a small visual regression that is one click to revert (open subtitle popover → pick `#1f1f1f` from the BG row, which is already a preset). The release note will mention this.
-- **Users who changed `bgColor` to anything**: their choice is respected; subtitle window and MainPanel both use it.
-
-We do not run a hydration migration that rewrites persisted `#000000` to `#1f1f1f`. Distinguishing "user explicitly chose pure black" from "user was on the old default of pure black" is impossible without a flag, and rewriting the second silently overrides the first. The small regression for the second population is the lesser evil.
-
-The subtitle window's visual difference between pure-black-at-80%-opacity and dark-grey-at-80%-opacity is below typical perceptual threshold (about 5% lightness delta after compositing), so the new-user default does not look meaningfully different from the old default.
+1. **`conversationFontSize` and `conversationCompactMode` persistence is reset.** Users who previously customised conversation font size (range was 12–28 pre-#230, then 12–64 after #230) or toggled compact mode will see those settings revert to defaults (`14px`, `false`) on first launch after this change. The old `settings.common.conversationFontSize` / `...conversationCompactMode` keys remain in storage but are abandoned (orphaned). Users can re-set their preferences from the conversation toolbar; they persist normally afterward to the new keys. This is an explicit decision: the migration code would be simple but adds maintenance debt for an audience that can re-tap a font-size button once.
+2. **No migration cleanup.** We do not write code to delete the orphaned old keys. They are tiny, only-on-disk, and will be ignored by all current code paths. A future cleanup could remove them with no functional impact.
+3. **Subtitle window behavior is fully unchanged.** No defaults change, no keys move, no fields are removed from `subtitleStore`. Existing subtitle users see no difference except the popover now has more chips on the source/translation rows and a "+" custom-color chip; their previously-saved colors continue to apply.
 
 ### Persistence and port mirror
 
-No new persisted fields. No changes to `sessionPortMirror` (which mirrors session/conversation state from side panel to extension overlay; the overlay reads its own `subtitleStore` for color settings and is unaffected by this change).
+No new persisted fields beyond the new namespace. No changes to `sessionPortMirror` (which mirrors session/conversation state from side panel to extension overlay; the overlay reads its own `subtitleStore` for color settings and is unaffected by this change — it does not read `conversationDisplayStore`, since the overlay does not render `MainPanel`).
+
+The new `conversationDisplayStore` is hydrated at app boot from the same `SettingsService` infrastructure as the existing stores. Wire its `hydrate()` into the same boot path as `subtitleStore.hydrate()` (search `subtitleStore.*hydrate` for the existing call site).
 
 ## Testing
 
 ### Automated
 
-- New `src/components/Subtitle/SubtitleSettingsPopover.test.tsx` (about 60 lines):
-  - Clicking a preset chip calls the corresponding setter with the chip's hex.
-  - Clicking the "+" chip dispatches a `click` on the underlying hidden `<input type="color">`.
-  - Firing `change` events on the hidden input batches into a single setter call after the debounce window.
+- **New `src/stores/conversationDisplayStore.test.ts`** — described in [the new store section](#new-srcstoresconversationdisplaystorets) above.
+- **Modified `src/stores/settingsStore.test.ts`** — described in [the modified settings store section](#modified-srcstoressettingsstoretestts) above. Confirm the rest of the suite still passes.
+- **New `src/components/Display/DisplaySettingsPopover.test.tsx`** (about 80 lines, rewritten from the old `SubtitleSettingsPopover.test.tsx` if it exists; today there is no test file at that path, so this is net-new):
+  - With `source="subtitle"`: clicking a preset chip calls the corresponding `subtitleStore` setter; opacity slider is rendered.
+  - With `source="conversation"`: clicking a preset chip calls the corresponding `conversationDisplayStore` setter; opacity slider is **not** rendered.
+  - With either source: clicking the "+" chip dispatches a `click` on the underlying hidden `<input type="color">`.
+  - Firing `change` events on the hidden input batches into a single setter call after the debounce window (test the debounce by advancing fake timers).
   - When the current store value is in the preset row, the matching preset chip has the `selected` class and the "+" chip does not.
   - When the current store value is not in the preset row, no preset chip is selected and the "+" chip is selected.
-- Extend the existing `subtitleStore` test to assert the new default `bgColor === '#1f1f1f'` and that hydration of a persisted `'#000000'` is preserved (no migration).
-- No new MainPanel test. Add one assertion to the existing MainPanel render test (or its closest analogue) confirming the wrapper element receives the three CSS custom properties matching the current store values.
+- **New MainPanel test assertion** — extend the existing MainPanel render test to confirm the wrapper element receives the three `--conversation-*` CSS custom properties matching the current `conversationDisplayStore` values.
+- **Search-and-replace audit** — grep for old field names and CSS variable references that should no longer exist:
+  - `useConversationFontSize` / `useConversationCompactMode` imported from `settingsStore` (should be from `conversationDisplayStore`).
+  - `--subtitle-source-color` / `--subtitle-translation-color` references in `MainPanel.scss` or `ConversationRow.scss` (should be `--conversation-*` in those files; the `--subtitle-*` names live only under `Subtitle/`).
 
 ### Manual
 
-- In the Electron app: open the subtitle settings popover, click each preset chip, confirm both the floating subtitle window and the side-panel MainPanel update.
-- Click the "+" chip on each of the three rows; confirm the OS color picker opens and that picking a color updates the corresponding surface (debounce: dragging inside the picker should not stutter or flood logs).
-- Reproduce the four email examples (white background + black text, black background + white text, deep-blue background + white text; the "larger high-contrast" example confirms the colors part — font size is out of scope) and confirm both the subtitle window and the conversation panel render them correctly.
-- In Electron with the floating subtitle window pinned always-on-top, open the OS color picker from the popover; confirm the picker appears above the always-on-top window and is interactive.
-- In the browser extension, open the side-panel popover and the in-tab overlay's popover separately; confirm the OS color picker opens in both contexts (the overlay runs inside an iframe; verify there is no blocked-popup behavior).
-- In `uiMode === 'basic'` and `uiMode === 'advanced'`, visually inspect MainPanel after a theme change: the conversation content area changes background; control footer and text input section keep their existing dark colors.
+- In the Electron app: open the **subtitle** ⚙ popover, click a preset chip, confirm the floating subtitle window updates and the side-panel MainPanel **does not change**.
+- Open the **conversation toolbar** ⚙ popover, click a preset chip, confirm the side-panel MainPanel updates and the floating subtitle window **does not change**.
+- Click the "+" chip in each popover, on each of the three color rows; confirm the OS color picker opens and that picking a color updates only the corresponding surface (debounce: dragging inside the picker should not stutter or flood logs).
+- Reproduce the four email examples in the conversation toolbar popover (white background + black text, black background + white text, deep-blue background + white text; the "larger high-contrast" example confirms the colors part — font size is in #230). Confirm the conversation panel renders them correctly. Repeat in the subtitle popover for the subtitle window.
+- In Electron with the floating subtitle window pinned always-on-top, open the OS color picker from the subtitle popover; confirm the picker appears above the always-on-top window and is interactive.
+- In the browser extension, open the side-panel **conversation toolbar** popover and the in-tab subtitle overlay's popover separately; confirm the OS color picker opens in both contexts (the overlay runs inside an iframe; verify there is no blocked-popup behavior).
+- In `uiMode === 'basic'` and `uiMode === 'advanced'`, visually inspect MainPanel after changing colors via the conversation toolbar: the conversation content area changes background; control footer and text input section keep their existing dark colors.
 - Confirm no `.message-bubble.user` / `.assistant` / `.participant-source` rules survive in the built CSS (grep the build output) — sanity check for the SCSS cleanup.
-- Fresh-install on a new profile: confirm the subtitle window opens at `#1f1f1f` and the MainPanel matches.
-- Existing-install with persisted `bgColor === '#000000'`: confirm subtitle window opens at pure black and MainPanel content area is also pure black (the documented small regression). Pick `#1f1f1f` from the BG row and confirm it reverts.
+- Fresh-install on a new profile: confirm the conversation panel renders at `#1f1f1f` (matches today's implicit dark) and the subtitle window opens at pure black at 80% opacity (unchanged from today). Confirm font-size and compact-mode start at default `14px` / `false`.
+- Existing-install with previously-customised `conversationFontSize` (e.g., 22): confirm font size resets to `14` on first launch (the documented persistence reset). Adjust via the toolbar buttons; confirm the new value persists across a restart.
+- Existing-install that had customised subtitle colors: confirm those still apply to the subtitle window.
 
 ## Out of Scope / Future Follow-ups
 
-- **Saved named themes**: a future "+ Save current as theme" affordance can layer cleanly on top of this design without changing the underlying fields. Defer until at least one user reports cycling between configurations frequently.
-- **Per-side colors**: would require additional fields (`participantSourceTextColor`, etc.) and a matching popover row. Out of scope until requested.
+- **Saved named themes** for either surface: a future "+ Save current as theme" affordance can layer on top of either store without changing the underlying fields. Defer until at least one user reports cycling between configurations frequently.
+- **Per-side colors** (different speaker / participant colors): would require additional fields on `conversationDisplayStore` and a matching popover row. Out of scope until requested.
 - **App-wide light chrome theme**: would require a full design-token pass across all chrome components. Out of scope until a second projector user reports chrome readability problems.
 - **Hex / named color text input**: the OS color picker covers this need.
-- **Larger font sizes**: tracked separately.
-- **Migration that rewrites persisted `#000000` to `#1f1f1f`**: deliberately avoided to preserve users' explicit choice of pure black.
+- **Larger font sizes**: tracked in [#230](2026-05-14-conversation-font-size-cap-design.md).
+- **Cleanup of orphaned `settings.common.conversationFontSize` / `...conversationCompactMode` keys in storage**: harmless to leave; can be added later if the SettingsService grows a `removeSetting` helper.
+- **A "copy from subtitle" / "copy from conversation" button** in either popover that snapshots the other surface's settings into the current one: a possible UX shortcut once we see how often users want to keep them in sync.
+- **Renaming the `subtitle.settings.*` i18n key namespace** to something display-neutral like `display.settings.*`: deferred — the labels are already display-neutral; the namespace name is internal.

--- a/docs/superpowers/specs/2026-05-14-more-color-options-design.md
+++ b/docs/superpowers/specs/2026-05-14-more-color-options-design.md
@@ -69,7 +69,7 @@ When the user changes any of the three color settings via the conversation-toolb
 - **Conversation content area background** follows `conversationDisplayStore.bgColor`.
 - **Original-language text** in conversation rows follows `conversationDisplayStore.sourceTextColor`.
 - **Translated text** in conversation rows follows `conversationDisplayStore.translationTextColor`.
-- **Currently-playing row** is indicated by a 1px ring in the translation-text color around the row body, instead of the existing translucent green background. The ring works against any background color; the translucent green stops being visible against translation-color backgrounds.
+- **Currently-playing row** is indicated by a translucent overlay in the translation-text color (`color-mix(in srgb, var(--conversation-translation-color, #10a37f) 15%, transparent)`) on top of the row body, replacing the previous hardcoded translucent green. The overlay stays subtle and follows the user's chosen translation color so it remains visible (and consistent with the theme) against any background. An earlier draft of this spec called for a 1px translation-color ring around the row; that was reverted during review because, on a row that spans the full conversation-display width, the ring read as an oversized box around the row rather than a subtle now-playing hint.
 
 The chrome (control footer, text input section, titlebar, sidebar) does **not** change color and stays on its existing dark tokens.
 
@@ -224,7 +224,7 @@ Two distinct changes:
 Two functional edits and one cleanup:
 
 1. `.conversation-display` gets `background: var(--conversation-bg-color, #1f1f1f);` — the conversation content area becomes themable from `conversationDisplayStore`.
-2. `.conversation-list .row-body.playing` (currently `background: rgba(16, 163, 127, 0.1)`) drops the background and gets `box-shadow: 0 0 0 1px var(--conversation-translation-color, #10a37f); border-radius: 4px;` — playing-state indicator becomes a translation-color ring that survives any background.
+2. `.conversation-list .row-body.playing` (currently `background: rgba(16, 163, 127, 0.1)`) keeps the translucent-overlay shape but derives its color from the active translation color via `color-mix`: `background: color-mix(in srgb, var(--conversation-translation-color, #10a37f) 15%, transparent); border-radius: 4px;`. The transition stays on `background-color`. Earlier drafts proposed a `box-shadow` ring; see the User-Visible Behavior section for why the overlay shape was kept.
 3. **Cleanup**: remove the `.message-bubble.user`, `.message-bubble.assistant`, `.message-bubble.user.playing`, `.message-bubble.assistant.playing`, `.message-bubble.participant-source.user`, `.message-bubble.participant-source.assistant` (and their `.playing` nested rules) blocks, plus the `.message-bubble.assistant .karaoke-played` override. These selectors are no longer rendered: `MainPanel.tsx` only emits `message-bubble error` and `message-bubble system` for the bubble class today; conversation rows go through `<ConversationRow>`. Removing them prevents future readers from inferring user/assistant visual differentiation that no longer exists.
 
 `.message-bubble.error`, `.message-bubble.system`, `.text-input-section`, `.control-footer`, and `.conversation-toolbar` are unchanged: error and system are status-semantic colors; the rest are chrome.

--- a/src/components/Display/DisplaySettingsPopover.scss
+++ b/src/components/Display/DisplaySettingsPopover.scss
@@ -35,6 +35,14 @@
         padding: 0;
         position: relative;
 
+        // Keyboard focus indicator. Reuses the green "selected" colour and
+        // sits outside the chip so it doesn't compete with the selected
+        // border. :focus-visible (not :focus) so mouse-clicks don't show it.
+        &:focus-visible {
+          outline: 2px solid #10a37f;
+          outline-offset: 2px;
+        }
+
         &.selected {
           border-color: #10a37f;
         }
@@ -50,6 +58,14 @@
           justify-content: center;
           color: #fff;
           filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.9));
+
+          // The hidden <input type="color"> takes the focus, not the label.
+          // Mirror it back to the label via :focus-within so the visible
+          // chip shows the ring instead of the invisible input.
+          &:focus-within {
+            outline: 2px solid #10a37f;
+            outline-offset: 2px;
+          }
 
           input[type="color"] {
             position: absolute;

--- a/src/components/Display/DisplaySettingsPopover.scss
+++ b/src/components/Display/DisplaySettingsPopover.scss
@@ -24,6 +24,7 @@
     .palette {
       display: flex;
       gap: 6px;
+      flex-wrap: wrap;
 
       .swatch {
         width: 20px;
@@ -32,9 +33,32 @@
         border: 2px solid transparent;
         cursor: pointer;
         padding: 0;
+        position: relative;
 
         &.selected {
           border-color: #10a37f;
+        }
+
+        // Custom-color chip: a <label> wrapping a hidden <input type="color">.
+        // The chip's background reflects the current chosen color so it
+        // doubles as a "current value" indicator. The Plus icon is rendered
+        // in white with a thin dark outline so it stays legible regardless
+        // of the chip background.
+        &.custom {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+          color: #fff;
+          filter: drop-shadow(0 0 1px rgba(0, 0, 0, 0.9));
+
+          input[type="color"] {
+            position: absolute;
+            inset: 0;
+            opacity: 0;
+            cursor: pointer;
+            border: none;
+            padding: 0;
+          }
         }
       }
     }

--- a/src/components/Display/DisplaySettingsPopover.scss
+++ b/src/components/Display/DisplaySettingsPopover.scss
@@ -1,4 +1,4 @@
-.subtitle-settings-popover {
+.display-settings-popover {
   background: #1a1a1a;
   color: #e8e8e8;
   border: 1px solid #3a3a3a;

--- a/src/components/Display/DisplaySettingsPopover.test.tsx
+++ b/src/components/Display/DisplaySettingsPopover.test.tsx
@@ -1,0 +1,122 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, fireEvent, act } from '@testing-library/react';
+import DisplaySettingsPopover from './DisplaySettingsPopover';
+import { useSubtitleStore } from '../../stores/subtitleStore';
+import { useConversationDisplayStore } from '../../stores/conversationDisplayStore';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_key: string, fallback?: string) => fallback ?? _key,
+  }),
+}));
+
+vi.mock('../../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: vi.fn(async (_key: string, def: unknown) => def),
+      setSetting: vi.fn(async () => ({ success: true })),
+    }),
+  },
+}));
+
+describe('DisplaySettingsPopover', () => {
+  beforeEach(() => {
+    // Reset both stores to known starting state
+    useSubtitleStore.setState({
+      bgColor: '#000000',
+      sourceTextColor: '#FFFFFF',
+      translationTextColor: '#6CC5FF',
+      bgOpacity: 80,
+    } as Partial<ReturnType<typeof useSubtitleStore.getState>> as never);
+    useConversationDisplayStore.setState({
+      bgColor: '#1f1f1f',
+      sourceTextColor: '#9aa0a6',
+      translationTextColor: '#e8e8e8',
+    } as Partial<ReturnType<typeof useConversationDisplayStore.getState>> as never);
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('renders opacity slider when source=subtitle', () => {
+    const { container } = render(<DisplaySettingsPopover source="subtitle" />);
+    expect(container.querySelector('input[type="range"]')).not.toBeNull();
+  });
+
+  it('does NOT render opacity slider when source=conversation', () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    expect(container.querySelector('input[type="range"]')).toBeNull();
+  });
+
+  it('clicking a preset chip in subtitle mode updates only subtitleStore', async () => {
+    const { container } = render(<DisplaySettingsPopover source="subtitle" />);
+    const whiteChip = container.querySelector(
+      'button.swatch[aria-label="#FFFFFF"]',
+    ) as HTMLButtonElement;
+    expect(whiteChip).not.toBeNull();
+    await act(async () => { fireEvent.click(whiteChip); });
+    expect(useSubtitleStore.getState().bgColor).toBe('#FFFFFF');
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#1f1f1f');
+  });
+
+  it('clicking a preset chip in conversation mode updates only conversationDisplayStore', async () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    const whiteChip = container.querySelector(
+      'button.swatch[aria-label="#FFFFFF"]',
+    ) as HTMLButtonElement;
+    await act(async () => { fireEvent.click(whiteChip); });
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#FFFFFF');
+    expect(useSubtitleStore.getState().bgColor).toBe('#000000');
+  });
+
+  it('clicking the new dark source-text preset updates the source color', async () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    // The new "#1B5E20" deep-forest chip is in the SOURCE row only.
+    const allChips = container.querySelectorAll('button.swatch[aria-label="#1B5E20"]');
+    expect(allChips.length).toBe(1);
+    await act(async () => { fireEvent.click(allChips[0] as HTMLButtonElement); });
+    expect(useConversationDisplayStore.getState().sourceTextColor).toBe('#1B5E20');
+  });
+
+  it('preset chip is selected when current value matches', () => {
+    useConversationDisplayStore.setState({ bgColor: '#000000' } as never);
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    const blackChip = container.querySelector('button.swatch[aria-label="#000000"]');
+    expect(blackChip?.classList.contains('selected')).toBe(true);
+    const customChip = container.querySelector('label.swatch.custom');
+    expect(customChip?.classList.contains('selected')).toBe(false);
+  });
+
+  it('"+" chip is selected when current value is not in the row presets', () => {
+    useConversationDisplayStore.setState({ bgColor: '#abcdef' } as never);
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    // BG row's custom chip
+    const customChips = container.querySelectorAll('label.swatch.custom');
+    expect(customChips.length).toBe(3);
+    expect(customChips[0].classList.contains('selected')).toBe(true);
+  });
+
+  it('debounces "+" chip color picker changes by ~150ms (only last value applied)', async () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    // The first custom chip's hidden input is the BG row's picker.
+    const colorInput = container.querySelector(
+      'label.swatch.custom input[type="color"]',
+    ) as HTMLInputElement;
+    expect(colorInput).not.toBeNull();
+
+    fireEvent.change(colorInput, { target: { value: '#aaaaaa' } });
+    fireEvent.change(colorInput, { target: { value: '#bbbbbb' } });
+    fireEvent.change(colorInput, { target: { value: '#cccccc' } });
+
+    // Before debounce window: setter NOT called yet
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#1f1f1f');
+
+    // Advance past the 150ms debounce
+    await act(async () => { vi.advanceTimersByTime(160); });
+
+    // After debounce: only the LAST value applied
+    expect(useConversationDisplayStore.getState().bgColor).toBe('#cccccc');
+  });
+});

--- a/src/components/Display/DisplaySettingsPopover.test.tsx
+++ b/src/components/Display/DisplaySettingsPopover.test.tsx
@@ -119,4 +119,28 @@ describe('DisplaySettingsPopover', () => {
     // After debounce: only the LAST value applied
     expect(useConversationDisplayStore.getState().bgColor).toBe('#cccccc');
   });
+
+  it('first chip in each row reflects the source store default (subtitle)', () => {
+    const { container } = render(<DisplaySettingsPopover source="subtitle" />);
+    const fields = container.querySelectorAll('.field');
+    // Field 0 = opacity slider; fields 1-3 = bg/source/translation
+    const bgFirstChip = fields[1].querySelector('button.swatch') as HTMLButtonElement;
+    const sourceFirstChip = fields[2].querySelector('button.swatch') as HTMLButtonElement;
+    const translationFirstChip = fields[3].querySelector('button.swatch') as HTMLButtonElement;
+    expect(bgFirstChip.getAttribute('aria-label')).toBe('#000000');
+    expect(sourceFirstChip.getAttribute('aria-label')).toBe('#ffffff');
+    expect(translationFirstChip.getAttribute('aria-label')).toBe('#9ad0ff');
+  });
+
+  it('first chip in each row reflects the source store default (conversation)', () => {
+    const { container } = render(<DisplaySettingsPopover source="conversation" />);
+    const fields = container.querySelectorAll('.field');
+    // No opacity slider in conversation source; fields 0-2 = bg/source/translation
+    const bgFirstChip = fields[0].querySelector('button.swatch') as HTMLButtonElement;
+    const sourceFirstChip = fields[1].querySelector('button.swatch') as HTMLButtonElement;
+    const translationFirstChip = fields[2].querySelector('button.swatch') as HTMLButtonElement;
+    expect(bgFirstChip.getAttribute('aria-label')).toBe('#1f1f1f');
+    expect(sourceFirstChip.getAttribute('aria-label')).toBe('#9aa0a6');
+    expect(translationFirstChip.getAttribute('aria-label')).toBe('#e8e8e8');
+  });
 });

--- a/src/components/Display/DisplaySettingsPopover.tsx
+++ b/src/components/Display/DisplaySettingsPopover.tsx
@@ -1,99 +1,211 @@
-import React from 'react';
+import React, { useCallback, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Plus } from 'lucide-react';
 import {
-  useSubtitleSettings,
+  useSubtitleBgOpacity,
+  useSubtitleBgColor,
+  useSubtitleSourceTextColor,
+  useSubtitleTranslationTextColor,
   useSetSubtitleBgOpacity,
   useSetSubtitleBgColor,
   useSetSubtitleSourceTextColor,
   useSetSubtitleTranslationTextColor,
 } from '../../stores/subtitleStore';
+import {
+  useConversationDisplayBgColor,
+  useConversationDisplaySourceTextColor,
+  useConversationDisplayTranslationTextColor,
+  useSetConversationDisplayBgColor,
+  useSetConversationDisplaySourceTextColor,
+  useSetConversationDisplayTranslationTextColor,
+} from '../../stores/conversationDisplayStore';
 import './DisplaySettingsPopover.scss';
 
 const BG_PRESETS = ['#000000', '#1a1a1a', '#0d2032', '#0f2419', '#FFFFFF', '#2a2a2a'];
-const SOURCE_PRESETS = ['#FFFFFF', '#E8E8E8', '#FFD27D', '#FFAA66', '#9aa0a6', '#FF6B6B'];
-const TRANSLATION_PRESETS = ['#6CC5FF', '#10a37f', '#FFFFFF', '#A8E6CF', '#FFB86C', '#BD93F9'];
+const SOURCE_PRESETS = [
+  '#FFFFFF', '#E8E8E8', '#FFD27D', '#FFAA66', '#9aa0a6', '#FF6B6B',
+  '#000000', '#003B6F', '#1B5E20',
+];
+const TRANSLATION_PRESETS = [
+  '#6CC5FF', '#10a37f', '#FFFFFF', '#A8E6CF', '#FFB86C', '#BD93F9',
+  '#000000', '#003B6F', '#7B1FA2',
+];
+
+const PICKER_DEBOUNCE_MS = 150;
+
+type Source = 'subtitle' | 'conversation';
 
 export interface DisplaySettingsPopoverProps {
-  source: 'subtitle' | 'conversation';
+  source: Source;
 }
 
-const DisplaySettingsPopover: React.FC<DisplaySettingsPopoverProps> = ({ source }) => {
-  const { t } = useTranslation();
-  const subtitle = useSubtitleSettings();
-  const setBgOpacity = useSetSubtitleBgOpacity();
-  const setBgColor = useSetSubtitleBgColor();
-  const setSourceColor = useSetSubtitleSourceTextColor();
-  const setTranslationColor = useSetSubtitleTranslationTextColor();
+interface InnerBindings {
+  bgOpacity: number | undefined;
+  bgColor: string;
+  sourceTextColor: string;
+  translationTextColor: string;
+  setBgOpacity: ((n: number) => Promise<void>) | undefined;
+  setBgColor: (s: string) => Promise<void>;
+  setSourceTextColor: (s: string) => Promise<void>;
+  setTranslationTextColor: (s: string) => Promise<void>;
+}
 
-  // Task 7 will add the source='conversation' branch; today this file
-  // still serves only the subtitle path.
-  if (source !== 'subtitle') {
-    return <div className="display-settings-popover" role="dialog" />;
-  }
+const DisplaySettingsPopover: React.FC<DisplaySettingsPopoverProps> = ({ source }) =>
+  source === 'subtitle' ? <SubtitleBoundPopover /> : <ConversationBoundPopover />;
+
+export default DisplaySettingsPopover;
+
+// ──────────── Source-bound wrappers ────────────
+// Each wrapper subscribes ONLY to its own store. This keeps the rules
+// of hooks satisfied: hooks are always called in the same order within
+// a given wrapper component.
+
+const SubtitleBoundPopover: React.FC = () => {
+  const bindings: InnerBindings = {
+    bgOpacity: useSubtitleBgOpacity(),
+    bgColor: useSubtitleBgColor(),
+    sourceTextColor: useSubtitleSourceTextColor(),
+    translationTextColor: useSubtitleTranslationTextColor(),
+    setBgOpacity: useSetSubtitleBgOpacity(),
+    setBgColor: useSetSubtitleBgColor(),
+    setSourceTextColor: useSetSubtitleSourceTextColor(),
+    setTranslationTextColor: useSetSubtitleTranslationTextColor(),
+  };
+  return <DisplaySettingsPopoverInner bindings={bindings} />;
+};
+
+const ConversationBoundPopover: React.FC = () => {
+  const bindings: InnerBindings = {
+    bgOpacity: undefined,
+    bgColor: useConversationDisplayBgColor(),
+    sourceTextColor: useConversationDisplaySourceTextColor(),
+    translationTextColor: useConversationDisplayTranslationTextColor(),
+    setBgOpacity: undefined,
+    setBgColor: useSetConversationDisplayBgColor(),
+    setSourceTextColor: useSetConversationDisplaySourceTextColor(),
+    setTranslationTextColor: useSetConversationDisplayTranslationTextColor(),
+  };
+  return <DisplaySettingsPopoverInner bindings={bindings} />;
+};
+
+// ──────────── Pure presentational inner ────────────
+
+const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bindings }) => {
+  const { t } = useTranslation();
+  const includeOpacity =
+    bindings.bgOpacity !== undefined && bindings.setBgOpacity !== undefined;
 
   return (
     <div className="display-settings-popover" role="dialog">
-      <div className="field">
-        <label>{t('subtitle.settings.bgOpacity', 'Background opacity')} ({subtitle.bgOpacity}%)</label>
-        <input
-          type="range"
-          min={0}
-          max={100}
-          step={1}
-          value={subtitle.bgOpacity}
-          onChange={(e) => setBgOpacity(Number(e.target.value))}
-        />
-      </div>
-
-      <div className="field">
-        <label>{t('subtitle.settings.bgColor', 'Display background')}</label>
-        <div className="palette">
-          {BG_PRESETS.map((c) => (
-            <button
-              key={c}
-              type="button"
-              aria-label={c}
-              className={`swatch ${subtitle.bgColor === c ? 'selected' : ''}`}
-              style={{ background: c }}
-              onClick={() => setBgColor(c)}
-            />
-          ))}
+      {includeOpacity && (
+        <div className="field">
+          <label>
+            {t('subtitle.settings.bgOpacity', 'Background opacity')} ({bindings.bgOpacity}%)
+          </label>
+          <input
+            type="range"
+            min={0}
+            max={100}
+            step={1}
+            value={bindings.bgOpacity}
+            onChange={(e) => bindings.setBgOpacity!(Number(e.target.value))}
+          />
         </div>
-      </div>
+      )}
 
-      <div className="field">
-        <label>{t('subtitle.settings.sourceColor', 'Source text')}</label>
-        <div className="palette">
-          {SOURCE_PRESETS.map((c) => (
-            <button
-              key={c}
-              type="button"
-              aria-label={c}
-              className={`swatch ${subtitle.sourceTextColor === c ? 'selected' : ''}`}
-              style={{ background: c }}
-              onClick={() => setSourceColor(c)}
-            />
-          ))}
-        </div>
-      </div>
-
-      <div className="field">
-        <label>{t('subtitle.settings.translationColor', 'Translation text')}</label>
-        <div className="palette">
-          {TRANSLATION_PRESETS.map((c) => (
-            <button
-              key={c}
-              type="button"
-              aria-label={c}
-              className={`swatch ${subtitle.translationTextColor === c ? 'selected' : ''}`}
-              style={{ background: c }}
-              onClick={() => setTranslationColor(c)}
-            />
-          ))}
-        </div>
-      </div>
+      <ColorRow
+        labelKey="subtitle.settings.bgColor"
+        labelDefault="Display background"
+        presets={BG_PRESETS}
+        value={bindings.bgColor}
+        onChange={bindings.setBgColor}
+      />
+      <ColorRow
+        labelKey="subtitle.settings.sourceColor"
+        labelDefault="Source text"
+        presets={SOURCE_PRESETS}
+        value={bindings.sourceTextColor}
+        onChange={bindings.setSourceTextColor}
+      />
+      <ColorRow
+        labelKey="subtitle.settings.translationColor"
+        labelDefault="Translation text"
+        presets={TRANSLATION_PRESETS}
+        value={bindings.translationTextColor}
+        onChange={bindings.setTranslationTextColor}
+      />
     </div>
   );
 };
 
-export default DisplaySettingsPopover;
+// ──────────── Reusable row with presets + custom chip ────────────
+
+interface ColorRowProps {
+  labelKey: string;
+  labelDefault: string;
+  presets: readonly string[];
+  value: string;
+  onChange: (s: string) => Promise<void>;
+}
+
+const ColorRow: React.FC<ColorRowProps> = ({
+  labelKey,
+  labelDefault,
+  presets,
+  value,
+  onChange,
+}) => {
+  const { t } = useTranslation();
+  const valueLower = value.toLowerCase();
+  const isCustom = !presets.some((p) => p.toLowerCase() === valueLower);
+
+  // Debounce the high-frequency change events emitted while the user
+  // drags inside the OS color picker.
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const onPickerChange = useCallback(
+    (next: string) => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+      debounceRef.current = setTimeout(() => {
+        onChange(next);
+      }, PICKER_DEBOUNCE_MS);
+    },
+    [onChange],
+  );
+  useEffect(
+    () => () => {
+      if (debounceRef.current) clearTimeout(debounceRef.current);
+    },
+    [],
+  );
+
+  return (
+    <div className="field">
+      <label>{t(labelKey, labelDefault)}</label>
+      <div className="palette">
+        {presets.map((c) => (
+          <button
+            key={c}
+            type="button"
+            aria-label={c}
+            className={`swatch ${valueLower === c.toLowerCase() ? 'selected' : ''}`}
+            style={{ background: c }}
+            onClick={() => onChange(c)}
+          />
+        ))}
+        <label
+          className={`swatch custom ${isCustom ? 'selected' : ''}`}
+          style={{ background: value }}
+          title={t('subtitle.settings.customColor', 'Custom color')}
+          aria-label={t('subtitle.settings.customColor', 'Custom color')}
+        >
+          <Plus size={10} />
+          <input
+            type="color"
+            value={value}
+            onChange={(e) => onPickerChange(e.target.value)}
+          />
+        </label>
+      </div>
+    </div>
+  );
+};

--- a/src/components/Display/DisplaySettingsPopover.tsx
+++ b/src/components/Display/DisplaySettingsPopover.tsx
@@ -7,13 +7,17 @@ import {
   useSetSubtitleSourceTextColor,
   useSetSubtitleTranslationTextColor,
 } from '../../stores/subtitleStore';
-import './SubtitleSettingsPopover.scss';
+import './DisplaySettingsPopover.scss';
 
 const BG_PRESETS = ['#000000', '#1a1a1a', '#0d2032', '#0f2419', '#FFFFFF', '#2a2a2a'];
 const SOURCE_PRESETS = ['#FFFFFF', '#E8E8E8', '#FFD27D', '#FFAA66', '#9aa0a6', '#FF6B6B'];
 const TRANSLATION_PRESETS = ['#6CC5FF', '#10a37f', '#FFFFFF', '#A8E6CF', '#FFB86C', '#BD93F9'];
 
-const SubtitleSettingsPopover: React.FC = () => {
+export interface DisplaySettingsPopoverProps {
+  source: 'subtitle' | 'conversation';
+}
+
+const DisplaySettingsPopover: React.FC<DisplaySettingsPopoverProps> = ({ source }) => {
   const { t } = useTranslation();
   const subtitle = useSubtitleSettings();
   const setBgOpacity = useSetSubtitleBgOpacity();
@@ -21,8 +25,14 @@ const SubtitleSettingsPopover: React.FC = () => {
   const setSourceColor = useSetSubtitleSourceTextColor();
   const setTranslationColor = useSetSubtitleTranslationTextColor();
 
+  // Task 7 will add the source='conversation' branch; today this file
+  // still serves only the subtitle path.
+  if (source !== 'subtitle') {
+    return <div className="display-settings-popover" role="dialog" />;
+  }
+
   return (
-    <div className="subtitle-settings-popover" role="dialog">
+    <div className="display-settings-popover" role="dialog">
       <div className="field">
         <label>{t('subtitle.settings.bgOpacity', 'Background opacity')} ({subtitle.bgOpacity}%)</label>
         <input
@@ -36,7 +46,7 @@ const SubtitleSettingsPopover: React.FC = () => {
       </div>
 
       <div className="field">
-        <label>{t('subtitle.settings.bgColor', 'Background color')}</label>
+        <label>{t('subtitle.settings.bgColor', 'Display background')}</label>
         <div className="palette">
           {BG_PRESETS.map((c) => (
             <button
@@ -52,7 +62,7 @@ const SubtitleSettingsPopover: React.FC = () => {
       </div>
 
       <div className="field">
-        <label>{t('subtitle.settings.sourceColor', 'Source text color')}</label>
+        <label>{t('subtitle.settings.sourceColor', 'Source text')}</label>
         <div className="palette">
           {SOURCE_PRESETS.map((c) => (
             <button
@@ -68,7 +78,7 @@ const SubtitleSettingsPopover: React.FC = () => {
       </div>
 
       <div className="field">
-        <label>{t('subtitle.settings.translationColor', 'Translation color')}</label>
+        <label>{t('subtitle.settings.translationColor', 'Translation text')}</label>
         <div className="palette">
           {TRANSLATION_PRESETS.map((c) => (
             <button
@@ -86,4 +96,4 @@ const SubtitleSettingsPopover: React.FC = () => {
   );
 };
 
-export default SubtitleSettingsPopover;
+export default DisplaySettingsPopover;

--- a/src/components/Display/DisplaySettingsPopover.tsx
+++ b/src/components/Display/DisplaySettingsPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import {
@@ -106,26 +106,18 @@ const ConversationBoundPopover: React.FC = () => {
 // ──────────── Pure presentational inner ────────────
 
 const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bindings }) => {
-  const { t } = useTranslation();
   const includeOpacity =
     bindings.bgOpacity !== undefined && bindings.setBgOpacity !== undefined;
 
+  // Note: role="dialog" + accessible name are intentionally NOT set on this
+  // root. They live on the floating wrapper in SubtitleBar / MainPanel via
+  // @floating-ui/react's useRole, which also wires aria-haspopup / aria-
+  // expanded / aria-controls on the trigger. Keeping the role on a single
+  // level avoids duplicate dialog announcements.
   return (
-    <div className="display-settings-popover" role="dialog">
+    <div className="display-settings-popover">
       {includeOpacity && (
-        <div className="field">
-          <label>
-            {t('subtitle.settings.bgOpacity', 'Background opacity')} ({bindings.bgOpacity}%)
-          </label>
-          <input
-            type="range"
-            min={0}
-            max={100}
-            step={1}
-            value={bindings.bgOpacity}
-            onChange={(e) => bindings.setBgOpacity!(Number(e.target.value))}
-          />
-        </div>
+        <OpacitySlider value={bindings.bgOpacity!} onCommit={bindings.setBgOpacity!} />
       )}
 
       <ColorRow
@@ -151,6 +143,52 @@ const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bi
         presets={TRANSLATION_PRESETS}
         value={bindings.translationTextColor}
         onChange={bindings.setTranslationTextColor}
+      />
+    </div>
+  );
+};
+
+// ──────────── Opacity slider (subtitle-only) ────────────
+// Local state during pointer drag so we don't fire setBgOpacity (and the
+// async persist behind it) for every intermediate value. The store is
+// updated only when the user releases the pointer or finishes a keyboard
+// interaction.
+
+const OpacitySlider: React.FC<{
+  value: number;
+  onCommit: (n: number) => Promise<void>;
+}> = ({ value, onCommit }) => {
+  const { t } = useTranslation();
+  const id = useId();
+  const [local, setLocal] = useState(value);
+
+  // Sync local state if the bound value changes externally (hydration,
+  // someone else's update).
+  useEffect(() => {
+    setLocal(value);
+  }, [value]);
+
+  const commit = useCallback(() => {
+    if (local !== value) {
+      void onCommit(local);
+    }
+  }, [local, value, onCommit]);
+
+  return (
+    <div className="field">
+      <label htmlFor={id}>
+        {t('subtitle.settings.bgOpacity', 'Background opacity')} ({local}%)
+      </label>
+      <input
+        id={id}
+        type="range"
+        min={0}
+        max={100}
+        step={1}
+        value={local}
+        onChange={(e) => setLocal(Number(e.target.value))}
+        onPointerUp={commit}
+        onKeyUp={commit}
       />
     </div>
   );
@@ -231,6 +269,7 @@ const ColorRow: React.FC<ColorRowProps> = ({
           <input
             type="color"
             value={value}
+            aria-label={t('subtitle.settings.customColor', 'Custom color')}
             onChange={(e) => onPickerChange(e.target.value)}
           />
         </label>

--- a/src/components/Display/DisplaySettingsPopover.tsx
+++ b/src/components/Display/DisplaySettingsPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Plus } from 'lucide-react';
 import {
@@ -10,6 +10,9 @@ import {
   useSetSubtitleBgColor,
   useSetSubtitleSourceTextColor,
   useSetSubtitleTranslationTextColor,
+  SUBTITLE_DEFAULT_BG_COLOR,
+  SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR,
+  SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR,
 } from '../../stores/subtitleStore';
 import {
   useConversationDisplayBgColor,
@@ -18,6 +21,9 @@ import {
   useSetConversationDisplayBgColor,
   useSetConversationDisplaySourceTextColor,
   useSetConversationDisplayTranslationTextColor,
+  CONVERSATION_DISPLAY_DEFAULT_BG_COLOR,
+  CONVERSATION_DISPLAY_DEFAULT_SOURCE_TEXT_COLOR,
+  CONVERSATION_DISPLAY_DEFAULT_TRANSLATION_TEXT_COLOR,
 } from '../../stores/conversationDisplayStore';
 import './DisplaySettingsPopover.scss';
 
@@ -48,6 +54,9 @@ interface InnerBindings {
   setBgColor: (s: string) => Promise<void>;
   setSourceTextColor: (s: string) => Promise<void>;
   setTranslationTextColor: (s: string) => Promise<void>;
+  defaultBgColor: string;
+  defaultSourceTextColor: string;
+  defaultTranslationTextColor: string;
 }
 
 const DisplaySettingsPopover: React.FC<DisplaySettingsPopoverProps> = ({ source }) =>
@@ -70,6 +79,9 @@ const SubtitleBoundPopover: React.FC = () => {
     setBgColor: useSetSubtitleBgColor(),
     setSourceTextColor: useSetSubtitleSourceTextColor(),
     setTranslationTextColor: useSetSubtitleTranslationTextColor(),
+    defaultBgColor: SUBTITLE_DEFAULT_BG_COLOR,
+    defaultSourceTextColor: SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR,
+    defaultTranslationTextColor: SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR,
   };
   return <DisplaySettingsPopoverInner bindings={bindings} />;
 };
@@ -84,6 +96,9 @@ const ConversationBoundPopover: React.FC = () => {
     setBgColor: useSetConversationDisplayBgColor(),
     setSourceTextColor: useSetConversationDisplaySourceTextColor(),
     setTranslationTextColor: useSetConversationDisplayTranslationTextColor(),
+    defaultBgColor: CONVERSATION_DISPLAY_DEFAULT_BG_COLOR,
+    defaultSourceTextColor: CONVERSATION_DISPLAY_DEFAULT_SOURCE_TEXT_COLOR,
+    defaultTranslationTextColor: CONVERSATION_DISPLAY_DEFAULT_TRANSLATION_TEXT_COLOR,
   };
   return <DisplaySettingsPopoverInner bindings={bindings} />;
 };
@@ -116,6 +131,7 @@ const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bi
       <ColorRow
         labelKey="subtitle.settings.bgColor"
         labelDefault="Display background"
+        defaultColor={bindings.defaultBgColor}
         presets={BG_PRESETS}
         value={bindings.bgColor}
         onChange={bindings.setBgColor}
@@ -123,6 +139,7 @@ const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bi
       <ColorRow
         labelKey="subtitle.settings.sourceColor"
         labelDefault="Source text"
+        defaultColor={bindings.defaultSourceTextColor}
         presets={SOURCE_PRESETS}
         value={bindings.sourceTextColor}
         onChange={bindings.setSourceTextColor}
@@ -130,6 +147,7 @@ const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bi
       <ColorRow
         labelKey="subtitle.settings.translationColor"
         labelDefault="Translation text"
+        defaultColor={bindings.defaultTranslationTextColor}
         presets={TRANSLATION_PRESETS}
         value={bindings.translationTextColor}
         onChange={bindings.setTranslationTextColor}
@@ -143,6 +161,7 @@ const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bi
 interface ColorRowProps {
   labelKey: string;
   labelDefault: string;
+  defaultColor: string;
   presets: readonly string[];
   value: string;
   onChange: (s: string) => Promise<void>;
@@ -151,13 +170,23 @@ interface ColorRowProps {
 const ColorRow: React.FC<ColorRowProps> = ({
   labelKey,
   labelDefault,
+  defaultColor,
   presets,
   value,
   onChange,
 }) => {
   const { t } = useTranslation();
   const valueLower = value.toLowerCase();
-  const isCustom = !presets.some((p) => p.toLowerCase() === valueLower);
+
+  // First chip is always this surface's default. Drop any duplicate of the
+  // default that appears later in the shared preset list.
+  const orderedPresets = useMemo(() => {
+    const defaultLower = defaultColor.toLowerCase();
+    const rest = presets.filter((p) => p.toLowerCase() !== defaultLower);
+    return [defaultColor, ...rest] as const;
+  }, [defaultColor, presets]);
+
+  const isCustom = !orderedPresets.some((p) => p.toLowerCase() === valueLower);
 
   // Debounce the high-frequency change events emitted while the user
   // drags inside the OS color picker.
@@ -182,7 +211,7 @@ const ColorRow: React.FC<ColorRowProps> = ({
     <div className="field">
       <label>{t(labelKey, labelDefault)}</label>
       <div className="palette">
-        {presets.map((c) => (
+        {orderedPresets.map((c) => (
           <button
             key={c}
             type="button"

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -65,14 +65,14 @@
   padding: 2px 0 2px 30px; // indent so the line aligns under the name, avatar reserves space
   line-height: 1.4;
   font-size: var(--conversation-font-size, 14px);
-  transition: background-color 0.3s ease;
+  transition: box-shadow 0.15s ease, border-radius 0.15s ease;
 
   .conversation-row.grouped & {
     padding-left: 30px;
   }
 
   &.playing {
-    background: rgba(16, 163, 127, 0.1);
+    box-shadow: 0 0 0 1px var(--conversation-translation-color, #10a37f);
     border-radius: 4px;
   }
 }
@@ -111,12 +111,12 @@
   overflow-wrap: anywhere;
 
   &.src {
-    color: var(--subtitle-source-color, #9aa0a6);
+    color: var(--conversation-source-color, #9aa0a6);
     font-style: italic;
   }
 
   &.tr {
-    color: var(--subtitle-translation-color, #e8e8e8);
+    color: var(--conversation-translation-color, #e8e8e8);
   }
 }
 

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -65,14 +65,14 @@
   padding: 2px 0 2px 30px; // indent so the line aligns under the name, avatar reserves space
   line-height: 1.4;
   font-size: var(--conversation-font-size, 14px);
-  transition: box-shadow 0.15s ease, border-radius 0.15s ease;
+  transition: background-color 0.15s ease, border-radius 0.15s ease;
 
   .conversation-row.grouped & {
     padding-left: 30px;
   }
 
   &.playing {
-    box-shadow: 0 0 0 1px var(--conversation-translation-color, #10a37f);
+    background: color-mix(in srgb, var(--conversation-translation-color, #10a37f) 15%, transparent);
     border-radius: 4px;
   }
 }

--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -31,6 +31,7 @@
   -webkit-overflow-scrolling: touch;
   overscroll-behavior: contain;
   position: relative;
+  background: var(--conversation-bg-color, #1f1f1f);
 
   &::-webkit-scrollbar { width: 6px; }
   &::-webkit-scrollbar-track { background: transparent; }
@@ -124,30 +125,6 @@
 
   // ── Role variants ──
 
-  &.user {
-    align-self: flex-end;
-    background: #2a2a2a;
-    margin-left: auto;
-    border-bottom-right-radius: 4px;
-
-    &.playing {
-      background: #353535;
-      box-shadow: 0 0 10px rgba(16, 163, 127, 0.3);
-    }
-  }
-
-  &.assistant {
-    align-self: flex-start;
-    background: #10a37f;
-    margin-right: auto;
-    border-bottom-left-radius: 4px;
-
-    &.playing {
-      background: #12b88f;
-      box-shadow: 0 0 10px rgba(16, 163, 127, 0.5);
-    }
-  }
-
   &.system {
     align-self: center;
     background: #444;
@@ -157,22 +134,6 @@
     &.playing {
       background: #555;
       box-shadow: 0 0 10px rgba(16, 163, 127, 0.3);
-    }
-  }
-
-  // ── Participant source (orange) ──
-
-  &.participant-source {
-    border-left: 3px solid #f39c12;
-
-    &.user {
-      background: rgba(243, 156, 18, 0.15);
-      &.playing { background: rgba(243, 156, 18, 0.25); box-shadow: 0 0 10px rgba(243, 156, 18, 0.3); }
-    }
-
-    &.assistant {
-      background: #e67e22;
-      &.playing { background: #f39c12; box-shadow: 0 0 10px rgba(243, 156, 18, 0.5); }
     }
   }
 
@@ -235,12 +196,6 @@
 .karaoke-unplayed {
   opacity: 0.7;
   transition: all 0.2s ease;
-}
-
-// Assistant bubble (green bg) → white highlight
-.message-bubble.assistant .karaoke-played {
-  color: #fff;
-  text-shadow: 0 0 8px rgba(255, 255, 255, 0.8);
 }
 
 // ─── Advanced-only Content Items ───────────────────

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -24,6 +24,8 @@ import {
   useNavigateToSettings,
   useConversationFontSize,
   useSetConversationFontSize,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
   useConversationCompactMode,
   useSetConversationCompactMode,
   useSpeakerDisplayMode,
@@ -2933,8 +2935,8 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             )}
             <button
               className="font-size-btn"
-              onClick={() => setConversationFontSize(Math.max(12, conversationFontSize - 2))}
-              disabled={conversationFontSize <= 12}
+              onClick={() => setConversationFontSize(Math.max(CONVERSATION_FONT_SIZE_MIN, conversationFontSize - 2))}
+              disabled={conversationFontSize <= CONVERSATION_FONT_SIZE_MIN}
               title={t('mainPanel.decreaseFontSize', 'Decrease font size')}
               aria-label={t('mainPanel.decreaseFontSize', 'Decrease font size')}
               type="button"
@@ -2943,8 +2945,8 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             </button>
             <button
               className="font-size-btn"
-              onClick={() => setConversationFontSize(Math.min(28, conversationFontSize + 2))}
-              disabled={conversationFontSize >= 28}
+              onClick={() => setConversationFontSize(Math.min(CONVERSATION_FONT_SIZE_MAX, conversationFontSize + 2))}
+              disabled={conversationFontSize >= CONVERSATION_FONT_SIZE_MAX}
               title={t('mainPanel.increaseFontSize', 'Increase font size')}
               aria-label={t('mainPanel.increaseFontSize', 'Increase font size')}
               type="button"

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -68,7 +68,7 @@ import ConversationRow from './ConversationRow';
 import { shouldShowItem } from './conversationFilter';
 import ExportButton from './ExportButton';
 import {
-  useFloating, useClick, useDismiss, useInteractions, offset, flip, FloatingPortal,
+  useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
 } from '@floating-ui/react';
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 
@@ -274,9 +274,12 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     placement: 'bottom-end',
     middleware: [offset(8), flip()],
   });
+  // useRole wires aria-haspopup / aria-expanded / aria-controls on the
+  // trigger button and role="dialog" / aria-modal on the floating wrapper.
   const displayPopoverInteractions = useInteractions([
     useClick(displayPopoverFloating.context),
     useDismiss(displayPopoverFloating.context),
+    useRole(displayPopoverFloating.context, { role: 'dialog' }),
   ]);
 
   /**
@@ -3038,6 +3041,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
               <div
                 ref={displayPopoverFloating.refs.setFloating}
                 style={displayPopoverFloating.floatingStyles}
+                aria-label={t('mainPanel.displaySettings', 'Display settings')}
                 {...displayPopoverInteractions.getFloatingProps()}
               >
                 <DisplaySettingsPopover source="conversation" />

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -22,12 +22,6 @@ import {
   useCreateSessionConfig,
   useTransportType,
   useNavigateToSettings,
-  useConversationFontSize,
-  useSetConversationFontSize,
-  CONVERSATION_FONT_SIZE_MIN,
-  CONVERSATION_FONT_SIZE_MAX,
-  useConversationCompactMode,
-  useSetConversationCompactMode,
   useSpeakerDisplayMode,
   useParticipantDisplayMode,
   useSetSpeakerDisplayMode,
@@ -36,6 +30,14 @@ import {
   useSubtitleModeActive
 } from '../../stores/settingsStore';
 import useSettingsStore, { createParticipantLocalInferenceConfig } from '../../stores/settingsStore';
+import {
+  useConversationDisplayFontSize,
+  useSetConversationDisplayFontSize,
+  useConversationDisplayCompactMode,
+  useSetConversationDisplayCompactMode,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+} from '../../stores/conversationDisplayStore';
 import useSessionStore, { useSession, useIsReconnecting, useSetIsReconnecting, useSetItems as useSetStoreItems, useSetSystemAudioItems as useSetStoreSystemAudioItems, useClearConversationVersion, useRequestClearConversation } from '../../stores/sessionStore';
 import { useAudioContext, useNoiseSuppressionMode } from '../../stores/audioStore';
 import { useLogActions } from '../../stores/logStore';
@@ -126,10 +128,10 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const uiMode = useUIMode();
   const subtitleModeActive = useSubtitleModeActive();
   const subtitleTakeover = subtitleModeActive && isExtension();
-  const conversationFontSize = useConversationFontSize();
-  const setConversationFontSize = useSetConversationFontSize();
-  const conversationCompactMode = useConversationCompactMode();
-  const setConversationCompactMode = useSetConversationCompactMode();
+  const conversationFontSize = useConversationDisplayFontSize();
+  const setConversationFontSize = useSetConversationDisplayFontSize();
+  const conversationCompactMode = useConversationDisplayCompactMode();
+  const setConversationCompactMode = useSetConversationDisplayCompactMode();
   const speakerDisplayMode = useSpeakerDisplayMode();
   const participantDisplayMode = useParticipantDisplayMode();
   const setSpeakerDisplayMode = useSetSpeakerDisplayMode();

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -35,6 +35,9 @@ import {
   useSetConversationDisplayFontSize,
   useConversationDisplayCompactMode,
   useSetConversationDisplayCompactMode,
+  useConversationDisplayBgColor,
+  useConversationDisplaySourceTextColor,
+  useConversationDisplayTranslationTextColor,
   CONVERSATION_FONT_SIZE_MIN,
   CONVERSATION_FONT_SIZE_MAX,
 } from '../../stores/conversationDisplayStore';
@@ -136,6 +139,9 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const setConversationFontSize = useSetConversationDisplayFontSize();
   const conversationCompactMode = useConversationDisplayCompactMode();
   const setConversationCompactMode = useSetConversationDisplayCompactMode();
+  const conversationBgColor = useConversationDisplayBgColor();
+  const conversationSourceTextColor = useConversationDisplaySourceTextColor();
+  const conversationTranslationTextColor = useConversationDisplayTranslationTextColor();
   const speakerDisplayMode = useSpeakerDisplayMode();
   const participantDisplayMode = useParticipantDisplayMode();
   const setSpeakerDisplayMode = useSetSpeakerDisplayMode();
@@ -2933,7 +2939,14 @@ const MainPanel: React.FC<MainPanelProps> = () => {
 
   // Unified render for both modes
   return (
-    <div className="main-panel-wrapper">
+    <div
+      className="main-panel-wrapper"
+      style={{
+        '--conversation-bg-color': conversationBgColor,
+        '--conversation-source-color': conversationSourceTextColor,
+        '--conversation-translation-color': conversationTranslationTextColor,
+      } as React.CSSProperties}
+    >
       <UpdateBanner />
       <UpdateDialog />
       <div className="main-panel">

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
-import {X, Zap, Mic, MicOff, Loader, Volume2, VolumeX, Wrench, Send, AlertCircle, MessageSquare, Trash2, AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown, Captions} from 'lucide-react';
+import {X, Zap, Mic, MicOff, Loader, Volume2, VolumeX, Wrench, Send, AlertCircle, MessageSquare, Trash2, AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown, Captions, Settings} from 'lucide-react';
 import './MainPanel.scss';
 import {
   useProvider,
@@ -64,6 +64,10 @@ import DisplayModeButton from './DisplayModeButton';
 import ConversationRow from './ConversationRow';
 import { shouldShowItem } from './conversationFilter';
 import ExportButton from './ExportButton';
+import {
+  useFloating, useClick, useDismiss, useInteractions, offset, flip, FloatingPortal,
+} from '@floating-ui/react';
+import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 
 
 /**
@@ -255,6 +259,19 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   // AI response state for text input queueing (OpenAI only)
   const [isAIResponding, setIsAIResponding] = useState(false);
   const pendingTextRef = useRef<string | null>(null);
+
+  // Display settings popover (conversation-toolbar ⚙)
+  const [displayPopoverOpen, setDisplayPopoverOpen] = useState(false);
+  const displayPopoverFloating = useFloating({
+    open: displayPopoverOpen,
+    onOpenChange: setDisplayPopoverOpen,
+    placement: 'bottom-end',
+    middleware: [offset(8), flip()],
+  });
+  const displayPopoverInteractions = useInteractions([
+    useClick(displayPopoverFloating.context),
+    useDismiss(displayPopoverFloating.context),
+  ]);
 
   /**
    * Convert settings to SessionConfig
@@ -2922,6 +2939,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       <div className="main-panel">
         {/* Conversation toolbar */}
         {(isSessionActive || combinedItems.length > 0) && (
+          <>
           <div className="conversation-toolbar">
             <DisplayModeButton
               scope="speaker"
@@ -2983,6 +3001,16 @@ const MainPanel: React.FC<MainPanelProps> = () => {
               targetLanguage={targetLanguage}
             />
             <button
+              className="font-size-btn"
+              ref={displayPopoverFloating.refs.setReference}
+              {...displayPopoverInteractions.getReferenceProps()}
+              title={t('mainPanel.displaySettings', 'Display settings')}
+              aria-label={t('mainPanel.displaySettings', 'Display settings')}
+              type="button"
+            >
+              <Settings size={14} />
+            </button>
+            <button
               className="clear-conversation-btn"
               onClick={requestClearConversation}
               title={t('mainPanel.clearConversation', 'Clear conversation')}
@@ -2992,6 +3020,18 @@ const MainPanel: React.FC<MainPanelProps> = () => {
               <Trash2 size={14} />
             </button>
           </div>
+          {displayPopoverOpen && (
+            <FloatingPortal>
+              <div
+                ref={displayPopoverFloating.refs.setFloating}
+                style={displayPopoverFloating.floatingStyles}
+                {...displayPopoverInteractions.getFloatingProps()}
+              >
+                <DisplaySettingsPopover source="conversation" />
+              </div>
+            </FloatingPortal>
+          )}
+          </>
         )}
         {/* Conversation Display */}
         <div

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -6,7 +6,7 @@ import {
   Pin, Lock, X, Settings, Trash2,
 } from 'lucide-react';
 import {
-  useFloating, useClick, useDismiss, useInteractions, offset, flip, FloatingPortal,
+  useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
 } from '@floating-ui/react';
 import DisplayModeButton from '../MainPanel/DisplayModeButton';
 import ExportButton from '../MainPanel/ExportButton';
@@ -91,7 +91,10 @@ const SubtitleBar: React.FC<Props> = ({
   });
   const click = useClick(context);
   const dismiss = useDismiss(context);
-  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss]);
+  // useRole wires aria-haspopup / aria-expanded / aria-controls on the
+  // trigger button and role="dialog" / aria-modal on the floating wrapper.
+  const role = useRole(context, { role: 'dialog' });
+  const { getReferenceProps, getFloatingProps } = useInteractions([click, dismiss, role]);
 
   return (
     <div
@@ -201,7 +204,12 @@ const SubtitleBar: React.FC<Props> = ({
 
       {popoverOpen && (
         <FloatingPortal>
-          <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+          <div
+            ref={refs.setFloating}
+            style={floatingStyles}
+            aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
+            {...getFloatingProps()}
+          >
             <DisplaySettingsPopover source="subtitle" />
           </div>
         </FloatingPortal>

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -24,7 +24,7 @@ import {
   FONT_SIZE_MIN,
   FONT_SIZE_MAX,
 } from '../../stores/subtitleStore';
-import SubtitleSettingsPopover from './SubtitleSettingsPopover';
+import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 import type { SubtitleSurfaceKind } from './SubtitleApp';
 import { useOverlayDragResize } from './useOverlayDragResize';
 import './SubtitleBar.scss';
@@ -202,7 +202,7 @@ const SubtitleBar: React.FC<Props> = ({
       {popoverOpen && (
         <FloatingPortal>
           <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-            <SubtitleSettingsPopover />
+            <DisplaySettingsPopover source="subtitle" />
           </div>
         </FloatingPortal>
       )}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -573,6 +573,7 @@
     "decreaseFontSize": "Decrease font size",
     "increaseFontSize": "Increase font size",
     "compactView": "Compact view",
+    "displaySettings": "Display settings",
     "expandedView": "Expanded view",
     "displayMode": {
       "speaker": "Speaker",
@@ -899,9 +900,10 @@
     },
     "settings": {
       "bgOpacity": "Background opacity",
-      "bgColor": "Background color",
-      "sourceColor": "Source text color",
-      "translationColor": "Translation color"
+      "bgColor": "Display background",
+      "sourceColor": "Source text",
+      "translationColor": "Translation text",
+      "customColor": "Custom color"
     },
     "pttHint": "Press Space to speak"
   },

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -5,6 +5,7 @@ import { OnboardingProvider } from '../contexts/OnboardingContext';
 import { useInitializeAudioService } from '../stores/audioStore';
 import { useLoadSettings } from '../stores/settingsStore';
 import { useSubtitleStore } from '../stores/subtitleStore';
+import { useConversationDisplayStore } from '../stores/conversationDisplayStore';
 import { SettingsInitializer } from '../components/SettingsInitializer/SettingsInitializer';
 
 export function Home() {
@@ -17,12 +18,13 @@ export function Home() {
     initializeAudioService();
 
     console.info('[Home] Loading settings');
-    // Hydrate settingsStore and subtitleStore in parallel from persisted storage.
+    // Hydrate settingsStore, subtitleStore, and conversationDisplayStore in parallel from persisted storage.
     Promise.all([
       loadSettings(),
       useSubtitleStore.getState().hydrate(),
+      useConversationDisplayStore.getState().hydrate(),
     ]).catch((err) => {
-      console.warn('[Home] Settings/subtitle hydration error:', err);
+      console.warn('[Home] Settings/subtitle/conversationDisplay hydration error:', err);
     });
   }, []); // Empty dependency array - only run once on mount
 

--- a/src/stores/conversationDisplayStore.test.ts
+++ b/src/stores/conversationDisplayStore.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import {
   useConversationDisplayStore,
   CONVERSATION_FONT_SIZE_MIN,
@@ -100,6 +100,13 @@ describe('conversationDisplayStore', () => {
     const calls = mockGetSetting.mock.calls.map((c) => c[0] as string);
     expect(calls).not.toContain('settings.common.conversationFontSize');
     expect(calls).not.toContain('settings.common.conversationCompactMode');
+  });
+
+  it('rolls back optimistic state when persistence fails', async () => {
+    mockSetSetting.mockRejectedValueOnce(new Error('disk full'));
+    const before = useConversationDisplayStore.getState().bgColor;
+    await useConversationDisplayStore.getState().setBgColor('#FFFFFF');
+    expect(useConversationDisplayStore.getState().bgColor).toBe(before);
   });
 
   it('selector hooks exist', () => {

--- a/src/stores/conversationDisplayStore.test.ts
+++ b/src/stores/conversationDisplayStore.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  useConversationDisplayStore,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+  useConversationDisplayFontSize,
+  useConversationDisplayBgColor,
+} from './conversationDisplayStore';
+
+const mockSetSetting = vi.fn(async () => ({ success: true }));
+const mockGetSetting = vi.fn(async (_key: string, def: unknown) => def);
+
+vi.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: mockGetSetting,
+      setSetting: mockSetSetting,
+    }),
+  },
+}));
+
+describe('conversationDisplayStore', () => {
+  beforeEach(() => {
+    mockSetSetting.mockClear();
+    mockGetSetting.mockClear();
+    useConversationDisplayStore.setState({
+      fontSize: 14,
+      compactMode: false,
+      bgColor: '#1f1f1f',
+      sourceTextColor: '#9aa0a6',
+      translationTextColor: '#e8e8e8',
+    });
+  });
+
+  it('exports CONVERSATION_FONT_SIZE_MIN=12 and CONVERSATION_FONT_SIZE_MAX=64', () => {
+    expect(CONVERSATION_FONT_SIZE_MIN).toBe(12);
+    expect(CONVERSATION_FONT_SIZE_MAX).toBe(64);
+  });
+
+  it('has the documented defaults', () => {
+    const s = useConversationDisplayStore.getState();
+    expect(s.fontSize).toBe(14);
+    expect(s.compactMode).toBe(false);
+    expect(s.bgColor).toBe('#1f1f1f');
+    expect(s.sourceTextColor).toBe('#9aa0a6');
+    expect(s.translationTextColor).toBe('#e8e8e8');
+  });
+
+  it('clamps setFontSize to [12, 64]', async () => {
+    await useConversationDisplayStore.getState().setFontSize(8);
+    expect(useConversationDisplayStore.getState().fontSize).toBe(12);
+    await useConversationDisplayStore.getState().setFontSize(99);
+    expect(useConversationDisplayStore.getState().fontSize).toBe(64);
+    await useConversationDisplayStore.getState().setFontSize(28);
+    expect(useConversationDisplayStore.getState().fontSize).toBe(28);
+  });
+
+  it('persists each setter under the conversationDisplay namespace', async () => {
+    await useConversationDisplayStore.getState().setBgColor('#FFFFFF');
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.bgColor',
+      '#FFFFFF',
+    );
+    await useConversationDisplayStore.getState().setSourceTextColor('#000000');
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.sourceTextColor',
+      '#000000',
+    );
+    await useConversationDisplayStore.getState().setTranslationTextColor('#003B6F');
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.translationTextColor',
+      '#003B6F',
+    );
+    await useConversationDisplayStore.getState().setFontSize(20);
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.fontSize',
+      20,
+    );
+    await useConversationDisplayStore.getState().setCompactMode(true);
+    expect(mockSetSetting).toHaveBeenCalledWith(
+      'settings.common.conversationDisplay.compactMode',
+      true,
+    );
+  });
+
+  it('hydrate reads only from settings.common.conversationDisplay.* keys', async () => {
+    await useConversationDisplayStore.getState().hydrate();
+    const calls = mockGetSetting.mock.calls.map((c) => c[0] as string);
+    expect(calls.length).toBeGreaterThan(0);
+    for (const key of calls) {
+      expect(key.startsWith('settings.common.conversationDisplay.')).toBe(true);
+    }
+    const s = useConversationDisplayStore.getState();
+    expect(s.fontSize).toBe(14);
+    expect(s.bgColor).toBe('#1f1f1f');
+  });
+
+  it('hydrate does NOT read the old conversationFontSize / conversationCompactMode keys', async () => {
+    await useConversationDisplayStore.getState().hydrate();
+    const calls = mockGetSetting.mock.calls.map((c) => c[0] as string);
+    expect(calls).not.toContain('settings.common.conversationFontSize');
+    expect(calls).not.toContain('settings.common.conversationCompactMode');
+  });
+
+  it('selector hooks exist', () => {
+    expect(typeof useConversationDisplayFontSize).toBe('function');
+    expect(typeof useConversationDisplayBgColor).toBe('function');
+  });
+});

--- a/src/stores/conversationDisplayStore.ts
+++ b/src/stores/conversationDisplayStore.ts
@@ -22,12 +22,17 @@ interface ConversationDisplayState {
   hydrate: () => Promise<void>;
 }
 
+// ──────────── Default colors (exported for popover preset wiring) ────────────
+export const CONVERSATION_DISPLAY_DEFAULT_BG_COLOR = '#1f1f1f';
+export const CONVERSATION_DISPLAY_DEFAULT_SOURCE_TEXT_COLOR = '#9aa0a6';
+export const CONVERSATION_DISPLAY_DEFAULT_TRANSLATION_TEXT_COLOR = '#e8e8e8';
+
 const DEFAULTS = {
   fontSize: 14,
   compactMode: false,
-  bgColor: '#1f1f1f',
-  sourceTextColor: '#9aa0a6',
-  translationTextColor: '#e8e8e8',
+  bgColor: CONVERSATION_DISPLAY_DEFAULT_BG_COLOR,
+  sourceTextColor: CONVERSATION_DISPLAY_DEFAULT_SOURCE_TEXT_COLOR,
+  translationTextColor: CONVERSATION_DISPLAY_DEFAULT_TRANSLATION_TEXT_COLOR,
 };
 
 export const CONVERSATION_FONT_SIZE_MIN = 12;

--- a/src/stores/conversationDisplayStore.ts
+++ b/src/stores/conversationDisplayStore.ts
@@ -1,0 +1,137 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+import { useShallow } from 'zustand/shallow';
+import { ServiceFactory } from '../services/ServiceFactory';
+
+interface ConversationDisplayState {
+  // Typography
+  fontSize: number;            // clamped [CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX]
+  compactMode: boolean;
+  // Colors (hex)
+  bgColor: string;
+  sourceTextColor: string;
+  translationTextColor: string;
+
+  // Actions (async because persistence is async — matches subtitleStore)
+  setFontSize: (n: number) => Promise<void>;
+  setCompactMode: (b: boolean) => Promise<void>;
+  setBgColor: (s: string) => Promise<void>;
+  setSourceTextColor: (s: string) => Promise<void>;
+  setTranslationTextColor: (s: string) => Promise<void>;
+
+  // Hydration (called once at app boot from src/routes/Home.tsx)
+  hydrate: () => Promise<void>;
+}
+
+const DEFAULTS = {
+  fontSize: 14,
+  compactMode: false,
+  bgColor: '#1f1f1f',
+  sourceTextColor: '#9aa0a6',
+  translationTextColor: '#e8e8e8',
+};
+
+export const CONVERSATION_FONT_SIZE_MIN = 12;
+export const CONVERSATION_FONT_SIZE_MAX = 64;
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, n));
+}
+
+const KEY = (suffix: string) => `settings.common.conversationDisplay.${suffix}`;
+
+async function persist(
+  keySuffix: string,
+  value: unknown,
+  fieldNameForLog: string,
+): Promise<{ ok: boolean }> {
+  try {
+    await ServiceFactory.getSettingsService().setSetting(KEY(keySuffix), value);
+    return { ok: true };
+  } catch (error) {
+    console.error(`[ConversationDisplayStore] Error persisting ${fieldNameForLog}:`, error);
+    return { ok: false };
+  }
+}
+
+export const useConversationDisplayStore = create<ConversationDisplayState>()(
+  subscribeWithSelector((set, get) => ({
+    ...DEFAULTS,
+
+    setFontSize: async (n) => {
+      const clamped = clamp(Math.round(n), CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX);
+      const previous = get().fontSize;
+      set({ fontSize: clamped });
+      const { ok } = await persist('fontSize', clamped, 'fontSize');
+      if (!ok) set({ fontSize: previous });
+    },
+    setCompactMode: async (b) => {
+      const previous = get().compactMode;
+      set({ compactMode: b });
+      const { ok } = await persist('compactMode', b, 'compactMode');
+      if (!ok) set({ compactMode: previous });
+    },
+    setBgColor: async (s) => {
+      const previous = get().bgColor;
+      set({ bgColor: s });
+      const { ok } = await persist('bgColor', s, 'bgColor');
+      if (!ok) set({ bgColor: previous });
+    },
+    setSourceTextColor: async (s) => {
+      const previous = get().sourceTextColor;
+      set({ sourceTextColor: s });
+      const { ok } = await persist('sourceTextColor', s, 'sourceTextColor');
+      if (!ok) set({ sourceTextColor: previous });
+    },
+    setTranslationTextColor: async (s) => {
+      const previous = get().translationTextColor;
+      set({ translationTextColor: s });
+      const { ok } = await persist('translationTextColor', s, 'translationTextColor');
+      if (!ok) set({ translationTextColor: previous });
+    },
+
+    hydrate: async () => {
+      const svc = ServiceFactory.getSettingsService();
+      const [fontSize, compactMode, bgColor, sourceTextColor, translationTextColor] =
+        await Promise.all([
+          svc.getSetting(KEY('fontSize'), DEFAULTS.fontSize),
+          svc.getSetting(KEY('compactMode'), DEFAULTS.compactMode),
+          svc.getSetting(KEY('bgColor'), DEFAULTS.bgColor),
+          svc.getSetting(KEY('sourceTextColor'), DEFAULTS.sourceTextColor),
+          svc.getSetting(KEY('translationTextColor'), DEFAULTS.translationTextColor),
+        ]);
+      set({
+        fontSize: clamp(Math.round(fontSize), CONVERSATION_FONT_SIZE_MIN, CONVERSATION_FONT_SIZE_MAX),
+        compactMode,
+        bgColor,
+        sourceTextColor,
+        translationTextColor,
+      });
+    },
+  })),
+);
+
+// ──────────── Selector hooks ────────────
+export const useConversationDisplayFontSize = () => useConversationDisplayStore((s) => s.fontSize);
+export const useConversationDisplayCompactMode = () => useConversationDisplayStore((s) => s.compactMode);
+export const useConversationDisplayBgColor = () => useConversationDisplayStore((s) => s.bgColor);
+export const useConversationDisplaySourceTextColor = () => useConversationDisplayStore((s) => s.sourceTextColor);
+export const useConversationDisplayTranslationTextColor = () => useConversationDisplayStore((s) => s.translationTextColor);
+
+export const useConversationDisplaySettings = () =>
+  useConversationDisplayStore(
+    useShallow((s) => ({
+      fontSize: s.fontSize,
+      compactMode: s.compactMode,
+      bgColor: s.bgColor,
+      sourceTextColor: s.sourceTextColor,
+      translationTextColor: s.translationTextColor,
+    })),
+  );
+
+// ──────────── Action hooks ────────────
+export const useSetConversationDisplayFontSize = () => useConversationDisplayStore((s) => s.setFontSize);
+export const useSetConversationDisplayCompactMode = () => useConversationDisplayStore((s) => s.setCompactMode);
+export const useSetConversationDisplayBgColor = () => useConversationDisplayStore((s) => s.setBgColor);
+export const useSetConversationDisplaySourceTextColor = () => useConversationDisplayStore((s) => s.setSourceTextColor);
+export const useSetConversationDisplayTranslationTextColor = () => useConversationDisplayStore((s) => s.setTranslationTextColor);

--- a/src/stores/conversationDisplayStore.ts
+++ b/src/stores/conversationDisplayStore.ts
@@ -1,6 +1,5 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
-import { useShallow } from 'zustand/shallow';
 import { ServiceFactory } from '../services/ServiceFactory';
 
 interface ConversationDisplayState {
@@ -117,17 +116,6 @@ export const useConversationDisplayCompactMode = () => useConversationDisplaySto
 export const useConversationDisplayBgColor = () => useConversationDisplayStore((s) => s.bgColor);
 export const useConversationDisplaySourceTextColor = () => useConversationDisplayStore((s) => s.sourceTextColor);
 export const useConversationDisplayTranslationTextColor = () => useConversationDisplayStore((s) => s.translationTextColor);
-
-export const useConversationDisplaySettings = () =>
-  useConversationDisplayStore(
-    useShallow((s) => ({
-      fontSize: s.fontSize,
-      compactMode: s.compactMode,
-      bgColor: s.bgColor,
-      sourceTextColor: s.sourceTextColor,
-      translationTextColor: s.translationTextColor,
-    })),
-  );
 
 // ──────────── Action hooks ────────────
 export const useSetConversationDisplayFontSize = () => useConversationDisplayStore((s) => s.setFontSize);

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -327,11 +327,19 @@ describe('settingsStore', () => {
       expect(useSettingsStore.getState().conversationFontSize).toBe(
         CONVERSATION_FONT_SIZE_MIN,
       );
+      expect(mockSetSetting).toHaveBeenCalledWith(
+        'settings.common.conversationFontSize',
+        CONVERSATION_FONT_SIZE_MIN,
+      );
     });
 
     it('clamps values above MAX', async () => {
       await useSettingsStore.getState().setConversationFontSize(200);
       expect(useSettingsStore.getState().conversationFontSize).toBe(
+        CONVERSATION_FONT_SIZE_MAX,
+      );
+      expect(mockSetSetting).toHaveBeenCalledWith(
+        'settings.common.conversationFontSize',
         CONVERSATION_FONT_SIZE_MAX,
       );
     });

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -27,8 +27,6 @@ vi.mock('../lib/local-inference/modelManifest', async () => {
 // Import after mocking
 const {
   default: useSettingsStore,
-  CONVERSATION_FONT_SIZE_MIN,
-  CONVERSATION_FONT_SIZE_MAX,
 } = await import('./settingsStore');
 
 describe('settingsStore', () => {
@@ -316,39 +314,6 @@ describe('settingsStore', () => {
     });
   });
 
-  describe('conversationFontSize clamping', () => {
-    it('exports MIN=12 and MAX=64 constants', () => {
-      expect(CONVERSATION_FONT_SIZE_MIN).toBe(12);
-      expect(CONVERSATION_FONT_SIZE_MAX).toBe(64);
-    });
-
-    it('clamps values below MIN', async () => {
-      await useSettingsStore.getState().setConversationFontSize(5);
-      expect(useSettingsStore.getState().conversationFontSize).toBe(
-        CONVERSATION_FONT_SIZE_MIN,
-      );
-      expect(mockSetSetting).toHaveBeenCalledWith(
-        'settings.common.conversationFontSize',
-        CONVERSATION_FONT_SIZE_MIN,
-      );
-    });
-
-    it('clamps values above MAX', async () => {
-      await useSettingsStore.getState().setConversationFontSize(200);
-      expect(useSettingsStore.getState().conversationFontSize).toBe(
-        CONVERSATION_FONT_SIZE_MAX,
-      );
-      expect(mockSetSetting).toHaveBeenCalledWith(
-        'settings.common.conversationFontSize',
-        CONVERSATION_FONT_SIZE_MAX,
-      );
-    });
-
-    it('passes through in-range values', async () => {
-      await useSettingsStore.getState().setConversationFontSize(20);
-      expect(useSettingsStore.getState().conversationFontSize).toBe(20);
-    });
-  });
 });
 
 describe('createParticipantLocalInferenceConfig', () => {

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -25,7 +25,11 @@ vi.mock('../lib/local-inference/modelManifest', async () => {
 });
 
 // Import after mocking
-const { default: useSettingsStore } = await import('./settingsStore');
+const {
+  default: useSettingsStore,
+  CONVERSATION_FONT_SIZE_MIN,
+  CONVERSATION_FONT_SIZE_MAX,
+} = await import('./settingsStore');
 
 describe('settingsStore', () => {
   beforeEach(() => {
@@ -309,6 +313,32 @@ describe('settingsStore', () => {
       });
       await store.updateKizunaAI({ transportType: 'webrtc' });
       expect(useSettingsStore.getState().kizunaai.turnDetectionMode).toBe('Disabled');
+    });
+  });
+
+  describe('conversationFontSize clamping', () => {
+    it('exports MIN=12 and MAX=64 constants', () => {
+      expect(CONVERSATION_FONT_SIZE_MIN).toBe(12);
+      expect(CONVERSATION_FONT_SIZE_MAX).toBe(64);
+    });
+
+    it('clamps values below MIN', async () => {
+      await useSettingsStore.getState().setConversationFontSize(5);
+      expect(useSettingsStore.getState().conversationFontSize).toBe(
+        CONVERSATION_FONT_SIZE_MIN,
+      );
+    });
+
+    it('clamps values above MAX', async () => {
+      await useSettingsStore.getState().setConversationFontSize(200);
+      expect(useSettingsStore.getState().conversationFontSize).toBe(
+        CONVERSATION_FONT_SIZE_MAX,
+      );
+    });
+
+    it('passes through in-range values', async () => {
+      await useSettingsStore.getState().setConversationFontSize(20);
+      expect(useSettingsStore.getState().conversationFontSize).toBe(20);
     });
   });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -182,6 +182,17 @@ interface CacheEntry {
   timestamp: number;
 }
 
+// ==================== Font Size Constants ====================
+
+export const CONVERSATION_FONT_SIZE_MIN = 12;
+export const CONVERSATION_FONT_SIZE_MAX = 64;
+
+const clampConversationFontSize = (n: number): number =>
+  Math.max(
+    CONVERSATION_FONT_SIZE_MIN,
+    Math.min(CONVERSATION_FONT_SIZE_MAX, Math.round(n)),
+  );
+
 // ==================== Default Values ====================
 
 const defaultCommonSettings: CommonSettings = {
@@ -899,11 +910,12 @@ const useSettingsStore = create<SettingsStore>()(
     },
 
     setConversationFontSize: async (conversationFontSize) => {
+      const clamped = clampConversationFontSize(conversationFontSize);
       const previous = get().conversationFontSize;
-      set({conversationFontSize});
+      set({conversationFontSize: clamped});
       try {
         const service = ServiceFactory.getSettingsService();
-        await service.setSetting('settings.common.conversationFontSize', conversationFontSize);
+        await service.setSetting('settings.common.conversationFontSize', clamped);
       } catch (error) {
         console.error('[SettingsStore] Error persisting conversationFontSize setting:', error);
         set({conversationFontSize: previous});
@@ -1457,7 +1469,8 @@ const useSettingsStore = create<SettingsStore>()(
         const useTemplateMode = await service.getSetting('settings.common.useTemplateMode', defaultCommonSettings.useTemplateMode);
         const participantSystemInstructions = await service.getSetting('settings.common.participantSystemInstructions', defaultCommonSettings.participantSystemInstructions);
         const textOnly = await service.getSetting('settings.common.textOnly', defaultCommonSettings.textOnly);
-        const conversationFontSize = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
+        const conversationFontSizeRaw = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
+        const conversationFontSize = clampConversationFontSize(conversationFontSizeRaw);
         const conversationCompactMode = await service.getSetting('settings.common.conversationCompactMode', defaultCommonSettings.conversationCompactMode);
         const speakerDisplayMode = await service.getSetting<DisplayMode>('settings.common.speakerDisplayMode', defaultCommonSettings.speakerDisplayMode);
         const participantDisplayMode = await service.getSetting<DisplayMode>('settings.common.participantDisplayMode', defaultCommonSettings.participantDisplayMode);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -40,8 +40,6 @@ export interface CommonSettings {
   useTemplateMode: boolean;
   participantSystemInstructions: string;
   textOnly: boolean;
-  conversationFontSize: number;
-  conversationCompactMode: boolean;
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
 }
@@ -182,17 +180,6 @@ interface CacheEntry {
   timestamp: number;
 }
 
-// ==================== Font Size Constants ====================
-
-export const CONVERSATION_FONT_SIZE_MIN = 12;
-export const CONVERSATION_FONT_SIZE_MAX = 64;
-
-const clampConversationFontSize = (n: number): number =>
-  Math.max(
-    CONVERSATION_FONT_SIZE_MIN,
-    Math.min(CONVERSATION_FONT_SIZE_MAX, Math.round(n)),
-  );
-
 // ==================== Default Values ====================
 
 const defaultCommonSettings: CommonSettings = {
@@ -200,8 +187,6 @@ const defaultCommonSettings: CommonSettings = {
   uiLanguage: 'en',
   uiMode: 'basic',
   textOnly: false,
-  conversationFontSize: 14,
-  conversationCompactMode: false,
   systemInstructions:
     "# ROLE & OBJECTIVE\n" +
     "You are a simultaneous interpreter.\n" +
@@ -414,12 +399,6 @@ interface SettingsStore {
   // Text-only mode (no audio output)
   textOnly: boolean;
 
-  // Conversation font size
-  conversationFontSize: number;
-
-  // Conversation compact mode — hide chat chrome (avatars, names, timestamps, badges, play button) in the conversation panel
-  conversationCompactMode: boolean;
-
   // Conversation display mode filters
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
@@ -433,8 +412,6 @@ interface SettingsStore {
   setUILanguage: (lang: string) => void;
   setUIMode: (mode: 'basic' | 'advanced') => void;
   setTextOnly: (textOnly: boolean) => void;
-  setConversationFontSize: (size: number) => void;
-  setConversationCompactMode: (compact: boolean) => Promise<void>;
   setSpeakerDisplayMode: (mode: DisplayMode) => Promise<void>;
   setParticipantDisplayMode: (mode: DisplayMode) => Promise<void>;
   enterSubtitleMode: () => Promise<void>;
@@ -906,31 +883,6 @@ const useSettingsStore = create<SettingsStore>()(
       } catch (error) {
         console.error('[SettingsStore] Error persisting textOnly setting:', error);
         set({textOnly: previous});
-      }
-    },
-
-    setConversationFontSize: async (conversationFontSize) => {
-      const clamped = clampConversationFontSize(conversationFontSize);
-      const previous = get().conversationFontSize;
-      set({conversationFontSize: clamped});
-      try {
-        const service = ServiceFactory.getSettingsService();
-        await service.setSetting('settings.common.conversationFontSize', clamped);
-      } catch (error) {
-        console.error('[SettingsStore] Error persisting conversationFontSize setting:', error);
-        set({conversationFontSize: previous});
-      }
-    },
-
-    setConversationCompactMode: async (conversationCompactMode) => {
-      const previous = get().conversationCompactMode;
-      set({conversationCompactMode});
-      try {
-        const service = ServiceFactory.getSettingsService();
-        await service.setSetting('settings.common.conversationCompactMode', conversationCompactMode);
-      } catch (error) {
-        console.error('[SettingsStore] Error persisting conversationCompactMode setting:', error);
-        set({conversationCompactMode: previous});
       }
     },
 
@@ -1469,9 +1421,6 @@ const useSettingsStore = create<SettingsStore>()(
         const useTemplateMode = await service.getSetting('settings.common.useTemplateMode', defaultCommonSettings.useTemplateMode);
         const participantSystemInstructions = await service.getSetting('settings.common.participantSystemInstructions', defaultCommonSettings.participantSystemInstructions);
         const textOnly = await service.getSetting('settings.common.textOnly', defaultCommonSettings.textOnly);
-        const conversationFontSizeRaw = await service.getSetting('settings.common.conversationFontSize', defaultCommonSettings.conversationFontSize);
-        const conversationFontSize = clampConversationFontSize(conversationFontSizeRaw);
-        const conversationCompactMode = await service.getSetting('settings.common.conversationCompactMode', defaultCommonSettings.conversationCompactMode);
         const speakerDisplayMode = await service.getSetting<DisplayMode>('settings.common.speakerDisplayMode', defaultCommonSettings.speakerDisplayMode);
         const participantDisplayMode = await service.getSetting<DisplayMode>('settings.common.participantDisplayMode', defaultCommonSettings.participantDisplayMode);
         // Subtitle settings now hydrated by subtitleStore.hydrate(); see stores/subtitleStore.ts.
@@ -1509,8 +1458,6 @@ const useSettingsStore = create<SettingsStore>()(
           useTemplateMode,
           participantSystemInstructions,
           textOnly,
-          conversationFontSize,
-          conversationCompactMode,
           speakerDisplayMode,
           participantDisplayMode,
           openai,
@@ -1673,8 +1620,6 @@ const useSettingsStore = create<SettingsStore>()(
 export const useProvider = () => useSettingsStore((state) => state.provider);
 export const useUILanguage = () => useSettingsStore((state) => state.uiLanguage);
 export const useUIMode = () => useSettingsStore((state) => state.uiMode);
-export const useConversationFontSize = () => useSettingsStore((state) => state.conversationFontSize);
-export const useConversationCompactMode = () => useSettingsStore((state) => state.conversationCompactMode);
 export const useSpeakerDisplayMode = () => useSettingsStore((state) => state.speakerDisplayMode);
 export const useParticipantDisplayMode = () => useSettingsStore((state) => state.participantDisplayMode);
 export const useSubtitleModeActive = () => useSettingsStore((state) => state.subtitleModeActive);
@@ -1727,8 +1672,6 @@ export const useSetProvider = () => useSettingsStore((state) => state.setProvide
 export const useSetUILanguage = () => useSettingsStore((state) => state.setUILanguage);
 export const useSetUIMode = () => useSettingsStore((state) => state.setUIMode);
 export const useSetTextOnly = () => useSettingsStore((state) => state.setTextOnly);
-export const useSetConversationFontSize = () => useSettingsStore((state) => state.setConversationFontSize);
-export const useSetConversationCompactMode = () => useSettingsStore((state) => state.setConversationCompactMode);
 export const useSetSpeakerDisplayMode = () => useSettingsStore((state) => state.setSpeakerDisplayMode);
 export const useSetParticipantDisplayMode = () => useSettingsStore((state) => state.setParticipantDisplayMode);
 export const useSetSystemInstructions = () => useSettingsStore((state) => state.setSystemInstructions);

--- a/src/stores/subtitleStore.test.ts
+++ b/src/stores/subtitleStore.test.ts
@@ -28,11 +28,11 @@ describe('subtitleStore', () => {
     });
   });
 
-  it('clamps fontSize to [12, 48]', async () => {
+  it('clamps fontSize to [12, 64]', async () => {
     await useSubtitleStore.getState().setFontSize(8);
     expect(useSubtitleStore.getState().fontSize).toBe(12);
     await useSubtitleStore.getState().setFontSize(99);
-    expect(useSubtitleStore.getState().fontSize).toBe(48);
+    expect(useSubtitleStore.getState().fontSize).toBe(64);
     await useSubtitleStore.getState().setFontSize(28);
     expect(useSubtitleStore.getState().fontSize).toBe(28);
   });

--- a/src/stores/subtitleStore.ts
+++ b/src/stores/subtitleStore.ts
@@ -62,7 +62,7 @@ const DEFAULTS = {
 };
 
 export const FONT_SIZE_MIN = 12;
-export const FONT_SIZE_MAX = 48;
+export const FONT_SIZE_MAX = 64;
 const BG_OPACITY_MIN = 0;
 const BG_OPACITY_MAX = 100;
 

--- a/src/stores/subtitleStore.ts
+++ b/src/stores/subtitleStore.ts
@@ -47,13 +47,18 @@ interface SubtitleState {
   hydrate: () => Promise<void>;
 }
 
+// ──────────── Default colors (exported for popover preset wiring) ────────────
+export const SUBTITLE_DEFAULT_BG_COLOR = '#000000';
+export const SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR = '#ffffff';
+export const SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR = '#9ad0ff';
+
 const DEFAULTS = {
   fontSize: 24,
   compactMode: false,
   bgOpacity: 80,
-  bgColor: '#000000',
-  sourceTextColor: '#ffffff',
-  translationTextColor: '#9ad0ff',
+  bgColor: SUBTITLE_DEFAULT_BG_COLOR,
+  sourceTextColor: SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR,
+  translationTextColor: SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR,
   alwaysOnTop: false,
   positionLocked: false,
   windowBounds: null as SubtitleWindowBounds | null,


### PR DESCRIPTION
Closes #231.

## Summary

- Subtitle window and conversation panel each get **independent color settings** — changing one no longer affects the other.
- New ⚙ entry point on the conversation toolbar (mirrors the existing one on the subtitle bar). Both open the same `<DisplaySettingsPopover>` component, switched by a `source: 'subtitle' | 'conversation'` prop via two thin store-binding wrappers (rules-of-hooks compliant).
- Three new dark presets per text row (source: `#000000`, `#003B6F`, `#1B5E20`; translation: `#000000`, `#003B6F`, `#7B1FA2`) so users projecting on a white background can finally configure black-on-white.
- A "+" custom-color chip on every row opens the OS color picker, debounced 150 ms.
- First chip in each row is now the **active store's default color** (subtitle: `#000000` / `#ffffff` / `#9ad0ff`; conversation: `#1f1f1f` / `#9aa0a6` / `#e8e8e8`), exported from each store as named constants.
- Conversation display fields (`fontSize`, `compactMode`, plus the new colors) extracted from `settingsStore` into a dedicated `conversationDisplayStore`, mirroring the v0.26 `subtitleStore` extraction.
- New `--conversation-*` CSS variables for MainPanel; subtitle surface continues to use `--subtitle-*`.

## Architecture & decisions

Spec: `docs/superpowers/specs/2026-05-14-more-color-options-design.md`
Plan: `docs/superpowers/plans/2026-05-14-more-color-options.md`

Key non-goals (deliberately deferred): named theme presets, saved custom themes, per-side colors, app-wide light chrome, font-size changes (#230 territory).

Compatibility: no migration for the old `settings.common.conversationFontSize` / `...conversationCompactMode` keys; old persisted values are abandoned and users see one-time defaults reset (re-tap font-size buttons once). Subtitle store and persistence keys are completely unchanged.

## Heads-up about the diff

This PR's diff visibly includes 9 commits from issue #230 (font-size cap → 64 px) at the bottom, because **origin/main is also behind those commits** at the time of this push. They're not part of this PR's logical scope — they're shown only because GitHub diffs against the lagging `origin/main`. Once #230 lands on `main`, this PR's diff will narrow to just the issue #231 changes.

## Test plan

- [x] All 311 worktree tests pass; on merged main 924 tests pass
- [x] `npm run build` succeeds
- [x] Sanity greps confirm clean migration: no `SubtitleSettingsPopover` references, no `useConversationFontSize` from `settingsStore`, no `--subtitle-*` CSS vars in MainPanel scope
- [ ] Manual: subtitle popover updates only the subtitle window
- [ ] Manual: conversation toolbar's ⚙ popover updates only the conversation panel
- [ ] Manual: "+" chip opens OS color picker on Linux/macOS/Windows
- [ ] Manual: extension overlay popover works inside the in-tab iframe
- [ ] Manual: white background + dark source/translation text combination is now configurable end-to-end
- [ ] Manual: playing-row indicator (translucent overlay derived from translation color) is subtle, not a hard ring

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Increased conversation and subtitle font-size limits to 64px
  * Independent color customization for subtitle and conversation panels with presets and a custom color picker
  * Added a display settings (gear) button to the conversation toolbar to open the popover

* **Refactor**
  * Unified subtitle and conversation display UI into a shared popover component
  * Moved conversation display preferences into a dedicated store and removed them from common settings

* **Tests**
  * Added tests for the display popover and conversation display store clamping/persistence

* **Documentation**
  * Added design specs and implementation plans for font-size caps and color options

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/234)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->