### PR TITLE
feat(subtitle): highlight newly-arrived text in compact band (#236)

### DIFF
--- a/docs/superpowers/plans/2026-05-18-subtitle-new-item-highlight.md
+++ b/docs/superpowers/plans/2026-05-18-subtitle-new-item-highlight.md
@@ -1,0 +1,639 @@
+# Subtitle New-Item Highlight Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make newly-arrived items in the compact subtitle band visually obvious via a one-shot fade-in plus a decaying background-luminance-aware overlay, without re-animating the items that were already on screen when subtitle mode opened.
+
+**Architecture:** Replace the per-bucket `bucket.join(' ')` string with an array of `{id, text}` items in the `SubtitleStream` compact branch, then render each item as a `<span key={item.id}>`. Track item lifecycle in two refs (`itemStatesRef: Map<id, 'existing'|'new'>` and `isFirstRenderRef: boolean`) — `existing` for items present at first mount, `new` for items that arrive after. The `--new` modifier triggers a single combined CSS keyframe animation. The overlay color is set via the CSS variable `--subtitle-highlight-overlay`, picked by a YIQ-based helper that inverts against the user's `bgColor`.
+
+**Tech Stack:** React 18 (refs + `useLayoutEffect`), TypeScript, Vitest + `@testing-library/react`, SCSS (`@keyframes`).
+
+**Spec:** [`docs/superpowers/specs/2026-05-18-subtitle-new-item-highlight-design.md`](../specs/2026-05-18-subtitle-new-item-highlight-design.md)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `src/components/Subtitle/SubtitleApp.tsx` | Owns the YIQ helper `getHighlightOverlayForBg` and injects `--subtitle-highlight-overlay` on the subtitle root |
+| `src/components/Subtitle/SubtitleApp.test.tsx` (new) | Unit tests for the helper |
+| `src/components/Subtitle/SubtitleStream.tsx` | Bucket shape change, per-item span rendering, item-state refs |
+| `src/components/Subtitle/SubtitleStream.scss` | `.subtitle-stream__item` styles, `.subtitle-stream__item--new`, `@keyframes subtitle-item-highlight` |
+| `src/components/Subtitle/SubtitleStream.test.tsx` | New assertions for per-item spans, first-mount suppression, post-mount arrival, streaming-growth stability |
+
+No other files change.
+
+---
+
+## Task 1: Helper — `getHighlightOverlayForBg`
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleApp.tsx` (add an exported helper near the existing `hexToRgba` at line 39)
+- Create: `src/components/Subtitle/SubtitleApp.test.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/Subtitle/SubtitleApp.test.tsx`:
+
+```tsx
+import { describe, it, expect } from 'vitest';
+import { getHighlightOverlayForBg } from './SubtitleApp';
+
+describe('getHighlightOverlayForBg', () => {
+  it('returns a translucent white overlay for the default black background', () => {
+    expect(getHighlightOverlayForBg('#000000')).toBe('rgba(255, 255, 255, 0.3)');
+  });
+
+  it('returns a translucent black overlay for a white background', () => {
+    expect(getHighlightOverlayForBg('#ffffff')).toBe('rgba(0, 0, 0, 0.3)');
+  });
+
+  it('flips at the YIQ midpoint (≈ 128)', () => {
+    // YIQ for #555555 = 0.299*85 + 0.587*85 + 0.114*85 = 85 < 128 → dark → white overlay
+    expect(getHighlightOverlayForBg('#555555')).toBe('rgba(255, 255, 255, 0.3)');
+    // YIQ for #aaaaaa = 170 > 128 → light → black overlay
+    expect(getHighlightOverlayForBg('#aaaaaa')).toBe('rgba(0, 0, 0, 0.3)');
+  });
+
+  it('weights green most heavily (YIQ luminance)', () => {
+    // Pure red (#ff0000): YIQ = 0.299*255 ≈ 76 → dark → white
+    expect(getHighlightOverlayForBg('#ff0000')).toBe('rgba(255, 255, 255, 0.3)');
+    // Pure green (#00ff00): YIQ = 0.587*255 ≈ 150 → light → black
+    expect(getHighlightOverlayForBg('#00ff00')).toBe('rgba(0, 0, 0, 0.3)');
+    // Pure blue (#0000ff): YIQ = 0.114*255 ≈ 29 → dark → white
+    expect(getHighlightOverlayForBg('#0000ff')).toBe('rgba(255, 255, 255, 0.3)');
+  });
+
+  it('returns the dark-bg default when the input is malformed', () => {
+    expect(getHighlightOverlayForBg('#fff')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('not-a-hex')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('')).toBe('rgba(255, 255, 255, 0.3)');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/Subtitle/SubtitleApp.test.tsx`
+Expected: FAIL — `getHighlightOverlayForBg` is not exported.
+
+- [ ] **Step 3: Add the helper to `SubtitleApp.tsx`**
+
+Insert this function in `src/components/Subtitle/SubtitleApp.tsx` immediately below the existing `hexToRgba` function (around line 50, right after the closing brace of `hexToRgba`):
+
+```tsx
+const HIGHLIGHT_ALPHA = 0.3;
+
+/**
+ * Returns a CSS color for the "newly-arrived item" overlay, chosen so it
+ * contrasts with the user-selected background. YIQ luminance < 128 means
+ * the background is dark → use a light overlay; otherwise use dark.
+ *
+ * The user-set bgOpacity is intentionally not factored in. When opacity is
+ * very low and the actual visible background is whatever sits behind the
+ * subtitle window, this falls back to the bgColor's nominal lightness —
+ * a known limitation accepted in the design spec.
+ */
+export function getHighlightOverlayForBg(hex: string): string {
+  const cleaned = hex.replace('#', '');
+  if (cleaned.length !== 6) return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
+  }
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq < 128
+    ? `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`
+    : `rgba(0, 0, 0, ${HIGHLIGHT_ALPHA})`;
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/Subtitle/SubtitleApp.test.tsx`
+Expected: PASS — all 5 test cases green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleApp.tsx src/components/Subtitle/SubtitleApp.test.tsx
+git commit -m "feat(subtitle): add getHighlightOverlayForBg YIQ helper"
+```
+
+---
+
+## Task 2: Inject `--subtitle-highlight-overlay` CSS variable
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleApp.tsx` (the `rootStyle` block around line 199)
+
+`SubtitleApp` has heavy dependencies (`useSettingsStore`, `useSessionStore`, electron surface logic) and is not currently rendered in isolation by any test in the codebase. Building a full mock harness just to assert one CSS var would be disproportionate. The helper itself is exhaustively unit-tested in Task 1; the wiring is one declarative line and verified manually in Task 6.
+
+- [ ] **Step 1: Wire the var into `rootStyle`**
+
+In `src/components/Subtitle/SubtitleApp.tsx`, modify the existing `rootStyle` block (around lines 199-203):
+
+```tsx
+const bgAlpha = subtitle.bgOpacity / 100;
+const rootStyle: React.CSSProperties & Record<string, string | number> = {
+  background: hexToRgba(subtitle.bgColor, bgAlpha),
+  '--bar-opacity': barVisible ? 1 : 0,
+  '--bar-pointer-events': barVisible ? 'auto' : 'none',
+  '--subtitle-highlight-overlay': getHighlightOverlayForBg(subtitle.bgColor),
+};
+```
+
+- [ ] **Step 2: Run the existing tests to confirm no regression**
+
+Run: `npx vitest run src/components/Subtitle/`
+Expected: PASS — every test in `SubtitleApp.test.tsx`, `SubtitleStream.test.tsx`, and `SubtitleSessionEnded.test.tsx` still passes (Task 1's helper tests stay green; nothing else changed).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleApp.tsx
+git commit -m "feat(subtitle): inject --subtitle-highlight-overlay CSS var on root"
+```
+
+---
+
+## Task 3: Per-item spans in compact branch
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleStream.tsx` (compact branch + `useMemo`)
+- Modify: `src/components/Subtitle/SubtitleStream.test.tsx` (add assertions)
+
+This task changes the bucket shape from `string` to `{id, text}[]` and renders each entry as its own `<span>`. Existing tests already assert `p.textContent` rather than checking for a single text node, so they continue to pass.
+
+- [ ] **Step 1: Write the failing test**
+
+Add a new `it` block inside the existing `describe('SubtitleStream — compact mode (up to 4 equal-height lines)'` block in `src/components/Subtitle/SubtitleStream.test.tsx`:
+
+```tsx
+it('renders one span per visible item with the item id as the key', () => {
+  const many: any[] = [
+    { id: '1', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'hello' },  sourceLanguage: 'en', targetLanguage: 'zh' },
+    { id: '5', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'world' },  sourceLanguage: 'en', targetLanguage: 'zh' },
+    { id: '9', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'again' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+  ];
+  const { container } = render(
+    <SubtitleStream
+      items={many}
+      compact
+      fontSize={24}
+      speakerMode="both"
+      participantMode="both"
+      sourceLanguage="en"
+      targetLanguage="zh"
+    />,
+  );
+  const spans = container.querySelectorAll(
+    '.subtitle-stream__line--speaker.subtitle-stream__line--source .subtitle-stream__item',
+  );
+  expect(spans.length).toBe(3);
+  // Chronological order: oldest first
+  expect(spans[0].textContent).toBe('hello');
+  expect(spans[1].textContent).toBe(' world');
+  expect(spans[2].textContent).toBe(' again');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: FAIL — selector `.subtitle-stream__item` returns 0 elements (compact branch still uses a flat `<p>{text}</p>`).
+
+- [ ] **Step 3: Refactor bucket shape and compact render**
+
+In `src/components/Subtitle/SubtitleStream.tsx`, replace the existing `SubtitleLine` interface, the `useMemo` body that builds `lines`, and the compact JSX render. The full replacement for the `lines` computation:
+
+```tsx
+interface SubtitleLineItem {
+  id: string;
+  text: string;
+}
+interface SubtitleLine {
+  id: string;
+  kind: LineKind;
+  source: LineSource;
+  items: SubtitleLineItem[];
+}
+
+const lines = useMemo<SubtitleLine[]>(() => {
+  const buckets: Record<string, SubtitleLineItem[]> = {
+    'speaker-source': [],
+    'speaker-translation': [],
+    'participant-source': [],
+    'participant-translation': [],
+  };
+  const bucketLen: Record<string, number> = {
+    'speaker-source': 0,
+    'speaker-translation': 0,
+    'participant-source': 0,
+    'participant-translation': 0,
+  };
+
+  // Walk items newest-first, prepending each item's text to its bucket
+  // until that bucket reaches BUCKET_MAX_CHARS. Older items beyond the
+  // cap are dropped — the band only shows the tail anyway. shouldShowItem
+  // lets error/system rows pass; route them to the translation bucket of
+  // whichever side produced them so they remain visible.
+  for (let i = filtered.length - 1; i >= 0; i--) {
+    const item = filtered[i];
+    const text = itemText(item).trim();
+    if (!text) continue;
+    const side: LineSource = item.source === 'participant' ? 'participant' : 'speaker';
+    let kind: LineKind;
+    if (item.role === 'user') kind = 'source';
+    else if (item.role === 'assistant') kind = 'translation';
+    else if (item.type === 'error' || item.role === 'system') kind = 'translation';
+    else continue;
+    const key = `${side}-${kind}`;
+    if (bucketLen[key] >= BUCKET_MAX_CHARS) continue;
+    buckets[key].unshift({ id: item.id, text });
+    bucketLen[key] += text.length + 1; // +1 for the joining space
+  }
+
+  const order: Array<{ source: LineSource; kind: LineKind }> = [
+    { source: 'speaker', kind: 'source' },
+    { source: 'speaker', kind: 'translation' },
+    { source: 'participant', kind: 'source' },
+    { source: 'participant', kind: 'translation' },
+  ];
+  return order
+    .map(({ source, kind }) => ({
+      id: `${source}-${kind}`,
+      source,
+      kind,
+      items: buckets[`${source}-${kind}`],
+    }))
+    .filter((l) => l.items.length > 0);
+}, [filtered]);
+```
+
+Replace the compact-branch JSX inside the returned `<div className={...}>`:
+
+```tsx
+{compact
+  ? lines.map((line) => (
+      <div
+        key={line.id}
+        className={`subtitle-stream__line subtitle-stream__line--${line.kind} subtitle-stream__line--${line.source}`}
+      >
+        <p>
+          {line.items.map((it, idx) => (
+            <span key={it.id} className="subtitle-stream__item">
+              {idx > 0 ? ' ' : ''}{it.text}
+            </span>
+          ))}
+        </p>
+      </div>
+    ))
+  : filtered.map((item, i) => (
+      <ConversationRow
+        key={item.id}
+        item={item}
+        prevItem={filtered[i - 1] ?? null}
+        compact={false}
+        sourceLanguage={sourceLanguage}
+        targetLanguage={targetLanguage}
+        isPlaying={false}
+        highlightedChars={0}
+        canPlay={false}
+      />
+    ))}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: PASS — all existing test cases still green (they assert via `p.textContent`, which transparently reads through child spans), and the new per-span assertion is green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleStream.tsx src/components/Subtitle/SubtitleStream.test.tsx
+git commit -m "feat(subtitle): render compact bucket items as per-item spans"
+```
+
+---
+
+## Task 4: First-mount suppression + new-item class
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleStream.tsx` (refs + state machine)
+- Modify: `src/components/Subtitle/SubtitleStream.test.tsx` (two new assertions)
+
+- [ ] **Step 1: Write the failing tests**
+
+Add these `it` blocks inside the same `describe('SubtitleStream — compact mode (up to 4 equal-height lines)'` block:
+
+```tsx
+it('does not mark items as new on the very first render (no flash for pre-existing items)', () => {
+  const { container } = render(
+    <SubtitleStream
+      items={items}
+      compact
+      fontSize={24}
+      speakerMode="both"
+      participantMode="both"
+      sourceLanguage="en"
+      targetLanguage="zh"
+    />,
+  );
+  const newSpans = container.querySelectorAll('.subtitle-stream__item--new');
+  expect(newSpans.length).toBe(0);
+});
+
+it('marks only items that arrive after the first render as new', () => {
+  const { container, rerender } = render(
+    <SubtitleStream
+      items={items}
+      compact
+      fontSize={24}
+      speakerMode="both"
+      participantMode="both"
+      sourceLanguage="en"
+      targetLanguage="zh"
+    />,
+  );
+  // First render — none should be new
+  expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+
+  // A new speaker source item arrives
+  const arrived: any[] = [
+    ...items,
+    { id: 'NEW1', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'just arrived' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+  ];
+  rerender(
+    <SubtitleStream
+      items={arrived}
+      compact
+      fontSize={24}
+      speakerMode="both"
+      participantMode="both"
+      sourceLanguage="en"
+      targetLanguage="zh"
+    />,
+  );
+  const newSpans = container.querySelectorAll('.subtitle-stream__item--new');
+  expect(newSpans.length).toBe(1);
+  expect(newSpans[0].textContent).toContain('just arrived');
+});
+
+it('does not re-toggle the --new class when a streaming item grows in place', () => {
+  // Item is present at first render → marked 'existing' permanently.
+  // Then it "grows" (text changes while id stays the same).
+  const initial: any[] = [
+    { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'in_progress', formatted: { text: 'Hel' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+  ];
+  const { container, rerender } = render(
+    <SubtitleStream
+      items={initial}
+      compact
+      fontSize={24}
+      speakerMode="both"
+      participantMode="both"
+      sourceLanguage="en"
+      targetLanguage="zh"
+    />,
+  );
+  expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+
+  const grown: any[] = [
+    { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'Hello world' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+  ];
+  rerender(
+    <SubtitleStream
+      items={grown}
+      compact
+      fontSize={24}
+      speakerMode="both"
+      participantMode="both"
+      sourceLanguage="en"
+      targetLanguage="zh"
+    />,
+  );
+  // Same id → 'existing' state preserved → still no --new class.
+  expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: FAIL — the streaming-growth test passes (no class yet), but the "marks items that arrive after first render as new" assertion fails (`querySelectorAll('.subtitle-stream__item--new').length` is 0 instead of 1).
+
+- [ ] **Step 3: Add refs and decision rule**
+
+In `src/components/Subtitle/SubtitleStream.tsx`, after the `useEffect` for `endRef` (around the existing block at line 126), add:
+
+```tsx
+// Each item is classified once and locked: 'existing' = present at first
+// render of this component instance (never animates), 'new' = arrived later
+// (animates exactly once on first paint via CSS @keyframes).
+const itemStatesRef = useRef<Map<string, 'existing' | 'new'>>(new Map());
+const isFirstRenderRef = useRef(true);
+
+const itemStateFor = (id: string): 'existing' | 'new' => {
+  const known = itemStatesRef.current.get(id);
+  if (known) return known;
+  return isFirstRenderRef.current ? 'existing' : 'new';
+};
+
+useLayoutEffect(() => {
+  for (const line of lines) {
+    for (const it of line.items) {
+      if (!itemStatesRef.current.has(it.id)) {
+        itemStatesRef.current.set(
+          it.id,
+          isFirstRenderRef.current ? 'existing' : 'new',
+        );
+      }
+    }
+  }
+  isFirstRenderRef.current = false;
+});
+```
+
+Then update the import line at the top of the file to include `useLayoutEffect`:
+
+```tsx
+import React, { useEffect, useLayoutEffect, useRef, useMemo } from 'react';
+```
+
+Then update the compact-branch JSX so the span carries `--new` when applicable:
+
+```tsx
+{line.items.map((it, idx) => {
+  const className =
+    itemStateFor(it.id) === 'new'
+      ? 'subtitle-stream__item subtitle-stream__item--new'
+      : 'subtitle-stream__item';
+  return (
+    <span key={it.id} className={className}>
+      {idx > 0 ? ' ' : ''}{it.text}
+    </span>
+  );
+})}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: PASS — all three new tests green, and previously-passing tests still green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleStream.tsx src/components/Subtitle/SubtitleStream.test.tsx
+git commit -m "feat(subtitle): mark newly-arrived bucket items with --new modifier"
+```
+
+---
+
+## Task 5: SCSS keyframe + item styles
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleStream.scss`
+
+This task is visual; the JSX assertions in Task 4 already verified the class is applied to the right elements. We add the styles, then re-run the full test suite to confirm no regression.
+
+- [ ] **Step 1: Add styles**
+
+In `src/components/Subtitle/SubtitleStream.scss`, append inside the existing `.subtitle-stream` block (right after the `&.compact { ... }` block closes — same indentation level as `&.compact` and `&.expanded`). Place this block above `&.expanded`:
+
+```scss
+  // ------------------------------------------------------------------
+  // Per-item highlight in compact mode.
+  // The item-aware spans created by SubtitleStream are styled here.
+  // `--new` modifier triggers a one-shot fade-in + decaying overlay
+  // animation; the class persists on the span afterwards (harmless —
+  // CSS animations only fire once per class application).
+  // ------------------------------------------------------------------
+  .subtitle-stream__item {
+    // No styles in the un-animated case — the span is a plain inline.
+  }
+
+  .subtitle-stream__item--new {
+    animation: subtitle-item-highlight 2s ease-out both;
+    border-radius: 2px;
+    padding: 1px 3px;
+  }
+}
+
+@keyframes subtitle-item-highlight {
+  0% {
+    opacity: 0;
+    background-color: var(--subtitle-highlight-overlay, rgba(255, 255, 255, 0.3));
+  }
+  20% {
+    opacity: 1;
+    background-color: var(--subtitle-highlight-overlay, rgba(255, 255, 255, 0.3));
+  }
+  100% {
+    opacity: 1;
+    background-color: transparent;
+  }
+}
+```
+
+Important: the closing brace `}` shown above on the line "}" closes the outer `.subtitle-stream` block. Place the `@keyframes` *outside* that block (keyframes cannot be nested inside a selector — well, Sass would let you, but keeping it top-level is clearer). Adjust placement to match the file's existing structure if needed.
+
+- [ ] **Step 2: Run all relevant tests**
+
+Run: `npx vitest run src/components/Subtitle/`
+Expected: PASS — every test in `SubtitleApp.test.tsx`, `SubtitleStream.test.tsx`, and `SubtitleSessionEnded.test.tsx` still passes. The SCSS change is a no-op for jsdom (which doesn't run animations) but JSX assertions still validate class application.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleStream.scss
+git commit -m "feat(subtitle): add highlight keyframe and per-item span styles"
+```
+
+---
+
+## Task 6: Full test suite + manual verification
+
+This task locks the work in: full suite run, then a short manual checklist against the spec's "Manual verification" section.
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `npm run test -- --run`
+Expected: PASS — no regressions anywhere in the repo. If anything else breaks, debug and fix before continuing.
+
+- [ ] **Step 2: Manual verification — local provider (non-streaming)**
+
+If a local-provider environment is set up locally:
+
+1. `npm run electron:dev`
+2. Configure local provider with HY-MT translation.
+3. Start a session, open subtitle mode (compact band).
+4. Speak a long sentence. Observe the translation: fade-in + light overlay should appear and decay over ~2 s.
+
+If no local provider available, skip — Task 7 covers OpenAI Realtime as a streaming smoke test.
+
+- [ ] **Step 3: Manual verification — streaming provider**
+
+1. With the same dev electron app, switch to OpenAI Realtime.
+2. Start a session, open subtitle mode.
+3. Speak a short utterance. Observe the streaming item: it fades in once at first text, then continues growing without re-animating.
+
+- [ ] **Step 4: Manual verification — first-mount suppression**
+
+1. Have a few items already in the conversation (speak briefly in the main panel).
+2. Toggle subtitle mode on.
+3. Observe: the pre-existing items appear without any animation. Only the *next* arriving item animates.
+
+- [ ] **Step 5: Manual verification — overlay color flip**
+
+1. Open subtitle settings (⚙).
+2. Change `bgColor` to white (`#ffffff`).
+3. Speak again. Observe: the next arriving item has a dark (translucent black) overlay instead of light.
+4. Revert `bgColor` to black to keep dev state clean.
+
+- [ ] **Step 6: Final commit (if any tweaks)**
+
+If steps 2-5 surface a visual issue (e.g., padding too aggressive, 2 s too slow), tweak `SubtitleStream.scss` and commit:
+
+```bash
+git add src/components/Subtitle/SubtitleStream.scss
+git commit -m "fix(subtitle): tune highlight animation timing / padding"
+```
+
+Otherwise, no commit needed — the previous task already finalised the implementation.
+
+---
+
+## Self-Review Checklist (against spec)
+
+The implementation must satisfy every item in this checklist before considering the work done.
+
+- [ ] **Visual treatment**: fade-in (opacity 0 → 1 by ~20% of animation = 400 ms in a 2 s run) + overlay decay to transparent → covered by Task 5 keyframe.
+- [ ] **Overlay color auto-inverts**: YIQ < 128 → white, else black → covered by Task 1 helper + Task 2 CSS var injection.
+- [ ] **All four buckets supported**: speaker source / speaker translation / participant source / participant translation → covered by Task 3 (per-item rendering replaces the per-bucket join uniformly).
+- [ ] **Error / system items get the same highlight**: bucket routing for `type==='error'` / `role==='system'` to translation bucket is unchanged → handled by Task 3 preserving existing routing logic.
+- [ ] **Per-item span keyed by `item.id`**: covered by Task 3.
+- [ ] **First-mount suppression** (no flash for items present at component mount): covered by Task 4's `isFirstRenderRef` gate + tests.
+- [ ] **New-arrival animation** (one-shot per item via CSS keyframe + class): covered by Task 4 (state) + Task 5 (CSS).
+- [ ] **Streaming-growth stability** (same id → state preserved → no re-toggle): covered by Task 4's `itemStatesRef.has(it.id)` short-circuit + dedicated test.
+- [ ] **`BUCKET_MAX_CHARS` truncation honored**: Task 3 keeps the `bucketLen[key] += text.length + 1` accumulator + threshold check identical to today.
+- [ ] **Expanded mode unchanged**: Task 3 leaves the expanded-branch JSX untouched.
+- [ ] **No new persisted settings, no new UI controls**: confirmed — nothing in `subtitleStore`, `DisplaySettingsPopover`, or i18n changes.
+- [ ] **Helper exported for testing**: Task 1 declares `getHighlightOverlayForBg` with `export`.
+- [ ] **`useLayoutEffect` rather than `useEffect`** for committing item states: Task 4 specifies this explicitly to avoid a paint-race on the first arrival after mount.
+- [ ] **`bgOpacity` low limitation accepted**: documented in helper JSDoc (Task 1) and spec.
+
+---
+
+## Out of Scope (reminder)
+
+- Tuning constants beyond the spec's defaults (2 s animation, 0.30 peak alpha, 1 px / 3 px padding) — these are *implementation* choices the engineer can adjust if visually awkward, but the design accepts them.
+- Settings UI for highlight customisation.
+- Touching expanded mode.
+- Extracting `hexToRgba` to a shared utility module.
+- Any test infrastructure beyond what already exists (Vitest + jsdom).

--- a/docs/superpowers/plans/2026-05-18-subtitle-new-item-highlight.md
+++ b/docs/superpowers/plans/2026-05-18-subtitle-new-item-highlight.md
@@ -637,3 +637,39 @@ The implementation must satisfy every item in this checklist before considering 
 - Touching expanded mode.
 - Extracting `hexToRgba` to a shared utility module.
 - Any test infrastructure beyond what already exists (Vitest + jsdom).
+
+---
+
+## Follow-up Task 7: User Toggle (post-approval)
+
+Added after the original 6 tasks were implemented, in response to a user
+request to make the highlight feature opt-out. See the spec's
+"Follow-up Addition (post-approval)" section for design details.
+
+**Files modified:**
+
+- `src/stores/subtitleStore.ts` — new `newItemHighlightEnabled: boolean`
+  field (default `true`), `setNewItemHighlightEnabled` setter, hydration
+  entry, `useSubtitleNewItemHighlightEnabled` /
+  `useSetSubtitleNewItemHighlightEnabled` hooks.
+- `src/stores/subtitleStore.test.ts` — new `setNewItemHighlightEnabled`
+  test; reset state includes the new field.
+- `src/components/Subtitle/SubtitleStream.tsx` — new optional prop
+  `newItemHighlightEnabled?: boolean` (default `true`); compact branch
+  gates the `--new` modifier on this flag.
+- `src/components/Subtitle/SubtitleStream.test.tsx` — new test asserting
+  that `newItemHighlightEnabled={false}` suppresses the `--new` class
+  even for items arriving post-mount.
+- `src/components/Subtitle/SubtitleApp.tsx` — reads the setting and
+  passes it through to `SubtitleStream`.
+- `src/components/Display/DisplaySettingsPopover.tsx` — adds a
+  subtitle-only `ToggleSwitch` row consuming the new setter.
+- `src/components/Display/DisplaySettingsPopover.test.tsx` — verifies
+  the toggle renders in subtitle mode only and that clicking it flips
+  the store.
+- `src/locales/en/translation.json` — new English key
+  `subtitle.settings.newItemHighlight` → "Highlight newly-arrived text".
+
+The earlier "self-review checklist" item **"No new persisted settings,
+no new UI controls"** no longer holds; the toggle was explicitly added.
+All other checklist items still apply.

--- a/docs/superpowers/specs/2026-05-18-subtitle-new-item-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-18-subtitle-new-item-highlight-design.md
@@ -43,7 +43,7 @@ The state machine that decides *which* spans get the `--new` class lives in `Sub
 
 The decision rule is:
 
-```
+```text
 state = itemStatesRef.get(itemId)
 if state defined        → use that
 else if isFirstRender   → 'existing'   (do not animate)
@@ -317,3 +317,41 @@ New tests to add:
 | What about session-start where many items are already on screen? | Suppress first-mount animation (`isFirstRenderRef`). Only items arriving after first commit animate. |
 | Error / system items? | Same highlight. |
 | `bgOpacity` very low (transparent subtitle window over an arbitrary backdrop)? | Accepted limitation. Overlay color uses `bgColor` only. |
+
+## Follow-up Addition (post-approval): User Toggle
+
+After the original spec was approved and the implementation landed, the user
+requested an on/off switch for the highlight feature. This section records
+the change so the spec stays in sync with shipped reality.
+
+**What was added (PR #239):**
+
+- `subtitleStore` gains a `newItemHighlightEnabled: boolean` field (default
+  `true`), with the usual setter / hydration / selector / action hooks. The
+  persistence key is `settings.common.subtitle.newItemHighlightEnabled`.
+- `SubtitleStream` accepts a new optional prop `newItemHighlightEnabled`
+  (default `true`). When `false`, the lifecycle refs still run but the
+  `--new` modifier is never applied, so the CSS animation is suppressed.
+  Items still render correctly.
+- `SubtitleApp` reads the setting and passes it through.
+- `DisplaySettingsPopover` renders an additional row (subtitle-source only,
+  using the existing `ToggleSwitch` component) labelled
+  `subtitle.settings.newItemHighlight` → "Highlight newly-arrived text".
+  The conversation-display popover is unaffected (no equivalent feature).
+- i18n: new English key `subtitle.settings.newItemHighlight`.
+
+**Revisions to earlier sections:**
+
+- The "Goals & Non-Goals" non-goal "Adding a new user-facing setting for the
+  highlight (color, duration, on/off)" is partially superseded: the on/off
+  toggle is now in scope; color and duration remain out of scope.
+- The "Files Affected" table additionally touches `src/stores/subtitleStore.ts`,
+  `src/components/Display/DisplaySettingsPopover.tsx`, and
+  `src/locales/en/translation.json`.
+- The "Not touched" list line "`subtitleStore` — no new persisted settings" and
+  "`DisplaySettingsPopover` — no new controls" no longer hold.
+
+**What is still in scope as the design intended:** the on/off toggle gates
+visibility only — the entire item-lifecycle machinery (refs, first-mount
+suppression, per-item spans) runs unchanged regardless of the setting. The
+default is `true`, so behavior matches the original spec out of the box.

--- a/docs/superpowers/specs/2026-05-18-subtitle-new-item-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-18-subtitle-new-item-highlight-design.md
@@ -1,0 +1,319 @@
+# Subtitle — Visually Mark Newly-Arrived Text
+
+**Date:** 2026-05-18
+**Status:** Design approved, ready for implementation plan
+**Issue:** [#236](https://github.com/kizuna-ai-lab/sokuji/issues/236)
+
+## Problem
+
+In **subtitle mode** with the compact band, `SubtitleStream` concatenates the most recent visible items per category (`speaker-source`, `speaker-translation`, `participant-source`, `participant-translation`) up to `BUCKET_MAX_CHARS` (~2000 chars), joins them into one `<p>`, and clips overflow to the bottom (`src/components/Subtitle/SubtitleStream.tsx:88-118`).
+
+For **streaming** providers this works fine — text grows token-by-token at the tail, so the eye follows new content as it appears.
+
+For **non-streaming** providers (local provider's sherpa-onnx ASR + Opus-MT / HY-MT translation, several cloud providers' transcription/translation endpoints), an item arrives as one already-complete chunk. A long sentence or several sentences appear at once; the band re-flows and the newly-arrived portion sits anywhere in the visible tail. The user has to scan back through previously-read text to figure out where the *new* content begins before resuming reading.
+
+Expanded mode (per-item `ConversationRow`) is unaffected — each row is already its own visual unit.
+
+## Goals & Non-Goals
+
+**Goals**
+- Make newly-arrived text visually obvious in the compact subtitle band, regardless of provider streaming behavior.
+- Behave uniformly across streaming and non-streaming providers — one mental model, one code path.
+- Survive existing user customization of `bgColor` / `bgOpacity` / `sourceTextColor` / `translationTextColor` without designing in a new hue that can clash.
+- Do not animate the items that are already on screen when the user first enters subtitle mode (or when the subtitle window first mounts) — only items that *arrive* afterwards.
+
+**Non-Goals**
+- Touching expanded mode. Per-item `ConversationRow` already separates items visually.
+- Adding a new user-facing setting for the highlight (color, duration, on/off). The treatment is opinionated and fixed.
+- Solving the case where the user sets `bgOpacity` very low and the actual visible background is whatever sits behind the subtitle window. The auto-inverted overlay is computed from `bgColor` only; low-opacity scenarios accept reduced contrast as a known limitation.
+- Re-animating an item when its text is corrected/replaced (same `item.id`, different text). The animation fires once per item, on first appearance.
+
+## Design Overview
+
+Three coordinated changes:
+
+1. **Per-item spans in the compact branch.** Replace the `bucket.join(' ')` flat string with an array of `{id, text}` entries; render each as its own `<span key={item.id}>`. This is the "item-aware rendering in compact mode" direction from issue #236, and is the prerequisite for any per-item visual treatment.
+2. **CSS keyframe highlight on first appearance.** Each new span gets a class `subtitle-stream__item--new` that triggers a `@keyframes` animation combining fade-in (opacity 0 → 1, ~400 ms) and an overlay-decay (semi-transparent background fades from ~0.30 alpha to 0 over ~2 s). The animation fires once on apply and the class stays on the span afterwards (harmless once animation completes).
+3. **Background-luminance-aware overlay color.** A small pure helper picks `rgba(255,255,255, α)` for dark backgrounds and `rgba(0,0,0, α)` for light backgrounds based on the YIQ luminance of `bgColor`. Result is set on the subtitle root as a CSS variable `--subtitle-highlight-overlay` and consumed by the keyframe.
+
+The state machine that decides *which* spans get the `--new` class lives in `SubtitleStream` as two refs:
+
+- `itemStatesRef: Map<itemId, 'existing' | 'new'>` — records, for every item we have ever rendered, whether it was already on screen at first mount (`existing`) or arrived later (`new`).
+- `isFirstRenderRef: boolean` — true only during the very first render pass; flipped to `false` in `useLayoutEffect`.
+
+The decision rule is:
+
+```
+state = itemStatesRef.get(itemId)
+if state defined        → use that
+else if isFirstRender   → 'existing'   (do not animate)
+else                    → 'new'        (animate)
+```
+
+After commit (`useLayoutEffect`), every currently-rendered item that has no entry in the map gets one, locking its state for the rest of the component's lifetime. The map grows monotonically; with typical conversations this is hundreds of entries, fine to leave un-pruned for v1.
+
+## Component Changes
+
+### `SubtitleStream.tsx`
+
+Current shape of the memoized `lines` (compact branch):
+
+```ts
+interface SubtitleLine {
+  id: string;            // e.g. 'speaker-source'
+  kind: LineKind;
+  source: LineSource;
+  text: string;          // joined string
+}
+```
+
+New shape:
+
+```ts
+interface SubtitleLineItem {
+  id: string;            // item.id
+  text: string;
+}
+interface SubtitleLine {
+  id: string;
+  kind: LineKind;
+  source: LineSource;
+  items: SubtitleLineItem[];   // chronological: oldest first, newest last
+}
+```
+
+Bucket building logic stays — walk `filtered` newest-first, `unshift` into the bucket until `bucketLen[key] >= BUCKET_MAX_CHARS`. Only difference: each bucket now holds `{id, text}` objects, and `bucketLen` accumulates `text.length + 1` exactly as today (the `+1` continues to stand in for the inter-item separator).
+
+Compact render:
+
+```tsx
+{lines.map((line) => (
+  <div
+    key={line.id}
+    className={`subtitle-stream__line subtitle-stream__line--${line.kind} subtitle-stream__line--${line.source}`}
+  >
+    <p>
+      {line.items.map((it, idx) => {
+        const isNew = itemStateFor(it.id) === 'new';
+        return (
+          <span
+            key={it.id}
+            className={`subtitle-stream__item${isNew ? ' subtitle-stream__item--new' : ''}`}
+          >
+            {idx > 0 ? ' ' : ''}{it.text}
+          </span>
+        );
+      })}
+    </p>
+  </div>
+))}
+```
+
+The leading space for non-first items mirrors the previous `bucket.join(' ')` behavior.
+
+State refs and commit hook:
+
+```tsx
+const itemStatesRef = useRef<Map<string, 'existing' | 'new'>>(new Map());
+const isFirstRenderRef = useRef(true);
+
+const itemStateFor = (id: string): 'existing' | 'new' => {
+  const known = itemStatesRef.current.get(id);
+  if (known) return known;
+  return isFirstRenderRef.current ? 'existing' : 'new';
+};
+
+useLayoutEffect(() => {
+  for (const line of lines) {
+    for (const it of line.items) {
+      if (!itemStatesRef.current.has(it.id)) {
+        itemStatesRef.current.set(
+          it.id,
+          isFirstRenderRef.current ? 'existing' : 'new',
+        );
+      }
+    }
+  }
+  isFirstRenderRef.current = false;
+});
+```
+
+Why `useLayoutEffect` rather than `useEffect`: synchronous commit before the browser paints prevents a render-cycle race where an item is computed twice as "new" before its state lands in the map.
+
+The expanded branch is unchanged.
+
+### `SubtitleStream.scss`
+
+Add inside the `&.compact` block (or alongside, keyed off `.subtitle-stream__item`):
+
+```scss
+.subtitle-stream__item {
+  // The animation is only triggered by --new; without it, item is a plain inline span.
+}
+
+.subtitle-stream__item--new {
+  // Combined fade-in + overlay-decay. `both` keeps end-state styling after animation
+  // finishes (transparent overlay, full opacity), even though the class persists on
+  // the span — animations only fire once per class application.
+  animation: subtitle-item-highlight 2s ease-out both;
+  border-radius: 2px;
+  padding: 1px 3px;
+}
+
+@keyframes subtitle-item-highlight {
+  0%   {
+    opacity: 0;
+    background-color: var(--subtitle-highlight-overlay, rgba(255, 255, 255, 0.30));
+  }
+  20%  {
+    opacity: 1;
+    background-color: var(--subtitle-highlight-overlay, rgba(255, 255, 255, 0.30));
+  }
+  100% {
+    opacity: 1;
+    background-color: transparent;
+  }
+}
+```
+
+Fade-in completes by ~20% (~400 ms in a 2 s animation); the overlay decays linearly through the remainder.
+
+Notes:
+
+- `padding: 1px 3px` and `border-radius: 2px` give the overlay a slightly hugged shape rather than a hard inline rectangle. The padding is small enough not to perturb line layout meaningfully even when many items are present.
+- The `var(--subtitle-highlight-overlay, ...)` fallback uses dark-bg-appropriate white at 0.30 alpha, matching the default `bgColor: #000000`.
+
+### `SubtitleApp.tsx`
+
+Extend the existing CSS-var injection (around line 199) to add the overlay color:
+
+```ts
+const rootStyle: React.CSSProperties & Record<string, string | number> = {
+  background: hexToRgba(subtitle.bgColor, bgAlpha),
+  '--bar-opacity': barVisible ? 1 : 0,
+  '--bar-pointer-events': barVisible ? 'auto' : 'none',
+  '--subtitle-highlight-overlay': getHighlightOverlayForBg(subtitle.bgColor),
+};
+```
+
+### Helper: `getHighlightOverlayForBg`
+
+New small pure function. `hexToRgba` today is a local function inside `SubtitleApp.tsx` (line 39). Colocate `getHighlightOverlayForBg` in the same file alongside `hexToRgba`; no module extraction in this change.
+
+```ts
+const HIGHLIGHT_ALPHA = 0.30;
+
+/**
+ * Returns a CSS color for the "newly-arrived item" overlay, chosen so it
+ * contrasts with the user-selected background. YIQ luminance < 128 means
+ * the background is dark → use a light overlay; otherwise use dark.
+ *
+ * The user-set bgOpacity is intentionally not factored in. When opacity is
+ * very low and the actual visible background is whatever sits behind the
+ * subtitle window, this falls back to the bgColor's nominal lightness —
+ * a known limitation accepted in design.
+ */
+export function getHighlightOverlayForBg(hex: string): string {
+  const cleaned = hex.replace('#', '');
+  if (cleaned.length !== 6) return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq < 128
+    ? `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`
+    : `rgba(0, 0, 0, ${HIGHLIGHT_ALPHA})`;
+}
+```
+
+The 3-digit hex case (`#fff`) does not occur in practice — `bgColor` is always written as 6 digits by the color-picker UI — so the function only validates length 6 and otherwise returns the dark-bg default.
+
+## Behavior Across Item Categories
+
+The highlight applies uniformly to all four buckets:
+
+- `speaker-source`
+- `speaker-translation`
+- `participant-source`
+- `participant-translation`
+
+Error and system items are already routed to the translation bucket of whichever side produced them (`SubtitleStream.tsx:96`). They receive the same highlight treatment — surfacing transient error messages with the same "new arrival" cue is desirable.
+
+## Behavior Across Provider Types
+
+| Provider class | Item lifecycle | Highlight behavior |
+|---|---|---|
+| **Streaming** (OpenAI Realtime, Gemini Live, Palabra, etc.) | Item created → token-by-token deltas → finalized | Span mounts the moment the item first has non-empty text. Animation fires once on mount. Subsequent deltas update the existing span's text — no re-trigger. |
+| **Non-streaming** (local provider ASR + Opus-MT / HY-MT, several cloud transcription endpoints) | Item arrives once with complete text | Span mounts with full text. Animation fires once on mount. |
+| **Text correction/replacement** (rare; same `item.id`, new text) | Span re-renders with new text content | Same span, no remount → no re-trigger. By design. |
+
+The "first non-empty text" boundary is implicit in today's bucket-building loop: `if (!text) continue;` already drops empty items, so a streaming item only enters a bucket when it has text.
+
+## First-Mount Semantics
+
+When the subtitle window first mounts — either because the user just toggled subtitle mode on, or because the Electron app restarted into a session that already has many history items — the bucket can contain dozens of items at once. Without first-mount suppression, every visible item would animate simultaneously: a screen-wide flicker that is more distracting than informative.
+
+The `isFirstRenderRef` gate ensures every item present in `filtered` during the first render is recorded as `'existing'` and therefore never animates, even on subsequent renders. Items that arrive after first commit are recorded as `'new'` and animate exactly once.
+
+A subtle consequence: if the user *leaves* subtitle mode and re-enters, the `SubtitleStream` component unmounts and remounts. `itemStatesRef` and `isFirstRenderRef` reset. Items already present in the bucket at re-entry are again classified as `'existing'` — they don't animate. This matches the intent ("don't flash a wall of old text").
+
+## Files Affected
+
+| File | Change |
+|---|---|
+| `src/components/Subtitle/SubtitleStream.tsx` | Bucket shape, render compact spans, item-state refs |
+| `src/components/Subtitle/SubtitleStream.scss` | `.subtitle-stream__item` styles, `@keyframes` |
+| `src/components/Subtitle/SubtitleApp.tsx` | Add `getHighlightOverlayForBg` (alongside existing `hexToRgba`); inject `--subtitle-highlight-overlay` CSS var |
+| `src/components/Subtitle/SubtitleStream.test.tsx` | Update existing assertions, add per-item and first-mount tests |
+| `src/components/Subtitle/SubtitleApp.test.tsx` (new file or extend if exists) | Unit-test `getHighlightOverlayForBg` |
+
+Not touched:
+
+- `subtitleStore` — no new persisted settings.
+- `DisplaySettingsPopover` — no new controls.
+- `ConversationRow` and the expanded subtitle branch.
+- Any provider client or audio-pipeline code.
+- i18n files.
+
+## Testing
+
+### `SubtitleStream.test.tsx` updates
+
+Existing tests assert that the compact branch joins text into one paragraph per line. These need updating to assert per-item spans.
+
+New tests to add:
+
+- **Per-item rendering in compact mode**: bucket of 3 visible items in one category produces 3 `<span class*="subtitle-stream__item">` children inside the line's `<p>`, in chronological order.
+- **First-mount suppression**: render with 3 items present from the start; assert no span carries the `--new` modifier.
+- **Subsequent arrival**: render with 2 items, re-render with a third appended; only the third span has `--new`.
+- **Stable across text growth (streaming)**: render with an item whose text grows across renders (`'Hello'` → `'Hello world'`); the span retains its state — no toggling of `--new` after the first render that introduced it (or absence of it if first-mount).
+- **Bucket cap honored**: existing `BUCKET_MAX_CHARS` behavior unaffected (older items truncated when too many).
+- **Existing CSS-var passthrough**: the assertions that `--subtitle-source-color` and `--subtitle-translation-color` flow through stay; add an assertion for `--subtitle-highlight-overlay` set from `SubtitleApp`.
+
+### Helper unit tests
+
+`getHighlightOverlayForBg`:
+
+- Dark hex `#000000` → `rgba(255, 255, 255, 0.3)`.
+- Light hex `#ffffff` → `rgba(0, 0, 0, 0.3)`.
+- Mid-luminance hex on either side of YIQ 128 → flips as expected.
+- Invalid length → safe default (light overlay).
+
+### Manual verification
+
+- Toggle subtitle mode on mid-session — observe no flicker across already-shown items.
+- Speak a long sentence with the local provider (HY-MT translation) — observe a clear fade-in + overlay decay on the arriving translation item.
+- Speak a short sentence with OpenAI Realtime — observe the streaming text fades in once at item creation and continues to grow without further animation.
+- Change `bgColor` from black to white in the settings popover — observe the overlay flip from white-on-dark to dark-on-light on the next item arrival.
+- Customize `sourceTextColor` to bright green — observe the overlay still works (it's the background behind the text, not the text color).
+
+## Open Questions Resolved During Brainstorming
+
+| Question | Resolution |
+|---|---|
+| Apply to non-streaming items only, or to all new items? | All. Uniform across providers; trigger is "item span first mount". |
+| Tint with the speaker/participant accent color (green/orange)? | No. User-customizable text colors can clash. Use luminance-inverted neutral overlay. |
+| Add a new "highlight color" setting? | No. Keeps surface clean; auto-inverted overlay is good enough for the customization range we expose. |
+| What about session-start where many items are already on screen? | Suppress first-mount animation (`isFirstRenderRef`). Only items arriving after first commit animate. |
+| Error / system items? | Same highlight. |
+| `bgOpacity` very low (transparent subtitle window over an arbitrary backdrop)? | Accepted limitation. Overlay color uses `bgColor` only. |

--- a/src/components/Display/DisplaySettingsPopover.test.tsx
+++ b/src/components/Display/DisplaySettingsPopover.test.tsx
@@ -120,6 +120,35 @@ describe('DisplaySettingsPopover', () => {
     expect(useConversationDisplayStore.getState().bgColor).toBe('#cccccc');
   });
 
+  it('renders the new-item-highlight toggle in subtitle mode only', () => {
+    const subtitleRender = render(<DisplaySettingsPopover source="subtitle" />);
+    expect(
+      subtitleRender.container.querySelector('.toggle-switch-component'),
+    ).not.toBeNull();
+    subtitleRender.unmount();
+
+    const conversationRender = render(<DisplaySettingsPopover source="conversation" />);
+    expect(
+      conversationRender.container.querySelector('.toggle-switch-component'),
+    ).toBeNull();
+  });
+
+  it('clicking the new-item-highlight toggle flips subtitleStore.newItemHighlightEnabled', async () => {
+    useSubtitleStore.setState({ newItemHighlightEnabled: true } as never);
+    const { container } = render(<DisplaySettingsPopover source="subtitle" />);
+    const trigger = container.querySelector(
+      '.toggle-switch-component [role="switch"]',
+    ) as HTMLElement;
+    expect(trigger).not.toBeNull();
+    expect(trigger.getAttribute('aria-checked')).toBe('true');
+
+    await act(async () => { fireEvent.click(trigger); });
+    expect(useSubtitleStore.getState().newItemHighlightEnabled).toBe(false);
+
+    await act(async () => { fireEvent.click(trigger); });
+    expect(useSubtitleStore.getState().newItemHighlightEnabled).toBe(true);
+  });
+
   it('first chip in each row reflects the source store default (subtitle)', () => {
     const { container } = render(<DisplaySettingsPopover source="subtitle" />);
     const fields = container.querySelectorAll('.field');

--- a/src/components/Display/DisplaySettingsPopover.tsx
+++ b/src/components/Display/DisplaySettingsPopover.tsx
@@ -6,14 +6,17 @@ import {
   useSubtitleBgColor,
   useSubtitleSourceTextColor,
   useSubtitleTranslationTextColor,
+  useSubtitleNewItemHighlightEnabled,
   useSetSubtitleBgOpacity,
   useSetSubtitleBgColor,
   useSetSubtitleSourceTextColor,
   useSetSubtitleTranslationTextColor,
+  useSetSubtitleNewItemHighlightEnabled,
   SUBTITLE_DEFAULT_BG_COLOR,
   SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR,
   SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR,
 } from '../../stores/subtitleStore';
+import ToggleSwitch from '../Settings/shared/ToggleSwitch';
 import {
   useConversationDisplayBgColor,
   useConversationDisplaySourceTextColor,
@@ -50,10 +53,14 @@ interface InnerBindings {
   bgColor: string;
   sourceTextColor: string;
   translationTextColor: string;
+  // newItemHighlightEnabled is subtitle-only. Conversation-mode bindings
+  // leave it undefined so the toggle row is suppressed.
+  newItemHighlightEnabled: boolean | undefined;
   setBgOpacity: ((n: number) => Promise<void>) | undefined;
   setBgColor: (s: string) => Promise<void>;
   setSourceTextColor: (s: string) => Promise<void>;
   setTranslationTextColor: (s: string) => Promise<void>;
+  setNewItemHighlightEnabled: ((b: boolean) => Promise<void>) | undefined;
   defaultBgColor: string;
   defaultSourceTextColor: string;
   defaultTranslationTextColor: string;
@@ -75,10 +82,12 @@ const SubtitleBoundPopover: React.FC = () => {
     bgColor: useSubtitleBgColor(),
     sourceTextColor: useSubtitleSourceTextColor(),
     translationTextColor: useSubtitleTranslationTextColor(),
+    newItemHighlightEnabled: useSubtitleNewItemHighlightEnabled(),
     setBgOpacity: useSetSubtitleBgOpacity(),
     setBgColor: useSetSubtitleBgColor(),
     setSourceTextColor: useSetSubtitleSourceTextColor(),
     setTranslationTextColor: useSetSubtitleTranslationTextColor(),
+    setNewItemHighlightEnabled: useSetSubtitleNewItemHighlightEnabled(),
     defaultBgColor: SUBTITLE_DEFAULT_BG_COLOR,
     defaultSourceTextColor: SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR,
     defaultTranslationTextColor: SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR,
@@ -92,10 +101,12 @@ const ConversationBoundPopover: React.FC = () => {
     bgColor: useConversationDisplayBgColor(),
     sourceTextColor: useConversationDisplaySourceTextColor(),
     translationTextColor: useConversationDisplayTranslationTextColor(),
+    newItemHighlightEnabled: undefined,
     setBgOpacity: undefined,
     setBgColor: useSetConversationDisplayBgColor(),
     setSourceTextColor: useSetConversationDisplaySourceTextColor(),
     setTranslationTextColor: useSetConversationDisplayTranslationTextColor(),
+    setNewItemHighlightEnabled: undefined,
     defaultBgColor: CONVERSATION_DISPLAY_DEFAULT_BG_COLOR,
     defaultSourceTextColor: CONVERSATION_DISPLAY_DEFAULT_SOURCE_TEXT_COLOR,
     defaultTranslationTextColor: CONVERSATION_DISPLAY_DEFAULT_TRANSLATION_TEXT_COLOR,
@@ -106,8 +117,12 @@ const ConversationBoundPopover: React.FC = () => {
 // ──────────── Pure presentational inner ────────────
 
 const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bindings }) => {
+  const { t } = useTranslation();
   const includeOpacity =
     bindings.bgOpacity !== undefined && bindings.setBgOpacity !== undefined;
+  const includeHighlightToggle =
+    bindings.newItemHighlightEnabled !== undefined &&
+    bindings.setNewItemHighlightEnabled !== undefined;
 
   // Note: role="dialog" + accessible name are intentionally NOT set on this
   // root. They live on the floating wrapper in SubtitleBar / MainPanel via
@@ -144,6 +159,22 @@ const DisplaySettingsPopoverInner: React.FC<{ bindings: InnerBindings }> = ({ bi
         value={bindings.translationTextColor}
         onChange={bindings.setTranslationTextColor}
       />
+      {includeHighlightToggle && (
+        <div className="field">
+          <ToggleSwitch
+            checked={bindings.newItemHighlightEnabled!}
+            onChange={() =>
+              void bindings.setNewItemHighlightEnabled!(
+                !bindings.newItemHighlightEnabled,
+              )
+            }
+            label={t(
+              'subtitle.settings.newItemHighlight',
+              'Highlight newly-arrived text',
+            )}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Subtitle/SubtitleApp.test.tsx
+++ b/src/components/Subtitle/SubtitleApp.test.tsx
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { getHighlightOverlayForBg } from './SubtitleApp';
+
+describe('getHighlightOverlayForBg', () => {
+  it('returns a translucent white overlay for the default black background', () => {
+    expect(getHighlightOverlayForBg('#000000')).toBe('rgba(255, 255, 255, 0.3)');
+  });
+
+  it('returns a translucent black overlay for a white background', () => {
+    expect(getHighlightOverlayForBg('#ffffff')).toBe('rgba(0, 0, 0, 0.3)');
+  });
+
+  it('flips at the YIQ midpoint (≈ 128)', () => {
+    // YIQ for #555555 = 0.299*85 + 0.587*85 + 0.114*85 = 85 < 128 → dark → white overlay
+    expect(getHighlightOverlayForBg('#555555')).toBe('rgba(255, 255, 255, 0.3)');
+    // YIQ for #aaaaaa = 170 > 128 → light → black overlay
+    expect(getHighlightOverlayForBg('#aaaaaa')).toBe('rgba(0, 0, 0, 0.3)');
+  });
+
+  it('weights green most heavily (YIQ luminance)', () => {
+    // Pure red (#ff0000): YIQ = 0.299*255 ≈ 76 → dark → white
+    expect(getHighlightOverlayForBg('#ff0000')).toBe('rgba(255, 255, 255, 0.3)');
+    // Pure green (#00ff00): YIQ = 0.587*255 ≈ 150 → light → black
+    expect(getHighlightOverlayForBg('#00ff00')).toBe('rgba(0, 0, 0, 0.3)');
+    // Pure blue (#0000ff): YIQ = 0.114*255 ≈ 29 → dark → white
+    expect(getHighlightOverlayForBg('#0000ff')).toBe('rgba(255, 255, 255, 0.3)');
+  });
+
+  it('returns the dark-bg default when the input is malformed', () => {
+    expect(getHighlightOverlayForBg('#fff')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('not-a-hex')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('')).toBe('rgba(255, 255, 255, 0.3)');
+  });
+});

--- a/src/components/Subtitle/SubtitleApp.test.tsx
+++ b/src/components/Subtitle/SubtitleApp.test.tsx
@@ -3,32 +3,32 @@ import { getHighlightOverlayForBg } from './SubtitleApp';
 
 describe('getHighlightOverlayForBg', () => {
   it('returns a translucent white overlay for the default black background', () => {
-    expect(getHighlightOverlayForBg('#000000')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('#000000')).toBe('rgba(255,255,255,0.3)');
   });
 
   it('returns a translucent black overlay for a white background', () => {
-    expect(getHighlightOverlayForBg('#ffffff')).toBe('rgba(0, 0, 0, 0.3)');
+    expect(getHighlightOverlayForBg('#ffffff')).toBe('rgba(0,0,0,0.3)');
   });
 
   it('flips at the YIQ midpoint (≈ 128)', () => {
     // YIQ for #555555 = 0.299*85 + 0.587*85 + 0.114*85 = 85 < 128 → dark → white overlay
-    expect(getHighlightOverlayForBg('#555555')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('#555555')).toBe('rgba(255,255,255,0.3)');
     // YIQ for #aaaaaa = 170 > 128 → light → black overlay
-    expect(getHighlightOverlayForBg('#aaaaaa')).toBe('rgba(0, 0, 0, 0.3)');
+    expect(getHighlightOverlayForBg('#aaaaaa')).toBe('rgba(0,0,0,0.3)');
   });
 
   it('weights green most heavily (YIQ luminance)', () => {
     // Pure red (#ff0000): YIQ = 0.299*255 ≈ 76 → dark → white
-    expect(getHighlightOverlayForBg('#ff0000')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('#ff0000')).toBe('rgba(255,255,255,0.3)');
     // Pure green (#00ff00): YIQ = 0.587*255 ≈ 150 → light → black
-    expect(getHighlightOverlayForBg('#00ff00')).toBe('rgba(0, 0, 0, 0.3)');
+    expect(getHighlightOverlayForBg('#00ff00')).toBe('rgba(0,0,0,0.3)');
     // Pure blue (#0000ff): YIQ = 0.114*255 ≈ 29 → dark → white
-    expect(getHighlightOverlayForBg('#0000ff')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('#0000ff')).toBe('rgba(255,255,255,0.3)');
   });
 
   it('returns the dark-bg default when the input is malformed', () => {
-    expect(getHighlightOverlayForBg('#fff')).toBe('rgba(255, 255, 255, 0.3)');
-    expect(getHighlightOverlayForBg('not-a-hex')).toBe('rgba(255, 255, 255, 0.3)');
-    expect(getHighlightOverlayForBg('')).toBe('rgba(255, 255, 255, 0.3)');
+    expect(getHighlightOverlayForBg('#fff')).toBe('rgba(255,255,255,0.3)');
+    expect(getHighlightOverlayForBg('not-a-hex')).toBe('rgba(255,255,255,0.3)');
+    expect(getHighlightOverlayForBg('')).toBe('rgba(255,255,255,0.3)');
   });
 });

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -17,6 +17,7 @@ import {
   useSubtitlePositionLocked,
   useSubtitleSpeakerDisplayMode as useSpeakerDisplayMode,
   useSubtitleParticipantDisplayMode as useParticipantDisplayMode,
+  useSubtitleNewItemHighlightEnabled,
 } from '../../stores/subtitleStore';
 import { useOverlayDragResize } from './useOverlayDragResize';
 import {
@@ -82,6 +83,7 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
   const systemAudioItems = useSystemAudioItems();
   const speakerMode = useSpeakerDisplayMode();
   const participantMode = useParticipantDisplayMode();
+  const newItemHighlightEnabled = useSubtitleNewItemHighlightEnabled();
   const provider = useProvider();
   const localInferenceSettings = useLocalInferenceSettings();
   const isSessionActive = useIsSessionActive();
@@ -268,6 +270,7 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
             targetLanguage={targetLanguage}
             sourceTextColor={subtitle.sourceTextColor}
             translationTextColor={subtitle.translationTextColor}
+            newItemHighlightEnabled={newItemHighlightEnabled}
           />
         )
       ) : (

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -225,6 +225,7 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
     background: hexToRgba(subtitle.bgColor, bgAlpha),
     '--bar-opacity': barVisible ? 1 : 0,
     '--bar-pointer-events': barVisible ? 'auto' : 'none',
+    '--subtitle-highlight-overlay': getHighlightOverlayForBg(subtitle.bgColor),
   };
 
   return (

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -59,18 +59,16 @@ const HIGHLIGHT_ALPHA = 0.3;
  * a known limitation accepted in the design spec.
  */
 export function getHighlightOverlayForBg(hex: string): string {
-  const cleaned = hex.replace('#', '');
-  if (cleaned.length !== 6) return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
-  const r = parseInt(cleaned.slice(0, 2), 16);
-  const g = parseInt(cleaned.slice(2, 4), 16);
-  const b = parseInt(cleaned.slice(4, 6), 16);
-  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
-    return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
-  }
+  const m = /^#?([a-fA-F0-9]{6})$/.exec(hex);
+  if (!m) return `rgba(255,255,255,${HIGHLIGHT_ALPHA})`;
+  const v = parseInt(m[1], 16);
+  const r = (v >> 16) & 0xff;
+  const g = (v >> 8) & 0xff;
+  const b = v & 0xff;
   const yiq = (r * 299 + g * 587 + b * 114) / 1000;
   return yiq < 128
-    ? `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`
-    : `rgba(0, 0, 0, ${HIGHLIGHT_ALPHA})`;
+    ? `rgba(255,255,255,${HIGHLIGHT_ALPHA})`
+    : `rgba(0,0,0,${HIGHLIGHT_ALPHA})`;
 }
 
 export type SubtitleSurfaceKind = 'electron' | 'extension-overlay';

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -46,6 +46,33 @@ function hexToRgba(hex: string, alpha: number): string {
   return `rgba(${r},${g},${b},${alpha})`;
 }
 
+const HIGHLIGHT_ALPHA = 0.3;
+
+/**
+ * Returns a CSS color for the "newly-arrived item" overlay, chosen so it
+ * contrasts with the user-selected background. YIQ luminance < 128 means
+ * the background is dark → use a light overlay; otherwise use dark.
+ *
+ * The user-set bgOpacity is intentionally not factored in. When opacity is
+ * very low and the actual visible background is whatever sits behind the
+ * subtitle window, this falls back to the bgColor's nominal lightness —
+ * a known limitation accepted in the design spec.
+ */
+export function getHighlightOverlayForBg(hex: string): string {
+  const cleaned = hex.replace('#', '');
+  if (cleaned.length !== 6) return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
+    return `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`;
+  }
+  const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+  return yiq < 128
+    ? `rgba(255, 255, 255, ${HIGHLIGHT_ALPHA})`
+    : `rgba(0, 0, 0, ${HIGHLIGHT_ALPHA})`;
+}
+
 export type SubtitleSurfaceKind = 'electron' | 'extension-overlay';
 
 const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'electron' }) => {

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -62,10 +62,42 @@
     }
   }
 
+  // ------------------------------------------------------------------
+  // Per-item highlight in compact mode.
+  // The item-aware spans created by SubtitleStream are styled here.
+  // The `--new` modifier triggers a one-shot fade-in + decaying overlay
+  // animation; the class persists on the span afterwards (harmless —
+  // CSS animations only fire once per class application).
+  // ------------------------------------------------------------------
+  .subtitle-stream__item {
+    // No styles in the un-animated case — the span is a plain inline.
+  }
+
+  .subtitle-stream__item--new {
+    animation: subtitle-item-highlight 2s ease-out both;
+    border-radius: 2px;
+    padding: 1px 3px;
+  }
+
   // Expanded mode: ConversationRow drives its own layout; we just provide
   // the scroll container.
   &.expanded {
     overflow-y: auto;
     justify-content: flex-end;
+  }
+}
+
+@keyframes subtitle-item-highlight {
+  0% {
+    opacity: 0;
+    background-color: var(--subtitle-highlight-overlay, rgba(255,255,255,0.3));
+  }
+  20% {
+    opacity: 1;
+    background-color: var(--subtitle-highlight-overlay, rgba(255,255,255,0.3));
+  }
+  100% {
+    opacity: 1;
+    background-color: transparent;
   }
 }

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -69,14 +69,18 @@
   // animation; the class persists on the span afterwards (harmless —
   // CSS animations only fire once per class application).
   // ------------------------------------------------------------------
+  // padding + border-radius live on every item (not just `--new`) so the
+  // post-animation layout matches items that were present at first mount.
+  // If they sat only on `--new`, items rendered after mount would keep a
+  // few extra px of padding forever and drift visually away from their
+  // pre-mount siblings.
   .subtitle-stream__item {
-    // No styles in the un-animated case — the span is a plain inline.
+    border-radius: 2px;
+    padding: 1px 3px;
   }
 
   .subtitle-stream__item--new {
     animation: subtitle-item-highlight 2s ease-out both;
-    border-radius: 2px;
-    padding: 1px 3px;
   }
 
   // Expanded mode: ConversationRow drives its own layout; we just provide

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -241,6 +241,40 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
     expect(newSpans[0].textContent).toContain('just arrived');
   });
 
+  it('suppresses the --new class when newItemHighlightEnabled is false', () => {
+    const { container, rerender } = render(
+      <SubtitleStream
+        items={[] as any[]}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+        newItemHighlightEnabled={false}
+      />,
+    );
+    // Item arrives post-mount — would be 'new' if the highlight were enabled.
+    const arrived: any[] = [
+      { id: 'AFTER', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'after mount' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    rerender(
+      <SubtitleStream
+        items={arrived}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+        newItemHighlightEnabled={false}
+      />,
+    );
+    // Span exists, just without the highlight modifier.
+    expect(container.querySelectorAll('.subtitle-stream__item').length).toBe(1);
+    expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+  });
+
   it('does not re-toggle the --new class when a streaming item grows in place', () => {
     // Empty first render so the streaming item isn't classified 'existing'.
     const { container, rerender } = render(

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -158,6 +158,95 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
     expect(root.style.getPropertyValue('--subtitle-translation-color')).toBe('#00FF00');
     expect(root.style.getPropertyValue('--conversation-font-size')).toBe('36px');
   });
+
+  it('does not mark items as new on the very first render (no flash for pre-existing items)', () => {
+    const { container } = render(
+      <SubtitleStream
+        items={items}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const newSpans = container.querySelectorAll('.subtitle-stream__item--new');
+    expect(newSpans.length).toBe(0);
+  });
+
+  it('marks only items that arrive after the first render as new', () => {
+    const { container, rerender } = render(
+      <SubtitleStream
+        items={items}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    // First render — none should be new
+    expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+
+    // A new speaker source item arrives
+    const arrived: any[] = [
+      ...items,
+      { id: 'NEW1', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'just arrived' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    rerender(
+      <SubtitleStream
+        items={arrived}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const newSpans = container.querySelectorAll('.subtitle-stream__item--new');
+    expect(newSpans.length).toBe(1);
+    expect(newSpans[0].textContent).toContain('just arrived');
+  });
+
+  it('does not re-toggle the --new class when a streaming item grows in place', () => {
+    // Item is present at first render → marked 'existing' permanently.
+    // Then it "grows" (text changes while id stays the same).
+    const initial: any[] = [
+      { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'in_progress', formatted: { text: 'Hel' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    const { container, rerender } = render(
+      <SubtitleStream
+        items={initial}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+
+    const grown: any[] = [
+      { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'Hello world' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    rerender(
+      <SubtitleStream
+        items={grown}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    // Same id → 'existing' state preserved → still no --new class.
+    expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+  });
 });
 
 describe('SubtitleStream — expanded mode (per-item rows)', () => {

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -91,6 +91,36 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
     expect(speakerSrc.textContent).toBe('hello world');
   });
 
+  it('drops items beyond BUCKET_MAX_CHARS to keep the band fast', () => {
+    // ~2000-char cap; 10 × 250-char items = 2500 chars total → at least one drops.
+    const bigItems: any[] = Array.from({ length: 10 }, (_, i) => ({
+      id: String(i),
+      source: 'speaker',
+      role: 'user',
+      type: 'message',
+      status: 'completed',
+      formatted: { text: 'x'.repeat(250) },
+      sourceLanguage: 'en',
+      targetLanguage: 'zh',
+    }));
+    const { container } = render(
+      <SubtitleStream
+        items={bigItems}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const spans = container.querySelectorAll(
+      '.subtitle-stream__line--speaker.subtitle-stream__line--source .subtitle-stream__item',
+    );
+    expect(spans.length).toBeLessThan(10);
+    expect(spans.length).toBeGreaterThan(0);
+  });
+
   it('renders one span per visible item with the item id as the key', () => {
     const many: any[] = [
       { id: '1', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'hello' },  sourceLanguage: 'en', targetLanguage: 'zh' },

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -212,14 +212,10 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
   });
 
   it('does not re-toggle the --new class when a streaming item grows in place', () => {
-    // Item is present at first render → marked 'existing' permanently.
-    // Then it "grows" (text changes while id stays the same).
-    const initial: any[] = [
-      { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'in_progress', formatted: { text: 'Hel' }, sourceLanguage: 'en', targetLanguage: 'zh' },
-    ];
+    // Empty first render so the streaming item isn't classified 'existing'.
     const { container, rerender } = render(
       <SubtitleStream
-        items={initial}
+        items={[] as any[]}
         compact
         fontSize={24}
         speakerMode="both"
@@ -230,6 +226,26 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
     );
     expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
 
+    // Streaming item arrives post-mount → classified 'new', should animate.
+    const partial: any[] = [
+      { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'in_progress', formatted: { text: 'Hel' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    rerender(
+      <SubtitleStream
+        items={partial}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const afterArrival = container.querySelectorAll('.subtitle-stream__item--new');
+    expect(afterArrival.length).toBe(1);
+    expect(afterArrival[0].textContent).toContain('Hel');
+
+    // Same id, more text — state must remain 'new' (no re-toggle, no extra spans).
     const grown: any[] = [
       { id: 'GROW', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'Hello world' }, sourceLanguage: 'en', targetLanguage: 'zh' },
     ];
@@ -244,8 +260,9 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
         targetLanguage="zh"
       />,
     );
-    // Same id → 'existing' state preserved → still no --new class.
-    expect(container.querySelectorAll('.subtitle-stream__item--new').length).toBe(0);
+    const afterGrowth = container.querySelectorAll('.subtitle-stream__item--new');
+    expect(afterGrowth.length).toBe(1);
+    expect(afterGrowth[0].textContent).toContain('Hello world');
   });
 });
 

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -91,6 +91,33 @@ describe('SubtitleStream — compact mode (up to 4 equal-height lines)', () => {
     expect(speakerSrc.textContent).toBe('hello world');
   });
 
+  it('renders one span per visible item with the item id as the key', () => {
+    const many: any[] = [
+      { id: '1', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'hello' },  sourceLanguage: 'en', targetLanguage: 'zh' },
+      { id: '5', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'world' },  sourceLanguage: 'en', targetLanguage: 'zh' },
+      { id: '9', source: 'speaker', role: 'user', type: 'message', status: 'completed', formatted: { text: 'again' }, sourceLanguage: 'en', targetLanguage: 'zh' },
+    ];
+    const { container } = render(
+      <SubtitleStream
+        items={many}
+        compact
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const spans = container.querySelectorAll(
+      '.subtitle-stream__line--speaker.subtitle-stream__line--source .subtitle-stream__item',
+    );
+    expect(spans.length).toBe(3);
+    // Chronological order: oldest first
+    expect(spans[0].textContent).toBe('hello');
+    expect(spans[1].textContent).toBe(' world');
+    expect(spans[2].textContent).toBe(' again');
+  });
+
   it('routes error / system items into the translation bucket so they remain visible', () => {
     const withError: any[] = [
       ...items,

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -29,11 +29,15 @@ const BUCKET_MAX_CHARS = 2000;
 
 type LineKind = 'source' | 'translation';
 type LineSource = 'speaker' | 'participant';
+interface SubtitleLineItem {
+  id: string;
+  text: string;
+}
 interface SubtitleLine {
   id: string;
   kind: LineKind;
   source: LineSource;
-  text: string;
+  items: SubtitleLineItem[];
 }
 
 /**
@@ -67,7 +71,7 @@ const SubtitleStream: React.FC<Props> = ({
   );
 
   const lines = useMemo<SubtitleLine[]>(() => {
-    const buckets: Record<string, string[]> = {
+    const buckets: Record<string, SubtitleLineItem[]> = {
       'speaker-source': [],
       'speaker-translation': [],
       'participant-source': [],
@@ -97,7 +101,7 @@ const SubtitleStream: React.FC<Props> = ({
       else continue;
       const key = `${side}-${kind}`;
       if (bucketLen[key] >= BUCKET_MAX_CHARS) continue;
-      buckets[key].unshift(text);
+      buckets[key].unshift({ id: item.id, text });
       bucketLen[key] += text.length + 1; // +1 for the joining space
     }
 
@@ -112,9 +116,9 @@ const SubtitleStream: React.FC<Props> = ({
         id: `${source}-${kind}`,
         source,
         kind,
-        text: buckets[`${source}-${kind}`].join(' '),
+        items: buckets[`${source}-${kind}`],
       }))
-      .filter((l) => l.text.length > 0);
+      .filter((l) => l.items.length > 0);
   }, [filtered]);
 
   // Stick to bottom only in expanded mode, where ConversationRow rows pile
@@ -147,7 +151,13 @@ const SubtitleStream: React.FC<Props> = ({
               key={line.id}
               className={`subtitle-stream__line subtitle-stream__line--${line.kind} subtitle-stream__line--${line.source}`}
             >
-              <p>{line.text}</p>
+              <p>
+                {line.items.map((it, idx) => (
+                  <span key={it.id} className="subtitle-stream__item">
+                    {idx > 0 ? ' ' : ''}{it.text}
+                  </span>
+                ))}
+              </p>
             </div>
           ))
         : filtered.map((item, i) => (

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -136,16 +136,23 @@ const SubtitleStream: React.FC<Props> = ({
 
   // Each item is classified once and locked: 'existing' = present at first
   // render of this component instance (never animates), 'new' = arrived later
-  // (animates exactly once on first paint via CSS @keyframes).
+  // (animates exactly once on first paint via CSS @keyframes). The map grows
+  // monotonically — by design, no pruning — typical sessions hit hundreds
+  // of entries, well below any memory concern. StrictMode's double-invocation
+  // of effects is safe: the `has()` guard skips re-insertion on the second pass.
   const itemStatesRef = useRef<Map<string, 'existing' | 'new'>>(new Map());
   const isFirstRenderRef = useRef(true);
 
   const itemStateFor = (id: string): 'existing' | 'new' => {
     const known = itemStatesRef.current.get(id);
-    if (known) return known;
+    if (known !== undefined) return known;
     return isFirstRenderRef.current ? 'existing' : 'new';
   };
 
+  // No deps — runs after every render to lock in state for newly-visible
+  // items. Adding a [lines] dep would also work in practice; the no-deps
+  // form is chosen so future refactors of `lines` (e.g. additional memo
+  // layers) can't accidentally skip a commit.
   useLayoutEffect(() => {
     for (const line of lines) {
       for (const it of line.items) {

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useMemo } from 'react';
+import React, { useEffect, useLayoutEffect, useRef, useMemo } from 'react';
 import ConversationRow from '../MainPanel/ConversationRow';
 import { shouldShowItem } from '../MainPanel/conversationFilter';
 import type { DisplayMode } from '../../stores/subtitleStore';
@@ -134,6 +134,32 @@ const SubtitleStream: React.FC<Props> = ({
     }
   }, [compact, filtered.length]);
 
+  // Each item is classified once and locked: 'existing' = present at first
+  // render of this component instance (never animates), 'new' = arrived later
+  // (animates exactly once on first paint via CSS @keyframes).
+  const itemStatesRef = useRef<Map<string, 'existing' | 'new'>>(new Map());
+  const isFirstRenderRef = useRef(true);
+
+  const itemStateFor = (id: string): 'existing' | 'new' => {
+    const known = itemStatesRef.current.get(id);
+    if (known) return known;
+    return isFirstRenderRef.current ? 'existing' : 'new';
+  };
+
+  useLayoutEffect(() => {
+    for (const line of lines) {
+      for (const it of line.items) {
+        if (!itemStatesRef.current.has(it.id)) {
+          itemStatesRef.current.set(
+            it.id,
+            isFirstRenderRef.current ? 'existing' : 'new',
+          );
+        }
+      }
+    }
+    isFirstRenderRef.current = false;
+  });
+
   // Apply fontSize to both our flat-line styles and the CSS var that
   // ConversationRow reads in expanded mode.
   const style: React.CSSProperties & Record<string, string> = {
@@ -152,11 +178,17 @@ const SubtitleStream: React.FC<Props> = ({
               className={`subtitle-stream__line subtitle-stream__line--${line.kind} subtitle-stream__line--${line.source}`}
             >
               <p>
-                {line.items.map((it, idx) => (
-                  <span key={it.id} className="subtitle-stream__item">
-                    {idx > 0 ? ' ' : ''}{it.text}
-                  </span>
-                ))}
+                {line.items.map((it, idx) => {
+                  const className =
+                    itemStateFor(it.id) === 'new'
+                      ? 'subtitle-stream__item subtitle-stream__item--new'
+                      : 'subtitle-stream__item';
+                  return (
+                    <span key={it.id} className={className}>
+                      {idx > 0 ? ' ' : ''}{it.text}
+                    </span>
+                  );
+                })}
               </p>
             </div>
           ))

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -14,6 +14,10 @@ interface Props {
   targetLanguage: string;
   sourceTextColor?: string;
   translationTextColor?: string;
+  // When false, items that arrive after first mount are still tracked but
+  // do not receive the `--new` modifier — the CSS highlight never fires.
+  // Defaults to true; passed through from the persisted subtitle setting.
+  newItemHighlightEnabled?: boolean;
 }
 
 function itemText(item: any): string {
@@ -64,6 +68,7 @@ const SubtitleStream: React.FC<Props> = ({
   targetLanguage,
   sourceTextColor,
   translationTextColor,
+  newItemHighlightEnabled = true,
 }) => {
   const filtered = useMemo(
     () => items.filter((item) => shouldShowItem(item, speakerMode, participantMode)),
@@ -186,10 +191,11 @@ const SubtitleStream: React.FC<Props> = ({
             >
               <p>
                 {line.items.map((it, idx) => {
-                  const className =
-                    itemStateFor(it.id) === 'new'
-                      ? 'subtitle-stream__item subtitle-stream__item--new'
-                      : 'subtitle-stream__item';
+                  const showHighlight =
+                    newItemHighlightEnabled && itemStateFor(it.id) === 'new';
+                  const className = showHighlight
+                    ? 'subtitle-stream__item subtitle-stream__item--new'
+                    : 'subtitle-stream__item';
                   return (
                     <span key={it.id} className={className}>
                       {idx > 0 ? ' ' : ''}{it.text}

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -903,7 +903,8 @@
       "bgColor": "Display background",
       "sourceColor": "Source text",
       "translationColor": "Translation text",
-      "customColor": "Custom color"
+      "customColor": "Custom color",
+      "newItemHighlight": "Highlight newly-arrived text"
     },
     "pttHint": "Press Space to speak"
   },

--- a/src/stores/subtitleStore.test.ts
+++ b/src/stores/subtitleStore.test.ts
@@ -20,12 +20,21 @@ describe('subtitleStore', () => {
       bgColor: '#000000',
       sourceTextColor: '#ffffff',
       translationTextColor: '#9ad0ff',
+      newItemHighlightEnabled: true,
       alwaysOnTop: false,
       positionLocked: false,
       windowBounds: null,
       speakerDisplayMode: 'both',
       participantDisplayMode: 'both',
     });
+  });
+
+  it('setNewItemHighlightEnabled flips the boolean and defaults to true', async () => {
+    expect(useSubtitleStore.getState().newItemHighlightEnabled).toBe(true);
+    await useSubtitleStore.getState().setNewItemHighlightEnabled(false);
+    expect(useSubtitleStore.getState().newItemHighlightEnabled).toBe(false);
+    await useSubtitleStore.getState().setNewItemHighlightEnabled(true);
+    expect(useSubtitleStore.getState().newItemHighlightEnabled).toBe(true);
   });
 
   it('clamps fontSize to [12, 64]', async () => {

--- a/src/stores/subtitleStore.ts
+++ b/src/stores/subtitleStore.ts
@@ -22,6 +22,9 @@ interface SubtitleState {
   // Text colours
   sourceTextColor: string;
   translationTextColor: string;
+  // Visual cue for newly-arrived items in the compact band (issue #236).
+  // When false, the per-item fade-in + overlay animation is suppressed.
+  newItemHighlightEnabled: boolean;
   // Window/positioning (Electron path; extension surface ignores them)
   alwaysOnTop: boolean;
   positionLocked: boolean;
@@ -37,6 +40,7 @@ interface SubtitleState {
   setBgColor: (s: string) => Promise<void>;
   setSourceTextColor: (s: string) => Promise<void>;
   setTranslationTextColor: (s: string) => Promise<void>;
+  setNewItemHighlightEnabled: (b: boolean) => Promise<void>;
   toggleAlwaysOnTop: () => Promise<void>;
   togglePositionLocked: () => Promise<void>;
   saveWindowBounds: (b: SubtitleWindowBounds) => Promise<void>;
@@ -59,6 +63,7 @@ const DEFAULTS = {
   bgColor: SUBTITLE_DEFAULT_BG_COLOR,
   sourceTextColor: SUBTITLE_DEFAULT_SOURCE_TEXT_COLOR,
   translationTextColor: SUBTITLE_DEFAULT_TRANSLATION_TEXT_COLOR,
+  newItemHighlightEnabled: true,
   alwaysOnTop: false,
   positionLocked: false,
   windowBounds: null as SubtitleWindowBounds | null,
@@ -134,6 +139,12 @@ export const useSubtitleStore = create<SubtitleState>()(
       const { ok } = await persist('translationTextColor', s, 'translationTextColor');
       if (!ok) set({ translationTextColor: previous });
     },
+    setNewItemHighlightEnabled: async (b) => {
+      const previous = get().newItemHighlightEnabled;
+      set({ newItemHighlightEnabled: b });
+      const { ok } = await persist('newItemHighlightEnabled', b, 'newItemHighlightEnabled');
+      if (!ok) set({ newItemHighlightEnabled: previous });
+    },
     toggleAlwaysOnTop: async () => {
       const previous = get().alwaysOnTop;
       const next = !previous;
@@ -171,7 +182,7 @@ export const useSubtitleStore = create<SubtitleState>()(
       const svc = ServiceFactory.getSettingsService();
       const [
         fontSize, compactMode, bgOpacity, bgColor,
-        sourceTextColor, translationTextColor,
+        sourceTextColor, translationTextColor, newItemHighlightEnabled,
         alwaysOnTop, positionLocked, windowBounds,
         speakerDisplayMode, participantDisplayMode,
       ] = await Promise.all([
@@ -181,6 +192,7 @@ export const useSubtitleStore = create<SubtitleState>()(
         svc.getSetting(KEY('bgColor'), DEFAULTS.bgColor),
         svc.getSetting(KEY('sourceTextColor'), DEFAULTS.sourceTextColor),
         svc.getSetting(KEY('translationTextColor'), DEFAULTS.translationTextColor),
+        svc.getSetting(KEY('newItemHighlightEnabled'), DEFAULTS.newItemHighlightEnabled),
         svc.getSetting(KEY('alwaysOnTop'), DEFAULTS.alwaysOnTop),
         svc.getSetting(KEY('positionLocked'), DEFAULTS.positionLocked),
         svc.getSetting<SubtitleWindowBounds | null>(KEY('windowBounds'), DEFAULTS.windowBounds),
@@ -194,6 +206,7 @@ export const useSubtitleStore = create<SubtitleState>()(
         bgColor,
         sourceTextColor,
         translationTextColor,
+        newItemHighlightEnabled,
         alwaysOnTop,
         positionLocked,
         windowBounds,
@@ -211,6 +224,8 @@ export const useSubtitleBgOpacity = () => useSubtitleStore((s) => s.bgOpacity);
 export const useSubtitleBgColor = () => useSubtitleStore((s) => s.bgColor);
 export const useSubtitleSourceTextColor = () => useSubtitleStore((s) => s.sourceTextColor);
 export const useSubtitleTranslationTextColor = () => useSubtitleStore((s) => s.translationTextColor);
+export const useSubtitleNewItemHighlightEnabled = () =>
+  useSubtitleStore((s) => s.newItemHighlightEnabled);
 export const useSubtitleAlwaysOnTop = () => useSubtitleStore((s) => s.alwaysOnTop);
 export const useSubtitlePositionLocked = () => useSubtitleStore((s) => s.positionLocked);
 export const useSubtitleWindowBounds = () => useSubtitleStore((s) => s.windowBounds);
@@ -242,6 +257,8 @@ export const useSetSubtitleBgOpacity = () => useSubtitleStore((s) => s.setBgOpac
 export const useSetSubtitleBgColor = () => useSubtitleStore((s) => s.setBgColor);
 export const useSetSubtitleSourceTextColor = () => useSubtitleStore((s) => s.setSourceTextColor);
 export const useSetSubtitleTranslationTextColor = () => useSubtitleStore((s) => s.setTranslationTextColor);
+export const useSetSubtitleNewItemHighlightEnabled = () =>
+  useSubtitleStore((s) => s.setNewItemHighlightEnabled);
 export const useToggleSubtitleAlwaysOnTop = () => useSubtitleStore((s) => s.toggleAlwaysOnTop);
 export const useToggleSubtitlePositionLocked = () => useSubtitleStore((s) => s.togglePositionLocked);
 export const useSaveSubtitleWindowBounds = () => useSubtitleStore((s) => s.saveWindowBounds);


### PR DESCRIPTION
## Summary

Closes #236.

Makes newly-arrived items in the compact subtitle band visually obvious — a problem for non-streaming providers (local sherpa-onnx ASR + Opus-MT / HY-MT, several cloud transcription endpoints) where a long sentence lands as one chunk and the reader has to scan back to find the boundary.

- **Per-item spans + first-mount suppression**: compact bucket no longer joins to one string; each item gets its own `<span key={item.id}>`. A `Map<id, 'existing' | 'new'>` ref classifies items once. Items present at first mount stay `'existing'` and never animate; items arriving later get `'new'` and animate exactly once.
- **CSS animation**: fade-in (opacity 0 → 1 over ~400 ms) + decaying overlay (`var(--subtitle-highlight-overlay)` → transparent over 2 s), one combined `@keyframes`.
- **Background-luminance-aware overlay color**: YIQ-based helper picks `rgba(255,255,255,…)` on dark backgrounds and `rgba(0,0,0,…)` on light, set as a CSS variable on the subtitle root. Survives arbitrary user customisation of `bgColor` / `sourceTextColor` / `translationTextColor`.
- **User toggle**: `Highlight newly-arrived text` switch in the subtitle settings popover, persisted, defaults to on. When off, the lifecycle refs still run but the `--new` modifier is suppressed.
- **Uniform across providers**: streaming items animate once at first non-empty text and keep growing without re-animation. Non-streaming items animate once on arrival. Text corrections (same `item.id`) do not re-trigger.
- **Expanded mode unchanged**: only the compact branch is touched.

Spec: `docs/superpowers/specs/2026-05-18-subtitle-new-item-highlight-design.md`
Plan: `docs/superpowers/plans/2026-05-18-subtitle-new-item-highlight.md`

## Test plan

- [x] Full suite green: 672 / 672 across 60 files
- [x] Per-item span rendering and `BUCKET_MAX_CHARS` truncation covered by unit tests
- [x] First-mount suppression covered
- [x] Post-mount arrival → `--new` modifier covered
- [x] Streaming-growth stability (`'Hel'` arrives post-mount, grows to `'Hello world'`) covered
- [x] `getHighlightOverlayForBg` YIQ helper covered (dark/light, midpoint, channel weighting, malformed input)
- [x] Toggle popover row covered (renders in subtitle mode only, click flips store)
- [ ] **Manual** — local provider (HY-MT) speaks a long sentence, observe single fade-in + overlay decay on the new translation
- [ ] **Manual** — OpenAI Realtime streaming, observe single fade-in on first text, no re-animation as text grows
- [ ] **Manual** — toggle subtitle mode on with history present, confirm no pre-existing items flash
- [ ] **Manual** — `Highlight newly-arrived text` setting toggles off / on and the next arriving item respects the change
- [ ] **Manual** — flip `bgColor` from black to white in settings, confirm next item's overlay flips from light to dark

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Highlight newly-arrived text" toggle in subtitle settings (enabled by default).
  * Compact-mode subtitle items can be individually highlighted with a one-shot fade-in overlay; overlay color adapts to subtitle background for visibility.
* **Tests**
  * Added unit and component tests covering overlay color logic, first-mount suppression, subsequent-arrival highlighting, and the settings toggle behavior.
* **Documentation**
  * Added design and implementation plans plus a manual verification checklist for the feature.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/239?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->