### PR TITLE
feat(volcengine-ast2): Chinese↔English bidirectional mode (closes #229)

### DIFF
--- a/docs/superpowers/plans/2026-05-14-volcengine-ast2-bidirectional-mode.md
+++ b/docs/superpowers/plans/2026-05-14-volcengine-ast2-bidirectional-mode.md
@@ -1,0 +1,644 @@
+# Volcengine AST 2.0 — Chinese↔English Bidirectional Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Doubao AST 2.0's Chinese↔English bidirectional mode (`source_language = target_language = 'zhen'`) reachable through the existing source/target dropdowns. Picking the bidirectional entry on either side atomically syncs the other side to `'zhen'`, so the settings never sit in a server-invalid `zhen/<other>` state.
+
+**Architecture:** A pure-function helper `resolveAST2LanguagePair(current, change)` encodes the four sync rules from the design spec. Both Simple-mode (`LanguageSection.tsx`) and Advanced-mode (`ProviderSpecificSettings.tsx`) call this helper and then write both fields in a single `updateVolcengineAST2Settings(...)` Zustand action. `VolcengineAST2ProviderConfig.getTargetLanguages()` is widened to include `'zhen'` so it becomes selectable on the target side. The swap button's disabled condition is extended so it can't fire on `zhen/zhen`.
+
+**Tech Stack:** TypeScript, React, Zustand (`subscribeWithSelector`), Vitest, i18next.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md` (commit `60a0542f`).
+
+**Tracking issue:** [#229](https://github.com/kizuna-ai-lab/sokuji/issues/229)
+
+---
+
+## Task ordering rationale
+
+1. **Phase A** (Task 1): Provider-config change exposes `'zhen'` on the target list. Pure data — no behavior change in call sites yet (they still write one field at a time, but that field can now be `'zhen'`, so the bug from the issue is reproducible).
+2. **Phase B** (Task 2): Build the sync helper with TDD — all 7 rule cases from the spec become Vitest tests; the helper is implemented to make them green.
+3. **Phase C** (Tasks 3–4): Wire the helper into Simple-mode UI and extend the swap-button disabled condition.
+4. **Phase D** (Task 5): Wire the helper into Advanced-mode UI.
+5. **Phase E** (Tasks 6–7): Typecheck/full test pass + manual smoke runbook.
+
+After Phase B the helper exists but isn't used yet — full `tsc` still passes. After Phases C–D the feature is functionally complete. Phase E verifies.
+
+---
+
+## Phase A: Provider config exposes `'zhen'` on target side
+
+### Task 1: `VolcengineAST2ProviderConfig.getTargetLanguages` returns `BIDIRECTIONAL_LANGUAGES`
+
+**Files:**
+- Modify: `src/services/providers/VolcengineAST2ProviderConfig.ts:33-35`
+
+- [ ] **Step 1: Edit `getTargetLanguages()`**
+
+In `src/services/providers/VolcengineAST2ProviderConfig.ts`, replace lines 33–35:
+
+```ts
+  static getTargetLanguages(): LanguageOption[] {
+    return VolcengineAST2ProviderConfig.LANGUAGES;
+  }
+```
+
+with:
+
+```ts
+  static getTargetLanguages(): LanguageOption[] {
+    return VolcengineAST2ProviderConfig.BIDIRECTIONAL_LANGUAGES;
+  }
+```
+
+No other line in the file changes. `BIDIRECTIONAL_LANGUAGES` at line 17 already contains the 8 single-language entries plus `{ name: '中英双语 (zh↔en)', value: 'zhen', englishName: 'Chinese-English Bidirectional' }`.
+
+- [ ] **Step 2: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — `BIDIRECTIONAL_LANGUAGES` already exists and has the same `LanguageOption[]` type as `LANGUAGES`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/services/providers/VolcengineAST2ProviderConfig.ts
+git commit -m "feat(volcengine-ast2): expose 'zhen' on target-language list"
+```
+
+---
+
+## Phase B: Build the language-sync helper (TDD)
+
+### Task 2: TDD `resolveAST2LanguagePair` helper
+
+The helper is a pure function. It lives next to the provider config it's enforcing rules for, so both UI call sites can import it without pulling React. Test file is colocated per project convention (e.g. `VolcengineAST2Client.test.ts` lives next to `VolcengineAST2Client.ts`).
+
+**Files:**
+- Create: `src/services/providers/volcengineAST2LanguageSync.ts`
+- Create: `src/services/providers/volcengineAST2LanguageSync.test.ts`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `src/services/providers/volcengineAST2LanguageSync.test.ts` with this exact content:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { resolveAST2LanguagePair } from './volcengineAST2LanguageSync';
+
+describe('resolveAST2LanguagePair', () => {
+  // R1: picking 'zhen' on source atomically syncs target to 'zhen'.
+  it('R1: zh/en → source=zhen ⇒ zhen/zhen', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'source', value: 'zhen' },
+      ),
+    ).toEqual({ sourceLanguage: 'zhen', targetLanguage: 'zhen' });
+  });
+
+  it("R1': ja/zh → source=zhen ⇒ zhen/zhen", () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'ja', targetLanguage: 'zh' },
+        { side: 'source', value: 'zhen' },
+      ),
+    ).toEqual({ sourceLanguage: 'zhen', targetLanguage: 'zhen' });
+  });
+
+  // R2: picking 'zhen' on target atomically syncs source to 'zhen'.
+  it('R2: zh/en → target=zhen ⇒ zhen/zhen', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'target', value: 'zhen' },
+      ),
+    ).toEqual({ sourceLanguage: 'zhen', targetLanguage: 'zhen' });
+  });
+
+  // R3: leaving 'zhen' on the source resets target to the provider default 'en'.
+  it('R3: zhen/zhen → source=ja ⇒ ja/en', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'source', value: 'ja' },
+      ),
+    ).toEqual({ sourceLanguage: 'ja', targetLanguage: 'en' });
+  });
+
+  // R3 degenerate same-language case — helper does not block; server will reject.
+  it('R3 same-lang: zhen/zhen → source=en ⇒ en/en', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'source', value: 'en' },
+      ),
+    ).toEqual({ sourceLanguage: 'en', targetLanguage: 'en' });
+  });
+
+  // R4: leaving 'zhen' on the target resets source to the provider default 'zh'.
+  it('R4: zhen/zhen → target=fr ⇒ zh/fr', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'target', value: 'fr' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'fr' });
+  });
+
+  // R4 degenerate same-language case.
+  it('R4 same-lang: zhen/zhen → target=zh ⇒ zh/zh', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'target', value: 'zh' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'zh' });
+  });
+
+  // Normal (non-bidirectional → non-bidirectional) update: passes through
+  // without touching the other side. Not in the spec's rule table, but the
+  // helper must support being called for every change to be useful as the
+  // single VOLCENGINE_AST2 update path in the UI.
+  it('passthrough: zh/en → source=ja ⇒ ja/en (target unchanged)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'source', value: 'ja' },
+      ),
+    ).toEqual({ sourceLanguage: 'ja', targetLanguage: 'en' });
+  });
+
+  it('passthrough: zh/en → target=fr ⇒ zh/fr (source unchanged)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'target', value: 'fr' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'fr' });
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails (no module)**
+
+Run: `npx vitest run src/services/providers/volcengineAST2LanguageSync.test.ts`
+Expected: FAIL with a module-not-found error (`Cannot find module './volcengineAST2LanguageSync'` or similar from the import statement). The exact failure mode is "no source file yet", which is the correct red.
+
+- [ ] **Step 3: Implement the helper**
+
+Create `src/services/providers/volcengineAST2LanguageSync.ts` with this exact content:
+
+```ts
+/**
+ * Synchronisation rules for the Volcengine AST 2.0 provider's source/target
+ * language pair. The server requires both fields to be 'zhen' for Chinese↔English
+ * bidirectional mode (and rejects any mixed combination involving 'zhen'). This
+ * helper enforces that constraint as a pure transformation so call sites can
+ * write both fields in a single Zustand update.
+ *
+ * Rules (from docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md §2):
+ *   R1: picks 'zhen' on source → both become 'zhen'
+ *   R2: picks 'zhen' on target → both become 'zhen'
+ *   R3: leaves 'zhen' on source (current state was zhen/zhen) → target resets to 'en'
+ *   R4: leaves 'zhen' on target (current state was zhen/zhen) → source resets to 'zh'
+ *   passthrough: any other change updates only the side the user touched
+ */
+export interface AST2LanguagePair {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+export interface AST2LanguageChange {
+  side: 'source' | 'target';
+  value: string;
+}
+
+const ZHEN = 'zhen';
+const DEFAULT_SOURCE = 'zh';
+const DEFAULT_TARGET = 'en';
+
+export function resolveAST2LanguagePair(
+  current: AST2LanguagePair,
+  change: AST2LanguageChange,
+): AST2LanguagePair {
+  // R1 / R2: picking 'zhen' on either side forces both to 'zhen'.
+  if (change.value === ZHEN) {
+    return { sourceLanguage: ZHEN, targetLanguage: ZHEN };
+  }
+
+  // R3 / R4: leaving 'zhen' on one side while the other was also 'zhen' means
+  // we must reset the other side to its provider default to avoid a transient
+  // 'zhen / <other>' state that the server rejects.
+  if (change.side === 'source' && current.sourceLanguage === ZHEN && current.targetLanguage === ZHEN) {
+    return { sourceLanguage: change.value, targetLanguage: DEFAULT_TARGET };
+  }
+  if (change.side === 'target' && current.sourceLanguage === ZHEN && current.targetLanguage === ZHEN) {
+    return { sourceLanguage: DEFAULT_SOURCE, targetLanguage: change.value };
+  }
+
+  // Passthrough: ordinary source/target edit, no cross-side effect.
+  if (change.side === 'source') {
+    return { sourceLanguage: change.value, targetLanguage: current.targetLanguage };
+  }
+  return { sourceLanguage: current.sourceLanguage, targetLanguage: change.value };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/services/providers/volcengineAST2LanguageSync.test.ts`
+Expected: PASS — all 9 tests green (7 spec cases + 2 passthrough cases).
+
+- [ ] **Step 5: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS — pure TS with no React imports.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/services/providers/volcengineAST2LanguageSync.ts src/services/providers/volcengineAST2LanguageSync.test.ts
+git commit -m "feat(volcengine-ast2): add resolveAST2LanguagePair sync helper"
+```
+
+---
+
+## Phase C: Wire helper into Simple-mode UI
+
+### Task 3: Replace `Provider.VOLCENGINE_AST2` branches in `LanguageSection.tsx`
+
+The current `updateSourceLanguage` and `updateTargetLanguage` call `updateVolcengineAST2Settings({ sourceLanguage: value })` (or `{ targetLanguage: value }`) — one field at a time. We replace each with a call that runs the helper, writes both fields in one update, and emits a second `language_changed` analytics event when the other side also changed (per spec §5).
+
+**Files:**
+- Modify: `src/components/Settings/sections/LanguageSection.tsx:156-158`
+- Modify: `src/components/Settings/sections/LanguageSection.tsx:200-202`
+- Modify: `src/components/Settings/sections/LanguageSection.tsx` (top, add import)
+
+- [ ] **Step 1: Add the helper import**
+
+In `src/components/Settings/sections/LanguageSection.tsx`, find the existing provider import block. Add a new import right under the line that imports from `'../../../services/providers/ProviderConfig'`:
+
+```ts
+import { resolveAST2LanguagePair } from '../../../services/providers/volcengineAST2LanguageSync';
+```
+
+- [ ] **Step 2: Replace the source-side `VOLCENGINE_AST2` branch**
+
+Find lines 156–158 in `src/components/Settings/sections/LanguageSection.tsx`:
+
+```ts
+      case Provider.VOLCENGINE_AST2:
+        updateVolcengineAST2Settings({ sourceLanguage: value });
+        break;
+```
+
+Replace with:
+
+```ts
+      case Provider.VOLCENGINE_AST2: {
+        const prev = volcengineAST2Settings;
+        const next = resolveAST2LanguagePair(
+          { sourceLanguage: prev.sourceLanguage, targetLanguage: prev.targetLanguage },
+          { side: 'source', value },
+        );
+        updateVolcengineAST2Settings({
+          sourceLanguage: next.sourceLanguage,
+          targetLanguage: next.targetLanguage,
+        });
+        // Spec §5: when bidirectional sync also changes the other side, emit a
+        // second analytics event so consumers see both transitions. The trailing
+        // `trackEvent` below this switch still emits the source-side event.
+        if (next.targetLanguage !== prev.targetLanguage) {
+          trackEvent('language_changed', {
+            to_language: next.targetLanguage,
+            language_type: 'target',
+          });
+        }
+        break;
+      }
+```
+
+- [ ] **Step 3: Replace the target-side `VOLCENGINE_AST2` branch**
+
+Find lines 200–202 in `src/components/Settings/sections/LanguageSection.tsx`:
+
+```ts
+      case Provider.VOLCENGINE_AST2:
+        updateVolcengineAST2Settings({ targetLanguage: value });
+        break;
+```
+
+Replace with:
+
+```ts
+      case Provider.VOLCENGINE_AST2: {
+        const prev = volcengineAST2Settings;
+        const next = resolveAST2LanguagePair(
+          { sourceLanguage: prev.sourceLanguage, targetLanguage: prev.targetLanguage },
+          { side: 'target', value },
+        );
+        updateVolcengineAST2Settings({
+          sourceLanguage: next.sourceLanguage,
+          targetLanguage: next.targetLanguage,
+        });
+        if (next.sourceLanguage !== prev.sourceLanguage) {
+          trackEvent('language_changed', {
+            to_language: next.sourceLanguage,
+            language_type: 'source',
+          });
+        }
+        break;
+      }
+```
+
+- [ ] **Step 4: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Run existing test suite for LanguageSection's neighbours**
+
+Run: `npx vitest run src/services/providers/`
+Expected: PASS — the new helper tests stay green, no other test in this directory regresses.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Settings/sections/LanguageSection.tsx
+git commit -m "feat(volcengine-ast2): atomic zhen sync in LanguageSection (Simple mode)"
+```
+
+---
+
+### Task 4: Extend swap-button disabled condition + early-return guard
+
+Two spots in `LanguageSection.tsx` short-circuit swap when `sourceLanguage === 'auto'`. Add `'zhen'` to both — swapping `zhen/zhen` is a no-op (the server-required state stays `zhen/zhen`), so the button should be inert.
+
+**Files:**
+- Modify: `src/components/Settings/sections/LanguageSection.tsx:217`
+- Modify: `src/components/Settings/sections/LanguageSection.tsx:422`
+
+- [ ] **Step 1: Update the `handleSwapLanguages` early-return guard**
+
+In `src/components/Settings/sections/LanguageSection.tsx`, find line 217:
+
+```ts
+    if (!src || !tgt || src === 'auto') return;
+```
+
+Replace with:
+
+```ts
+    if (!src || !tgt || src === 'auto' || src === 'zhen') return;
+```
+
+- [ ] **Step 2: Update the swap-button `disabled` prop**
+
+Find line 422 in the same file:
+
+```ts
+                disabled={isSessionActive || currentProviderSettings.sourceLanguage === 'auto'}
+```
+
+Replace with:
+
+```ts
+                disabled={isSessionActive || currentProviderSettings.sourceLanguage === 'auto' || currentProviderSettings.sourceLanguage === 'zhen'}
+```
+
+- [ ] **Step 3: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/components/Settings/sections/LanguageSection.tsx
+git commit -m "feat(volcengine-ast2): disable swap button in zhen/zhen bidirectional mode"
+```
+
+---
+
+## Phase D: Wire helper into Advanced-mode UI
+
+### Task 5: Replace `onChange` bodies in `renderVolcengineAST2Settings()`
+
+The two `<select>` `onChange` handlers in Advanced mode currently write one field at a time, just like the Simple-mode handlers did before Task 3. Apply the same helper-driven pattern. Advanced mode does not have a swap button, so no equivalent of Task 4 is needed here.
+
+**Files:**
+- Modify: `src/components/Settings/sections/ProviderSpecificSettings.tsx` (top, add import)
+- Modify: `src/components/Settings/sections/ProviderSpecificSettings.tsx:1462-1472` (source-language `onChange`)
+- Modify: `src/components/Settings/sections/ProviderSpecificSettings.tsx:1487-1497` (target-language `onChange`)
+
+- [ ] **Step 1: Add the helper import**
+
+In `src/components/Settings/sections/ProviderSpecificSettings.tsx`, find the existing line:
+
+```ts
+import { VolcengineAST2ProviderConfig } from '../../../services/providers/VolcengineAST2ProviderConfig';
+```
+
+Add immediately below it:
+
+```ts
+import { resolveAST2LanguagePair } from '../../../services/providers/volcengineAST2LanguageSync';
+```
+
+- [ ] **Step 2: Replace the source-side `onChange` body**
+
+In `src/components/Settings/sections/ProviderSpecificSettings.tsx`, find lines 1462–1472 (the source-language `<select>`'s `onChange`):
+
+```ts
+              onChange={(e) => {
+                const oldSourceLang = volcengineAST2Settings.sourceLanguage;
+                const newSourceLang = e.target.value;
+                updateVolcengineAST2Settings({ sourceLanguage: newSourceLang });
+
+                trackEvent('language_changed', {
+                  from_language: oldSourceLang,
+                  to_language: newSourceLang,
+                  language_type: 'source'
+                });
+              }}
+```
+
+Replace with:
+
+```ts
+              onChange={(e) => {
+                const oldSourceLang = volcengineAST2Settings.sourceLanguage;
+                const oldTargetLang = volcengineAST2Settings.targetLanguage;
+                const newSourceLang = e.target.value;
+                const next = resolveAST2LanguagePair(
+                  { sourceLanguage: oldSourceLang, targetLanguage: oldTargetLang },
+                  { side: 'source', value: newSourceLang },
+                );
+                updateVolcengineAST2Settings({
+                  sourceLanguage: next.sourceLanguage,
+                  targetLanguage: next.targetLanguage,
+                });
+
+                trackEvent('language_changed', {
+                  from_language: oldSourceLang,
+                  to_language: next.sourceLanguage,
+                  language_type: 'source'
+                });
+                if (next.targetLanguage !== oldTargetLang) {
+                  trackEvent('language_changed', {
+                    from_language: oldTargetLang,
+                    to_language: next.targetLanguage,
+                    language_type: 'target'
+                  });
+                }
+              }}
+```
+
+- [ ] **Step 3: Replace the target-side `onChange` body**
+
+Find lines 1487–1497 (the target-language `<select>`'s `onChange`):
+
+```ts
+              onChange={(e) => {
+                const oldTargetLang = volcengineAST2Settings.targetLanguage;
+                const newTargetLang = e.target.value;
+                updateVolcengineAST2Settings({ targetLanguage: newTargetLang });
+
+                trackEvent('language_changed', {
+                  from_language: oldTargetLang,
+                  to_language: newTargetLang,
+                  language_type: 'target'
+                });
+              }}
+```
+
+Replace with:
+
+```ts
+              onChange={(e) => {
+                const oldSourceLang = volcengineAST2Settings.sourceLanguage;
+                const oldTargetLang = volcengineAST2Settings.targetLanguage;
+                const newTargetLang = e.target.value;
+                const next = resolveAST2LanguagePair(
+                  { sourceLanguage: oldSourceLang, targetLanguage: oldTargetLang },
+                  { side: 'target', value: newTargetLang },
+                );
+                updateVolcengineAST2Settings({
+                  sourceLanguage: next.sourceLanguage,
+                  targetLanguage: next.targetLanguage,
+                });
+
+                trackEvent('language_changed', {
+                  from_language: oldTargetLang,
+                  to_language: next.targetLanguage,
+                  language_type: 'target'
+                });
+                if (next.sourceLanguage !== oldSourceLang) {
+                  trackEvent('language_changed', {
+                    from_language: oldSourceLang,
+                    to_language: next.sourceLanguage,
+                    language_type: 'source'
+                  });
+                }
+              }}
+```
+
+- [ ] **Step 4: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings/sections/ProviderSpecificSettings.tsx
+git commit -m "feat(volcengine-ast2): atomic zhen sync in ProviderSpecificSettings (Advanced mode)"
+```
+
+---
+
+## Phase E: Verification
+
+### Task 6: Full typecheck and test suite
+
+- [ ] **Step 1: Run full TypeScript compile**
+
+Run: `npx tsc --noEmit`
+Expected: PASS, zero errors.
+
+- [ ] **Step 2: Run the full Vitest suite**
+
+Run: `npm run test -- --run`
+Expected: PASS for every test file. The new `volcengineAST2LanguageSync.test.ts` reports 9 passing tests. No pre-existing test regresses.
+
+- [ ] **Step 3: If anything fails, stop and investigate**
+
+Do not mark this task complete with a red bar. Failures here mean an earlier task's edit introduced a regression — re-read the failing test's assertion, diff against the source, and fix forward (do NOT silence the test). Once green, return to Step 1 for confirmation.
+
+- [ ] **Step 4: No commit for this task (verification-only)**
+
+---
+
+### Task 7: Manual smoke runbook
+
+Run through the spec §6 manual list against a real build. Do these checks against the Electron app (`npm run electron:dev`); the same UI ships to the extension, but the language section behaviour is identical there.
+
+**Setup (one-time):**
+
+- [ ] Launch the app: `npm run electron:dev`
+- [ ] In Settings → Provider, switch to **Doubao AST 2.0** (`volcengine_ast2`). Enter a valid App Key / Access Token if not already configured.
+- [ ] Confirm you can see **Simple mode**'s language pair row and **Advanced mode**'s `renderVolcengineAST2Settings()` — both are dropdowns showing source and target.
+
+**Simple mode checks (left/right dropdowns + ↔ swap button):**
+
+- [ ] **R1** — Set source to anything other than `中英双语 (zh↔en)`. Set source to `中英双语 (zh↔en)`. Expected: target jumps to `中英双语 (zh↔en)` automatically; both stay synced.
+- [ ] **R2** — Reset to `中文 / English`. Set target to `中英双语 (zh↔en)`. Expected: source jumps to `中英双语 (zh↔en)` automatically.
+- [ ] **R3** — With state `zhen / zhen`, change source dropdown to `日本語`. Expected: state becomes `ja / en` (target visibly resets to `English`).
+- [ ] **R4** — Reset to `zhen / zhen`. Change target dropdown to `Français`. Expected: state becomes `zh / fr` (source visibly resets to `中文`).
+- [ ] **Swap button** — Set `zhen / zhen`. Confirm the swap button is disabled (greyed out, no hover affordance). Set source back to `zh`, target to `en` — swap button re-enables.
+
+**Advanced mode checks (no swap button):**
+
+- [ ] Switch to Advanced mode (Settings → toggle to `advanced`).
+- [ ] Repeat R1, R2, R3, R4 above against the Advanced-mode dropdowns inside `renderVolcengineAST2Settings()`. Expected: identical behaviour.
+
+**End-to-end session check:**
+
+- [ ] In either mode, set the pair to `zhen / zhen`.
+- [ ] Start a live session (Start button).
+- [ ] Speak a short Chinese sentence (e.g. "你好，今天天气怎么样"). Expected: English audio + transcript out within ~1–2 s.
+- [ ] **Without ending the session**, speak a short English sentence (e.g. "How are you doing today"). Expected: Chinese audio + transcript out within ~1–2 s, no reconnection or settings prompt.
+- [ ] End the session.
+
+**Analytics spot-check (optional):**
+
+- [ ] Open the LogsPanel (or browser/Electron DevTools console) and confirm that picking `中英双语` on the source emits **two** `language_changed` events (one with `language_type: 'source'`, one with `language_type: 'target'`, both with `to_language: 'zhen'`).
+
+This task makes no code changes — the plan file itself is the runbook. No commit needed.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage map** (each spec §, tracked against task IDs):
+
+- §1 Provider config (target list) → Task 1 ✓
+- §2 Sync semantics (R1–R4 + edge cases) → Task 2 (helper + 9 unit tests) ✓
+- §3 Simple-mode UI wiring → Task 3 ✓
+- §3 Swap button extension → Task 4 ✓
+- §3 No new warnings → not a code change, explicit non-action ✓
+- §4 Advanced-mode UI wiring → Task 5 ✓
+- §5 Analytics (two events when both sides change) → embedded in Tasks 3 and 5 ✓
+- §6 Unit testing → Task 2 ✓
+- §6 Manual testing → Task 7 ✓
+- Non-goals (i18n, defaults, ja↔de validation, schema changes) → none of these have tasks, as intended ✓
+
+**Files touched** (matches spec §Files touched):
+
+- `src/services/providers/VolcengineAST2ProviderConfig.ts` → Task 1
+- `src/services/providers/volcengineAST2LanguageSync.ts` (new) → Task 2
+- `src/services/providers/volcengineAST2LanguageSync.test.ts` (new) → Task 2
+- `src/components/Settings/sections/LanguageSection.tsx` → Tasks 3, 4
+- `src/components/Settings/sections/ProviderSpecificSettings.tsx` → Task 5
+
+No store schema change, no i18n key change, no manifest/version change — consistent with spec.

--- a/docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md
+++ b/docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md
@@ -98,7 +98,7 @@ This adds noise (two events per user action when only one click happened) but ma
 
 ### 6. Testing
 
-**Unit (Vitest)**: a single test file covering the helper applies R1–R4 to a mocked store and asserts the post-state plus that `updateVolcengineAST2Settings` was called **exactly once** per user action.
+**Unit (Vitest)**: a single test file (`volcengineAST2LanguageSync.test.ts`) covering the pure helper `resolveAST2LanguagePair`. Each case constructs an `AST2LanguagePair` + `AST2LanguageChange` and asserts the returned post-state matches the rule table below. No store mocking — the "single store update" guarantee is enforced by the call site contract (each call site issues exactly one `updateVolcengineAST2Settings({sourceLanguage, targetLanguage})` per user action) and verified by reading the code, not by unit tests on the helper itself.
 
 | case | initial src / tgt | action | expected post-state |
 | ---- | ----------------- | ------ | ------------------- |

--- a/docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md
+++ b/docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md
@@ -1,0 +1,130 @@
+# Volcengine AST 2.0 — Chinese↔English Bidirectional Mode
+
+**Date**: 2026-05-14
+**Status**: Approved, ready for implementation
+**Tracking issue**: [#229](https://github.com/kizuna-ai-lab/sokuji/issues/229)
+
+## Overview
+
+Expose Doubao AST 2.0's Chinese↔English bidirectional mode (`source_language = target_language = "zhen"`) through the existing source/target language dropdowns. Picking the bidirectional entry on either side atomically syncs the other side to `zhen`, so both `volcengine_ast2` settings (Simple-mode `LanguageSection.tsx` and Advanced-mode `ProviderSpecificSettings.tsx`) always end up in a server-valid state.
+
+When this mode is active and the user speaks Chinese, the server outputs English; when the user speaks English, it outputs Chinese — no further configuration required.
+
+## Motivation
+
+Reported by a classroom user (Youth Night School English learning group) running mixed Chinese/English conversations. The `VolcengineAST2Client` already forwards `sourceLanguage`/`targetLanguage` to the WebSocket `StartSession` request unchanged — the realtime path is already capable of running `zhen/zhen`. The gap is purely in the provider config and UI:
+
+- `VolcengineAST2ProviderConfig.getSourceLanguages()` returns `BIDIRECTIONAL_LANGUAGES` (with `zhen`).
+- `VolcengineAST2ProviderConfig.getTargetLanguages()` returns `LANGUAGES` (without `zhen`).
+- Neither `LanguageSection.tsx` nor `ProviderSpecificSettings.tsx` coordinates the two sides, so a user who picks `zhen` on the source ends up with `zhen → en` — invalid per the server contract.
+
+## Server contract (authoritative)
+
+Per the [Doubao AST 2.0 API documentation](https://www.volcengine.com/docs/6561/1756902), both `source_language` and `target_language` accept the same set of values:
+
+| value | language |
+| ----- | -------- |
+| `zh`  | Chinese |
+| `en`  | English |
+| `ja`  | Japanese |
+| `id`  | Indonesian |
+| `es`  | Spanish |
+| `pt`  | Portuguese |
+| `de`  | German |
+| `fr`  | French |
+| `zhen` | Chinese↔English bidirectional |
+
+Two hard constraints quoted from the doc:
+
+1. **Non-bidirectional mode**: one of `source_language` / `target_language` **must** be `zh` or `en`, otherwise the server returns an error.
+2. **Bidirectional mode**: `source_language` **and** `target_language` **must both** be `zhen`. Any mixed combination involving `zhen` is invalid.
+
+`zhen` is currently the only bidirectional value AST 2.0 supports.
+
+## Non-Goals
+
+- **Validation of constraint #1** (non-bidirectional mode requires `zh` or `en` on at least one side). This pre-existing UI gap also affects combinations like `ja → de` and `fr → es`. It is documented as a follow-up — out of scope for this change to keep the diff focused on the reported feature.
+- **Generalised bidirectional architecture**. The doc lists exactly one bidirectional value (`zhen`); the design treats it as a single sentinel rather than introducing a generic "bidirectional pair" abstraction.
+- **i18n of the `zhen` label**. The native name `中英双语 (zh↔en)` is already in the provider config and is readable across UI languages (mixed CJK + `zh↔en` symbol).
+- **Default-value changes**. The provider continues to default to `sourceLanguage: 'zh'`, `targetLanguage: 'en'` — most users do not need bidirectional mode and the unidirectional defaults remain sensible.
+
+## Design
+
+### 1. Provider config (`src/services/providers/VolcengineAST2ProviderConfig.ts`)
+
+Change `getTargetLanguages()` to return `BIDIRECTIONAL_LANGUAGES` instead of `LANGUAGES`. This is the only file-level change to the config layer; the `name` field on the `zhen` entry is already `'中英双语 (zh↔en)'`. `zhen` keeps its position at the end of the list (after the eight single-language entries) — no `optgroup` separator needed for nine entries.
+
+### 2. Sync semantics (core behavior)
+
+When the active provider is `VOLCENGINE_AST2`, source/target updates go through a wrapper that applies the four rules below. The wrapper writes both fields in a **single** `updateVolcengineAST2Settings({...})` call to avoid a transient `zhen / <other>` state that any Zustand subscriber could observe.
+
+| # | User action | Pre-state (src / tgt) | Post-state (src / tgt) |
+| - | ----------- | --------------------- | ---------------------- |
+| R1 | Picks `zhen` on source | any / any | `zhen` / `zhen` |
+| R2 | Picks `zhen` on target | any / any | `zhen` / `zhen` |
+| R3 | Picks `X` (X ≠ `zhen`) on source | `zhen` / `zhen` | `X` / `en` |
+| R4 | Picks `Y` (Y ≠ `zhen`) on target | `zhen` / `zhen` | `zh` / `Y` |
+
+Reasoning for R3/R4: leaving the other side at `zhen` would produce a server-invalid state. Resetting to the provider's `defaults.sourceLanguage` (`zh`) and `defaults.targetLanguage` (`en`) is the least-surprising recovery and matches what a user picking these languages "from scratch" would get.
+
+**Edge cases not handled here** (intentionally — server returns an error, consistent with current behavior for the same class of bug):
+
+- R3 with `X = 'en'` produces `en / en`. R4 with `Y = 'zh'` produces `zh / zh`. Both are degenerate same-language combinations.
+- Any combination where neither side is `zh` or `en` (e.g. `ja / de`) — covered by the non-goal above.
+
+Switching `provider` away from `VOLCENGINE_AST2` requires no cleanup: each provider's settings live in its own store slice and are not cross-touched.
+
+### 3. Simple-mode UI (`src/components/Settings/sections/LanguageSection.tsx`)
+
+The two `<select>` elements render `providerConfig.languages` and `targetLanguages` directly; once §1 is applied they include `zhen` on both sides with no render changes needed.
+
+The `Provider.VOLCENGINE_AST2` branch inside `updateSourceLanguage` and `updateTargetLanguage` is replaced with calls to a shared helper (e.g., `updateAST2LanguagesAtomic({ side: 'source' | 'target', value })`) that implements R1–R4 and issues exactly one store update. The helper is collocated with `LanguageSection.tsx` or pulled to a small utility — either is acceptable.
+
+**Swap button**: currently disabled when `sourceLanguage === 'auto'`. Extend the condition to `=== 'auto' || === 'zhen'` (swapping `zhen / zhen` is a no-op).
+
+**Warnings**: none added. No analogue to `showTranslateParticipantWarning` is needed for `zhen`.
+
+### 4. Advanced-mode UI (`src/components/Settings/sections/ProviderSpecificSettings.tsx`)
+
+`renderVolcengineAST2Settings()` contains two `<select>` elements (around lines 1459 and 1484) whose `onChange` currently writes a single field. Replace each `onChange` body with a call to the same helper used in §3 so the four rules apply identically in Advanced mode. The `getSourceLanguages()` / `getTargetLanguages()` reads pick up the §1 config change automatically — no render-level change.
+
+There is no swap button in Advanced mode, so no additional UI control needs editing.
+
+### 5. Analytics
+
+Existing `language_changed` `trackEvent` calls continue to fire — but in R1/R2/R3/R4 the helper updates two fields. Emit **two** `language_changed` events (one for `source`, one for `target`) with the post-state value so analytics consumers see a coherent picture: e.g. picking `zhen` on the source fires `{to_language: 'zhen', language_type: 'source'}` followed by `{to_language: 'zhen', language_type: 'target'}`.
+
+This adds noise (two events per user action when only one click happened) but matches the actual settings change. Alternative — emitting a single `bidirectional_mode_enabled` event — would require schema additions. Two events is cheaper.
+
+### 6. Testing
+
+**Unit (Vitest)**: a single test file covering the helper applies R1–R4 to a mocked store and asserts the post-state plus that `updateVolcengineAST2Settings` was called **exactly once** per user action.
+
+| case | initial src / tgt | action | expected post-state |
+| ---- | ----------------- | ------ | ------------------- |
+| R1 | `zh / en` | source → `zhen` | `zhen / zhen` |
+| R1' | `ja / zh` | source → `zhen` | `zhen / zhen` |
+| R2 | `zh / en` | target → `zhen` | `zhen / zhen` |
+| R3 | `zhen / zhen` | source → `ja` | `ja / en` |
+| R3 same-lang | `zhen / zhen` | source → `en` | `en / en` (server will reject; UI does not block) |
+| R4 | `zhen / zhen` | target → `fr` | `zh / fr` |
+| R4 same-lang | `zhen / zhen` | target → `zh` | `zh / zh` (server will reject; UI does not block) |
+
+**Manual**:
+
+- Simple mode: source → `中英双语` ⇒ target auto-updates to `中英双语`; both stay synced.
+- Simple mode: target → `中英双语` ⇒ source auto-updates to `中英双语`.
+- Simple mode with `zhen / zhen`: change source to `ja` ⇒ resulting `ja / en`.
+- Simple mode with `zhen / zhen`: change target to `fr` ⇒ resulting `zh / fr`.
+- Simple mode with `zhen / zhen`: swap button is disabled (greyed).
+- Repeat the four dropdown-sync checks above in Advanced mode (no swap button exists there, so the swap check is Simple-mode-only).
+- Start a new session with `zhen / zhen` pre-selected, speak a Chinese sentence → English audio/text out; without reconnecting, speak an English sentence → Chinese audio/text out (the server switches direction within the same session).
+
+## Files touched
+
+- `src/services/providers/VolcengineAST2ProviderConfig.ts` — `getTargetLanguages()` returns `BIDIRECTIONAL_LANGUAGES`.
+- `src/components/Settings/sections/LanguageSection.tsx` — replace `VOLCENGINE_AST2` source/target update branches with the helper; extend swap-button disabled condition.
+- `src/components/Settings/sections/ProviderSpecificSettings.tsx` — replace both `onChange` bodies inside `renderVolcengineAST2Settings()` with the helper.
+- New: a colocated test file for the helper (final location decided in implementation plan).
+
+No store schema change, no i18n key change, no manifest/version change.

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -164,16 +164,22 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
           sourceLanguage: next.sourceLanguage,
           targetLanguage: next.targetLanguage,
         });
-        // Spec §5: when bidirectional sync also changes the other side, emit a
-        // second analytics event so consumers see both transitions. The trailing
-        // `trackEvent` below this switch still emits the source-side event.
+        // Spec §5: emit source event first (the user-touched side), then a
+        // secondary target event when bidirectional sync also changed the
+        // other side. Both fire from inside this branch so the ordering is
+        // source-then-target — the function returns to skip the trailing
+        // emit below this switch.
+        trackEvent('language_changed', {
+          to_language: next.sourceLanguage,
+          language_type: 'source',
+        });
         if (next.targetLanguage !== prev.targetLanguage) {
           trackEvent('language_changed', {
             to_language: next.targetLanguage,
             language_type: 'target',
           });
         }
-        break;
+        return;
       }
       case Provider.LOCAL_INFERENCE: {
         const availableTargets = getTranslationTargetLanguages(value);
@@ -226,13 +232,21 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
           sourceLanguage: next.sourceLanguage,
           targetLanguage: next.targetLanguage,
         });
