### PR TITLE
fix(edge-tts): compensate for system clock skew via server Date header

### DIFF
--- a/src/lib/edge-tts/edgeTts.ts
+++ b/src/lib/edge-tts/edgeTts.ts
@@ -89,10 +89,48 @@ function timestamp(): string {
   return new Date().toISOString().replace(/[-:.]/g, '').slice(0, -1);
 }
 
+// Sec-MS-GEC buckets the current time into 5-minute windows; if the user's
+// system clock is off by more than that, every request is rejected. We
+// compensate by sampling the server's Date header once and caching the
+// offset for the rest of the session.
+let serverTimeOffsetMs = 0;
+let serverTimeOffsetPromise: Promise<number> | null = null;
+
+export function getServerTimeOffsetMs(forceRefresh = false): Promise<number> {
+  if (forceRefresh) serverTimeOffsetPromise = null;
+  if (serverTimeOffsetPromise) return serverTimeOffsetPromise;
+
+  serverTimeOffsetPromise = (async () => {
+    try {
+      const t0 = Date.now();
+      const probeUrl = `https://${READALOUD_BASE}/voices/list?trustedclienttoken=${TRUSTED_CLIENT_TOKEN}`;
+      const response = await fetch(probeUrl, { method: 'HEAD', cache: 'no-store' });
+      const t1 = Date.now();
+      const dateHeader = response.headers.get('date');
+      if (dateHeader) {
+        const serverMs = new Date(dateHeader).getTime();
+        if (!Number.isNaN(serverMs)) {
+          // Midpoint of request/response brackets the moment the server
+          // stamped Date — gives ~RTT/2 accuracy, far below the 300s window.
+          serverTimeOffsetMs = serverMs - (t0 + t1) / 2;
+        }
+      }
+    } catch {
+      // Probe failed (offline / DNS / TLS). Fall through with offset=0;
+      // the actual TTS call will surface a more specific error.
+      serverTimeOffsetPromise = null;
+    }
+    return serverTimeOffsetMs;
+  })();
+
+  return serverTimeOffsetPromise;
+}
+
 export async function makeSecMsGec(): Promise<string> {
+  const offsetMs = await getServerTimeOffsetMs();
   const winEpoch = 11644473600;
   const secondsToNs = 1e9;
-  let ticks = Date.now() / 1000;
+  let ticks = (Date.now() + offsetMs) / 1000;
   ticks += winEpoch;
   ticks -= ticks % 300;
   ticks *= secondsToNs / 100;

--- a/src/lib/edge-tts/edgeTts.ts
+++ b/src/lib/edge-tts/edgeTts.ts
@@ -103,8 +103,7 @@ export function getServerTimeOffsetMs(forceRefresh = false): Promise<number> {
   serverTimeOffsetPromise = (async () => {
     try {
       const t0 = Date.now();
-      const probeUrl = `https://${READALOUD_BASE}/voices/list?trustedclienttoken=${TRUSTED_CLIENT_TOKEN}`;
-      const response = await fetch(probeUrl, { method: 'HEAD', cache: 'no-store' });
+      const response = await fetch(VOICE_LIST_URL, { method: 'HEAD', cache: 'no-store' });
       const t1 = Date.now();
       const dateHeader = response.headers.get('date');
       if (dateHeader) {


### PR DESCRIPTION
## Summary

- Edge TTS uses `Sec-MS-GEC`, a SHA-256 hash of the current time bucketed into 5-minute windows. If the user's system clock is off by more than the window size, **every** request is rejected with no audio.
- We now probe `https://speech.platform.bing.com/.../voices/list` with `HEAD` on first use, read the server's `Date` response header, and cache the offset between server and local time for the session. `makeSecMsGec` then computes the hash from `Date.now() + offset` instead of raw `Date.now()`.
- Probe-failure path leaves the offset at `0` and clears the cached promise — the actual TTS call still raises a real error rather than being masked.

## How this was found

Reproduced locally with a minimal Electron harness that mirrored the production code path (UA injection via `onBeforeSendHeaders` + browser `WebSocket` + the same Sec-MS-GEC algorithm). The voice-list HTTPS sanity check exposed a multi-minute drift between local and server time on the affected machine; correcting the OS clock made every other call succeed.

## Why this approach

- **One probe per session**: `getServerTimeOffsetMs` memoises the inflight promise so concurrent first-callers share one round-trip.
- **Midpoint correction**: offset = `serverDate − (t0 + t1) / 2` gives ~RTT/2 accuracy — far tighter than the 300s window we need to land inside.
- **No new endpoint**: the same Bing host that handles TTS sets the `Date` header on the existing voices URL, so no third-party time service or extra trust boundary.
- **No call-site changes**: `makeSecMsGec` is already async and is the single time source for both `fetchVoiceList` and `EdgeTtsConnection`, so both paths benefit automatically.

## Test plan

- [ ] Manually skew local clock by >5 minutes; confirm Edge TTS still produces audio.
- [ ] Disable network before first call; confirm error message is the same WebSocket-failure path, not silently swallowed.
- [ ] Run with correct clock; confirm no behavioural regression (offset ≈ 0).
- [ ] Verify same behaviour in Electron desktop and the browser extension build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate server time synchronization for the TTS service, improving timing-related headers so synthesized speech is more consistent across devices.
  * Caches server offset for faster repeat requests and gracefully falls back if the probe fails, improving reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/237)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->