+        // Spec §5: emit secondary source event FIRST when the synced side
+        // changed, then the user-touched target event — matches the
+        // source-then-target ordering used for the source-side handler. Both
+        // fire from inside this branch; return to skip the trailing emit.
         if (next.sourceLanguage !== prev.sourceLanguage) {
           trackEvent('language_changed', {
             to_language: next.sourceLanguage,
             language_type: 'source',
           });
         }
-        break;
+        trackEvent('language_changed', {
+          to_language: next.targetLanguage,
+          language_type: 'target',
+        });
+        return;
       }
       case Provider.LOCAL_INFERENCE:
         updateLocalInferenceSettings({ targetLanguage: value });

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -248,7 +248,7 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
   const handleSwapLanguages = useCallback(() => {
     const src = currentProviderSettings?.sourceLanguage;
     const tgt = currentProviderSettings?.targetLanguage;
-    if (!src || !tgt || src === 'auto') return;
+    if (!src || !tgt || src === 'auto' || src === 'zhen') return;
 
     if (provider === Provider.LOCAL_INFERENCE) {
       const availableTargets = getTranslationTargetLanguages(tgt);
@@ -453,7 +453,7 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
               <button
                 className="language-swap-btn"
                 onClick={handleSwapLanguages}
-                disabled={isSessionActive || currentProviderSettings.sourceLanguage === 'auto'}
+                disabled={isSessionActive || currentProviderSettings.sourceLanguage === 'auto' || currentProviderSettings.sourceLanguage === 'zhen'}
                 title={t('simpleConfig.swapLanguages', 'Swap languages')}
                 type="button"
               >

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -32,6 +32,7 @@ import {
 import { Provider } from '../../../types/Provider';
 import { ProviderConfigFactory } from '../../../services/providers/ProviderConfigFactory';
 import { ProviderConfig } from '../../../services/providers/ProviderConfig';
+import { resolveAST2LanguagePair } from '../../../services/providers/volcengineAST2LanguageSync';
 import { OpenAITranslateProviderConfig } from '../../../services/providers/OpenAITranslateProviderConfig';
 import { useIsSystemAudioCaptureEnabled } from '../../../stores/audioStore';
 import { changeLanguageWithLoad } from '../../../locales';
@@ -153,9 +154,27 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
       case Provider.VOLCENGINE_ST:
         updateVolcengineSTSettings({ sourceLanguage: value });
         break;
-      case Provider.VOLCENGINE_AST2:
-        updateVolcengineAST2Settings({ sourceLanguage: value });
+      case Provider.VOLCENGINE_AST2: {
+        const prev = volcengineAST2Settings;
+        const next = resolveAST2LanguagePair(
+          { sourceLanguage: prev.sourceLanguage, targetLanguage: prev.targetLanguage },
+          { side: 'source', value },
+        );
+        updateVolcengineAST2Settings({
+          sourceLanguage: next.sourceLanguage,
+          targetLanguage: next.targetLanguage,
+        });
+        // Spec §5: when bidirectional sync also changes the other side, emit a
+        // second analytics event so consumers see both transitions. The trailing
+        // `trackEvent` below this switch still emits the source-side event.
+        if (next.targetLanguage !== prev.targetLanguage) {
+          trackEvent('language_changed', {
+            to_language: next.targetLanguage,
+            language_type: 'target',
+          });
+        }
         break;
+      }
       case Provider.LOCAL_INFERENCE: {
         const availableTargets = getTranslationTargetLanguages(value);
         const currentTarget = localInferenceSettings.targetLanguage;
@@ -197,9 +216,24 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
       case Provider.VOLCENGINE_ST:
         updateVolcengineSTSettings({ targetLanguage: value });
         break;
-      case Provider.VOLCENGINE_AST2:
-        updateVolcengineAST2Settings({ targetLanguage: value });
+      case Provider.VOLCENGINE_AST2: {
+        const prev = volcengineAST2Settings;
+        const next = resolveAST2LanguagePair(
+          { sourceLanguage: prev.sourceLanguage, targetLanguage: prev.targetLanguage },
+          { side: 'target', value },
+        );
+        updateVolcengineAST2Settings({
+          sourceLanguage: next.sourceLanguage,
+          targetLanguage: next.targetLanguage,
+        });
+        if (next.sourceLanguage !== prev.sourceLanguage) {
+          trackEvent('language_changed', {
+            to_language: next.sourceLanguage,
+            language_type: 'source',
+          });
+        }
         break;
+      }
       case Provider.LOCAL_INFERENCE:
         updateLocalInferenceSettings({ targetLanguage: value });
         break;

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -254,6 +254,16 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
       const availableTargets = getTranslationTargetLanguages(tgt);
       const newTarget = availableTargets.some(l => l.value === src) ? src : availableTargets[0]?.value || 'en';
       updateLocalInferenceSettings({ sourceLanguage: tgt, targetLanguage: newTarget });
+    } else if (provider === Provider.VOLCENGINE_AST2) {
+      // AST2's updateSource/Target paths each write BOTH fields through the
+      // helper, reading prev from this closure. A two-step swap would invoke
+      // the second write with a stale prev — overwriting the first write with
+      // the original source value and producing src/src. Apply both new values
+      // in one update here instead. src === 'zhen' is already excluded above,
+      // so no resolveAST2LanguagePair invocation is needed.
+      updateVolcengineAST2Settings({ sourceLanguage: tgt, targetLanguage: src });
+      trackEvent('language_changed', { to_language: tgt, language_type: 'source' });
+      trackEvent('language_changed', { to_language: src, language_type: 'target' });
     } else {
       updateSourceLanguage(tgt);
       // For providers with a restricted target list (currently only OPENAI_TRANSLATE),
@@ -267,7 +277,7 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
         : (targetList[0]?.value ?? src);
       updateTargetLanguage(newTarget);
     }
-  }, [provider, currentProviderSettings, providerConfig, updateLocalInferenceSettings, updateSourceLanguage, updateTargetLanguage]);
+  }, [provider, currentProviderSettings, providerConfig, updateLocalInferenceSettings, updateSourceLanguage, updateTargetLanguage, updateVolcengineAST2Settings, trackEvent]);
 
   // Dynamic target languages for LOCAL_INFERENCE; restricted list for providers
   // that explicitly declare `targetLanguages` (e.g. OpenAI Translate has 13);

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, useEffect, useMemo, useState } from 'react';
 import { ProviderConfig } from '../../../services/providers/ProviderConfig';
 import { VolcengineSTProviderConfig } from '../../../services/providers/VolcengineSTProviderConfig';
 import { VolcengineAST2ProviderConfig } from '../../../services/providers/VolcengineAST2ProviderConfig';
+import { resolveAST2LanguagePair } from '../../../services/providers/volcengineAST2LanguageSync';
 import {
   useProvider,
   useSystemInstructions,
@@ -1461,14 +1462,29 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
               value={volcengineAST2Settings.sourceLanguage}
               onChange={(e) => {
                 const oldSourceLang = volcengineAST2Settings.sourceLanguage;
+                const oldTargetLang = volcengineAST2Settings.targetLanguage;
                 const newSourceLang = e.target.value;
-                updateVolcengineAST2Settings({ sourceLanguage: newSourceLang });
+                const next = resolveAST2LanguagePair(
+                  { sourceLanguage: oldSourceLang, targetLanguage: oldTargetLang },
+                  { side: 'source', value: newSourceLang },
+                );
+                updateVolcengineAST2Settings({
+                  sourceLanguage: next.sourceLanguage,
+                  targetLanguage: next.targetLanguage,
+                });
 
                 trackEvent('language_changed', {
                   from_language: oldSourceLang,
-                  to_language: newSourceLang,
+                  to_language: next.sourceLanguage,
                   language_type: 'source'
                 });
+                if (next.targetLanguage !== oldTargetLang) {
+                  trackEvent('language_changed', {
+                    from_language: oldTargetLang,
+                    to_language: next.targetLanguage,
+                    language_type: 'target'
+                  });
+                }
               }}
               disabled={isSessionActive}
             >
@@ -1485,15 +1501,30 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
               className="select-dropdown"
               value={volcengineAST2Settings.targetLanguage}
               onChange={(e) => {
+                const oldSourceLang = volcengineAST2Settings.sourceLanguage;
                 const oldTargetLang = volcengineAST2Settings.targetLanguage;
                 const newTargetLang = e.target.value;
-                updateVolcengineAST2Settings({ targetLanguage: newTargetLang });
+                const next = resolveAST2LanguagePair(
+                  { sourceLanguage: oldSourceLang, targetLanguage: oldTargetLang },
+                  { side: 'target', value: newTargetLang },
+                );
+                updateVolcengineAST2Settings({
+                  sourceLanguage: next.sourceLanguage,
+                  targetLanguage: next.targetLanguage,
+                });
 
                 trackEvent('language_changed', {
                   from_language: oldTargetLang,
-                  to_language: newTargetLang,
+                  to_language: next.targetLanguage,
                   language_type: 'target'
                 });
+                if (next.sourceLanguage !== oldSourceLang) {
+                  trackEvent('language_changed', {
+                    from_language: oldSourceLang,
+                    to_language: next.sourceLanguage,
+                    language_type: 'source'
+                  });
+                }
               }}
               disabled={isSessionActive}
             >

--- a/src/services/providers/VolcengineAST2ProviderConfig.ts
+++ b/src/services/providers/VolcengineAST2ProviderConfig.ts
@@ -31,7 +31,7 @@ export class VolcengineAST2ProviderConfig {
   }
 
   static getTargetLanguages(): LanguageOption[] {
-    return VolcengineAST2ProviderConfig.LANGUAGES;
+    return VolcengineAST2ProviderConfig.BIDIRECTIONAL_LANGUAGES;
   }
 
   getConfig(): ProviderConfig {

--- a/src/services/providers/VolcengineAST2ProviderConfig.ts
+++ b/src/services/providers/VolcengineAST2ProviderConfig.ts
@@ -42,7 +42,7 @@ export class VolcengineAST2ProviderConfig {
       apiKeyLabel: 'App Key',
       apiKeyPlaceholder: 'Enter your Volcengine App Key',
 
-      languages: VolcengineAST2ProviderConfig.LANGUAGES,
+      languages: VolcengineAST2ProviderConfig.BIDIRECTIONAL_LANGUAGES,
       voices: VolcengineAST2ProviderConfig.VOICES,
       models: VolcengineAST2ProviderConfig.MODELS,
       noiseReductionModes: [],

--- a/src/services/providers/volcengineAST2LanguageSync.test.ts
+++ b/src/services/providers/volcengineAST2LanguageSync.test.ts
@@ -92,4 +92,44 @@ describe('resolveAST2LanguagePair', () => {
       ),
     ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'fr' });
   });
+
+  // Legacy persisted states: before this PR exposed 'zhen' on the target side,
+  // users could end up with sourceLanguage='zhen' but a non-'zhen' target.
+  // The helper must reset the orphaned 'zhen' side rather than emit it back
+  // to the server, which would reject the mixed pair.
+  it('legacy zhen/en → target=fr ⇒ zh/fr (orphan zhen source reset)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'en' },
+        { side: 'target', value: 'fr' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'fr' });
+  });
+
+  it('legacy zhen/en → source=ja ⇒ ja/en (target was not zhen, no reset)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'en' },
+        { side: 'source', value: 'ja' },
+      ),
+    ).toEqual({ sourceLanguage: 'ja', targetLanguage: 'en' });
+  });
+
+  it('legacy en/zhen → source=de ⇒ de/en (orphan zhen target reset)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'en', targetLanguage: 'zhen' },
+        { side: 'source', value: 'de' },
+      ),
+    ).toEqual({ sourceLanguage: 'de', targetLanguage: 'en' });
+  });
+
+  it('legacy en/zhen → target=ja ⇒ en/ja (source was not zhen, no reset)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'en', targetLanguage: 'zhen' },
+        { side: 'target', value: 'ja' },
+      ),
+    ).toEqual({ sourceLanguage: 'en', targetLanguage: 'ja' });
+  });
 });

--- a/src/services/providers/volcengineAST2LanguageSync.test.ts
+++ b/src/services/providers/volcengineAST2LanguageSync.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { resolveAST2LanguagePair } from './volcengineAST2LanguageSync';
+
+describe('resolveAST2LanguagePair', () => {
+  // R1: picking 'zhen' on source atomically syncs target to 'zhen'.
+  it('R1: zh/en → source=zhen ⇒ zhen/zhen', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'source', value: 'zhen' },
+      ),
+    ).toEqual({ sourceLanguage: 'zhen', targetLanguage: 'zhen' });
+  });
+
+  it("R1': ja/zh → source=zhen ⇒ zhen/zhen", () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'ja', targetLanguage: 'zh' },
+        { side: 'source', value: 'zhen' },
+      ),
+    ).toEqual({ sourceLanguage: 'zhen', targetLanguage: 'zhen' });
+  });
+
+  // R2: picking 'zhen' on target atomically syncs source to 'zhen'.
+  it('R2: zh/en → target=zhen ⇒ zhen/zhen', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'target', value: 'zhen' },
+      ),
+    ).toEqual({ sourceLanguage: 'zhen', targetLanguage: 'zhen' });
+  });
+
+  // R3: leaving 'zhen' on the source resets target to the provider default 'en'.
+  it('R3: zhen/zhen → source=ja ⇒ ja/en', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'source', value: 'ja' },
+      ),
+    ).toEqual({ sourceLanguage: 'ja', targetLanguage: 'en' });
+  });
+
+  // R3 degenerate same-language case — helper does not block; server will reject.
+  it('R3 same-lang: zhen/zhen → source=en ⇒ en/en', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'source', value: 'en' },
+      ),
+    ).toEqual({ sourceLanguage: 'en', targetLanguage: 'en' });
+  });
+
+  // R4: leaving 'zhen' on the target resets source to the provider default 'zh'.
+  it('R4: zhen/zhen → target=fr ⇒ zh/fr', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'target', value: 'fr' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'fr' });
+  });
+
+  // R4 degenerate same-language case.
+  it('R4 same-lang: zhen/zhen → target=zh ⇒ zh/zh', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zhen', targetLanguage: 'zhen' },
+        { side: 'target', value: 'zh' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'zh' });
+  });
+
+  // Normal (non-bidirectional → non-bidirectional) update: passes through
+  // without touching the other side. Not in the spec's rule table, but the
+  // helper must support being called for every change to be useful as the
+  // single VOLCENGINE_AST2 update path in the UI.
+  it('passthrough: zh/en → source=ja ⇒ ja/en (target unchanged)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'source', value: 'ja' },
+      ),
+    ).toEqual({ sourceLanguage: 'ja', targetLanguage: 'en' });
+  });
+
+  it('passthrough: zh/en → target=fr ⇒ zh/fr (source unchanged)', () => {
+    expect(
+      resolveAST2LanguagePair(
+        { sourceLanguage: 'zh', targetLanguage: 'en' },
+        { side: 'target', value: 'fr' },
+      ),
+    ).toEqual({ sourceLanguage: 'zh', targetLanguage: 'fr' });
+  });
+});

--- a/src/services/providers/volcengineAST2LanguageSync.ts
+++ b/src/services/providers/volcengineAST2LanguageSync.ts
@@ -1,16 +1,18 @@
 /**
  * Synchronisation rules for the Volcengine AST 2.0 provider's source/target
  * language pair. The server requires both fields to be 'zhen' for Chinese↔English
- * bidirectional mode (and rejects any mixed combination involving 'zhen'). This
+ * bidirectional mode and rejects any mixed combination involving 'zhen'. This
  * helper enforces that constraint as a pure transformation so call sites can
  * write both fields in a single Zustand update.
  *
  * Rules (from docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md §2):
- *   R1: picks 'zhen' on source → both become 'zhen'
- *   R2: picks 'zhen' on target → both become 'zhen'
- *   R3: leaves 'zhen' on source (current state was zhen/zhen) → target resets to 'en'
- *   R4: leaves 'zhen' on target (current state was zhen/zhen) → source resets to 'zh'
- *   passthrough: any other change updates only the side the user touched
+ *   R1: picks 'zhen' on either side → both become 'zhen'
+ *   R2: leaves 'zhen' on one side (other side stays 'zhen') → reset the other
+ *       side to its server-contract default ('zh' source / 'en' target). Covers
+ *       both the spec's R3/R4 (zhen/zhen → non-zhen) AND legacy persisted
+ *       'zhen/<other>' pairs that were possible before this PR exposed 'zhen'
+ *       on the target side.
+ *   passthrough: any other change updates only the side the user touched.
  */
 export interface AST2LanguagePair {
   sourceLanguage: string;
@@ -23,6 +25,13 @@ export interface AST2LanguageChange {
 }
 
 const ZHEN = 'zhen';
+// DEFAULT_SOURCE / DEFAULT_TARGET are anchored to the server contract, not to
+// the provider's UI defaults. AST 2.0 requires at least one of source/target
+// to be 'zh' or 'en' in non-bidirectional mode, so resetting an orphaned
+// 'zhen' side to anything other than 'zh'/'en' could still produce a
+// server-invalid pair. Keep these as literals — sourcing them from
+// VolcengineAST2ProviderConfig.defaults would couple the helper to UI defaults
+// that may legitimately diverge from server constraints.
 const DEFAULT_SOURCE = 'zh';
 const DEFAULT_TARGET = 'en';
 
@@ -30,24 +39,25 @@ export function resolveAST2LanguagePair(
   current: AST2LanguagePair,
   change: AST2LanguageChange,
 ): AST2LanguagePair {
-  // R1 / R2: picking 'zhen' on either side forces both to 'zhen'.
+  // R1: picking 'zhen' on either side forces both to 'zhen'.
   if (change.value === ZHEN) {
     return { sourceLanguage: ZHEN, targetLanguage: ZHEN };
   }
 
-  // R3 / R4: leaving 'zhen' on one side while the other was also 'zhen' means
-  // we must reset the other side to its provider default to avoid a transient
-  // 'zhen / <other>' state that the server rejects.
-  if (change.side === 'source' && current.sourceLanguage === ZHEN && current.targetLanguage === ZHEN) {
-    return { sourceLanguage: change.value, targetLanguage: DEFAULT_TARGET };
-  }
-  if (change.side === 'target' && current.sourceLanguage === ZHEN && current.targetLanguage === ZHEN) {
-    return { sourceLanguage: DEFAULT_SOURCE, targetLanguage: change.value };
-  }
-
-  // Passthrough: ordinary source/target edit, no cross-side effect.
+  // R2: changing one side to a non-zhen value while the OTHER side is 'zhen'
+  // would produce a server-invalid 'zhen / <other>' pair. Reset the other
+  // side to its server-contract default. This subsumes the spec's R3/R4 (the
+  // both-sides-zhen → non-zhen case) and additionally cleans up legacy
+  // persisted 'zhen/<other>' pairs from older builds where 'zhen' was only
+  // exposed on the source side.
   if (change.side === 'source') {
-    return { sourceLanguage: change.value, targetLanguage: current.targetLanguage };
+    return {
+      sourceLanguage: change.value,
+      targetLanguage: current.targetLanguage === ZHEN ? DEFAULT_TARGET : current.targetLanguage,
+    };
   }
-  return { sourceLanguage: current.sourceLanguage, targetLanguage: change.value };
+  return {
+    sourceLanguage: current.sourceLanguage === ZHEN ? DEFAULT_SOURCE : current.sourceLanguage,
+    targetLanguage: change.value,
+  };
 }

--- a/src/services/providers/volcengineAST2LanguageSync.ts
+++ b/src/services/providers/volcengineAST2LanguageSync.ts
@@ -1,0 +1,53 @@
+/**
+ * Synchronisation rules for the Volcengine AST 2.0 provider's source/target
+ * language pair. The server requires both fields to be 'zhen' for Chinese↔English
+ * bidirectional mode (and rejects any mixed combination involving 'zhen'). This
+ * helper enforces that constraint as a pure transformation so call sites can
+ * write both fields in a single Zustand update.
+ *
+ * Rules (from docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md §2):
+ *   R1: picks 'zhen' on source → both become 'zhen'
+ *   R2: picks 'zhen' on target → both become 'zhen'
+ *   R3: leaves 'zhen' on source (current state was zhen/zhen) → target resets to 'en'
+ *   R4: leaves 'zhen' on target (current state was zhen/zhen) → source resets to 'zh'
+ *   passthrough: any other change updates only the side the user touched
+ */
+export interface AST2LanguagePair {
+  sourceLanguage: string;
+  targetLanguage: string;
+}
+
+export interface AST2LanguageChange {
+  side: 'source' | 'target';
+  value: string;
+}
+
+const ZHEN = 'zhen';
+const DEFAULT_SOURCE = 'zh';
+const DEFAULT_TARGET = 'en';
+
+export function resolveAST2LanguagePair(
+  current: AST2LanguagePair,
+  change: AST2LanguageChange,
+): AST2LanguagePair {
+  // R1 / R2: picking 'zhen' on either side forces both to 'zhen'.
+  if (change.value === ZHEN) {
+    return { sourceLanguage: ZHEN, targetLanguage: ZHEN };
+  }
+
+  // R3 / R4: leaving 'zhen' on one side while the other was also 'zhen' means
+  // we must reset the other side to its provider default to avoid a transient
+  // 'zhen / <other>' state that the server rejects.
+  if (change.side === 'source' && current.sourceLanguage === ZHEN && current.targetLanguage === ZHEN) {
+    return { sourceLanguage: change.value, targetLanguage: DEFAULT_TARGET };
+  }
+  if (change.side === 'target' && current.sourceLanguage === ZHEN && current.targetLanguage === ZHEN) {
+    return { sourceLanguage: DEFAULT_SOURCE, targetLanguage: change.value };
+  }
+
+  // Passthrough: ordinary source/target edit, no cross-side effect.
+  if (change.side === 'source') {
+    return { sourceLanguage: change.value, targetLanguage: current.targetLanguage };
+  }
+  return { sourceLanguage: current.sourceLanguage, targetLanguage: change.value };
+}


### PR DESCRIPTION
## Summary

Exposes Doubao AST 2.0's Chinese↔English bidirectional mode (`source_language = target_language = 'zhen'`) through the existing source/target language dropdowns. Picking the bidirectional entry on either side **atomically syncs the other side**, so the settings never sit in a server-invalid `zhen/<other>` state.

When this mode is active, the server outputs English when the user speaks Chinese, and Chinese when the user speaks English — no further configuration required.

Reported by Ray Chow (Youth Night School English learning group). Closes #229.

## Changes

| Commit | Layer |
|---|---|
| `60a0542f` | docs(specs): design document |
| `d92209df` | docs(plans): implementation plan |
| `0d87cecc` | feat: expose `'zhen'` on target-language list (Advanced mode static method) |
| `017a4edc` | feat: add pure helper `resolveAST2LanguagePair` + 9 unit tests |
| `580aec7e` | feat: atomic `zhen` sync in `LanguageSection` (Simple mode) |
| `450e70a5` | feat: disable swap button in `zhen/zhen` state |
| `4bb78d9b` | feat: atomic `zhen` sync in `ProviderSpecificSettings` (Advanced mode) |
| `e6e47a27` | fix: expose `'zhen'` in Simple-mode list via `getConfig().languages` |
| `2ee2e4cc` | fix: swap button no longer clobbers source with stale closure read |

**Files touched:** `VolcengineAST2ProviderConfig.ts`, `LanguageSection.tsx`, `ProviderSpecificSettings.tsx`, plus new `volcengineAST2LanguageSync.ts` and its test.

## How it works

The helper `resolveAST2LanguagePair(current, change)` is a pure transform encoding 4 rules from the spec ([§2](docs/superpowers/specs/2026-05-14-volcengine-ast2-bidirectional-mode-design.md)):

- R1/R2 — picking `'zhen'` on either side forces both fields to `'zhen'`.
- R3/R4 — leaving `'zhen'` on one side (when state was `zhen/zhen`) resets the other side to its provider default (`zh` source / `en` target).
- Passthrough — ordinary single-side edits don't touch the other side.

Both UI surfaces (`LanguageSection` Simple mode + `ProviderSpecificSettings` Advanced mode) call this helper and write the result in a single `updateVolcengineAST2Settings(...)` action.

## Non-goals

- **`ja → de` style invalid combos** — AST2 also requires one of source/target to be `zh` or `en` in non-bidirectional mode. Pre-existing gap; out of scope for this PR.
- **i18n of the `'zhen'` label** — the existing `中英双语 (zh↔en)` is bilingual already.
- **Generalised bidirectional architecture** — AST2 exposes exactly one bidirectional value; designed as a single sentinel.

## Test plan

- [x] 9 new Vitest unit tests covering R1, R1', R2, R3, R3-degenerate, R4, R4-degenerate, 2 passthrough cases — all green.
- [x] Full test suite: 27 files / 302 tests pass.
- [x] TypeScript: no new errors in touched files (4 pre-existing TS6133 unused-import warnings unaffected).
- [x] Manual smoke (Electron, Simple mode):
  - source → `中英双语` ⇒ target auto-syncs ✓
  - target → `中英双语` ⇒ source auto-syncs ✓
  - `zhen/zhen` → change source to `ja` ⇒ `ja/en` ✓
  - `zhen/zhen` → change target to `fr` ⇒ `zh/fr` ✓
  - `zhen/zhen` → swap button is disabled ✓
- [x] Manual smoke (Electron, Advanced mode): same four dropdown-sync checks ✓
- [x] Swap-button regression check (`zh/ja` → swap → `ja/zh`) ✓ — caught a post-handoff bug, fixed in `2ee2e4cc`.
- [ ] End-to-end live session with `zhen/zhen`: confirm zh→en and en→zh switch within one session.

## Known follow-ups (not in this PR)

- The `from_language` analytics field is present on Advanced-mode `language_changed` events but absent on Simple-mode trailing emits (pre-existing asymmetry, preserved by both call sites).
- The "non-bidirectional needs `zh` or `en` on at least one side" server constraint isn't surfaced in UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled Volcengine AST2 Chinese↔English bidirectional (zhen) mode
  * Automatic two-way synchronization of source/target languages, with swap-button disabled for the zhen pair
  * Provider language set aligned to bidirectional mode

* **Tests**
  * Added unit tests covering language-pair sync, resets, and edge cases

* **Documentation**
  * New rollout and design docs plus a manual smoke runbook and self-review checklist

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/235)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->