### PR TITLE
feat(subtitle): karaoke-style character highlighting in subtitle mode (#232)

### DIFF
--- a/docs/superpowers/plans/2026-05-19-subtitle-karaoke-highlight.md
+++ b/docs/superpowers/plans/2026-05-19-subtitle-karaoke-highlight.md
@@ -1,0 +1,2368 @@
+# Subtitle Karaoke-Style Character Highlight — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show character-by-character karaoke highlight on the currently-playing assistant message inside subtitle mode (compact + expanded layouts), covering Electron and Extension iframe contexts.
+
+**Architecture:** Lift `playingItemId` and playback progress into a shared Zustand `playbackStore` that runs the cumulative-time + monotonic-clamp state machine; extract `getHighlightedChars` to a pure module; consume via a single `usePlaybackHighlight(item)` hook in both `MainPanel` and `SubtitleStream`. For the Extension path, the side-panel surface forwards raw playback signals over the existing `chrome.runtime.Port` using a compact 3-decimal wire format; the iframe's `sessionPortMirror` decodes them into the iframe-side `playbackStore` so both contexts run identical state machines.
+
+**Tech Stack:** TypeScript + React 18 (Vite + Vitest), Zustand 5 (`subscribeWithSelector` middleware, `useShallow`), SASS, `@testing-library/react`, `chrome.runtime.Port` (Manifest V3 extension).
+
+**Spec:** [docs/superpowers/specs/2026-05-19-subtitle-karaoke-highlight-design.md](../specs/2026-05-19-subtitle-karaoke-highlight-design.md)
+
+---
+
+## File Map
+
+**New:**
+- `src/lib/playback/highlight.ts` — pure `getHighlightedChars(currentTime, segments, textLength, progressRatio): number`.
+- `src/lib/playback/highlight.test.ts` — unit tests for the pure function.
+- `src/stores/playbackStore.ts` — Zustand store with public state, internal trackers, actions, wire helpers, `usePlaybackHighlight` hook.
+- `src/stores/playbackStore.test.ts` — store + wire-helper unit tests.
+- `src/stores/playbackStore.usePlaybackHighlight.test.tsx` — hook tests with `@testing-library/react`.
+- `src/styles/karaoke.scss` — `.karaoke-played` CSS class.
+
+**Modified:**
+- `src/components/MainPanel/MainPanel.tsx` — replace local `useState` / `useMemo` / `useEffect` blocks with store hooks; extract `ConversationBubble` subcomponent.
+- `src/components/MainPanel/MainPanel.scss` — delete `.row-text-played` rule.
+- `src/components/MainPanel/ConversationRow.tsx` — rename `row-text-played` → `karaoke-played`; import `karaoke.scss`.
+- `src/components/Subtitle/SubtitleStream.tsx` — `itemsById` + `CompactSpan` + `SubtitleConversationRow`; import `karaoke.scss`.
+- `src/components/Subtitle/SubtitleStream.test.tsx` — update existing test cases, add karaoke split assertions.
+- `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts` — install fourth subscription (`subscribePlaybackForPort`); include `playback` in `state-init`.
+- `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts` — test playback forwarding and `state-init.playback`.
+- `src/stores/sessionPortMirror.ts` — add `InboundPlayback` case + `state-init.payload.playback` decode.
+- `src/stores/sessionPortMirror.test.ts` — test inbound `playback` and `state-init.playback`.
+
+---
+
+## Task 1: Pure `getHighlightedChars` Module — Test First
+
+**Files:**
+- Create: `src/lib/playback/highlight.ts`
+- Test: `src/lib/playback/highlight.test.ts`
+
+- [ ] **Step 1.1: Create the test file (failing tests)**
+
+Create `src/lib/playback/highlight.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { getHighlightedChars } from './highlight';
+
+describe('getHighlightedChars', () => {
+  describe('segment-based', () => {
+    const segments = [
+      { textEnd: 5, audioEnd: 1.0 },   // "Hello"
+      { textEnd: 11, audioEnd: 2.0 },  // "Hello world"
+      { textEnd: 14, audioEnd: 3.0 },  // "Hello world!!!"
+    ];
+
+    it('inside the first segment scales by segment progress', () => {
+      // half-way through segment 1: 0.5s of [0, 1.0s] → 50% of "Hello" (5 chars) = 2
+      expect(getHighlightedChars(0.5, segments, 14, 0)).toBe(2);
+    });
+
+    it('inside a later segment uses prevTextEnd + intra-segment progress', () => {
+      // 1.5s in: 0.5/1.0 through seg 2 (textEnd 11, prev 5, width 6) → 5 + 3 = 8
+      expect(getHighlightedChars(1.5, segments, 14, 0)).toBe(8);
+    });
+
+    it('past the final segment returns the last textEnd', () => {
+      expect(getHighlightedChars(99, segments, 14, 0)).toBe(14);
+    });
+
+    it('zero-duration segment returns its full textEnd immediately', () => {
+      const zeroDur = [
+        { textEnd: 3, audioEnd: 1.0 },
+        { textEnd: 7, audioEnd: 1.0 }, // same audioEnd → segDuration === 0
+      ];
+      // currentTime exactly at the boundary chooses seg 2 (currentTime < audioEnd false for seg 1)
+      expect(getHighlightedChars(1.0, zeroDur, 7, 0)).toBe(7);
+    });
+  });
+
+  describe('linear fallback', () => {
+    it('uses floor(textLength * progressRatio) when segments is undefined', () => {
+      expect(getHighlightedChars(0, undefined, 10, 0.5)).toBe(5);
+    });
+
+    it('uses floor(textLength * progressRatio) when segments is empty', () => {
+      expect(getHighlightedChars(0, [], 10, 0.3)).toBe(3);
+    });
+
+    it('progressRatio 0 returns 0', () => {
+      expect(getHighlightedChars(0, undefined, 10, 0)).toBe(0);
+    });
+
+    it('progressRatio 1 returns textLength', () => {
+      expect(getHighlightedChars(0, undefined, 10, 1)).toBe(10);
+    });
+  });
+
+  describe('boundaries', () => {
+    it('textLength 0 returns 0', () => {
+      expect(getHighlightedChars(0, undefined, 0, 0.5)).toBe(0);
+    });
+  });
+});
+```
+
+- [ ] **Step 1.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/lib/playback/highlight.test.ts`
+Expected: FAIL with import resolution error (`highlight` module not found).
+
+- [ ] **Step 1.3: Create the implementation**
+
+Create `src/lib/playback/highlight.ts`:
+
+```ts
+/**
+ * Given per-sentence audio segments and the current playback time,
+ * return the number of characters that should be highlighted.
+ * Falls back to linear interpolation when segments are not available.
+ *
+ * Lifted from MainPanel.tsx:91-113; identical logic, no behavioural changes.
+ */
+export function getHighlightedChars(
+  currentTime: number,
+  segments: Array<{ textEnd: number; audioEnd: number }> | undefined,
+  textLength: number,
+  progressRatio: number,
+): number {
+  if (!segments || segments.length === 0) {
+    return Math.floor(textLength * progressRatio);
+  }
+
+  let prevTextEnd = 0;
+  let prevAudioEnd = 0;
+  for (const seg of segments) {
+    if (currentTime < seg.audioEnd) {
+      const segDuration = seg.audioEnd - prevAudioEnd;
+      const segProgress = segDuration > 0 ? (currentTime - prevAudioEnd) / segDuration : 1;
+      return prevTextEnd + Math.floor((seg.textEnd - prevTextEnd) * segProgress);
+    }
+    prevTextEnd = seg.textEnd;
+    prevAudioEnd = seg.audioEnd;
+  }
+  return prevTextEnd;
+}
+```
+
+- [ ] **Step 1.4: Run tests to confirm they pass**
+
+Run: `npm run test -- src/lib/playback/highlight.test.ts`
+Expected: PASS, all 9 test cases green.
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/lib/playback/highlight.ts src/lib/playback/highlight.test.ts
+git commit -m "feat(playback): extract getHighlightedChars to pure module
+
+Lifts the karaoke-highlight calculator from MainPanel.tsx to a
+standalone testable module. Identical logic; behaviour unchanged.
+
+Issue #232 prep."
+```
+
+---
+
+## Task 2: `playbackStore` Skeleton + `setPlayingItem`
+
+**Files:**
+- Create: `src/stores/playbackStore.ts`
+- Test: `src/stores/playbackStore.test.ts`
+
+- [ ] **Step 2.1: Write the failing tests**
+
+Create `src/stores/playbackStore.test.ts`:
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePlaybackStore } from './playbackStore';
+
+function resetStore() {
+  usePlaybackStore.setState({
+    playingItemId: null,
+    currentTime: null,
+    progressRatio: 0,
+    _cumOffset: 0,
+    _lastBt: 0,
+    _lastCt: 0,
+    _maxProgress: 0,
+    _raw: null,
+  });
+}
+
+describe('playbackStore — setPlayingItem', () => {
+  beforeEach(resetStore);
+
+  it('starts with empty defaults', () => {
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+    expect(s.progressRatio).toBe(0);
+  });
+
+  it('setPlayingItem(id) writes id and zeros derived/trackers', () => {
+    usePlaybackStore.setState({
+      _cumOffset: 5,
+      _lastBt: 2,
+      _lastCt: 1,
+      _maxProgress: 0.4,
+    });
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(0);
+    expect(s.progressRatio).toBe(0);
+    expect(s._cumOffset).toBe(0);
+    expect(s._lastBt).toBe(0);
+    expect(s._lastCt).toBe(0);
+    expect(s._maxProgress).toBe(0);
+  });
+
+  it('setPlayingItem(sameId) is a no-op (preserves trackers)', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.setState({ _maxProgress: 0.7, currentTime: 1.5 });
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    const s = usePlaybackStore.getState();
+    expect(s._maxProgress).toBe(0.7);
+    expect(s.currentTime).toBe(1.5);
+  });
+
+  it('setPlayingItem(null) clears id; currentTime becomes null', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.setState({ currentTime: 1.2, _maxProgress: 0.3 });
+    usePlaybackStore.getState().setPlayingItem(null);
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+    expect(s._maxProgress).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 2.3: Create the store with `setPlayingItem`**
+
+Create `src/stores/playbackStore.ts`:
+
+```ts
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+
+interface PlaybackPublic {
+  playingItemId: string | null;
+  currentTime: number | null;
+  progressRatio: number;
+}
+
+interface PlaybackInternal {
+  _cumOffset: number;
+  _lastBt: number;
+  _lastCt: number;
+  _maxProgress: number;
+  _raw: { currentTime: number; duration: number; bufferedTime: number } | null;
+}
+
+interface PlaybackActions {
+  setPlayingItem: (id: string | null) => void;
+  setProgress: (raw: { currentTime: number; duration: number; bufferedTime: number } | null) => void;
+}
+
+type PlaybackState = PlaybackPublic & PlaybackInternal & PlaybackActions;
+
+const DEFAULTS: PlaybackPublic & PlaybackInternal = {
+  playingItemId: null,
+  currentTime: null,
+  progressRatio: 0,
+  _cumOffset: 0,
+  _lastBt: 0,
+  _lastCt: 0,
+  _maxProgress: 0,
+  _raw: null,
+};
+
+export const usePlaybackStore = create<PlaybackState>()(
+  subscribeWithSelector((set, get) => ({
+    ...DEFAULTS,
+
+    setPlayingItem(id) {
+      if (get().playingItemId === id) return;
+      set({
+        playingItemId: id,
+        currentTime: id === null ? null : 0,
+        progressRatio: 0,
+        _cumOffset: 0,
+        _lastBt: 0,
+        _lastCt: 0,
+        _maxProgress: 0,
+        _raw: null,
+      });
+    },
+
+    setProgress(_raw) {
+      // Implemented in Task 3.
+    },
+  })),
+);
+```
+
+- [ ] **Step 2.4: Run tests to confirm they pass**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: PASS, 4 tests green.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.test.ts
+git commit -m "feat(playback): add playbackStore skeleton with setPlayingItem
+
+Zustand store with public state (playingItemId / currentTime /
+progressRatio), internal trackers, and the item-change reset semantics
+from MainPanel. setProgress is a stub; implemented in the next commit.
+
+Issue #232."
+```
+
+---
+
+## Task 3: `setProgress` — Happy Path (Cumulative + Monotonic)
+
+**Files:**
+- Modify: `src/stores/playbackStore.ts`
+- Modify: `src/stores/playbackStore.test.ts`
+
+- [ ] **Step 3.1: Add failing tests for happy-path progress**
+
+Append to `src/stores/playbackStore.test.ts`:
+
+```ts
+describe('playbackStore — setProgress happy path', () => {
+  beforeEach(resetStore);
+
+  it('first non-null tick after setPlayingItem populates derived', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({
+      currentTime: 1.0,
+      duration: 5.0,
+      bufferedTime: 4.0,
+    });
+    const s = usePlaybackStore.getState();
+    expect(s.currentTime).toBe(1.0);
+    expect(s.progressRatio).toBeCloseTo(1.0 / 4.0, 5);
+    expect(s._raw).toEqual({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+  });
+
+  it('successive ticks advance derived monotonically', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 0.5, duration: 5.0, bufferedTime: 4.0 });
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+    const s = usePlaybackStore.getState();
+    expect(s.currentTime).toBe(1.0);
+    expect(s.progressRatio).toBeCloseTo(0.25, 5);
+  });
+
+  it('divisor falls back to duration when bufferedTime is 0', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 4.0, bufferedTime: 0 });
+    const s = usePlaybackStore.getState();
+    expect(s.progressRatio).toBeCloseTo(0.25, 5);
+  });
+
+  it('ratio clamps at 1.0 when currentTime exceeds bufferedTime', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 5.0, duration: 5.0, bufferedTime: 4.0 });
+    const s = usePlaybackStore.getState();
+    expect(s.progressRatio).toBe(1.0);
+  });
+});
+```
+
+- [ ] **Step 3.2: Run to verify they fail**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: FAIL on the new `describe` block — `setProgress` is a stub.
+
+- [ ] **Step 3.3: Implement the happy-path body of `setProgress`**
+
+In `src/stores/playbackStore.ts`, add the constant near the top (outside the store factory):
+
+```ts
+const ENTRY_RESET_THRESHOLD = 0.05; // seconds; matches MainPanel
+```
+
+Replace the stub `setProgress` body with:
+
+```ts
+setProgress(raw) {
+  const s = get();
+  if (raw === null) {
+    // Implemented in Task 5.
+    return;
+  }
+  if (s.playingItemId === null) return;
+
+  // Cumulative tracker (Task 4 adds eviction handling; here it just passes through).
+  const offset = s._cumOffset;
+  const cumCurrentTime = offset + raw.currentTime;
+  const cumBufferedTime = offset + raw.bufferedTime;
+  const cumDuration = offset + raw.duration;
+
+  // Monotonic-clamped ratio.
+  const divisor = cumBufferedTime || cumDuration || 1;
+  const calculatedRatio = Math.min(cumCurrentTime / divisor, 1);
+  const progressRatio = Math.max(calculatedRatio, s._maxProgress);
+
+  set({
+    currentTime: cumCurrentTime,
+    progressRatio,
+    _cumOffset: offset,
+    _lastBt: raw.bufferedTime,
+    _lastCt: raw.currentTime,
+    _maxProgress: progressRatio,
+    _raw: raw,
+  });
+},
+```
+
+- [ ] **Step 3.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: PASS, all happy-path + setPlayingItem cases (8 total).
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.test.ts
+git commit -m "feat(playback): implement setProgress happy-path derivation
+
+Cumulative time + monotonic-clamped ratio, mirroring MainPanel's
+existing useMemo logic. Entry-eviction handling lands in the next
+commit.
+
+Issue #232."
+```
+
+---
+
+## Task 4: `setProgress` — Entry Eviction Detection
+
+**Files:**
+- Modify: `src/stores/playbackStore.ts`
+- Modify: `src/stores/playbackStore.test.ts`
+
+- [ ] **Step 4.1: Add failing tests for entry eviction**
+
+Append to `src/stores/playbackStore.test.ts`:
+
+```ts
+describe('playbackStore — setProgress entry eviction', () => {
+  beforeEach(resetStore);
+
+  it('regression > 50ms with _lastBt > 0 bumps _cumOffset by _lastBt', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    // Entry 1 fills up: ct=1.0, bt=2.0
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 2.0, bufferedTime: 2.0 });
+    // Entry 1 evicted; new entry: ct regresses to 0.1 (1.0 - 0.9 > 0.05)
+    usePlaybackStore.getState().setProgress({ currentTime: 0.1, duration: 1.0, bufferedTime: 1.0 });
+    const s = usePlaybackStore.getState();
+    expect(s._cumOffset).toBe(2.0); // accumulated entry-1 bufferedTime
+    expect(s.currentTime).toBe(2.1); // offset + new ct
+  });
+
+  it('regression <= 50ms does NOT bump offset', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 2.0, bufferedTime: 2.0 });
+    // ct goes back 30ms — within threshold; treated as same entry jitter
+    usePlaybackStore.getState().setProgress({ currentTime: 0.97, duration: 2.0, bufferedTime: 2.0 });
+    expect(usePlaybackStore.getState()._cumOffset).toBe(0);
+  });
+
+  it('regression with _lastBt == 0 does NOT bump offset', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 2.0, bufferedTime: 0 });
+    usePlaybackStore.getState().setProgress({ currentTime: 0.1, duration: 1.0, bufferedTime: 1.0 });
+    expect(usePlaybackStore.getState()._cumOffset).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 4.2: Run tests to verify they fail**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: FAIL on the eviction `describe` block.
+
+- [ ] **Step 4.3: Patch the cumulative-tracker logic in `setProgress`**
+
+In `src/stores/playbackStore.ts`, replace the line `const offset = s._cumOffset;` with:
+
+```ts
+let offset = s._cumOffset;
+if (
+  raw.currentTime < s._lastCt - ENTRY_RESET_THRESHOLD &&
+  s._lastBt > 0
+) {
+  offset += s._lastBt;
+}
+```
+
+- [ ] **Step 4.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: PASS, all 11 tests green.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.test.ts
+git commit -m "feat(playback): detect player-entry eviction in setProgress
+
+When currentTime regresses by more than ENTRY_RESET_THRESHOLD (50ms)
+and the last entry had non-zero bufferedTime, accumulate _lastBt into
+_cumOffset so the highlight stays continuous across chunk boundaries.
+
+Issue #232."
+```
+
+---
+
+## Task 5: `setProgress(null)` — Preserve Derived, Null `_raw`
+
+**Files:**
+- Modify: `src/stores/playbackStore.ts`
+- Modify: `src/stores/playbackStore.test.ts`
+
+- [ ] **Step 5.1: Add failing tests**
+
+Append to `src/stores/playbackStore.test.ts`:
+
+```ts
+describe('playbackStore — setProgress(null)', () => {
+  beforeEach(resetStore);
+
+  it('preserves currentTime, progressRatio, and trackers; flips _raw to null', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+    const before = usePlaybackStore.getState();
+    const beforeSnap = {
+      currentTime: before.currentTime,
+      progressRatio: before.progressRatio,
+      _cumOffset: before._cumOffset,
+      _lastBt: before._lastBt,
+      _lastCt: before._lastCt,
+      _maxProgress: before._maxProgress,
+    };
+    usePlaybackStore.getState().setProgress(null);
+    const after = usePlaybackStore.getState();
+    expect(after.currentTime).toBe(beforeSnap.currentTime);
+    expect(after.progressRatio).toBe(beforeSnap.progressRatio);
+    expect(after._cumOffset).toBe(beforeSnap._cumOffset);
+    expect(after._lastBt).toBe(beforeSnap._lastBt);
+    expect(after._lastCt).toBe(beforeSnap._lastCt);
+    expect(after._maxProgress).toBe(beforeSnap._maxProgress);
+    expect(after._raw).toBeNull();
+  });
+
+  it('setProgress(null) when no item is playing is a no-op', () => {
+    usePlaybackStore.getState().setProgress(null);
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 5.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: FAIL — current stub returns early without writing `_raw = null`.
+
+- [ ] **Step 5.3: Implement `setProgress(null)`**
+
+In `src/stores/playbackStore.ts`, replace the `if (raw === null) { ... return; }` block with:
+
+```ts
+if (raw === null) {
+  // Preserve all derived trackers; only flip _raw to null so the port
+  // surface observes the pause transition. Avoids segment-based-provider
+  // chunk-gap flicker that currently affects MainPanel (improvement
+  // documented in the design spec).
+  if (s._raw !== null) {
+    set({ _raw: null });
+  }
+  return;
+}
+```
+
+- [ ] **Step 5.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: PASS, all 13 tests green.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.test.ts
+git commit -m "feat(playback): setProgress(null) preserves derived, nulls _raw
+
+Holds the last derived currentTime/progressRatio during chunk gaps so
+segment-based providers don't flicker the highlight back to 0. _raw
+flip-to-null gives the port surface an explicit pause edge to forward.
+
+Issue #232."
+```
+
+---
+
+## Task 6: Wire Helpers — `encodePlaybackForWire` + `rawEqual`
+
+**Files:**
+- Modify: `src/stores/playbackStore.ts`
+- Modify: `src/stores/playbackStore.test.ts`
+
+- [ ] **Step 6.1: Add failing tests**
+
+Append to `src/stores/playbackStore.test.ts`:
+
+```ts
+import { __internal__ } from './playbackStore';
+
+describe('playbackStore wire helpers', () => {
+  const { encodePlaybackForWire, rawEqual } = __internal__;
+
+  describe('encodePlaybackForWire', () => {
+    it('returns { i: null } when no item is playing', () => {
+      expect(encodePlaybackForWire({ playingItemId: null, _raw: null })).toEqual({ i: null });
+    });
+
+    it('returns { i, c: null } when item is set but _raw is null (paused)', () => {
+      expect(
+        encodePlaybackForWire({ playingItemId: 'item_a', _raw: null }),
+      ).toEqual({ i: 'item_a', c: null });
+    });
+
+    it('returns full shape and rounds c/d/b to 3 decimals', () => {
+      expect(
+        encodePlaybackForWire({
+          playingItemId: 'item_a',
+          _raw: { currentTime: 1.2345678, duration: 5.6789012, bufferedTime: 6.7890123 },
+        }),
+      ).toEqual({ i: 'item_a', c: 1.235, d: 5.679, b: 6.789 });
+    });
+  });
+
+  describe('rawEqual', () => {
+    it('returns true when both are null', () => {
+      expect(rawEqual(null, null)).toBe(true);
+    });
+
+    it('returns false when one side is null', () => {
+      expect(rawEqual(null, { currentTime: 0, duration: 0, bufferedTime: 0 })).toBe(false);
+      expect(rawEqual({ currentTime: 0, duration: 0, bufferedTime: 0 }, null)).toBe(false);
+    });
+
+    it('returns true when fields differ only beyond 3 decimals', () => {
+      expect(
+        rawEqual(
+          { currentTime: 1.2345, duration: 2.3455, bufferedTime: 3.4566 },
+          { currentTime: 1.2347, duration: 2.3459, bufferedTime: 3.4561 },
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when fields differ within 3 decimals', () => {
+      expect(
+        rawEqual(
+          { currentTime: 1.234, duration: 2.345, bufferedTime: 3.456 },
+          { currentTime: 1.235, duration: 2.345, bufferedTime: 3.456 },
+        ),
+      ).toBe(false);
+    });
+  });
+});
+```
+
+- [ ] **Step 6.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: FAIL — `__internal__` export missing.
+
+- [ ] **Step 6.3: Implement and export the helpers**
+
+In `src/stores/playbackStore.ts`, add at the bottom (after the `usePlaybackStore` definition):
+
+```ts
+const r3 = (x: number) => Math.round(x * 1000) / 1000;
+
+type RawProgress = { currentTime: number; duration: number; bufferedTime: number };
+
+function encodePlaybackForWire(s: {
+  playingItemId: string | null;
+  _raw: RawProgress | null;
+}): { i: string | null; c?: number | null; d?: number; b?: number } {
+  if (s.playingItemId === null) return { i: null };
+  if (s._raw === null) return { i: s.playingItemId, c: null };
+  return {
+    i: s.playingItemId,
+    c: r3(s._raw.currentTime),
+    d: r3(s._raw.duration),
+    b: r3(s._raw.bufferedTime),
+  };
+}
+
+function rawEqual(a: RawProgress | null, b: RawProgress | null): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    r3(a.currentTime) === r3(b.currentTime) &&
+    r3(a.duration) === r3(b.duration) &&
+    r3(a.bufferedTime) === r3(b.bufferedTime)
+  );
+}
+
+/** Internal exports for unit tests only. Do not consume from app code. */
+export const __internal__ = { encodePlaybackForWire, rawEqual };
+```
+
+- [ ] **Step 6.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: PASS, all 20 tests green.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.test.ts
+git commit -m "feat(playback): wire helpers (encodePlaybackForWire, rawEqual)
+
+Compact wire format for chrome.runtime.Port forwarding: short keys
+(i/c/d/b), 3-decimal precision. Helpers are module-private with
+__internal__ test export.
+
+Issue #232."
+```
+
+---
+
+## Task 7: `getRawSnapshot` + `subscribePlaybackForPort`
+
+**Files:**
+- Modify: `src/stores/playbackStore.ts`
+- Modify: `src/stores/playbackStore.test.ts`
+
+- [ ] **Step 7.1: Add failing tests**
+
+Append to `src/stores/playbackStore.test.ts`:
+
+```ts
+import { getRawSnapshot, subscribePlaybackForPort } from './playbackStore';
+
+describe('getRawSnapshot', () => {
+  beforeEach(resetStore);
+
+  it('returns null when no progress has been written', () => {
+    expect(getRawSnapshot()).toBeNull();
+  });
+
+  it('returns the latest raw input', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.234, duration: 5, bufferedTime: 4 });
+    expect(getRawSnapshot()).toEqual({ currentTime: 1.234, duration: 5, bufferedTime: 4 });
+  });
+});
+
+describe('subscribePlaybackForPort', () => {
+  beforeEach(resetStore);
+
+  it('fires callback when playingItemId changes', () => {
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toEqual({ i: 'item_a', c: null });
+    unsub();
+  });
+
+  it('fires callback when _raw changes (compared by rounded values)', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5, bufferedTime: 4 });
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toEqual({ i: 'item_a', c: 1.0, d: 5, b: 4 });
+    unsub();
+  });
+
+  it('does NOT fire callback when round-equal raw is re-written', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2345, duration: 5, bufferedTime: 4 });
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2347, duration: 5, bufferedTime: 4 });
+    expect(calls.length).toBe(0);
+    unsub();
+  });
+
+  it('unsub() detaches the listener', () => {
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    unsub();
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    expect(calls.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 7.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: FAIL — missing exports.
+
+- [ ] **Step 7.3: Implement `getRawSnapshot` and `subscribePlaybackForPort`**
+
+In `src/stores/playbackStore.ts`, add after the `__internal__` export:
+
+```ts
+export function getRawSnapshot(): RawProgress | null {
+  return usePlaybackStore.getState()._raw;
+}
+
+export type PlaybackWire = { i: string | null; c?: number | null; d?: number; b?: number };
+
+export function subscribePlaybackForPort(callback: (encoded: PlaybackWire) => void): () => void {
+  return usePlaybackStore.subscribe(
+    (s) => ({ playingItemId: s.playingItemId, _raw: s._raw }),
+    (next) => callback(encodePlaybackForWire(next)),
+    {
+      equalityFn: (a, b) =>
+        a.playingItemId === b.playingItemId && rawEqual(a._raw, b._raw),
+    },
+  );
+}
+```
+
+- [ ] **Step 7.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/playbackStore.test.ts`
+Expected: PASS, all 26 tests green.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.test.ts
+git commit -m "feat(playback): getRawSnapshot + subscribePlaybackForPort
+
+Exposes the playback signal to the extension content-script surface
+without leaking internal state shape: snapshot helper for initial
+state-init push, subscribe helper that wraps zustand subscribe with the
+wire-encoding and per-field dedup.
+
+Issue #232."
+```
+
+---
+
+## Task 8: `usePlaybackHighlight` Hook
+
+**Files:**
+- Modify: `src/stores/playbackStore.ts`
+- Create: `src/stores/playbackStore.usePlaybackHighlight.test.tsx`
+
+- [ ] **Step 8.1: Write the failing hook tests**
+
+Create `src/stores/playbackStore.usePlaybackHighlight.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { usePlaybackStore, usePlaybackHighlight } from './playbackStore';
+
+function resetStore() {
+  usePlaybackStore.setState({
+    playingItemId: null,
+    currentTime: null,
+    progressRatio: 0,
+    _cumOffset: 0,
+    _lastBt: 0,
+    _lastCt: 0,
+    _maxProgress: 0,
+    _raw: null,
+  });
+}
+
+function Probe({ item }: { item: any }) {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  const renders = useRef(0);
+  renders.current += 1;
+  return (
+    <div>
+      <span data-testid="playing">{String(isPlaying)}</span>
+      <span data-testid="chars">{highlightedChars}</span>
+      <span data-testid="renders">{renders.current}</span>
+    </div>
+  );
+}
+
+describe('usePlaybackHighlight', () => {
+  beforeEach(resetStore);
+
+  it('returns isPlaying=false / 0 when item is null', () => {
+    render(<Probe item={null} />);
+    expect(screen.getByTestId('playing').textContent).toBe('false');
+    expect(screen.getByTestId('chars').textContent).toBe('0');
+  });
+
+  it('returns isPlaying=true with linear fallback when no audioSegments', () => {
+    const item = { id: 'item_a', formatted: { text: 'Hello world' } };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ progressRatio: 0.5, currentTime: 2.0 });
+    });
+    render(<Probe item={item} />);
+    expect(screen.getByTestId('playing').textContent).toBe('true');
+    expect(screen.getByTestId('chars').textContent).toBe('5'); // floor(11 * 0.5)
+  });
+
+  it('uses audioSegments when present', () => {
+    const item = {
+      id: 'item_a',
+      formatted: {
+        transcript: 'Hello world',
+        audioSegments: [
+          { textEnd: 5, audioEnd: 1.0 },
+          { textEnd: 11, audioEnd: 2.0 },
+        ],
+      },
+    };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ currentTime: 1.5, progressRatio: 0 });
+    });
+    render(<Probe item={item} />);
+    // 1.5s → 0.5/1.0 through seg 2 (textEnd 11, prev 5, width 6) → 5 + 3 = 8
+    expect(screen.getByTestId('chars').textContent).toBe('8');
+  });
+
+  it('non-playing item does not re-render on currentTime tick', () => {
+    const itemA = { id: 'item_a', formatted: { text: 'A' } };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_b');
+      usePlaybackStore.setState({ currentTime: 1.0, progressRatio: 0.1 });
+    });
+    render(<Probe item={itemA} />);
+    const initialRenders = Number(screen.getByTestId('renders').textContent);
+
+    act(() => {
+      usePlaybackStore.setState({ currentTime: 1.1, progressRatio: 0.2 });
+    });
+    act(() => {
+      usePlaybackStore.setState({ currentTime: 1.2, progressRatio: 0.3 });
+    });
+
+    const finalRenders = Number(screen.getByTestId('renders').textContent);
+    expect(finalRenders).toBe(initialRenders);
+  });
+});
+```
+
+- [ ] **Step 8.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/stores/playbackStore.usePlaybackHighlight.test.tsx`
+Expected: FAIL — `usePlaybackHighlight` not exported.
+
+- [ ] **Step 8.3: Implement the hook**
+
+In `src/stores/playbackStore.ts`, add at the top with the other imports:
+
+```ts
+import { useShallow } from 'zustand/shallow';
+import { getHighlightedChars } from '../lib/playback/highlight';
+```
+
+Add at the bottom of the file:
+
+```ts
+export interface PlaybackHighlight {
+  isPlaying: boolean;
+  highlightedChars: number;
+}
+
+const EMPTY_HIGHLIGHT: PlaybackHighlight = { isPlaying: false, highlightedChars: 0 };
+
+export function usePlaybackHighlight(
+  item:
+    | {
+        id: string;
+        formatted?: {
+          transcript?: string;
+          text?: string;
+          audioSegments?: Array<{ textEnd: number; audioEnd: number }>;
+        };
+      }
+    | null
+    | undefined,
+): PlaybackHighlight {
+  return usePlaybackStore(
+    useShallow((s): PlaybackHighlight => {
+      if (!item || s.playingItemId !== item.id) return EMPTY_HIGHLIGHT;
+      const text = item.formatted?.transcript || item.formatted?.text || '';
+      const segments = item.formatted?.audioSegments;
+      return {
+        isPlaying: true,
+        highlightedChars: getHighlightedChars(
+          s.currentTime ?? 0,
+          segments,
+          text.length,
+          s.progressRatio,
+        ),
+      };
+    }),
+  );
+}
+```
+
+- [ ] **Step 8.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/playbackStore.usePlaybackHighlight.test.tsx`
+Expected: PASS, all 4 tests green.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add src/stores/playbackStore.ts src/stores/playbackStore.usePlaybackHighlight.test.tsx
+git commit -m "feat(playback): usePlaybackHighlight(item) hook
+
+Single hook consumed by MainPanel and SubtitleStream. Returns the
+EMPTY_HIGHLIGHT sentinel for non-playing rows so useShallow bails out
+of the 10Hz tick storm; only the active row re-renders per tick.
+
+Issue #232."
+```
+
+---
+
+## Task 9: `karaoke.scss` Shared Class + Rename in `ConversationRow`
+
+**Files:**
+- Create: `src/styles/karaoke.scss`
+- Modify: `src/components/MainPanel/ConversationRow.tsx`
+- Modify: `src/components/MainPanel/MainPanel.scss`
+- Modify: `src/components/MainPanel/MainPanel.tsx` (import only)
+- Modify: `src/components/Subtitle/SubtitleStream.tsx` (import only)
+
+- [ ] **Step 9.1: Create the shared stylesheet**
+
+Create `src/styles/karaoke.scss`:
+
+```scss
+.karaoke-played {
+  color: var(--karaoke-played-color, #10a37f);
+  transition: color 80ms ease-out;
+}
+```
+
+- [ ] **Step 9.2: Rename the class in `ConversationRow.tsx`**
+
+In `src/components/MainPanel/ConversationRow.tsx`, line 88, replace:
+
+```tsx
+        <span className="row-text-played">{text.slice(0, highlightedChars)}</span>
+```
+
+with:
+
+```tsx
+        <span className="karaoke-played">{text.slice(0, highlightedChars)}</span>
+```
+
+Add at the top of the file (after the existing `import './ConversationRow.scss';` line):
+
+```tsx
+import '../../styles/karaoke.scss';
+```
+
+- [ ] **Step 9.3: Add the import to `MainPanel.tsx`**
+
+In `src/components/MainPanel/MainPanel.tsx`, add near the other style imports:
+
+```tsx
+import '../../styles/karaoke.scss';
+```
+
+- [ ] **Step 9.4: Add the import to `SubtitleStream.tsx`**
+
+In `src/components/Subtitle/SubtitleStream.tsx`, add after the `import './SubtitleStream.scss';` line:
+
+```tsx
+import '../../styles/karaoke.scss';
+```
+
+- [ ] **Step 9.5: Delete the old rule from `MainPanel.scss`**
+
+Open `src/components/MainPanel/MainPanel.scss`, find the `.row-text-played` rule on or near line 240, and delete the entire block. (If the rule is nested inside another selector, delete just the inner `.row-text-played { ... }` block.)
+
+- [ ] **Step 9.6: Verify nothing else references `row-text-played`**
+
+Run: `git grep "row-text-played" -- ':!docs/'`
+Expected: empty output.
+
+- [ ] **Step 9.7: Run the full test suite**
+
+Run: `npm run test`
+Expected: PASS — no behavioural change, only a CSS class rename + style file move. (`SubtitleStream.test.tsx` may still pass against the unmodified hard-coded zeros at this point; that's fine.)
+
+- [ ] **Step 9.8: Commit**
+
+```bash
+git add src/styles/karaoke.scss \
+        src/components/MainPanel/ConversationRow.tsx \
+        src/components/MainPanel/MainPanel.tsx \
+        src/components/MainPanel/MainPanel.scss \
+        src/components/Subtitle/SubtitleStream.tsx
+git commit -m "refactor(subtitle): extract karaoke-played to shared stylesheet
+
+Renames row-text-played -> karaoke-played and moves the rule to
+src/styles/karaoke.scss so it's available to SubtitleStream too. No
+behaviour change.
+
+Issue #232 prep."
+```
+
+---
+
+## Task 10: Extract `ConversationBubble` From `MainPanel.tsx`
+
+This task is pure refactor: behaviour is preserved by threading the existing local `playingItemId` / `playbackProgress` values through props. Task 11 will switch those props to the store hook.
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.tsx`
+
+- [ ] **Step 10.1: Read the current `renderConversationItem` body**
+
+Read `src/components/MainPanel/MainPanel.tsx` lines 2820–2920 (or whichever range covers the helper). Identify every prop it uses from the enclosing closure (`item`, `index`, `playingItemId`, `cumulativeProgress`, `playbackProgress`, `progressRatio`, language, callbacks, `uiMode`, etc.).
+
+- [ ] **Step 10.2: Define the `ConversationBubble` component**
+
+At an appropriate location in `MainPanel.tsx` (just above the `MainPanel` component definition, or in a new co-located block), add:
+
+```tsx
+interface ConversationBubbleProps {
+  item: ConversationItem & { source?: string };
+  index: number;
+  prevItem: (ConversationItem & { source?: string }) | null;
+  sourceLanguage: string;
+  targetLanguage: string;
+  isPlaying: boolean;
+  highlightedChars: number;
+  canPlay: boolean;
+  onPlay?: () => void;
+  playDisabled: boolean;
+  uiMode: string;
+  // ... any other props the original helper consumed
+}
+
+const ConversationBubble: React.FC<ConversationBubbleProps> = (props) => {
+  // Move the entire body of renderConversationItem here, reading from
+  // props instead of from the MainPanel closure.
+};
+```
+
+Move the body of the existing `renderConversationItem` function into `ConversationBubble`, replacing closure reads with prop reads. The Karaoke calculation (`highlightedChars = ...`) still uses the local closure values for now — they will be replaced by the hook in Task 11.
+
+- [ ] **Step 10.3: Update the render site**
+
+Where `MainPanel` currently calls `filteredItems.map(renderConversationItem)`, replace with:
+
+```tsx
+filteredItems.map((item, i) => {
+  const prevItem = (() => {
+    // … keep the existing prevItem lookup logic
+  })();
+  const text = item.formatted?.transcript || item.formatted?.text || '';
+  const isItemPlaying = playingItemId === item.id;
+  const highlightedChars = isItemPlaying
+    ? getHighlightedChars(
+        cumulativeProgress?.currentTime ?? playbackProgress?.currentTime ?? 0,
+        item.formatted?.audioSegments,
+        text.length,
+        progressRatio,
+      )
+    : 0;
+  return (
+    <ConversationBubble
+      key={`${(item as any).source || 'speaker'}_${item.id || i}`}
+      item={item}
+      index={i}
+      prevItem={prevItem}
+      sourceLanguage={sourceLanguage}
+      targetLanguage={targetLanguage}
+      isPlaying={isItemPlaying}
+      highlightedChars={highlightedChars}
+      canPlay={/* existing canPlay logic */}
+      onPlay={/* existing onPlay handler */}
+      playDisabled={playingItemId !== null && !isItemPlaying}
+      uiMode={uiMode}
+      // … any other props
+    />
+  );
+})
+```
+
+Keep the imports of `getHighlightedChars` from `../../lib/playback/highlight` (or from MainPanel-local if you haven't deleted it yet). Delete the inline definition at MainPanel.tsx:91-113 if it still exists — replace with `import { getHighlightedChars } from '../../lib/playback/highlight';`.
+
+- [ ] **Step 10.4: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: no new errors. If new errors point at missing props on `ConversationBubble`, add them to the interface + thread through.
+
+- [ ] **Step 10.5: Run the full test suite**
+
+Run: `npm run test`
+Expected: PASS — refactor preserves behaviour.
+
+- [ ] **Step 10.6: Manual smoke test (optional but recommended)**
+
+Run: `npm run electron:dev`. Start a brief session; confirm assistant message still shows karaoke highlight in MainPanel.
+
+- [ ] **Step 10.7: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.tsx
+git commit -m "refactor(main-panel): extract ConversationBubble subcomponent
+
+Pulls the row-rendering helper out of MainPanel.renderConversationItem
+into a real component so we can call hooks per row. Behaviour
+unchanged; getHighlightedChars now imported from the shared module.
+
+Issue #232 prep."
+```
+
+---
+
+## Task 11: Wire `MainPanel` to `playbackStore`
+
+**Files:**
+- Modify: `src/components/MainPanel/MainPanel.tsx`
+
+- [ ] **Step 11.1: Switch audio callbacks and progress poll to store actions**
+
+In `src/components/MainPanel/MainPanel.tsx`, near the top of the component body (after other store hooks), add:
+
+```tsx
+import {
+  usePlaybackStore,
+  usePlaybackHighlight,
+} from '../../stores/playbackStore';
+
+// inside the component:
+const setPlayingItem = usePlaybackStore((s) => s.setPlayingItem);
+const setProgress = usePlaybackStore((s) => s.setProgress);
+```
+
+Find every `setPlayingItemId(...)` call in MainPanel (audio status callback around L2188-2229) and replace with `setPlayingItem(...)`. Find every `setPlaybackProgress(...)` call (progress interval around L2232-2245) and replace with `setProgress(...)`.
+
+Example, in the progress interval body:
+
+```tsx
+const progressInterval = setInterval(() => {
+  const status = player.getCurrentPlaybackStatus();
+  if (status && status.isPlaying) {
+    setProgress({
+      currentTime: status.currentTime,
+      duration: status.duration,
+      bufferedTime: status.bufferedTime,
+    });
+  } else {
+    setProgress(null);
+  }
+}, PROGRESS_UPDATE_INTERVAL);
+```
+
+The `ITEM_END_DEBOUNCE_MS` debounce that wraps `setPlayingItemId(null) + setPlaybackProgress(null)` becomes `setPlayingItem(null) + setProgress(null)` — keep the timer logic.
+
+- [ ] **Step 11.2: Delete the obsolete local state and derivations**
+
+Delete (in `src/components/MainPanel/MainPanel.tsx`):
+
+- The two `useState` declarations near L254–259:
+  ```tsx
+  const [playingItemId, setPlayingItemId] = useState<string | null>(null);
+  const [playbackProgress, setPlaybackProgress] = useState<...>(null);
+  ```
+- The `cumulativeAudioRef` declaration and the `lastMaxProgressRef` declaration (~L775).
+- The `cumulativeProgress` `useMemo` block (L2099–2131).
+- The `progressRatio` `useMemo` block (L2141–2154).
+- The two `useEffect`s — "Reset max progress and cumulative tracker when playing a new item" (L2163–2166) and "Update max progress ref after calculation" (L2171–2176).
+- The inline `function getHighlightedChars(...)` at L91–113 if it still exists. (Step 10.3 should already have replaced its usage with the import.)
+
+If any remaining code still references `playingItemId` or `playbackProgress` as locals, replace them with selectors from the store:
+
+```tsx
+const playingItemId = usePlaybackStore((s) => s.playingItemId);
+```
+
+(Some callsites — like the test-tone effect or the `playDisabled` calculation — may need this.)
+
+- [ ] **Step 11.3: Update `ConversationBubble` callsite to use the hook**
+
+In the render block introduced in Step 10.3, replace the manual `isItemPlaying` / `highlightedChars` calculation with the hook. The simplest way: move the hook call into `ConversationBubble` itself so we don't compute it twice. Inside `ConversationBubble`:
+
+```tsx
+const ConversationBubble: React.FC<ConversationBubbleProps> = (props) => {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(props.item);
+  // ... use isPlaying / highlightedChars in the body
+};
+```
+
+Remove `isPlaying` and `highlightedChars` from `ConversationBubbleProps`, and remove the corresponding props from the caller in `MainPanel`. The `playDisabled` prop still needs to know whether *some other* item is playing — pass `someItemPlaying = playingItemId !== null` instead, or read it from the store inside `ConversationBubble`. Simplest: keep a `someItemPlaying` boolean prop:
+
+```tsx
+// In MainPanel render:
+const playingItemId = usePlaybackStore((s) => s.playingItemId);
+// ...
+<ConversationBubble
+  /* ... */
+  someItemPlaying={playingItemId !== null}
+/>
+
+// In ConversationBubble:
+const playDisabled = props.someItemPlaying && !isPlaying;
+```
+
+- [ ] **Step 11.4: TypeScript compile check**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 11.5: Run the full test suite**
+
+Run: `npm run test`
+Expected: PASS. Existing MainPanel-related tests (if any) should still pass; they don't depend on the deleted internals.
+
+- [ ] **Step 11.6: Manual smoke test**
+
+Run: `npm run electron:dev`. Start a session, generate an assistant message, verify karaoke highlight tracks playback as before. Specifically watch for chunk-gap behaviour — segment-based providers should no longer flicker to char 0 between chunks (improvement).
+
+- [ ] **Step 11.7: Commit**
+
+```bash
+git add src/components/MainPanel/MainPanel.tsx
+git commit -m "feat(main-panel): consume playbackStore via usePlaybackHighlight
+
+Removes the local useState/useMemo/useEffect machinery that owned
+playingItemId, playbackProgress, cumulativeProgress, progressRatio,
+and the monotonic-clamp ref. MainPanel now writes to playbackStore
+and reads via usePlaybackHighlight, identical to SubtitleStream.
+
+Side benefit: segment-based providers no longer flicker the highlight
+to char 0 during chunk gaps (setProgress(null) preserves derived).
+
+Issue #232."
+```
+
+---
+
+## Task 12: `SubtitleStream` — Expanded Mode Highlight
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleStream.tsx`
+
+- [ ] **Step 12.1: Add an `itemsById` memo and a `SubtitleConversationRow` wrapper**
+
+In `src/components/Subtitle/SubtitleStream.tsx`, add at the top of the `SubtitleStream` component (after the `filtered` and `lines` memos):
+
+```tsx
+const itemsById = useMemo(
+  () => new Map<string, any>(items.map((it) => [it.id, it])),
+  [items],
+);
+```
+
+Add at the top of the file with the other imports:
+
+```tsx
+import { usePlaybackHighlight } from '../../stores/playbackStore';
+```
+
+At the bottom of the file (below the `SubtitleStream` component, above `export default`):
+
+```tsx
+const SubtitleConversationRow: React.FC<{
+  item: any;
+  prevItem: any;
+  sourceLanguage: string;
+  targetLanguage: string;
+}> = ({ item, prevItem, sourceLanguage, targetLanguage }) => {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  return (
+    <ConversationRow
+      item={item}
+      prevItem={prevItem}
+      compact={false}
+      sourceLanguage={sourceLanguage}
+      targetLanguage={targetLanguage}
+      isPlaying={isPlaying}
+      highlightedChars={highlightedChars}
+      canPlay={false}
+    />
+  );
+};
+```
+
+- [ ] **Step 12.2: Replace the expanded-mode mapping**
+
+In the JSX returned by `SubtitleStream`, replace the existing expanded-mode block:
+
+```tsx
+: filtered.map((item, i) => (
+    <ConversationRow
+      key={item.id}
+      item={item}
+      prevItem={filtered[i - 1] ?? null}
+      compact={false}
+      sourceLanguage={sourceLanguage}
+      targetLanguage={targetLanguage}
+      isPlaying={false}
+      highlightedChars={0}
+      canPlay={false}
+    />
+  ))}
+```
+
+with:
+
+```tsx
+: filtered.map((item, i) => (
+    <SubtitleConversationRow
+      key={item.id}
+      item={item}
+      prevItem={filtered[i - 1] ?? null}
+      sourceLanguage={sourceLanguage}
+      targetLanguage={targetLanguage}
+    />
+  ))}
+```
+
+- [ ] **Step 12.3: Run the existing test suite**
+
+Run: `npm run test -- src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: existing expanded-mode test cases that asserted `isPlaying={false}` / `highlightedChars={0}` may FAIL. That's expected — they reflected the bug we're fixing.
+
+- [ ] **Step 12.4: Update / rewrite the affected existing test cases**
+
+Open `src/components/Subtitle/SubtitleStream.test.tsx`. Find any test that asserts `isPlaying === false` or `highlightedChars === 0` for an expanded-mode ConversationRow. Replace those assertions with:
+
+- "When playbackStore has no playing item, expanded rows receive `isPlaying=false` and `highlightedChars=0`" — mock the store before render via `usePlaybackStore.setState({ playingItemId: null, currentTime: null, progressRatio: 0 })`. Assert the same thing as before.
+
+(If no existing tests assert this specifically, no update needed — only the new test cases below.)
+
+- [ ] **Step 12.5: Add a new expanded-mode test**
+
+Append to `src/components/Subtitle/SubtitleStream.test.tsx`:
+
+```tsx
+import { usePlaybackStore } from '../../stores/playbackStore';
+
+describe('SubtitleStream — expanded karaoke highlight', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+  });
+
+  it('renders karaoke split on the playing assistant item', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 0.5,
+      });
+    });
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={false}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    // floor(11 * 0.5) = 5 → "Hello"
+    const played = container.querySelector('.karaoke-played');
+    expect(played?.textContent).toBe('Hello');
+  });
+});
+```
+
+Add the required imports at the top of the test file: `act` from `@testing-library/react`. (`render`, `screen` are likely already there.)
+
+- [ ] **Step 12.6: Run the test file**
+
+Run: `npm run test -- src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 12.7: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleStream.tsx \
+        src/components/Subtitle/SubtitleStream.test.tsx
+git commit -m "feat(subtitle): wire expanded-mode ConversationRow to playbackStore
+
+SubtitleConversationRow wrapper calls usePlaybackHighlight(item) and
+forwards the result to ConversationRow's existing karaoke props. The
+hard-coded isPlaying=false / highlightedChars=0 are gone.
+
+Issue #232 — phase 1 (Electron path)."
+```
+
+---
+
+## Task 13: `SubtitleStream` — Compact Mode `CompactSpan`
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleStream.tsx`
+- Modify: `src/components/Subtitle/SubtitleStream.test.tsx`
+
+- [ ] **Step 13.1: Add the failing test for compact karaoke**
+
+Append to `src/components/Subtitle/SubtitleStream.test.tsx`:
+
+```tsx
+describe('SubtitleStream — compact karaoke highlight', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+  });
+
+  it('compact band splits the playing assistant item into played/unplayed spans', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        source: 'speaker',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 0.5,
+      });
+    });
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const played = container.querySelector('.karaoke-played');
+    expect(played?.textContent).toBe('Hello');
+  });
+
+  it('compact band does not split spans for non-playing items', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        source: 'speaker',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    // playingItemId is null in the beforeEach reset
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelector('.karaoke-played')).toBeNull();
+  });
+
+  it('compact band renders plain text when item is missing from items[]', () => {
+    // line bucket has an id that isn't in items (rare timing race)
+    const items: any[] = [];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 0.5,
+      });
+    });
+    // We can't simulate "in lines but not in items" directly without
+    // restructuring the test; assert at minimum that an empty items
+    // array doesn't crash and renders no .karaoke-played.
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelector('.karaoke-played')).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 13.2: Run to confirm the compact karaoke test fails**
+
+Run: `npm run test -- src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: FAIL on the new compact test cases — current compact branch hardcodes plain text.
+
+- [ ] **Step 13.3: Add the `CompactSpan` subcomponent**
+
+In `src/components/Subtitle/SubtitleStream.tsx`, add at the bottom of the file (above or below `SubtitleConversationRow`):
+
+```tsx
+interface CompactSpanProps {
+  it: SubtitleLineItem;
+  item: any | undefined;
+  showNewHighlight: boolean;
+  leadingSpace: boolean;
+}
+
+const CompactSpan: React.FC<CompactSpanProps> = ({
+  it,
+  item,
+  showNewHighlight,
+  leadingSpace,
+}) => {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  const baseClass = showNewHighlight
+    ? 'subtitle-stream__item subtitle-stream__item--new'
+    : 'subtitle-stream__item';
+  const prefix = leadingSpace ? ' ' : '';
+
+  if (!isPlaying || highlightedChars <= 0 || highlightedChars >= it.text.length) {
+    return <span className={baseClass}>{prefix}{it.text}</span>;
+  }
+  return (
+    <span className={baseClass}>
+      {prefix}
+      <span className="karaoke-played">{it.text.slice(0, highlightedChars)}</span>
+      <span>{it.text.slice(highlightedChars)}</span>
+    </span>
+  );
+};
+```
+
+- [ ] **Step 13.4: Replace the inline compact-mode `<span>` mapping**
+
+In the compact branch inside the `SubtitleStream` return JSX, replace:
+
+```tsx
+<p>
+  {line.items.map((it, idx) => {
+    const showHighlight =
+      newItemHighlightEnabled && itemStateFor(it.id) === 'new';
+    const className = showHighlight
+      ? 'subtitle-stream__item subtitle-stream__item--new'
+      : 'subtitle-stream__item';
+    return (
+      <span key={it.id} className={className}>
+        {idx > 0 ? ' ' : ''}{it.text}
+      </span>
+    );
+  })}
+</p>
+```
+
+with:
+
+```tsx
+<p>
+  {line.items.map((it, idx) => (
+    <CompactSpan
+      key={it.id}
+      it={it}
+      item={itemsById.get(it.id)}
+      showNewHighlight={newItemHighlightEnabled && itemStateFor(it.id) === 'new'}
+      leadingSpace={idx > 0}
+    />
+  ))}
+</p>
+```
+
+- [ ] **Step 13.5: Run the tests to confirm pass**
+
+Run: `npm run test -- src/components/Subtitle/SubtitleStream.test.tsx`
+Expected: PASS, all new compact tests green; existing tests still green.
+
+- [ ] **Step 13.6: Manual smoke test (Electron)**
+
+Run: `npm run electron:dev`. Start a session. Open the subtitle window. Confirm:
+- Compact band shows assistant translation;
+- During playback, the currently-playing item shows a colour change advancing character by character;
+- Non-playing items in the same band remain plain.
+
+- [ ] **Step 13.7: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleStream.tsx \
+        src/components/Subtitle/SubtitleStream.test.tsx
+git commit -m "feat(subtitle): karaoke split in compact band via CompactSpan
+
+CompactSpan calls usePlaybackHighlight per item; only the actively-
+playing span re-renders per tick (useShallow + EMPTY_HIGHLIGHT bailout).
+Leading space stays on the outer span to keep playback-induced colour
+changes off whitespace.
+
+Issue #232 — phase 1 (Electron path) complete."
+```
+
+---
+
+## Task 14: Extension Surface — Forward Playback Over the Port
+
+**Files:**
+- Modify: `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts`
+- Modify: `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts`
+
+- [ ] **Step 14.1: Add failing tests for the new playback forwarding**
+
+Append to `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts` (uses the existing `listeners` + `makePort` pattern from the "port reconnect does not leak" test in the same file):
+
+```ts
+import { usePlaybackStore } from '../../../stores/playbackStore';
+
+describe('ExtensionContentScriptSubtitleSurface — playback forwarding', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+  });
+
+  const makePort = () => ({
+    name: 'sokuji-subtitle',
+    onMessage: { addListener: vi.fn() },
+    onDisconnect: { addListener: vi.fn() },
+    postMessage: vi.fn(),
+    disconnect: vi.fn(),
+  });
+
+  it('state-init carries playback=null when nothing is playing', async () => {
+    const surface = new ExtensionContentScriptSubtitleSurface();
+    await surface.enter();
+    const port = makePort();
+    listeners.onConnect[0](port);
+    // Drain the lazy import + initial state-init push.
+    await new Promise((r) => setTimeout(r, 0));
+
+    const init = port.postMessage.mock.calls.find(
+      (call: any[]) => call[0]?.type === 'state-init',
+    );
+    expect(init).toBeDefined();
+    expect(init![0].payload.playback).toBeNull();
+  });
+
+  it('state-init carries playback snapshot when item is playing', async () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.234, duration: 5, bufferedTime: 4 });
+
+    const surface = new ExtensionContentScriptSubtitleSurface();
+    await surface.enter();
+    const port = makePort();
+    listeners.onConnect[0](port);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const init = port.postMessage.mock.calls.find(
+      (call: any[]) => call[0]?.type === 'state-init',
+    );
+    expect(init![0].payload.playback).toEqual({ i: 'item_a', c: 1.234, d: 5, b: 4 });
+  });
+
+  it('forwards playback changes as typed messages', async () => {
+    const surface = new ExtensionContentScriptSubtitleSurface();
+    await surface.enter();
+    const port = makePort();
+    listeners.onConnect[0](port);
+    await new Promise((r) => setTimeout(r, 0));
+    port.postMessage.mockClear();
+
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    await new Promise((r) => setTimeout(r, 0));
+    expect(port.postMessage.mock.calls).toContainEqual([
+      { type: 'playback', i: 'item_a', c: null },
+    ]);
+
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(port.postMessage.mock.calls).toContainEqual([
+      { type: 'playback', i: 'item_a', c: 1, d: 5, b: 4 },
+    ]);
+  });
+
+  it('dedupes round-equal raw values', async () => {
+    const surface = new ExtensionContentScriptSubtitleSurface();
+    await surface.enter();
+    const port = makePort();
+    listeners.onConnect[0](port);
+    await new Promise((r) => setTimeout(r, 0));
+
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2345, duration: 5, bufferedTime: 4 });
+    await new Promise((r) => setTimeout(r, 0));
+    port.postMessage.mockClear();
+
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2347, duration: 5, bufferedTime: 4 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const playbackMsgs = port.postMessage.mock.calls.filter(
+      (c: any[]) => c[0]?.type === 'playback',
+    );
+    expect(playbackMsgs.length).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 14.2: Run to confirm tests fail**
+
+Run: `npm run test -- src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 14.3: Implement the playback subscription in the surface**
+
+In `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts`, inside `installStoreSubscriptions()`:
+
+Just after the existing line:
+
+```ts
+const { default: useSessionStore } = await import('../../../stores/sessionStore');
+```
+
+add a second lazy import for the playback module:
+
+```ts
+const {
+  usePlaybackStore,
+  getRawSnapshot,
+  subscribePlaybackForPort,
+} = await import('../../../stores/playbackStore');
+```
+
+Extend the initial `state-init` push to include the playback snapshot. Find the existing block:
+
+```ts
+this.port.postMessage({
+  type: 'state-init',
+  payload: {
+    items: session.items,
+    systemAudioItems: session.systemAudioItems,
+    isSessionActive: session.isSessionActive,
+    sessionStartTime: session.sessionStartTime,
+    provider: lastConfig.provider,
+    sourceLanguage: lastConfig.sourceLanguage,
+    targetLanguage: lastConfig.targetLanguage,
+    turnDetectionMode: lastConfig.turnDetectionMode,
+  },
+});
+```
+
+Add `playback` to the payload:
+
+```ts
+const playbackSnapshot = (() => {
+  const playingItemId = usePlaybackStore.getState().playingItemId;
+  const raw = getRawSnapshot();
+  if (playingItemId === null) return null;
+  if (raw === null) return { i: playingItemId, c: null };
+  const r3 = (x: number) => Math.round(x * 1000) / 1000;
+  return { i: playingItemId, c: r3(raw.currentTime), d: r3(raw.duration), b: r3(raw.bufferedTime) };
+})();
+
+this.port.postMessage({
+  type: 'state-init',
+  payload: {
+    items: session.items,
+    systemAudioItems: session.systemAudioItems,
+    isSessionActive: session.isSessionActive,
+    sessionStartTime: session.sessionStartTime,
+    provider: lastConfig.provider,
+    sourceLanguage: lastConfig.sourceLanguage,
+    targetLanguage: lastConfig.targetLanguage,
+    turnDetectionMode: lastConfig.turnDetectionMode,
+    playback: playbackSnapshot,
+  },
+});
+```
+
+Below the existing three subscriptions (`unsubItems`, `unsubSession`, `unsubConfig`), add the fourth:
+
+```ts
+const unsubPlayback = subscribePlaybackForPort((encoded) => {
+  this.port?.postMessage({ type: 'playback', ...encoded });
+});
+```
+
+Append it to the subscriptions array:
+
+```ts
+this.subscriptions = [unsubItems, unsubSession, unsubConfig, unsubPlayback];
+```
+
+- [ ] **Step 14.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts`
+Expected: PASS.
+
+- [ ] **Step 14.5: Run the full test suite**
+
+Run: `npm run test`
+Expected: PASS — no regressions elsewhere.
+
+- [ ] **Step 14.6: Commit**
+
+```bash
+git add src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts \
+        src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
+git commit -m "feat(subtitle/ext): forward playback over chrome.runtime.Port
+
+Side-panel surface subscribes to playbackStore and pushes a compact
+'playback' message (short keys, 3-decimal precision) to the iframe.
+Initial state-init carries a snapshot so mid-playback joiners pick
+up the correct highlight immediately.
+
+Issue #232 — phase 2 (side-panel side)."
+```
+
+---
+
+## Task 15: `sessionPortMirror` — Iframe-Side Inbound Decode
+
+**Files:**
+- Modify: `src/stores/sessionPortMirror.ts`
+- Modify: `src/stores/sessionPortMirror.test.ts`
+
+- [ ] **Step 15.1: Add failing tests for `playback` inbound**
+
+Append to `src/stores/sessionPortMirror.test.ts` (uses the file's existing `connectedPort` + `installSessionPortMirror` pattern; the inbound `onMessage` handler is captured via `connectedPort.onMessage.addListener.mock.calls[0][0]`):
+
+```ts
+import { usePlaybackStore } from './playbackStore';
+
+describe('sessionPortMirror — playback inbound', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+    useSessionStore.setState({
+      items: [],
+      systemAudioItems: [],
+      isSessionActive: false,
+      sessionStartTime: null,
+    } as any);
+
+    connectedPort = {
+      name: 'sokuji-subtitle',
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+      onDisconnect: { addListener: vi.fn(), removeListener: vi.fn() },
+      postMessage: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    globalThis.chrome = {
+      runtime: { connect: vi.fn(() => connectedPort) },
+    };
+  });
+
+  it('applies playback message with full c/d/b', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'playback', i: 'item_a', c: 1.0, d: 5.0, b: 4.0 });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(1.0);
+    expect(s._raw).toEqual({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+  });
+
+  it('applies playback message with c:null (pause) preserving derived', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'playback', i: 'item_a', c: 1.0, d: 5.0, b: 4.0 });
+    onMessage({ type: 'playback', i: 'item_a', c: null });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(1.0);
+    expect(s._raw).toBeNull();
+  });
+
+  it('applies playback message with i:null (clear)', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'playback', i: 'item_a', c: 1.0, d: 5.0, b: 4.0 });
+    onMessage({ type: 'playback', i: null });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+  });
+
+  it('state-init.payload.playback populates the store on connect', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({
+      type: 'state-init',
+      payload: { items: [], playback: { i: 'item_a', c: 0.5, d: 5, b: 4 } },
+    });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(0.5);
+  });
+
+  it('state-init without playback leaves the playback store at defaults', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'state-init', payload: { items: [] } });
+    expect(usePlaybackStore.getState().playingItemId).toBeNull();
+  });
+});
+```
+
+Add `import useSessionStore from './sessionStore';` to the top of the file if it isn't already imported in the same scope as this describe block.
+
+- [ ] **Step 15.2: Run tests to confirm they fail**
+
+Run: `npm run test -- src/stores/sessionPortMirror.test.ts`
+Expected: FAIL.
+
+- [ ] **Step 15.3: Implement inbound handling in `sessionPortMirror.ts`**
+
+In `src/stores/sessionPortMirror.ts`:
+
+Add the import at the top:
+
+```ts
+import usePlaybackStore from './playbackStore';
+```
+
+Wait — `usePlaybackStore` is exported as a named export from `playbackStore.ts`. Use the named import:
+
+```ts
+import { usePlaybackStore } from './playbackStore';
+```
+
+Add the new inbound type to the union near the existing interfaces:
+
+```ts
+interface InboundPlayback {
+  type: 'playback';
+  i: string | null;
+  c?: number | null;
+  d?: number;
+  b?: number;
+}
+
+type Inbound =
+  | InboundStateInit
+  | InboundItems
+  | InboundSession
+  | InboundConfig
+  | InboundPlayback;
+```
+
+Extend `InboundStateInit.payload` with an optional `playback` field:
+
+```ts
+interface InboundStateInit {
+  type: 'state-init';
+  payload: {
+    items?: any[];
+    systemAudioItems?: any[];
+    isSessionActive?: boolean;
+    sessionStartTime?: number | null;
+    provider?: string;
+    sourceLanguage?: string;
+    targetLanguage?: string;
+    turnDetectionMode?: string;
+    playback?: { i: string | null; c?: number | null; d?: number; b?: number } | null;
+  };
+}
+```
+
+Add an `applyPlayback` helper near `applyConfig`:
+
+```ts
+function applyPlayback(msg: { i: string | null; c?: number | null; d?: number; b?: number }) {
+  const playback = usePlaybackStore.getState();
+  if (msg.i === null) {
+    playback.setPlayingItem(null);
+    return;
+  }
+  playback.setPlayingItem(msg.i);
+  if (msg.c === null || msg.c === undefined) {
+    playback.setProgress(null);
+    return;
+  }
+  playback.setProgress({
+    currentTime: msg.c,
+    duration: msg.d ?? 0,
+    bufferedTime: msg.b ?? 0,
+  });
+}
+```
+
+Update `handle()` to dispatch on the new type and read the new `state-init` field:
+
+```ts
+function handle(msg: Inbound): void {
+  if (!msg || typeof msg !== 'object') return;
+  if (msg.type === 'state-init') {
+    useSessionStore.setState({
+      items: msg.payload.items ?? [],
+      systemAudioItems: msg.payload.systemAudioItems ?? [],
+      isSessionActive: msg.payload.isSessionActive ?? false,
+      sessionStartTime: msg.payload.sessionStartTime ?? null,
+    } as any);
+    if (msg.payload.provider) {
+      applyConfig(
+        msg.payload.provider,
+        msg.payload.sourceLanguage ?? 'en',
+        msg.payload.targetLanguage ?? 'zh',
+        msg.payload.turnDetectionMode,
+      );
+    }
+    if (msg.payload.playback) applyPlayback(msg.payload.playback);
+  } else if (msg.type === 'playback') {
+    applyPlayback(msg);
+  } else if (msg.type === 'items') {
+    useSessionStore.setState({
+      items: msg.items,
+      systemAudioItems: msg.systemAudioItems ?? useSessionStore.getState().systemAudioItems,
+    } as any);
+  } else if (msg.type === 'session') {
+    useSessionStore.setState({
+      isSessionActive: msg.isSessionActive,
+      sessionStartTime: msg.sessionStartTime ?? null,
+    } as any);
+  } else if (msg.type === 'config') {
+    applyConfig(msg.provider, msg.sourceLanguage, msg.targetLanguage, msg.turnDetectionMode);
+  }
+}
+```
+
+- [ ] **Step 15.4: Run tests to confirm pass**
+
+Run: `npm run test -- src/stores/sessionPortMirror.test.ts`
+Expected: PASS.
+
+- [ ] **Step 15.5: Run the full test suite**
+
+Run: `npm run test`
+Expected: PASS — no regressions.
+
+- [ ] **Step 15.6: Commit**
+
+```bash
+git add src/stores/sessionPortMirror.ts src/stores/sessionPortMirror.test.ts
+git commit -m "feat(subtitle/ext): decode playback messages in iframe mirror
+
+sessionPortMirror handles the new 'playback' inbound type and the
+optional state-init.payload.playback snapshot, dispatching to the
+iframe-side playbackStore. The same setPlayingItem + setProgress
+calls run on both sides; derivation logic is identical.
+
+Issue #232 — phase 2 complete."
+```
+
+---
+
+## Task 16: TypeScript & Tests Full Sweep
+
+**Files:**
+- Verify only (no edits).
+
+- [ ] **Step 16.1: TypeScript compile**
+
+Run: `npx tsc --noEmit`
+Expected: clean. Investigate and fix any new errors before moving on.
+
+- [ ] **Step 16.2: Full test suite**
+
+Run: `npm run test`
+Expected: PASS, all suites green.
+
+- [ ] **Step 16.3: Lint (if configured)**
+
+Run: `npm run lint 2>/dev/null || echo "no lint script"`
+Expected: no errors (or "no lint script" if the project has none — that's fine).
+
+- [ ] **Step 16.4: Grep for leftover references**
+
+Run:
+```bash
+git grep -nE "row-text-played" -- ':!docs/'
+git grep -nE "playingItemId.*useState|playbackProgress.*useState" src/
+```
+Expected: both empty. (`row-text-played` is gone; the two `useState`s have moved to `playbackStore`.)
+
+- [ ] **Step 16.5: Commit a no-op marker if anything was cleaned up**
+
+If any leftovers were found and removed, commit. Otherwise skip.
+
+```bash
+git status
+# If there are changes:
+git add -A
+git commit -m "chore(playback): clean up leftover references after refactor"
+```
+
+---
+
+## Task 17: Manual Verification (Electron + Extension)
+
+**Files:** none.
+
+- [ ] **Step 17.1: Electron MainPanel smoke test**
+
+Run: `npm run electron:dev`
+- Start a session with the default provider.
+- Generate an assistant message (say something into the mic).
+- Verify the assistant translation in MainPanel still shows the karaoke colour advance.
+- Specifically: during long assistant messages with chunk gaps, confirm the highlight does NOT flash back to character 0 between chunks (this is the intentional improvement from `setProgress(null)` preserving derived).
+
+- [ ] **Step 17.2: Electron subtitle window**
+
+In the same dev session:
+- Open the subtitle window from the UI.
+- Confirm the **compact** band shows the assistant translation with character-by-character colour fill during playback.
+- Toggle to **expanded** mode; confirm the same highlight via ConversationRow.
+
+- [ ] **Step 17.3: Extension build + sideload**
+
+Run: `cd extension && npm install && npm run build`
+(Refer to existing extension docs in the repo if these scripts differ.)
+
+- Load the unpacked extension in Chrome → `chrome://extensions/` → Developer mode → "Load unpacked" → select `extension/dist`.
+- Join `https://meet.google.com/<test-room>`.
+- Click the Sokuji icon → enter subtitle mode on the meeting tab.
+- Speak into the mic; confirm the overlay subtitle bar shows karaoke highlight on the assistant translation.
+
+- [ ] **Step 17.4: Bandwidth verification (Extension)**
+
+Temporarily instrument `ExtensionContentScriptSubtitleSurface.installStoreSubscriptions()` to log the size of each `postMessage`:
+
+```ts
+// inside subscribePlaybackForPort callback (TEMP — remove before merge):
+const encoded = { type: 'playback', ...e };
+const bytes = new TextEncoder().encode(JSON.stringify(encoded)).length;
+console.info('[Sokuji bandwidth]', bytes, 'B');
+this.port?.postMessage(encoded);
+```
+
+- Open the side-panel DevTools (`chrome://extensions/` → Sokuji → "Inspect views: service worker" / side panel).
+- Generate a continuous assistant message ~30 s long.
+- Sum the per-message bytes from the console; divide by elapsed seconds.
+- Confirm the average is under 1 KB/s. Record the number for the PR description.
+- **Remove the instrumentation log before final commit.**
+
+- [ ] **Step 17.5: Smoothness comparison**
+
+- Open Electron MainPanel and the Electron subtitle bar side by side.
+- Play the same assistant message in both.
+- Visually confirm the subtitle highlight motion is at least as smooth as MainPanel's.
+
+- [ ] **Step 17.6: Edge case — non-streaming provider**
+
+- Switch the provider to a non-streaming one (local inference Opus-MT, or any provider where translations arrive as one chunk).
+- Play an assistant message; confirm the karaoke linear fallback still advances smoothly.
+
+- [ ] **Step 17.7: Edge case — chunk-gap-prone provider**
+
+- Switch to a streaming provider (OpenAI Realtime / Gemini) that produces chunk-segmented audio.
+- Watch the highlight during chunk boundaries; confirm no flash-to-zero.
+
+- [ ] **Step 17.8: Note manual-verification results**
+
+In the PR description (template separately), include:
+- Bandwidth measurement (e.g., "Measured 780 B/s over 30 s continuous playback").
+- Brief note that Electron + Extension paths were verified.
+- Mention any visual co-occurrence between `subtitle-stream__item--new` and `karaoke-played` on freshly-arrived playing items (likely fine; only mitigate if conspicuous).
+
+- [ ] **Step 17.9: Final commit if instrumentation was added/removed**
+
+```bash
+git status
+# Should be clean. If there were temporary edits:
+git restore .
+```
+
+---
+
+## Verification Checklist (Acceptance Criteria from Issue #232)
+
+- [ ] Subtitle bar highlights the currently-playing assistant message character-by-character in Electron. *(Task 12 + Task 13 + Task 17.2)*
+- [ ] No regression in MainPanel highlighting. *(Task 11.6, Task 17.1)*
+- [ ] Subtitle bar highlights work in extension iframe overlay when an assistant message is playing in the sidepanel. *(Task 14 + Task 15 + Task 17.3)*
+- [ ] Sustained port-tick bandwidth < 1 KB/s. *(Task 6, Task 7, Task 17.4)*
+- [ ] Smoothness ≥ what MainPanel currently delivers. *(Task 17.5)*
+
+---
+
+## Out of Scope (Already Documented in Spec)
+
+- Word-level timing.
+- Speaker (user) message highlighting.
+- Cross-port-disconnect `_maxProgress` continuity (single ≤ 100 ms snap on iframe reconnect is acceptable).
+- Visual coordination polish between `subtitle-stream__item--new` and `karaoke-played` — observe; only mitigate if conspicuous.
+- A user toggle for the karaoke highlight (treatment is opinionated and ships on by default).

--- a/docs/superpowers/specs/2026-05-19-subtitle-karaoke-highlight-design.md
+++ b/docs/superpowers/specs/2026-05-19-subtitle-karaoke-highlight-design.md
@@ -1,0 +1,408 @@
+# Subtitle — Karaoke-Style Character Highlighting
+
+**Date:** 2026-05-19
+**Status:** Design approved, ready for implementation plan
+**Issue:** [#232](https://github.com/kizuna-ai-lab/sokuji/issues/232)
+
+## Problem
+
+`MainPanel` already paints a karaoke-style character-by-character highlight on the currently-playing assistant message: `getHighlightedChars()` (`MainPanel.tsx:91-113`) maps cumulative playback time to a character offset using per-sentence `audioSegments` from the provider (with a linear-interpolation fallback), and `ConversationRow` (`ConversationRow.tsx:83-89`) renders the result as two spans — a `row-text-played` prefix + an unstyled remainder.
+
+In **subtitle mode**, that same data is dropped. `SubtitleStream.tsx` forwards `highlightedChars={0}` and `isPlaying={false}` to `ConversationRow` in expanded mode, and concatenates plain `<span>` items per band in compact mode with no per-item highlight at all. The view layer is ready; the blocker is plumbing — `playingItemId` and the playback progress are MainPanel-local `useState` (`MainPanel.tsx:254-259`), so subtitle mode has no way to read them.
+
+Two contexts:
+
+- **Electron**: `MainPanel` and `SubtitleApp` share the same React tree (the side-panel surface). Lifting the state into a shared store is all that's needed.
+- **Extension**: `SubtitleApp` lives in an iframe injected into the meeting page (Google Meet, Teams, Zoom, …). The iframe has no audio of its own — audio plays in the side panel. The side panel already maintains a long-lived `chrome.runtime.Port` to the iframe for items / session / config mirroring (`sessionPortMirror.ts`); playback state needs to ride the same port.
+
+## Goals & Non-Goals
+
+**Goals**
+
+- Show the same character-by-character highlight in subtitle mode that the main panel shows for the currently-playing assistant message.
+- Cover both compact and expanded subtitle layouts.
+- No regression in `MainPanel` highlighting.
+- Sustained port-tick bandwidth < 1 KB/s during continuous playback.
+- Subtitle smoothness ≥ what `MainPanel` currently delivers (10 Hz).
+- Source-of-truth playback logic lives in **one** module; both Electron and Extension paths share the same state machine.
+
+**Non-Goals**
+
+- Word-level timing. Current upstream data is character-level (`audioSegments` from the provider).
+- Highlighting the speaker (user) message. Only the assistant playback gets highlighted today, and that doesn't change.
+- Per-character animation polish (CSS transitions beyond the existing `karaoke-played` colour change).
+- Cross-port-disconnect monotonic-progress continuity. Mid-playback port reconnects are rare and a single ≤ 100 ms visual snap-back is acceptable.
+
+## Design Overview
+
+A new Zustand store `playbackStore` owns playback state and runs the existing derivation logic (cumulative time across player-entry boundaries + monotonic-clamped progress ratio). Both `MainPanel` and `SubtitleApp` consume it via a single hook `usePlaybackHighlight(item)` that returns `{ isPlaying, highlightedChars }`. The pure `getHighlightedChars()` function moves out of `MainPanel.tsx` to `src/lib/playback/highlight.ts`.
+
+For the Extension path, the side-panel surface (`ExtensionContentScriptSubtitleSurface`) subscribes to its local `playbackStore` and forwards raw playback signals over the existing `chrome.runtime.Port` using a compact wire format. The iframe's `sessionPortMirror` decodes them and feeds the iframe-side `playbackStore` through the same setters. Both sides run identical derivation; `MainPanel` and `SubtitleApp` (Electron or iframe) consume identical results.
+
+```
+                      ┌───────────────────────────────────┐
+                      │  ModernAudioPlayer (side panel)   │
+                      │  status callback + 100ms poll     │
+                      └───────────┬───────────────────────┘
+                                  │ raw signal @10Hz
+                                  ▼
+   ┌──────────────────────────────────────────────────────────┐
+   │  playbackStore (Zustand) — side-panel process            │
+   │   actions: setPlayingItem(id), setProgress(raw)          │
+   │   public:  playingItemId, currentTime, progressRatio     │
+   │   internal:_cumOffset, _lastBt, _lastCt, _maxProgress,   │
+   │            _raw                                          │
+   └──────┬─────────────────────────────────────────┬──────────┘
+          │ in-process subscribe                    │ in-process subscribe
+          ▼                                         ▼
+   ┌──────────────┐                          ┌──────────────────────────────┐
+   │  MainPanel   │                          │ ExtensionContentScriptSubt…  │
+   │  Conversation│                          │  subscribePlaybackForPort →  │
+   │  Bubble      │                          │  port.postMessage(wire)      │
+   └──────────────┘                          └────────────┬─────────────────┘
+                                                          │ ≤ 90 B × 10 Hz
+                                                          ▼ ≈ 800 B/s
+                                          ┌────────────────────────────────┐
+                                          │ sessionPortMirror (iframe)     │
+                                          │  decode → playbackStore        │
+                                          │  setPlayingItem + setProgress  │
+                                          └────────────┬───────────────────┘
+                                                       ▼
+                                          ┌───────────────────────────────┐
+                                          │ SubtitleApp / SubtitleStream  │
+                                          │  usePlaybackHighlight(item)   │
+                                          └───────────────────────────────┘
+```
+
+## Component Changes
+
+### New file: `src/lib/playback/highlight.ts`
+
+Lifts `getHighlightedChars()` from `MainPanel.tsx:91-113` verbatim. Pure function, zero dependencies, exported. Imported by `playbackStore.usePlaybackHighlight` and (optionally) reused by tests.
+
+### New file: `src/stores/playbackStore.ts`
+
+Zustand store with `subscribeWithSelector` middleware (matches the existing store style in `audioStore.ts` / `sessionStore.ts`).
+
+**Public state** (read via selector hooks):
+
+```ts
+interface PlaybackPublic {
+  playingItemId: string | null;
+  currentTime: number | null;  // cumulative-adjusted seconds in the item's timeline
+  progressRatio: number;        // monotonic-clamped [0, 1]
+}
+```
+
+**Internal state** (in the same state object, underscore-prefixed; not read by consumers):
+
+```ts
+interface PlaybackInternal {
+  _cumOffset: number;   // cumulative offset across player-entry resets
+  _lastBt: number;      // last raw bufferedTime
+  _lastCt: number;      // last raw currentTime
+  _maxProgress: number; // monotonic-clamp guard
+  _raw: { currentTime: number; duration: number; bufferedTime: number } | null;
+}
+```
+
+**Actions**:
+
+- `setPlayingItem(id: string | null)` — writes id; on actual change (not same-id no-op) resets all internal trackers and clears public derived values (`currentTime` to `null` if `id === null`, else `0`; `progressRatio` to `0`).
+- `setProgress(raw)` — accepts the raw `{ currentTime, duration, bufferedTime }` from the player. Stores `_raw`. Computes cumulative time (offset bumps by `_lastBt` when `raw.currentTime` regresses by more than `ENTRY_RESET_THRESHOLD = 0.05`) and monotonic-clamped ratio (`max(calculated, _maxProgress)`); writes both into public state. `setProgress(null)` **preserves all derived trackers and writes `_raw = null`** (improved from `MainPanel`'s current behaviour, which transiently snaps segment-based providers' highlight to 0 between chunk gaps; see "Behaviour Differences" below). The `_raw = null` write is what the port surface observes to forward a `c: null` pause signal.
+
+**Helpers**:
+
+- `getRawSnapshot(): InternalRaw | null` — exported pure function returning `state._raw`. Used by the surface for the initial `state-init` push and by tests.
+- `subscribePlaybackForPort(callback): unsub` — exported. Wraps `useStore.subscribe` with the wire-encoding pipeline:
+  - Selector reads `{ playingItemId, _raw }`.
+  - Equality fn compares `playingItemId` and a per-field, 3-decimal-rounded comparison of `_raw` (`rawEqual`).
+  - On change, encodes via `encodePlaybackForWire(...)` and invokes `callback(encoded)`.
+  - `encodePlaybackForWire` and `rawEqual` are module-private but exported under `__internal__` for `playbackStore.test.ts`.
+
+**Selector hooks** (granular, for low-level use; SubtitleStream / MainPanel use `usePlaybackHighlight` instead):
+
+- `usePlayingItemId()`, `usePlaybackCurrentTime()`, `usePlaybackProgressRatio()`, `usePlaybackActions()`.
+
+### New file: `src/stores/playbackStore.ts` — `usePlaybackHighlight(item)` hook
+
+Co-located with the store. Signature: `(item: ConversationItem | null | undefined) => { isPlaying: boolean; highlightedChars: number }`.
+
+Internally uses a single `useStore` call with a per-item selector and `useShallow`:
+
+```ts
+const EMPTY_HIGHLIGHT: PlaybackHighlight = { isPlaying: false, highlightedChars: 0 };
+
+return usePlaybackStore(
+  useShallow((s): PlaybackHighlight => {
+    if (!item || s.playingItemId !== item.id) return EMPTY_HIGHLIGHT;
+    const text = item.formatted?.transcript || item.formatted?.text || '';
+    const segments = item.formatted?.audioSegments;
+    return {
+      isPlaying: true,
+      highlightedChars: getHighlightedChars(s.currentTime ?? 0, segments, text.length, s.progressRatio),
+    };
+  }),
+);
+```
+
+The selector returns the module-level `EMPTY_HIGHLIGHT` reference for all non-playing rows, so Zustand's shallow-equality bailout suppresses re-renders during the 10 Hz tick storm for rows that aren't currently highlighted. Only the actively-playing row re-renders per tick.
+
+### New file: `src/styles/karaoke.scss`
+
+```scss
+.karaoke-played {
+  color: var(--karaoke-played-color, #10a37f);
+  transition: color 80ms ease-out;
+}
+```
+
+Imported once in each consuming TSX (SCSS files in this project compile to flat global CSS; duplicate `@import` is idempotent).
+
+### Modified: `src/components/MainPanel/MainPanel.tsx`
+
+Removals:
+
+- `function getHighlightedChars` (`L91-113`) — moved to `src/lib/playback/highlight.ts`.
+- `const [playingItemId, setPlayingItemId]` and `const [playbackProgress, setPlaybackProgress]` (`L254-259`).
+- `const lastMaxProgressRef = useRef<number>(0)` (`L775`).
+- `const cumulativeProgress = useMemo(...)` (`L2099-2131`).
+- `const progressRatio = useMemo(...)` (`L2141-2154`).
+- `useEffect` "reset on playingItemId change" (`L2163-2166`).
+- `useEffect` "update max progress ref" (`L2171-2176`).
+- `cumulativeAudioRef` declaration (paired with the above blocks).
+- The inline `getHighlightedChars(...)` call inside `renderConversationItem` (`L2832-2839`).
+
+Edits:
+
+- `setPlayingItemId(...)` callsites → `usePlaybackActions().setPlayingItem(...)`.
+- `setPlaybackProgress(...)` callsites → `usePlaybackActions().setProgress(...)`.
+- `ITEM_END_DEBOUNCE_MS` debounce timer logic stays — it compensates for `ModernAudioPlayer`'s entry-eviction "ended" events during chunk gaps. The debounce wraps the calls to `setPlayingItem(null)` + `setProgress(null)`.
+- `PROGRESS_UPDATE_INTERVAL` (100 ms) stays. The interval body changes to feed the store instead of local state.
+- Audio status callback (`L2188-2229`) updated analogously.
+
+`renderConversationItem` extraction: the helper function currently lives inside MainPanel and is called from `filteredItems.map(...)`. To call `usePlaybackHighlight` per row, the row body becomes a real subcomponent `ConversationBubble` (new, in the same file or a sibling file) that owns the hook call. The map becomes:
+
+```tsx
+filteredItems.map((item, i) => (
+  <ConversationBubble
+    key={`${item.source || 'speaker'}_${item.id || i}`}
+    item={item}
+    index={i}
+    prevItem={/* same lookup as before */}
+    {/* … other props that the existing helper consumed: callbacks, language, mode flags, etc. */}
+  />
+))
+```
+
+`ConversationBubble` internally calls `usePlaybackHighlight(item)` and passes `isPlaying` / `highlightedChars` to the inner `<ConversationRow>` instance (and to the message-bubble basic-mode rendering path). The remainder of MainPanel's render logic is unchanged.
+
+### Modified: `src/components/MainPanel/ConversationRow.tsx`
+
+Single rename: `className="row-text-played"` → `className="karaoke-played"` (`L88`). Add `import '../../styles/karaoke.scss';`.
+
+### Modified: `src/components/MainPanel/MainPanel.scss`
+
+Delete the `.row-text-played` rule on `L240`. Replaced by `karaoke.scss`.
+
+### Modified: `src/components/Subtitle/SubtitleStream.tsx`
+
+Add `import '../../styles/karaoke.scss';`.
+
+Add a memoized id→item index used by both rendering paths:
+
+```ts
+const itemsById = useMemo(
+  () => new Map<string, any>(items.map((it) => [it.id, it])),
+  [items],
+);
+```
+
+Compact branch: replace the inline `<span>` mapping with a new local subcomponent `CompactSpan` (defined at the bottom of the same file). `CompactSpan` receives `{ it, item, showNewHighlight, leadingSpace }`; calls `usePlaybackHighlight(item)`; renders either a plain `<span>` (not playing, or no chars to highlight) or a `<span>` containing a `karaoke-played` prefix span + plain remainder span. Leading space stays on the outer span so it never participates in the played/unplayed split.
+
+Expanded branch: replace the inline `<ConversationRow ... isPlaying={false} highlightedChars={0} />` with a local subcomponent `SubtitleConversationRow` that calls `usePlaybackHighlight(item)` and passes its result to `<ConversationRow>`. The wrapper exists because `usePlaybackHighlight` must be called per row, and React's rules-of-hooks forbid calling hooks inside the map callback when iteration count varies.
+
+### Modified: `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts`
+
+In `installStoreSubscriptions()`:
+
+- After the lazy-import of `useSessionStore`, also lazy-import `playbackStore`'s `getRawSnapshot` and `subscribePlaybackForPort`.
+- The initial `state-init` payload gains a `playback` field populated via `getRawSnapshot()` + `playingItemId`.
+- A 4th subscription is installed via `subscribePlaybackForPort(encoded => this.port?.postMessage({ type: 'playback', ...encoded }))`; the unsubscribe is appended to `this.subscriptions`.
+
+### Modified: `src/stores/sessionPortMirror.ts`
+
+Add `InboundPlayback` to the inbound union:
+
+```ts
+interface InboundPlayback {
+  type: 'playback';
+  i: string | null;
+  c?: number | null;
+  d?: number;
+  b?: number;
+}
+```
+
+Extend `InboundStateInit.payload` with an optional `playback` field of the same shape (minus `type`).
+
+Add `applyPlayback(p)` helper (translates wire fields back to store actions) and a `msg.type === 'playback'` branch in `handle()`. The `state-init` branch invokes `applyPlayback(msg.payload.playback)` if present.
+
+## Wire Protocol
+
+Message type `'playback'`. Fields:
+
+```ts
+// active playback tick
+{ type: 'playback', i: 'item_AbC123XyZ', c: 1.234, d: 5.679, b: 6.789 }
+
+// player paused, item still selected
+{ type: 'playback', i: 'item_AbC123XyZ', c: null }
+
+// nothing playing
+{ type: 'playback', i: null }
+```
+
+`c`, `d`, `b` are rounded to 3 decimal places (1 ms precision) before serialisation. The dedup `rawEqual` also compares rounded values, so two consecutive ticks whose raw values differ only in sub-millisecond noise produce no port message.
+
+`state-init` carries the same payload under `playback` (optional):
+
+```ts
+{ type: 'state-init', payload: { /* items, session, config */ playback: { i, c, d, b } | null } }
+```
+
+### Bandwidth
+
+Per-tick worst case (UUID-style 36-char item ID, full payload):
+
+```
+{"type":"playback","i":"550e8400-e29b-41d4-a716-446655440000","c":1.234,"d":5.679,"b":6.789}
+```
+
+≈ 90 B; 10 Hz → 900 B/s. Common case (item_ prefix ~24 chars): ≈ 78 B × 10 Hz ≈ 780 B/s. Both fit the acceptance ceiling < 1 KB/s with margin. Paused / idle states emit at most one transition message per state change due to `rawEqual` dedup.
+
+## Behaviour Differences From Current `MainPanel`
+
+`setProgress(null)` in the new store **preserves all derived values**. In current `MainPanel`, when `playbackProgress` momentarily becomes `null` during chunk gaps, the `cumulativeProgress` useMemo returns `null` and the highlight call falls back to `playbackProgress?.currentTime ?? 0` — for segment-based providers this snaps the highlight to character 0 for one frame before the next non-null tick (`progressRatio` stays clamped, so linear-fallback providers don't see this). The new behaviour holds the last derived `currentTime` through the gap, eliminating the per-chunk flicker. This change is intentional, lives at the boundary between "regression" and "improvement", and is in scope.
+
+No other observable behaviour changes for `MainPanel`.
+
+## Files Affected
+
+**New (6):**
+
+- `src/lib/playback/highlight.ts`
+- `src/lib/playback/highlight.test.ts`
+- `src/stores/playbackStore.ts`
+- `src/stores/playbackStore.test.ts`
+- `src/stores/playbackStore.usePlaybackHighlight.test.tsx`
+- `src/styles/karaoke.scss`
+
+**Modified (6):**
+
+- `src/components/MainPanel/MainPanel.tsx` — remove ~120 lines of state/derivation, extract `ConversationBubble`, switch to store actions.
+- `src/components/MainPanel/MainPanel.scss` — delete `.row-text-played` rule.
+- `src/components/MainPanel/ConversationRow.tsx` — class rename + karaoke.scss import.
+- `src/components/Subtitle/SubtitleStream.tsx` — `itemsById` + `CompactSpan` + `SubtitleConversationRow` + karaoke.scss import.
+- `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts` — fourth subscription + `state-init.playback`.
+- `src/stores/sessionPortMirror.ts` — inbound `playback` case + `state-init.playback` decode.
+
+## Testing
+
+### Unit — `src/lib/playback/highlight.test.ts`
+
+- Segment-based: `currentTime` inside segment N → `prevTextEnd + floor(progressInSeg * width)`.
+- Segment-based: `currentTime` past last segment → final `prevTextEnd`.
+- Linear fallback: `segments` is undefined / `[]` → `floor(textLength * progressRatio)`.
+- Boundary: `textLength = 0`, `progressRatio = 0`, `progressRatio = 1`.
+- Boundary: segment with `audioEnd === prevAudioEnd` (zero duration) returns full `textEnd` for that segment.
+
+### Unit — `src/stores/playbackStore.test.ts`
+
+- `setPlayingItem(id)` resets all trackers; `currentTime = 0`, `progressRatio = 0`.
+- `setPlayingItem(sameId)` is a no-op.
+- `setPlayingItem(null)` sets `currentTime = null`; trackers cleared.
+- `setProgress(raw)` happy path: derived `currentTime` and `progressRatio` advance.
+- `setProgress(raw)` entry eviction: `raw.currentTime` regresses > 50 ms, `_lastBt > 0` → `_cumOffset` increments by `_lastBt`.
+- `setProgress(raw)` entry-eviction edge cases: regression ≤ 50 ms or `_lastBt === 0` → no offset bump.
+- `setProgress(raw)` monotonic clamp: calculated ratio drops → returns `_maxProgress`.
+- `setProgress(null)`: all public + internal derived trackers (`currentTime`, `progressRatio`, `_cumOffset`, `_lastBt`, `_lastCt`, `_maxProgress`) preserved; only `_raw` is set to `null`. This is what lets the surface observe the pause transition and forward it over the port without dropping derived continuity.
+- `getRawSnapshot()` returns the latest raw input.
+- `subscribePlaybackForPort` fires callback on `playingItemId` change; on `_raw` change (compared by rounded fields); does not fire on round-equal changes; returns working unsub.
+- `encodePlaybackForWire` shapes for `i = null` / `c = null` / full path; rounds c/d/b to 3 decimals.
+- `rawEqual`: same / different / null↔non-null paths.
+
+### Unit — `src/stores/playbackStore.usePlaybackHighlight.test.tsx`
+
+Uses `@testing-library/react` (already a dev dep).
+
+- Item is playing → returns `isPlaying: true`, correct `highlightedChars`.
+- Item is not playing → returns the `EMPTY_HIGHLIGHT` constant (assert via `Object.is`).
+- Store ticks while item is not playing → component does not re-render (track via a `useRef` render counter inside a test-only wrapper).
+- `item` is `null` / `undefined` → returns `EMPTY_HIGHLIGHT`.
+- `item` lacks `audioSegments` → linear-fallback path through `getHighlightedChars`.
+
+### Unit — `src/components/Subtitle/SubtitleStream.test.tsx` (updates)
+
+- Compact: store mocked with `setState({ playingItemId, currentTime, progressRatio, ... })`; the matching `CompactSpan` contains a `.karaoke-played` child span; text is split at the correct boundary.
+- Compact: non-playing spans contain no `.karaoke-played`.
+- Compact: `itemsById.get(it.id)` returns `undefined` (rare timing where the line still has the id but `items` has dropped it) → renders plain text, no error.
+- Expanded: playing item's wrapped `ConversationRow` receives `isPlaying = true` and a non-zero `highlightedChars`.
+- Replace the existing test cases that hard-coded `isPlaying = false` / `highlightedChars = 0` to instead assert the empty-store default produces those values.
+
+### Unit — `src/stores/sessionPortMirror.test.ts` (updates)
+
+- `state-init` with `payload.playback` populated → iframe `playbackStore` reaches the expected state.
+- `state-init` without `playback` → iframe `playbackStore` remains at defaults.
+- Inbound `{ type: 'playback', i, c, d, b }` → `setPlayingItem(i)` + `setProgress({ ... })`.
+- Inbound `{ type: 'playback', i: null }` → `setPlayingItem(null)`.
+- Inbound `{ type: 'playback', i, c: null }` → `setPlayingItem(i)` + `setProgress(null)`; derived values preserved.
+
+### Unit — `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts` (updates)
+
+- On connect, `state-init.payload.playback` is populated from `getRawSnapshot()`.
+- `playbackStore` mutation fires exactly one `port.postMessage({ type: 'playback', ... })`.
+- Two consecutive raws differing only beyond 3 decimals produce one message (dedup).
+- Port reconnect: previous subscription is torn down; new subscription is installed (no duplicate fan-out).
+
+### Manual verification
+
+Mapped to the issue's acceptance criteria:
+
+| Criterion | Procedure |
+|---|---|
+| Karaoke highlight in Electron subtitle bar | `npm run electron:dev`; start a session with a chatty assistant; enter subtitle mode; visually confirm assistant translation in compact band shows character-by-character colour-fill |
+| No MainPanel regression | Same session; toggle between subtitle / main views; confirm MainPanel highlight matches pre-change behaviour |
+| Karaoke in extension iframe overlay | Build extension; load into Chrome; join meet.google.com; start session; enter subtitle; visually confirm overlay band shows highlight |
+| Port bandwidth < 1 KB/s | Add a temporary instrumentation log in `ExtensionContentScriptSubtitleSurface` summing `postMessage` JSON byte lengths over a rolling 10 s window during continuous playback. Record the average in the PR description. Remove the log before merge |
+| Smoothness ≥ MainPanel | Side-by-side comparison: open MainPanel and Electron subtitle bar simultaneously, play the same item, confirm subtitle highlight motion is at least as smooth as MainPanel |
+
+## Risk Register
+
+| Risk | Mitigation |
+|---|---|
+| Compact band's `--new` keyframe (issue #236) visually clashes with `karaoke-played` overlay on freshly-arrived items that immediately begin playing | Accept on first pass; only add a `:not(.subtitle-stream__item--new)` guard if manual testing surfaces a visible conflict |
+| `karaoke.scss` not loaded in some render path (e.g. SubtitleStream mounted without ConversationRow ever rendering) | Import in all three consuming TSX files; verified by code review, not by automated test (jsdom does not apply CSS) |
+| Mid-playback port disconnect resets `_maxProgress` on the iframe side → momentary highlight regression | Out of scope; documented as known minor — single ≤ 100 ms snap-back, extremely rare trigger |
+| Refactor breaks an obscure MainPanel callsite of `playingItemId` / `playbackProgress` | TypeScript catches accidental removals at compile time; `grep -rn 'playingItemId\|playbackProgress\|getHighlightedChars' src/` after the refactor should yield only intended references |
+| `setPlayingItem(null)` debounce timing differs between MainPanel and iframe | Debounce lives in MainPanel only — the side-panel store sees the already-debounced signal; the iframe sees what the side panel sends. Both layers are coherent with the side panel as source of truth |
+
+## Out of Scope
+
+- Word-level timing.
+- Speaker (user) message highlighting.
+- Cross-port-disconnect `_maxProgress` continuity.
+- Visual coordination polish between `subtitle-stream__item--new` and `karaoke-played`.
+- A user toggle for the karaoke highlight. The treatment is opinionated and ships on by default.
+
+## Open Questions Resolved During Brainstorming
+
+- **Scope**: both compact and expanded subtitle modes get the highlight.
+- **Hook API**: `usePlaybackHighlight(item)` — takes the full item, so the store stays decoupled from `sessionStore`.
+- **Derivation location**: inside the store. Identical state machines run on both Electron and iframe sides, fed identical raw inputs over the port.
+- **Wire format**: compact short-key object (`i/c/d/b`) keeping `type: 'playback'`; 3-decimal precision; ≈ 800 B/s sustained.
+- **Tracker storage**: in store state (underscore-prefixed) rather than module-level — improves testability and avoids HMR pitfalls.
+- **`setProgress(null)` semantics**: preserves derived values — improvement over current MainPanel behaviour, eliminates segment-based-provider chunk-gap flicker.
+- **`_raw` exposure**: internal only; surfaced through `getRawSnapshot()` and `subscribePlaybackForPort` helpers.
+- **`karaoke-played` class**: new shared class in `src/styles/karaoke.scss`; old `row-text-played` deleted and renamed at its single render site.
+- **Compact span subcomponent**: required for React's rules of hooks (loop iteration count varies); also provides per-span subscription granularity so only the active span re-renders per tick.

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -120,10 +120,6 @@
   }
 }
 
-.row-text-played {
-  color: #10a37f;
-}
-
 .row-play-btn {
   flex-shrink: 0;
   display: inline-flex;

--- a/src/components/MainPanel/ConversationRow.tsx
+++ b/src/components/MainPanel/ConversationRow.tsx
@@ -81,8 +81,12 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
   );
 
   const renderText = () => {
-    if (!isPlaying || highlightedChars <= 0 || highlightedChars >= text.length) {
+    if (!isPlaying || highlightedChars <= 0) {
       return <span>{text}</span>;
+    }
+    if (highlightedChars >= text.length) {
+      // Fully played — color the entire text, not strip the styling.
+      return <span className="karaoke-played">{text}</span>;
     }
     return (
       <>

--- a/src/components/MainPanel/ConversationRow.tsx
+++ b/src/components/MainPanel/ConversationRow.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Play, User, Users } from 'lucide-react';
 import type { ConversationItem } from '../../services/interfaces/IClient';
 import './ConversationRow.scss';
+import '../../styles/karaoke.scss';
 
 interface ConversationRowProps {
   item: ConversationItem & {
@@ -85,7 +86,7 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
     }
     return (
       <>
-        <span className="row-text-played">{text.slice(0, highlightedChars)}</span>
+        <span className="karaoke-played">{text.slice(0, highlightedChars)}</span>
         <span>{text.slice(highlightedChars)}</span>
       </>
     );

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2947,40 +2947,43 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             </div>
           ) : (
             <div className="conversation-list">
-              {filteredItems.map((item, i) => {
+              {(() => {
                 // prevItem must be the previous *rendered-as-row* item (other
                 // types — tool calls, audio-only, errors — would incorrectly
                 // collapse the header because they default source='speaker').
-                let prevItem: (ConversationItem & { source?: string }) | null = null;
-                for (let p = i - 1; p >= 0; p -= 1) {
-                  const cand = filteredItems[p] as ConversationItem & { source?: string };
-                  if (cand.type !== 'message') continue;
-                  const candText = cand.formatted?.transcript || cand.formatted?.text;
-                  if (candText) { prevItem = cand; break; }
-                }
+                // Single forward pass tracking the last text-bearing message
+                // avoids an O(N²) backward scan per render.
+                let lastTextMsg: (ConversationItem & { source?: string }) | null = null;
+                return filteredItems.map((item, i) => {
+                  const prevItem = lastTextMsg;
+                  const hasText = !!(item.formatted?.transcript || item.formatted?.text);
+                  if (item.type === 'message' && hasText) {
+                    lastTextMsg = item as ConversationItem & { source?: string };
+                  }
 
-                const audio = item.formatted?.audio as any;
-                const audioSize = audio?.length ?? audio?.byteLength ?? 0;
-                const canPlay =
-                  ((item as any).status === 'completed' || (item as any).status === 'incomplete') &&
-                  audioSize > 0;
+                  const audio = item.formatted?.audio as any;
+                  const audioSize = audio?.length ?? audio?.byteLength ?? 0;
+                  const canPlay =
+                    ((item as any).status === 'completed' || (item as any).status === 'incomplete') &&
+                    audioSize > 0;
 
-                return (
-                  <ConversationBubble
-                    key={`${(item as any).source || 'speaker'}_${item.id || i}`}
-                    item={item}
-                    index={i}
-                    prevItem={prevItem}
-                    sourceLanguage={sourceLanguage}
-                    targetLanguage={targetLanguage}
-                    canPlay={canPlay}
-                    onPlay={() => handlePlayAudio(item)}
-                    someItemPlaying={playingItemId !== null}
-                    uiMode={uiMode}
-                    compact={conversationCompactMode}
-                  />
-                );
-              })}
+                  return (
+                    <ConversationBubble
+                      key={`${(item as any).source || 'speaker'}_${item.id || i}`}
+                      item={item}
+                      index={i}
+                      prevItem={prevItem}
+                      sourceLanguage={sourceLanguage}
+                      targetLanguage={targetLanguage}
+                      canPlay={canPlay}
+                      onPlay={() => handlePlayAudio(item)}
+                      someItemPlaying={playingItemId !== null}
+                      uiMode={uiMode}
+                      compact={conversationCompactMode}
+                    />
+                  );
+                });
+              })()}
             </div>
           )}
         </div>

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useCallback, useEffect, useRef, useMemo } from 'react';
 import {X, Zap, Mic, MicOff, Loader, Volume2, VolumeX, Wrench, Send, AlertCircle, MessageSquare, Trash2, AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown, Captions, Settings} from 'lucide-react';
 import './MainPanel.scss';
+import '../../styles/karaoke.scss';
 import {
   useProvider,
   useUIMode,

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -72,6 +72,7 @@ import {
   useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
 } from '@floating-ui/react';
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
+import { getHighlightedChars } from '../../lib/playback/highlight';
 
 
 /**
@@ -84,34 +85,131 @@ function isPttLikeMode(mode: string): boolean {
 }
 
 
-/**
- * Given per-sentence audio segments and the current playback time,
- * return the number of characters that should be highlighted.
- * Falls back to linear interpolation when segments are not available.
- */
-function getHighlightedChars(
-  currentTime: number,
-  segments: Array<{ textEnd: number; audioEnd: number }> | undefined,
-  textLength: number,
-  progressRatio: number,
-): number {
-  if (!segments || segments.length === 0) {
-    return Math.floor(textLength * progressRatio);
+// ---------------------------------------------------------------------------
+// ConversationBubble – row renderer extracted from MainPanel.renderConversationItem
+// so that Task 11 can call hooks (usePlaybackHighlight) per row without
+// violating the rules-of-hooks (hooks cannot be called inside non-component
+// functions / plain map callbacks).
+// ---------------------------------------------------------------------------
+
+interface ConversationBubbleProps {
+  item: ConversationItem & { source?: string };
+  index: number;
+  /** Previous item that was rendered as a message row (used for header collapsing). */
+  prevItem: (ConversationItem & { source?: string }) | null;
+  sourceLanguage: string;
+  targetLanguage: string;
+  isPlaying: boolean;
+  highlightedChars: number;
+  canPlay: boolean;
+  onPlay?: () => void;
+  playDisabled: boolean;
+  uiMode: string;
+  compact: boolean;
+}
+
+const ConversationBubble: React.FC<ConversationBubbleProps> = ({
+  item,
+  index,
+  prevItem,
+  sourceLanguage,
+  targetLanguage,
+  isPlaying,
+  highlightedChars,
+  canPlay,
+  onPlay,
+  playDisabled,
+  uiMode,
+  compact,
+}) => {
+  const { t } = useTranslation();
+
+  // Error bubble
+  if (item.type === 'error') {
+    return (
+      <div key={`${(item as any).source || 'speaker'}_${item.id || index}`} className="message-bubble error">
+        <div className="message-header">
+          <AlertCircle size={12} />
+          {t('mainPanel.error', 'Error')}
+        </div>
+        <div className="message-content error-content">
+          {item.formatted?.text || t('mainPanel.unknownError', 'Unknown error')}
+        </div>
+      </div>
+    );
   }
 
-  let prevTextEnd = 0;
-  let prevAudioEnd = 0;
-  for (const seg of segments) {
-    if (currentTime < seg.audioEnd) {
-      const segDuration = seg.audioEnd - prevAudioEnd;
-      const segProgress = segDuration > 0 ? (currentTime - prevAudioEnd) / segDuration : 1;
-      return prevTextEnd + Math.floor((seg.textEnd - prevTextEnd) * segProgress);
-    }
-    prevTextEnd = seg.textEnd;
-    prevAudioEnd = seg.audioEnd;
+  const text = item.formatted?.transcript || item.formatted?.text || '';
+
+  // Text / transcript bubble (common for both modes)
+  if (text) {
+    return (
+      <ConversationRow
+        key={`${(item as any).source || 'speaker'}_${item.id || index}`}
+        item={item}
+        prevItem={prevItem as (ConversationItem & { source?: 'speaker' | 'participant' }) | null}
+        sourceLanguage={sourceLanguage}
+        targetLanguage={targetLanguage}
+        isPlaying={isPlaying}
+        highlightedChars={highlightedChars}
+        canPlay={canPlay}
+        onPlay={onPlay}
+        playDisabled={playDisabled}
+        compact={compact}
+      />
+    );
   }
-  return prevTextEnd;
-}
+
+  // Advanced-only content types
+  if (uiMode === 'advanced') {
+    // Audio without transcript: audio still plays through the audio
+    // service; we deliberately render no bubble. This used to render an
+    // "Audio content" placeholder, but that fallback had no production
+    // utility (no info beyond an icon, play button only in dev) and
+    // produced ghost bubbles for translate sessions when the auto-create
+    // recovery path kicked in (e.g. when output_transcript wasn't sent).
+
+    // Tool calls
+    if (item.formatted?.tool) {
+      const toolArgs = item.formatted.tool.arguments;
+      let formattedArgs = toolArgs;
+      try {
+        formattedArgs = JSON.stringify(JSON.parse(toolArgs), null, 2);
+      } catch (e) { /* keep original */ }
+
+      return (
+        <div key={`${(item as any).source || 'speaker'}_${item.id || index}`} className={`message-bubble system`}>
+          <div className="message-content">
+            <div className="content-item tool-call">
+              <div className="tool-name">{t('mainPanel.function')}: {item.formatted.tool.name}</div>
+              <div className="tool-args"><pre>{formattedArgs}</pre></div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    // Tool outputs
+    if (item.formatted?.output) {
+      let formattedOutput = item.formatted.output;
+      try {
+        formattedOutput = JSON.stringify(JSON.parse(item.formatted.output), null, 2);
+      } catch (e) { /* keep original */ }
+
+      return (
+        <div key={`${(item as any).source || 'speaker'}_${item.id || index}`} className={`message-bubble system`}>
+          <div className="message-content">
+            <div className="content-item tool-output">
+              <div className="output-content"><pre>{formattedOutput}</pre></div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  }
+
+  return null;
+};
 
 interface MainPanelProps {}
 
@@ -2821,125 +2919,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const sourceLanguage = currentSettings.sourceLanguage ?? 'EN';
   const targetLanguage = currentSettings.targetLanguage ?? 'EN';
 
-  // Helper: render a single conversation item as a bubble
-  const renderConversationItem = (item: ConversationItem & { source?: string }, index: number) => {
-    const isItemPlaying = playingItemId === item.id;
-    const text = item.formatted?.transcript || item.formatted?.text || '';
-
-    // Karaoke highlight calculation. Uses cumulativeProgress.currentTime so
-    // segment-based providers see continuous time across player-entry resets
-    // (issue #216). Falls back to raw playbackProgress when cumulative is not
-    // tracked yet (e.g., very first frame).
-    const highlightedChars = isItemPlaying
-      ? getHighlightedChars(
-          cumulativeProgress?.currentTime ?? playbackProgress?.currentTime ?? 0,
-          item.formatted?.audioSegments,
-          text.length,
-          progressRatio,
-        )
-      : 0;
-
-    // Error bubble
-    if (item.type === 'error') {
-      return (
-        <div key={`${(item as any).source || 'speaker'}_${item.id || index}`} className="message-bubble error">
-          <div className="message-header">
-            <AlertCircle size={12} />
-            {t('mainPanel.error', 'Error')}
-          </div>
-          <div className="message-content error-content">
-            {item.formatted?.text || t('mainPanel.unknownError', 'Unknown error')}
-          </div>
-        </div>
-      );
-    }
-
-    // Text / transcript bubble (common for both modes)
-    if (text) {
-      // prevItem must be the previous *rendered-as-row* item (other
-      // types — tool calls, audio-only, errors — would incorrectly
-      // collapse the header because they default source='speaker').
-      let prevItem: (ConversationItem & { source?: string }) | null = null;
-      for (let i = index - 1; i >= 0; i -= 1) {
-        const cand = filteredItems[i] as ConversationItem & { source?: string };
-        if (cand.type !== 'message') continue;
-        const candText = cand.formatted?.transcript || cand.formatted?.text;
-        if (candText) { prevItem = cand; break; }
-      }
-
-      const audio = item.formatted?.audio as any;
-      const audioSize = audio?.length ?? audio?.byteLength ?? 0;
-      const canPlay =
-        ((item as any).status === 'completed' || (item as any).status === 'incomplete') &&
-        audioSize > 0;
-
-      return (
-        <ConversationRow
-          key={`${(item as any).source || 'speaker'}_${item.id || index}`}
-          item={item}
-          prevItem={prevItem as (ConversationItem & { source?: 'speaker' | 'participant' }) | null}
-          sourceLanguage={sourceLanguage}
-          targetLanguage={targetLanguage}
-          isPlaying={isItemPlaying}
-          highlightedChars={highlightedChars}
-          canPlay={canPlay}
-          onPlay={() => handlePlayAudio(item)}
-          playDisabled={playingItemId !== null && !isItemPlaying}
-          compact={conversationCompactMode}
-        />
-      );
-    }
-
-    // Advanced-only content types
-    if (uiMode === 'advanced') {
-      // Audio without transcript: audio still plays through the audio
-      // service; we deliberately render no bubble. This used to render an
-      // "Audio content" placeholder, but that fallback had no production
-      // utility (no info beyond an icon, play button only in dev) and
-      // produced ghost bubbles for translate sessions when the auto-create
-      // recovery path kicked in (e.g. when output_transcript wasn't sent).
-
-      // Tool calls
-      if (item.formatted?.tool) {
-        const toolArgs = item.formatted.tool.arguments;
-        let formattedArgs = toolArgs;
-        try {
-          formattedArgs = JSON.stringify(JSON.parse(toolArgs), null, 2);
-        } catch (e) { /* keep original */ }
-
-        return (
-          <div key={`${(item as any).source || 'speaker'}_${item.id || index}`} className={`message-bubble system`}>
-            <div className="message-content">
-              <div className="content-item tool-call">
-                <div className="tool-name">{t('mainPanel.function')}: {item.formatted.tool.name}</div>
-                <div className="tool-args"><pre>{formattedArgs}</pre></div>
-              </div>
-            </div>
-          </div>
-        );
-      }
-
-      // Tool outputs
-      if (item.formatted?.output) {
-        let formattedOutput = item.formatted.output;
-        try {
-          formattedOutput = JSON.stringify(JSON.parse(item.formatted.output), null, 2);
-        } catch (e) { /* keep original */ }
-
-        return (
-          <div key={`${(item as any).source || 'speaker'}_${item.id || index}`} className={`message-bubble system`}>
-            <div className="message-content">
-              <div className="content-item tool-output">
-                <div className="output-content"><pre>{formattedOutput}</pre></div>
-              </div>
-            </div>
-          </div>
-        );
-      }
-    }
-
-    return null;
-  };
+  // (renderConversationItem has been extracted to ConversationBubble above the component.)
 
   // Unified render for both modes
   return (
@@ -3069,7 +3049,57 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             </div>
           ) : (
             <div className="conversation-list">
-              {filteredItems.map((item, index) => renderConversationItem(item, index))}
+              {filteredItems.map((item, i) => {
+                // prevItem must be the previous *rendered-as-row* item (other
+                // types — tool calls, audio-only, errors — would incorrectly
+                // collapse the header because they default source='speaker').
+                let prevItem: (ConversationItem & { source?: string }) | null = null;
+                for (let p = i - 1; p >= 0; p -= 1) {
+                  const cand = filteredItems[p] as ConversationItem & { source?: string };
+                  if (cand.type !== 'message') continue;
+                  const candText = cand.formatted?.transcript || cand.formatted?.text;
+                  if (candText) { prevItem = cand; break; }
+                }
+
+                const text = item.formatted?.transcript || item.formatted?.text || '';
+                const isItemPlaying = playingItemId === item.id;
+                // Karaoke highlight calculation. Uses cumulativeProgress.currentTime so
+                // segment-based providers see continuous time across player-entry resets
+                // (issue #216). Falls back to raw playbackProgress when cumulative is not
+                // tracked yet (e.g., very first frame).
+                const highlightedChars = isItemPlaying
+                  ? getHighlightedChars(
+                      cumulativeProgress?.currentTime ?? playbackProgress?.currentTime ?? 0,
+                      item.formatted?.audioSegments,
+                      text.length,
+                      progressRatio,
+                    )
+                  : 0;
+
+                const audio = item.formatted?.audio as any;
+                const audioSize = audio?.length ?? audio?.byteLength ?? 0;
+                const canPlay =
+                  ((item as any).status === 'completed' || (item as any).status === 'incomplete') &&
+                  audioSize > 0;
+
+                return (
+                  <ConversationBubble
+                    key={`${(item as any).source || 'speaker'}_${item.id || i}`}
+                    item={item}
+                    index={i}
+                    prevItem={prevItem}
+                    sourceLanguage={sourceLanguage}
+                    targetLanguage={targetLanguage}
+                    isPlaying={isItemPlaying}
+                    highlightedChars={highlightedChars}
+                    canPlay={canPlay}
+                    onPlay={() => handlePlayAudio(item)}
+                    playDisabled={playingItemId !== null && !isItemPlaying}
+                    uiMode={uiMode}
+                    compact={conversationCompactMode}
+                  />
+                );
+              })}
             </div>
           )}
         </div>

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -72,7 +72,7 @@ import {
   useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
 } from '@floating-ui/react';
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
-import { getHighlightedChars } from '../../lib/playback/highlight';
+import { usePlaybackStore, usePlaybackHighlight } from '../../stores/playbackStore';
 
 
 /**
@@ -99,11 +99,10 @@ interface ConversationBubbleProps {
   prevItem: (ConversationItem & { source?: string }) | null;
   sourceLanguage: string;
   targetLanguage: string;
-  isPlaying: boolean;
-  highlightedChars: number;
   canPlay: boolean;
   onPlay?: () => void;
-  playDisabled: boolean;
+  /** True when some other item (not this one) is playing; disables the play button. */
+  someItemPlaying: boolean;
   uiMode: string;
   compact: boolean;
 }
@@ -114,14 +113,14 @@ const ConversationBubble: React.FC<ConversationBubbleProps> = ({
   prevItem,
   sourceLanguage,
   targetLanguage,
-  isPlaying,
-  highlightedChars,
   canPlay,
   onPlay,
-  playDisabled,
+  someItemPlaying,
   uiMode,
   compact,
 }) => {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  const playDisabled = someItemPlaying && !isPlaying;
   const { t } = useTranslation();
 
   // Error bubble
@@ -350,12 +349,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
 
   // Add state variables to track if test tone is playing and currently playing audio item
   const [isTestTonePlaying, setIsTestTonePlaying] = useState(false);
-  const [playingItemId, setPlayingItemId] = useState<string | null>(null);
-  const [playbackProgress, setPlaybackProgress] = useState<{
-    currentTime: number;
-    duration: number;
-    bufferedTime: number;
-  } | null>(null);
+
+  // Playback state is now managed by playbackStore
+  const setPlayingItem = usePlaybackStore((s) => s.setPlayingItem);
+  const setProgress = usePlaybackStore((s) => s.setProgress);
+  const playingItemId = usePlaybackStore((s) => s.playingItemId);
   
   // Audio feedback warning state
   const [showFeedbackWarning, setShowFeedbackWarning] = useState(false);
@@ -870,25 +868,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const UPDATE_THROTTLE_MS = 50; // Throttle UI updates to max 20Hz
   
-  // Reference to track the maximum progress ratio to prevent backwards movement
-  const lastMaxProgressRef = useRef<number>(0);
-
-  // Cumulative played-time tracking across player-entry boundaries within the
-  // same item (issue #216). The ModernAudioPlayer evicts an itemQueue entry as
-  // soon as its samples are consumed; if the next chunk for the same itemId
-  // arrives after eviction, a fresh entry is created with its own startSample,
-  // so getCurrentPlaybackStatus()'s currentTime/bufferedTime restart from
-  // ~zero. This wrecks the karaoke math, which needs item-level cumulative
-  // time. We reconstruct it on the consumer side by detecting currentTime
-  // regressions and adding the previous entry's last-seen bufferedTime to an
-  // offset.
-  const cumulativeAudioRef = useRef<{
-    itemId: string;
-    offset: number;       // seconds accumulated from prior evicted entries
-    lastBt: number;       // last bufferedTime seen for current entry
-    lastCt: number;       // last currentTime seen for current entry
-  } | null>(null);
-
   // Debounce timer for clearing playingItemId on the player's 'ended' callback.
   // The player fires 'ended' on every itemQueue entry eviction (chunk
   // boundary), not just on true item end. Without debouncing, playingItemId
@@ -899,7 +878,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
 
   // Constants for karaoke progress tracking
   const PROGRESS_UPDATE_INTERVAL = 100; // ms
-  const ENTRY_RESET_THRESHOLD = 0.05; // ct drop > 50ms = entry was evicted and re-created
   // Longest observed intra-item content gap on translate is ~2s; debounce
   // longer than that to avoid prematurely clearing playingItemId during a
   // natural pause between sentences within a single response.
@@ -1967,7 +1945,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       // If already playing something, interrupt it first
       if (playingItemId) {
         await audioService.interruptAudio();
-        setPlayingItemId(null);
+        setPlayingItem(null);
       }
 
       // If this is the same item that was playing, just stop it
@@ -2011,7 +1989,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       
       // Store the current item ID to use in the timeout
       const currentItemId = item.id;
-      setPlayingItemId(currentItemId);
+      setPlayingItem(currentItemId);
       
       // Calculate audio duration based on the audio data
       let audioLength = 0;
@@ -2048,15 +2026,18 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       
       // Set a timeout to clear the playing state
       setTimeout(() => {
-        setPlayingItemId(prevId => prevId === currentItemId ? null : prevId);
+        // Use getState() for a fresh read inside the async timeout callback
+        if (usePlaybackStore.getState().playingItemId === currentItemId) {
+          setPlayingItem(null);
+        }
       }, actualDurationMs + 50); // Add 50ms buffer
-      
+
       console.info('[Sokuji] [MainPanel] Playing audio from item ' + item.id);
     } catch (error) {
       console.error('[Sokuji] [MainPanel] Error playing audio:', error);
-      setPlayingItemId(null);
+      setPlayingItem(null);
     }
-  }, [isMonitorDeviceOn, selectedMonitorDevice, selectMonitorDevice, playingItemId]);
+  }, [isMonitorDeviceOn, selectedMonitorDevice, selectMonitorDevice, playingItemId, setPlayingItem]);
 
   /**
    * Play or stop test tone for debugging
@@ -2191,89 +2172,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     }
   }, [isMonitorDeviceOn, selectedMonitorDevice, selectMonitorDevice, isTestTonePlaying]);
 
-  // Item-level cumulative playback time. Reconstructs continuous progress
-  // across ModernAudioPlayer entry boundaries (see cumulativeAudioRef comment).
-  // Returns null when nothing is playing. Mutates cumulativeAudioRef as a side
-  // effect — same pattern as the lastMaxProgressRef updates below.
-  const cumulativeProgress = useMemo(() => {
-    if (!playbackProgress || !playingItemId) return null;
-
-    const tracker = cumulativeAudioRef.current;
-    let offset = 0;
-    if (tracker && tracker.itemId === playingItemId) {
-      offset = tracker.offset;
-      // Detect entry eviction + re-creation: currentTime regressed substantially
-      // (within an entry, ct is monotonic). The previous entry was played to
-      // completion (eviction only happens after read head passes its end), so
-      // its full last-seen bufferedTime contributes to the offset.
-      if (
-        playbackProgress.currentTime < tracker.lastCt - ENTRY_RESET_THRESHOLD &&
-        tracker.lastBt > 0
-      ) {
-        offset += tracker.lastBt;
-      }
-    }
-
-    cumulativeAudioRef.current = {
-      itemId: playingItemId,
-      offset,
-      lastBt: playbackProgress.bufferedTime,
-      lastCt: playbackProgress.currentTime,
-    };
-
-    return {
-      currentTime: offset + playbackProgress.currentTime,
-      bufferedTime: offset + playbackProgress.bufferedTime,
-      duration: offset + playbackProgress.duration,
-      offset,
-    };
-  }, [playbackProgress, playingItemId]);
-
-  // Memoize progress calculation to reduce re-renders.
-  // Monotonic-within-item via max clamp; reset only on playingItemId change
-  // (effect below). The raw cumulative ratio can still dip mid-item — when a
-  // new chunk extends cumBt faster than cumCt advances — so the clamp is
-  // load-bearing. The previous BACKWARD_TIMEOUT and diff>0.5 escape paths
-  // existed to recover from per-chunk player resets that we now handle via
-  // cumulative tracking, and they were causing spurious mid-item snap-backs
-  // on natural pauses (issue #216).
-  const progressRatio = useMemo(() => {
-    // Hold the last max during transient gaps where the player has no audible
-    // entry (e.g., one chunk drained, next not arrived). Otherwise the
-    // highlight would briefly snap to 0 between chunks.
-    if (!cumulativeProgress) return lastMaxProgressRef.current;
-
-    const divisor = cumulativeProgress.bufferedTime || cumulativeProgress.duration || 1;
-    const calculatedRatio = Math.min(cumulativeProgress.currentTime / divisor, 1);
-
-    if (calculatedRatio < lastMaxProgressRef.current) {
-      return lastMaxProgressRef.current;
-    }
-    return calculatedRatio;
-  }, [cumulativeProgress]);
-
-  /**
-   * Reset max progress and cumulative tracker when playing a new item.
-   * Note: there is intentionally no playback-stopped reset effect — between
-   * translate audio chunks `playbackProgress` momentarily becomes null while
-   * the player is buffering, and resetting max on those transitions caused
-   * the karaoke highlight to repeatedly snap back to zero (issue #216).
-   */
-  useEffect(() => {
-    lastMaxProgressRef.current = 0;
-    cumulativeAudioRef.current = null;
-  }, [playingItemId]);
-
-  /**
-   * Update max progress ref after calculation
-   */
-  useEffect(() => {
-    // Update the ref after the render to avoid side effects in useMemo
-    if (progressRatio > lastMaxProgressRef.current) {
-      lastMaxProgressRef.current = progressRatio;
-    }
-  }, [progressRatio]);
-
   /**
    * Set up playback status tracking
    */
@@ -2293,7 +2191,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           clearTimeout(itemEndDebounceRef.current);
           itemEndDebounceRef.current = null;
         }
-        setPlayingItemId(status.itemId);
+        setPlayingItem(status.itemId);
         return;
       }
 
@@ -2306,8 +2204,8 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           clearTimeout(itemEndDebounceRef.current);
           itemEndDebounceRef.current = null;
         }
-        setPlayingItemId(null);
-        setPlaybackProgress(null);
+        setPlayingItem(null);
+        setProgress(null);
         return;
       }
 
@@ -2318,28 +2216,28 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         // from a real end. Debounce: only clear if no new chunk arrives.
         if (itemEndDebounceRef.current) clearTimeout(itemEndDebounceRef.current);
         itemEndDebounceRef.current = setTimeout(() => {
-          setPlayingItemId(null);
-          setPlaybackProgress(null);
+          setPlayingItem(null);
+          setProgress(null);
           itemEndDebounceRef.current = null;
         }, ITEM_END_DEBOUNCE_MS);
       }
       // currentStatus.itemId === status.itemId means another entry for the
       // same item is already audible (rare); leave state alone.
     });
-    
+
     // Set up progress tracking
     const progressInterval = setInterval(() => {
       const status = player.getCurrentPlaybackStatus();
-      
+
       if (status && status.isPlaying) {
-        setPlaybackProgress({
+        setProgress({
           currentTime: status.currentTime,
           duration: status.duration,
-          bufferedTime: status.bufferedTime
+          bufferedTime: status.bufferedTime,
         });
       } else {
         // Clear progress when nothing is playing to prevent stale data
-        setPlaybackProgress(null);
+        setProgress(null);
       }
     }, PROGRESS_UPDATE_INTERVAL);
     
@@ -3061,21 +2959,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
                   if (candText) { prevItem = cand; break; }
                 }
 
-                const text = item.formatted?.transcript || item.formatted?.text || '';
-                const isItemPlaying = playingItemId === item.id;
-                // Karaoke highlight calculation. Uses cumulativeProgress.currentTime so
-                // segment-based providers see continuous time across player-entry resets
-                // (issue #216). Falls back to raw playbackProgress when cumulative is not
-                // tracked yet (e.g., very first frame).
-                const highlightedChars = isItemPlaying
-                  ? getHighlightedChars(
-                      cumulativeProgress?.currentTime ?? playbackProgress?.currentTime ?? 0,
-                      item.formatted?.audioSegments,
-                      text.length,
-                      progressRatio,
-                    )
-                  : 0;
-
                 const audio = item.formatted?.audio as any;
                 const audioSize = audio?.length ?? audio?.byteLength ?? 0;
                 const canPlay =
@@ -3090,11 +2973,9 @@ const MainPanel: React.FC<MainPanelProps> = () => {
                     prevItem={prevItem}
                     sourceLanguage={sourceLanguage}
                     targetLanguage={targetLanguage}
-                    isPlaying={isItemPlaying}
-                    highlightedChars={highlightedChars}
                     canPlay={canPlay}
                     onPlay={() => handlePlayAudio(item)}
-                    playDisabled={playingItemId !== null && !isItemPlaying}
+                    someItemPlaying={playingItemId !== null}
                     uiMode={uiMode}
                     compact={conversationCompactMode}
                   />

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -390,9 +390,41 @@ describe('SubtitleStream — expanded karaoke highlight', () => {
         targetLanguage="zh"
       />,
     );
-    // floor(11 * 0.5) = 5 → "Hello"
+    // round(11 * 0.5) = 6 → "Hello "
     const played = container.querySelector('.karaoke-played');
-    expect(played?.textContent).toBe('Hello');
+    expect(played?.textContent).toBe('Hello ');
+  });
+
+  it('renders the whole text with karaoke-played at completion', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 1,
+      });
+    });
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={false}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    // Full completion: highlightedChars === text.length → whole text colored.
+    const played = container.querySelector('.karaoke-played');
+    expect(played?.textContent).toBe('Hello world');
   });
 });
 
@@ -438,8 +470,41 @@ describe('SubtitleStream — compact karaoke highlight', () => {
         targetLanguage="zh"
       />,
     );
+    // round(11 * 0.5) = 6 → "Hello "
     const played = container.querySelector('.karaoke-played');
-    expect(played?.textContent).toBe('Hello');
+    expect(played?.textContent).toBe('Hello ');
+  });
+
+  it('compact band colors the full span at completion', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        source: 'speaker',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 1,
+      });
+    });
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const played = container.querySelector('.karaoke-played');
+    expect(played?.textContent).toBe('Hello world');
   });
 
   it('compact band does not split spans for non-playing items', () => {

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -1,6 +1,7 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, act } from '@testing-library/react';
 import SubtitleStream from './SubtitleStream';
+import { usePlaybackStore } from '../../stores/playbackStore';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -345,5 +346,52 @@ describe('SubtitleStream — expanded mode (per-item rows)', () => {
     );
     expect(container.querySelectorAll('.conversation-row').length).toBe(4);
     expect(container.querySelector('.subtitle-stream__line')).toBeNull();
+  });
+});
+
+describe('SubtitleStream — expanded karaoke highlight', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+  });
+
+  it('renders karaoke split on the playing assistant item', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 0.5,
+      });
+    });
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={false}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    // floor(11 * 0.5) = 5 → "Hello"
+    const played = container.querySelector('.karaoke-played');
+    expect(played?.textContent).toBe('Hello');
   });
 });

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -395,3 +395,102 @@ describe('SubtitleStream — expanded karaoke highlight', () => {
     expect(played?.textContent).toBe('Hello');
   });
 });
+
+describe('SubtitleStream — compact karaoke highlight', () => {
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+  });
+
+  it('compact band splits the playing assistant item into played/unplayed spans', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        source: 'speaker',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 0.5,
+      });
+    });
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    const played = container.querySelector('.karaoke-played');
+    expect(played?.textContent).toBe('Hello');
+  });
+
+  it('compact band does not split spans for non-playing items', () => {
+    const items = [
+      {
+        id: 'item_a',
+        role: 'assistant',
+        type: 'message',
+        source: 'speaker',
+        formatted: { transcript: 'Hello world' },
+      },
+    ];
+    // playingItemId is null in the beforeEach reset
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelector('.karaoke-played')).toBeNull();
+  });
+
+  it('compact band renders plain text when item is missing from items[]', () => {
+    // line bucket has an id that isn't in items (rare timing race)
+    const items: any[] = [];
+    act(() => {
+      usePlaybackStore.setState({
+        playingItemId: 'item_a',
+        currentTime: 0,
+        progressRatio: 0.5,
+      });
+    });
+    // We can't simulate "in lines but not in items" directly without
+    // restructuring the test; assert at minimum that an empty items
+    // array doesn't crash and renders no .karaoke-played.
+    const { container } = render(
+      <SubtitleStream
+        items={items as any}
+        compact={true}
+        fontSize={24}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+      />,
+    );
+    expect(container.querySelector('.karaoke-played')).toBeNull();
+  });
+});

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useLayoutEffect, useRef, useMemo } from 'react';
 import ConversationRow from '../MainPanel/ConversationRow';
 import { shouldShowItem } from '../MainPanel/conversationFilter';
 import type { DisplayMode } from '../../stores/subtitleStore';
+import { usePlaybackHighlight } from '../../stores/playbackStore';
 import './SubtitleStream.scss';
 import '../../styles/karaoke.scss';
 
@@ -127,6 +128,11 @@ const SubtitleStream: React.FC<Props> = ({
       .filter((l) => l.items.length > 0);
   }, [filtered]);
 
+  const itemsById = useMemo(
+    () => new Map<string, any>(items.map((it) => [it.id, it])),
+    [items],
+  );
+
   // Stick to bottom only in expanded mode, where ConversationRow rows pile
   // up in a scrollable column and need to follow the latest content. In
   // compact mode each band is a fixed flex slot with internal overflow:
@@ -207,20 +213,37 @@ const SubtitleStream: React.FC<Props> = ({
             </div>
           ))
         : filtered.map((item, i) => (
-            <ConversationRow
+            <SubtitleConversationRow
               key={item.id}
               item={item}
               prevItem={filtered[i - 1] ?? null}
-              compact={false}
               sourceLanguage={sourceLanguage}
               targetLanguage={targetLanguage}
-              isPlaying={false}
-              highlightedChars={0}
-              canPlay={false}
             />
           ))}
       <div ref={endRef} />
     </div>
+  );
+};
+
+const SubtitleConversationRow: React.FC<{
+  item: any;
+  prevItem: any;
+  sourceLanguage: string;
+  targetLanguage: string;
+}> = ({ item, prevItem, sourceLanguage, targetLanguage }) => {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  return (
+    <ConversationRow
+      item={item}
+      prevItem={prevItem}
+      compact={false}
+      sourceLanguage={sourceLanguage}
+      targetLanguage={targetLanguage}
+      isPlaying={isPlaying}
+      highlightedChars={highlightedChars}
+      canPlay={false}
+    />
   );
 };
 

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -3,6 +3,7 @@ import ConversationRow from '../MainPanel/ConversationRow';
 import { shouldShowItem } from '../MainPanel/conversationFilter';
 import type { DisplayMode } from '../../stores/subtitleStore';
 import './SubtitleStream.scss';
+import '../../styles/karaoke.scss';
 
 interface Props {
   items: any[];

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -242,8 +242,18 @@ const CompactSpan: React.FC<CompactSpanProps> = ({
     : 'subtitle-stream__item';
   const prefix = leadingSpace ? ' ' : '';
 
-  if (!isPlaying || highlightedChars <= 0 || highlightedChars >= it.text.length) {
+  if (!isPlaying || highlightedChars <= 0) {
     return <span className={baseClass}>{prefix}{it.text}</span>;
+  }
+  if (highlightedChars >= it.text.length) {
+    // Fully played — color the whole span (the previous behaviour stripped
+    // the styling here, producing a brief "all uncolored" frame at completion).
+    return (
+      <span className={baseClass}>
+        {prefix}
+        <span className="karaoke-played">{it.text}</span>
+      </span>
+    );
   }
   return (
     <span className={baseClass}>

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -197,18 +197,15 @@ const SubtitleStream: React.FC<Props> = ({
               className={`subtitle-stream__line subtitle-stream__line--${line.kind} subtitle-stream__line--${line.source}`}
             >
               <p>
-                {line.items.map((it, idx) => {
-                  const showHighlight =
-                    newItemHighlightEnabled && itemStateFor(it.id) === 'new';
-                  const className = showHighlight
-                    ? 'subtitle-stream__item subtitle-stream__item--new'
-                    : 'subtitle-stream__item';
-                  return (
-                    <span key={it.id} className={className}>
-                      {idx > 0 ? ' ' : ''}{it.text}
-                    </span>
-                  );
-                })}
+                {line.items.map((it, idx) => (
+                  <CompactSpan
+                    key={it.id}
+                    it={it}
+                    item={itemsById.get(it.id)}
+                    showNewHighlight={newItemHighlightEnabled && itemStateFor(it.id) === 'new'}
+                    leadingSpace={idx > 0}
+                  />
+                ))}
               </p>
             </div>
           ))
@@ -223,6 +220,37 @@ const SubtitleStream: React.FC<Props> = ({
           ))}
       <div ref={endRef} />
     </div>
+  );
+};
+
+interface CompactSpanProps {
+  it: SubtitleLineItem;
+  item: any | undefined;
+  showNewHighlight: boolean;
+  leadingSpace: boolean;
+}
+
+const CompactSpan: React.FC<CompactSpanProps> = ({
+  it,
+  item,
+  showNewHighlight,
+  leadingSpace,
+}) => {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  const baseClass = showNewHighlight
+    ? 'subtitle-stream__item subtitle-stream__item--new'
+    : 'subtitle-stream__item';
+  const prefix = leadingSpace ? ' ' : '';
+
+  if (!isPlaying || highlightedChars <= 0 || highlightedChars >= it.text.length) {
+    return <span className={baseClass}>{prefix}{it.text}</span>;
+  }
+  return (
+    <span className={baseClass}>
+      {prefix}
+      <span className="karaoke-played">{it.text.slice(0, highlightedChars)}</span>
+      <span>{it.text.slice(highlightedChars)}</span>
+    </span>
   );
 };
 

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -236,7 +236,7 @@ const CompactSpan: React.FC<CompactSpanProps> = ({
   showNewHighlight,
   leadingSpace,
 }) => {
-  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item, it.text);
   const baseClass = showNewHighlight
     ? 'subtitle-stream__item subtitle-stream__item--new'
     : 'subtitle-stream__item';

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ExtensionContentScriptSubtitleSurface } from './ExtensionContentScriptSubtitleSurface';
+import { usePlaybackStore } from '../../../stores/playbackStore';
 
 // Mock SettingsService factory so settingsStore can be imported without
 // pulling audio worklet side-effects through ServiceFactory.
@@ -136,5 +137,101 @@ describe('ExtensionContentScriptSubtitleSurface', () => {
       (call: any[]) => call[0]?.type === 'items',
     );
     expect(itemsMessages.length).toBe(1);
+  });
+
+  describe('playback forwarding', () => {
+    beforeEach(() => {
+      usePlaybackStore.setState({
+        playingItemId: null,
+        currentTime: null,
+        progressRatio: 0,
+        _cumOffset: 0,
+        _lastBt: 0,
+        _lastCt: 0,
+        _maxProgress: 0,
+        _raw: null,
+      });
+    });
+
+    const makePort = () => ({
+      name: 'sokuji-subtitle',
+      onMessage: { addListener: vi.fn() },
+      onDisconnect: { addListener: vi.fn() },
+      postMessage: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    it('state-init carries playback=null when nothing is playing', async () => {
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      // Drain the lazy import + initial state-init push.
+      await new Promise((r) => setTimeout(r, 0));
+
+      const init = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'state-init',
+      );
+      expect(init).toBeDefined();
+      expect(init![0].payload.playback).toBeNull();
+    });
+
+    it('state-init carries playback snapshot when item is playing', async () => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.getState().setProgress({ currentTime: 1.234, duration: 5, bufferedTime: 4 });
+
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+
+      const init = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'state-init',
+      );
+      expect(init![0].payload.playback).toEqual({ i: 'item_a', c: 1.234, d: 5, b: 4 });
+    });
+
+    it('forwards playback changes as typed messages', async () => {
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+      port.postMessage.mockClear();
+
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      await new Promise((r) => setTimeout(r, 0));
+      expect(port.postMessage.mock.calls).toContainEqual([
+        { type: 'playback', i: 'item_a', c: null },
+      ]);
+
+      usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(port.postMessage.mock.calls).toContainEqual([
+        { type: 'playback', i: 'item_a', c: 1, d: 5, b: 4 },
+      ]);
+    });
+
+    it('dedupes round-equal raw values', async () => {
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.getState().setProgress({ currentTime: 1.2345, duration: 5, bufferedTime: 4 });
+      await new Promise((r) => setTimeout(r, 0));
+      port.postMessage.mockClear();
+
+      usePlaybackStore.getState().setProgress({ currentTime: 1.2347, duration: 5, bufferedTime: 4 });
+      await new Promise((r) => setTimeout(r, 0));
+
+      const playbackMsgs = port.postMessage.mock.calls.filter(
+        (c: any[]) => c[0]?.type === 'playback',
+      );
+      expect(playbackMsgs.length).toBe(0);
+    });
   });
 });

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
@@ -139,6 +139,11 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     // that don't want to pull in sessionStore (and its audio dependencies)
     // until the surface is actually used.
     const { default: useSessionStore } = await import('../../../stores/sessionStore');
+    const {
+      usePlaybackStore,
+      getRawSnapshot,
+      subscribePlaybackForPort,
+    } = await import('../../../stores/playbackStore');
     // If the port was torn down while we awaited the import, bail out.
     if (!this.port) return;
 
@@ -166,6 +171,15 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
       turnDetectionMode,
     };
 
+    const playbackSnapshot = (() => {
+      const playingItemId = usePlaybackStore.getState().playingItemId;
+      const raw = getRawSnapshot();
+      if (playingItemId === null) return null;
+      if (raw === null) return { i: playingItemId, c: null };
+      const r3 = (x: number) => Math.round(x * 1000) / 1000;
+      return { i: playingItemId, c: r3(raw.currentTime), d: r3(raw.duration), b: r3(raw.bufferedTime) };
+    })();
+
     this.port.postMessage({
       type: 'state-init',
       payload: {
@@ -177,6 +191,7 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
         sourceLanguage: lastConfig.sourceLanguage,
         targetLanguage: lastConfig.targetLanguage,
         turnDetectionMode: lastConfig.turnDetectionMode,
+        playback: playbackSnapshot,
       },
     });
 
@@ -243,7 +258,11 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     };
     const unsubConfig = useSettingsStore.subscribe(pushConfigIfChanged);
 
-    this.subscriptions = [unsubItems, unsubSession, unsubConfig];
+    const unsubPlayback = subscribePlaybackForPort((encoded) => {
+      this.port?.postMessage({ type: 'playback', ...encoded });
+    });
+
+    this.subscriptions = [unsubItems, unsubSession, unsubConfig, unsubPlayback];
   }
 }
 

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
@@ -140,8 +140,7 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     // until the surface is actually used.
     const { default: useSessionStore } = await import('../../../stores/sessionStore');
     const {
-      usePlaybackStore,
-      getRawSnapshot,
+      getWirePlaybackSnapshot,
       subscribePlaybackForPort,
     } = await import('../../../stores/playbackStore');
     // If the port was torn down while we awaited the import, bail out.
@@ -171,14 +170,7 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
       turnDetectionMode,
     };
 
-    const playbackSnapshot = (() => {
-      const playingItemId = usePlaybackStore.getState().playingItemId;
-      const raw = getRawSnapshot();
-      if (playingItemId === null) return null;
-      if (raw === null) return { i: playingItemId, c: null };
-      const r3 = (x: number) => Math.round(x * 1000) / 1000;
-      return { i: playingItemId, c: r3(raw.currentTime), d: r3(raw.duration), b: r3(raw.bufferedTime) };
-    })();
+    const playbackSnapshot = getWirePlaybackSnapshot();
 
     this.port.postMessage({
       type: 'state-init',

--- a/src/lib/playback/highlight.test.ts
+++ b/src/lib/playback/highlight.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { getHighlightedChars } from './highlight';
+
+describe('getHighlightedChars', () => {
+  describe('segment-based', () => {
+    const segments = [
+      { textEnd: 5, audioEnd: 1.0 },   // "Hello"
+      { textEnd: 11, audioEnd: 2.0 },  // "Hello world"
+      { textEnd: 14, audioEnd: 3.0 },  // "Hello world!!!"
+    ];
+
+    it('inside the first segment scales by segment progress', () => {
+      // half-way through segment 1: 0.5s of [0, 1.0s] → 50% of "Hello" (5 chars) = 2
+      expect(getHighlightedChars(0.5, segments, 14, 0)).toBe(2);
+    });
+
+    it('inside a later segment uses prevTextEnd + intra-segment progress', () => {
+      // 1.5s in: 0.5/1.0 through seg 2 (textEnd 11, prev 5, width 6) → 5 + 3 = 8
+      expect(getHighlightedChars(1.5, segments, 14, 0)).toBe(8);
+    });
+
+    it('past the final segment returns the last textEnd', () => {
+      expect(getHighlightedChars(99, segments, 14, 0)).toBe(14);
+    });
+
+    it('zero-duration segment returns its full textEnd immediately', () => {
+      const zeroDur = [
+        { textEnd: 3, audioEnd: 1.0 },
+        { textEnd: 7, audioEnd: 1.0 }, // same audioEnd → segDuration === 0
+      ];
+      // currentTime exactly at the boundary chooses seg 2 (currentTime < audioEnd false for seg 1)
+      expect(getHighlightedChars(1.0, zeroDur, 7, 0)).toBe(7);
+    });
+  });
+
+  describe('linear fallback', () => {
+    it('uses floor(textLength * progressRatio) when segments is undefined', () => {
+      expect(getHighlightedChars(0, undefined, 10, 0.5)).toBe(5);
+    });
+
+    it('uses floor(textLength * progressRatio) when segments is empty', () => {
+      expect(getHighlightedChars(0, [], 10, 0.3)).toBe(3);
+    });
+
+    it('progressRatio 0 returns 0', () => {
+      expect(getHighlightedChars(0, undefined, 10, 0)).toBe(0);
+    });
+
+    it('progressRatio 1 returns textLength', () => {
+      expect(getHighlightedChars(0, undefined, 10, 1)).toBe(10);
+    });
+  });
+
+  describe('boundaries', () => {
+    it('textLength 0 returns 0', () => {
+      expect(getHighlightedChars(0, undefined, 0, 0.5)).toBe(0);
+    });
+  });
+});

--- a/src/lib/playback/highlight.test.ts
+++ b/src/lib/playback/highlight.test.ts
@@ -10,8 +10,9 @@ describe('getHighlightedChars', () => {
     ];
 
     it('inside the first segment scales by segment progress', () => {
-      // half-way through segment 1: 0.5s of [0, 1.0s] → 50% of "Hello" (5 chars) = 2
-      expect(getHighlightedChars(0.5, segments, 14, 0)).toBe(2);
+      // half-way through segment 1: 0.5s of [0, 1.0s] → 50% of "Hello" (5 chars).
+      // Math.round(2.5) = 3 (round-half-up).
+      expect(getHighlightedChars(0.5, segments, 14, 0)).toBe(3);
     });
 
     it('inside a later segment uses prevTextEnd + intra-segment progress', () => {
@@ -31,14 +32,24 @@ describe('getHighlightedChars', () => {
       // currentTime exactly at the boundary chooses seg 2 (currentTime < audioEnd false for seg 1)
       expect(getHighlightedChars(1.0, zeroDur, 7, 0)).toBe(7);
     });
+
+    it('near end of final segment highlights the last character', () => {
+      // The end-of-playback case from the bug: currentTime hovers just under
+      // audioEnd because the player polls at 10Hz and stops before reaching
+      // the segment boundary exactly. Math.round bridges the gap; floor would
+      // leave the last char permanently uncolored.
+      // 2.95s into seg 3 (range [2.0, 3.0], width 3): segProgress 0.95.
+      // Math.round(3 * 0.95) = 3. prevTextEnd 11 + 3 = 14 = textLength.
+      expect(getHighlightedChars(2.95, segments, 14, 0)).toBe(14);
+    });
   });
 
   describe('linear fallback', () => {
-    it('uses floor(textLength * progressRatio) when segments is undefined', () => {
+    it('rounds textLength * progressRatio when segments is undefined', () => {
       expect(getHighlightedChars(0, undefined, 10, 0.5)).toBe(5);
     });
 
-    it('uses floor(textLength * progressRatio) when segments is empty', () => {
+    it('rounds textLength * progressRatio when segments is empty', () => {
       expect(getHighlightedChars(0, [], 10, 0.3)).toBe(3);
     });
 
@@ -48,6 +59,13 @@ describe('getHighlightedChars', () => {
 
     it('progressRatio 1 returns textLength', () => {
       expect(getHighlightedChars(0, undefined, 10, 1)).toBe(10);
+    });
+
+    it('near-complete progressRatio still highlights the final character', () => {
+      // Math.floor(11 * 0.95) = 10 (last char missed).
+      // Math.round(11 * 0.95) = 10. But Math.round(11 * 0.96) = 11.
+      // The key end-of-playback case: even slightly under 1.0 reaches textLength.
+      expect(getHighlightedChars(0, undefined, 11, 0.96)).toBe(11);
     });
   });
 

--- a/src/lib/playback/highlight.ts
+++ b/src/lib/playback/highlight.ts
@@ -1,0 +1,30 @@
+/**
+ * Given per-sentence audio segments and the current playback time,
+ * return the number of characters that should be highlighted.
+ * Falls back to linear interpolation when segments are not available.
+ *
+ * Lifted from MainPanel.tsx:91-113; identical logic, no behavioural changes.
+ */
+export function getHighlightedChars(
+  currentTime: number,
+  segments: Array<{ textEnd: number; audioEnd: number }> | undefined,
+  textLength: number,
+  progressRatio: number,
+): number {
+  if (!segments || segments.length === 0) {
+    return Math.floor(textLength * progressRatio);
+  }
+
+  let prevTextEnd = 0;
+  let prevAudioEnd = 0;
+  for (const seg of segments) {
+    if (currentTime < seg.audioEnd) {
+      const segDuration = seg.audioEnd - prevAudioEnd;
+      const segProgress = segDuration > 0 ? (currentTime - prevAudioEnd) / segDuration : 1;
+      return prevTextEnd + Math.floor((seg.textEnd - prevTextEnd) * segProgress);
+    }
+    prevTextEnd = seg.textEnd;
+    prevAudioEnd = seg.audioEnd;
+  }
+  return prevTextEnd;
+}

--- a/src/lib/playback/highlight.ts
+++ b/src/lib/playback/highlight.ts
@@ -3,7 +3,10 @@
  * return the number of characters that should be highlighted.
  * Falls back to linear interpolation when segments are not available.
  *
- * Lifted from MainPanel.tsx:91-113; identical logic, no behavioural changes.
+ * Uses Math.round so the final character actually gets highlighted at
+ * end-of-playback: Math.floor would peg at width-1 because segProgress
+ * never quite reaches 1.0 (the player's poll tick before isPlaying flips
+ * to false has currentTime slightly under audioEnd).
  */
 export function getHighlightedChars(
   currentTime: number,
@@ -12,7 +15,7 @@ export function getHighlightedChars(
   progressRatio: number,
 ): number {
   if (!segments || segments.length === 0) {
-    return Math.floor(textLength * progressRatio);
+    return Math.min(Math.round(textLength * progressRatio), textLength);
   }
 
   let prevTextEnd = 0;
@@ -21,7 +24,8 @@ export function getHighlightedChars(
     if (currentTime < seg.audioEnd) {
       const segDuration = seg.audioEnd - prevAudioEnd;
       const segProgress = segDuration > 0 ? (currentTime - prevAudioEnd) / segDuration : 1;
-      return prevTextEnd + Math.floor((seg.textEnd - prevTextEnd) * segProgress);
+      const width = seg.textEnd - prevTextEnd;
+      return prevTextEnd + Math.min(Math.round(width * segProgress), width);
     }
     prevTextEnd = seg.textEnd;
     prevAudioEnd = seg.audioEnd;

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -61,3 +61,43 @@ describe('playbackStore — setPlayingItem', () => {
     expect(s._maxProgress).toBe(0);
   });
 });
+
+describe('playbackStore — setProgress happy path', () => {
+  beforeEach(resetStore);
+
+  it('first non-null tick after setPlayingItem populates derived', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({
+      currentTime: 1.0,
+      duration: 5.0,
+      bufferedTime: 4.0,
+    });
+    const s = usePlaybackStore.getState();
+    expect(s.currentTime).toBe(1.0);
+    expect(s.progressRatio).toBeCloseTo(1.0 / 4.0, 5);
+    expect(s._raw).toEqual({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+  });
+
+  it('successive ticks advance derived monotonically', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 0.5, duration: 5.0, bufferedTime: 4.0 });
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+    const s = usePlaybackStore.getState();
+    expect(s.currentTime).toBe(1.0);
+    expect(s.progressRatio).toBeCloseTo(0.25, 5);
+  });
+
+  it('divisor falls back to duration when bufferedTime is 0', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 4.0, bufferedTime: 0 });
+    const s = usePlaybackStore.getState();
+    expect(s.progressRatio).toBeCloseTo(0.25, 5);
+  });
+
+  it('ratio clamps at 1.0 when currentTime exceeds bufferedTime', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 5.0, duration: 5.0, bufferedTime: 4.0 });
+    const s = usePlaybackStore.getState();
+    expect(s.progressRatio).toBe(1.0);
+  });
+});

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -166,7 +166,7 @@ describe('playbackStore — setProgress(null)', () => {
   });
 });
 
-import { __internal__, getRawSnapshot, subscribePlaybackForPort } from './playbackStore';
+import { __internal__, getRawSnapshot, getWirePlaybackSnapshot, subscribePlaybackForPort } from './playbackStore';
 
 describe('playbackStore wire helpers', () => {
   const { encodePlaybackForWire, rawEqual } = __internal__;
@@ -274,5 +274,29 @@ describe('subscribePlaybackForPort', () => {
     unsub();
     usePlaybackStore.getState().setPlayingItem('item_a');
     expect(calls.length).toBe(0);
+  });
+});
+
+describe('getWirePlaybackSnapshot', () => {
+  beforeEach(resetStore);
+
+  it('returns null when nothing is playing', () => {
+    expect(getWirePlaybackSnapshot()).toBeNull();
+  });
+
+  it('returns { i, c: null } when item is set but no progress yet', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    expect(getWirePlaybackSnapshot()).toEqual({ i: 'item_a', c: null });
+  });
+
+  it('returns full wire shape with 3-decimal rounding when playing', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2347, duration: 5.6789, bufferedTime: 4.1234 });
+    expect(getWirePlaybackSnapshot()).toEqual({
+      i: 'item_a',
+      c: 1.235,
+      d: 5.679,
+      b: 4.123,
+    });
   });
 });

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -131,3 +131,37 @@ describe('playbackStore — setProgress entry eviction', () => {
     expect(usePlaybackStore.getState()._cumOffset).toBe(0);
   });
 });
+
+describe('playbackStore — setProgress(null)', () => {
+  beforeEach(resetStore);
+
+  it('preserves currentTime, progressRatio, and trackers; flips _raw to null', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+    const before = usePlaybackStore.getState();
+    const beforeSnap = {
+      currentTime: before.currentTime,
+      progressRatio: before.progressRatio,
+      _cumOffset: before._cumOffset,
+      _lastBt: before._lastBt,
+      _lastCt: before._lastCt,
+      _maxProgress: before._maxProgress,
+    };
+    usePlaybackStore.getState().setProgress(null);
+    const after = usePlaybackStore.getState();
+    expect(after.currentTime).toBe(beforeSnap.currentTime);
+    expect(after.progressRatio).toBe(beforeSnap.progressRatio);
+    expect(after._cumOffset).toBe(beforeSnap._cumOffset);
+    expect(after._lastBt).toBe(beforeSnap._lastBt);
+    expect(after._lastCt).toBe(beforeSnap._lastCt);
+    expect(after._maxProgress).toBe(beforeSnap._maxProgress);
+    expect(after._raw).toBeNull();
+  });
+
+  it('setProgress(null) when no item is playing is a no-op', () => {
+    usePlaybackStore.getState().setProgress(null);
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+  });
+});

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -101,3 +101,33 @@ describe('playbackStore — setProgress happy path', () => {
     expect(s.progressRatio).toBe(1.0);
   });
 });
+
+describe('playbackStore — setProgress entry eviction', () => {
+  beforeEach(resetStore);
+
+  it('regression > 50ms with _lastBt > 0 bumps _cumOffset by _lastBt', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    // Entry 1 fills up: ct=1.0, bt=2.0
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 2.0, bufferedTime: 2.0 });
+    // Entry 1 evicted; new entry: ct regresses to 0.1 (1.0 - 0.9 > 0.05)
+    usePlaybackStore.getState().setProgress({ currentTime: 0.1, duration: 1.0, bufferedTime: 1.0 });
+    const s = usePlaybackStore.getState();
+    expect(s._cumOffset).toBe(2.0); // accumulated entry-1 bufferedTime
+    expect(s.currentTime).toBe(2.1); // offset + new ct
+  });
+
+  it('regression <= 50ms does NOT bump offset', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 2.0, bufferedTime: 2.0 });
+    // ct goes back 30ms — within threshold; treated as same entry jitter
+    usePlaybackStore.getState().setProgress({ currentTime: 0.97, duration: 2.0, bufferedTime: 2.0 });
+    expect(usePlaybackStore.getState()._cumOffset).toBe(0);
+  });
+
+  it('regression with _lastBt == 0 does NOT bump offset', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 2.0, bufferedTime: 0 });
+    usePlaybackStore.getState().setProgress({ currentTime: 0.1, duration: 1.0, bufferedTime: 1.0 });
+    expect(usePlaybackStore.getState()._cumOffset).toBe(0);
+  });
+});

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -165,3 +165,59 @@ describe('playbackStore — setProgress(null)', () => {
     expect(s.currentTime).toBeNull();
   });
 });
+
+import { __internal__ } from './playbackStore';
+
+describe('playbackStore wire helpers', () => {
+  const { encodePlaybackForWire, rawEqual } = __internal__;
+
+  describe('encodePlaybackForWire', () => {
+    it('returns { i: null } when no item is playing', () => {
+      expect(encodePlaybackForWire({ playingItemId: null, _raw: null })).toEqual({ i: null });
+    });
+
+    it('returns { i, c: null } when item is set but _raw is null (paused)', () => {
+      expect(
+        encodePlaybackForWire({ playingItemId: 'item_a', _raw: null }),
+      ).toEqual({ i: 'item_a', c: null });
+    });
+
+    it('returns full shape and rounds c/d/b to 3 decimals', () => {
+      expect(
+        encodePlaybackForWire({
+          playingItemId: 'item_a',
+          _raw: { currentTime: 1.2345678, duration: 5.6789012, bufferedTime: 6.7890123 },
+        }),
+      ).toEqual({ i: 'item_a', c: 1.235, d: 5.679, b: 6.789 });
+    });
+  });
+
+  describe('rawEqual', () => {
+    it('returns true when both are null', () => {
+      expect(rawEqual(null, null)).toBe(true);
+    });
+
+    it('returns false when one side is null', () => {
+      expect(rawEqual(null, { currentTime: 0, duration: 0, bufferedTime: 0 })).toBe(false);
+      expect(rawEqual({ currentTime: 0, duration: 0, bufferedTime: 0 }, null)).toBe(false);
+    });
+
+    it('returns true when fields differ only beyond 3 decimals', () => {
+      expect(
+        rawEqual(
+          { currentTime: 1.2345, duration: 2.3455, bufferedTime: 3.4566 },
+          { currentTime: 1.2347, duration: 2.3459, bufferedTime: 3.4561 },
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when fields differ within 3 decimals', () => {
+      expect(
+        rawEqual(
+          { currentTime: 1.234, duration: 2.345, bufferedTime: 3.456 },
+          { currentTime: 1.235, duration: 2.345, bufferedTime: 3.456 },
+        ),
+      ).toBe(false);
+    });
+  });
+});

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -206,7 +206,7 @@ describe('playbackStore wire helpers', () => {
       expect(
         rawEqual(
           { currentTime: 1.2345, duration: 2.3455, bufferedTime: 3.4566 },
-          { currentTime: 1.2347, duration: 2.3459, bufferedTime: 3.4561 },
+          { currentTime: 1.2347, duration: 2.3459, bufferedTime: 3.4569 },
         ),
       ).toBe(true);
     });

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -166,7 +166,7 @@ describe('playbackStore — setProgress(null)', () => {
   });
 });
 
-import { __internal__ } from './playbackStore';
+import { __internal__, getRawSnapshot, subscribePlaybackForPort } from './playbackStore';
 
 describe('playbackStore wire helpers', () => {
   const { encodePlaybackForWire, rawEqual } = __internal__;
@@ -219,5 +219,60 @@ describe('playbackStore wire helpers', () => {
         ),
       ).toBe(false);
     });
+  });
+});
+
+describe('getRawSnapshot', () => {
+  beforeEach(resetStore);
+
+  it('returns null when no progress has been written', () => {
+    expect(getRawSnapshot()).toBeNull();
+  });
+
+  it('returns the latest raw input', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.234, duration: 5, bufferedTime: 4 });
+    expect(getRawSnapshot()).toEqual({ currentTime: 1.234, duration: 5, bufferedTime: 4 });
+  });
+});
+
+describe('subscribePlaybackForPort', () => {
+  beforeEach(resetStore);
+
+  it('fires callback when playingItemId changes', () => {
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toEqual({ i: 'item_a', c: null });
+    unsub();
+  });
+
+  it('fires callback when _raw changes (compared by rounded values)', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    usePlaybackStore.getState().setProgress({ currentTime: 1.0, duration: 5, bufferedTime: 4 });
+    expect(calls.length).toBe(1);
+    expect(calls[0]).toEqual({ i: 'item_a', c: 1.0, d: 5, b: 4 });
+    unsub();
+  });
+
+  it('does NOT fire callback when round-equal raw is re-written', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2345, duration: 5, bufferedTime: 4 });
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    usePlaybackStore.getState().setProgress({ currentTime: 1.2347, duration: 5, bufferedTime: 4 });
+    expect(calls.length).toBe(0);
+    unsub();
+  });
+
+  it('unsub() detaches the listener', () => {
+    const calls: any[] = [];
+    const unsub = subscribePlaybackForPort((encoded) => calls.push(encoded));
+    unsub();
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    expect(calls.length).toBe(0);
   });
 });

--- a/src/stores/playbackStore.test.ts
+++ b/src/stores/playbackStore.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePlaybackStore } from './playbackStore';
+
+function resetStore() {
+  usePlaybackStore.setState({
+    playingItemId: null,
+    currentTime: null,
+    progressRatio: 0,
+    _cumOffset: 0,
+    _lastBt: 0,
+    _lastCt: 0,
+    _maxProgress: 0,
+    _raw: null,
+  });
+}
+
+describe('playbackStore — setPlayingItem', () => {
+  beforeEach(resetStore);
+
+  it('starts with empty defaults', () => {
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+    expect(s.progressRatio).toBe(0);
+  });
+
+  it('setPlayingItem(id) writes id and zeros derived/trackers', () => {
+    usePlaybackStore.setState({
+      _cumOffset: 5,
+      _lastBt: 2,
+      _lastCt: 1,
+      _maxProgress: 0.4,
+    });
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(0);
+    expect(s.progressRatio).toBe(0);
+    expect(s._cumOffset).toBe(0);
+    expect(s._lastBt).toBe(0);
+    expect(s._lastCt).toBe(0);
+    expect(s._maxProgress).toBe(0);
+  });
+
+  it('setPlayingItem(sameId) is a no-op (preserves trackers)', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.setState({ _maxProgress: 0.7, currentTime: 1.5 });
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    const s = usePlaybackStore.getState();
+    expect(s._maxProgress).toBe(0.7);
+    expect(s.currentTime).toBe(1.5);
+  });
+
+  it('setPlayingItem(null) clears id; currentTime becomes null', () => {
+    usePlaybackStore.getState().setPlayingItem('item_a');
+    usePlaybackStore.setState({ currentTime: 1.2, _maxProgress: 0.3 });
+    usePlaybackStore.getState().setPlayingItem(null);
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+    expect(s._maxProgress).toBe(0);
+  });
+});

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -100,7 +100,6 @@ export const usePlaybackStore = create<PlaybackState>()(
 );
 
 const r3 = (x: number) => Math.round(x * 1000) / 1000;
-const t3 = (x: number) => Math.trunc(x * 1000) / 1000;
 
 type RawProgress = { currentTime: number; duration: number; bufferedTime: number };
 
@@ -121,9 +120,9 @@ function encodePlaybackForWire(s: {
 function rawEqual(a: RawProgress | null, b: RawProgress | null): boolean {
   if (a === null || b === null) return a === b;
   return (
-    t3(a.currentTime) === t3(b.currentTime) &&
-    t3(a.duration) === t3(b.duration) &&
-    t3(a.bufferedTime) === t3(b.bufferedTime)
+    r3(a.currentTime) === r3(b.currentTime) &&
+    r3(a.duration) === r3(b.duration) &&
+    r3(a.bufferedTime) === r3(b.bufferedTime)
   );
 }
 

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -61,8 +61,16 @@ export const usePlaybackStore = create<PlaybackState>()(
       }
       if (s.playingItemId === null) return;
 
-      // Cumulative tracker (Task 4 adds eviction handling; here it just passes through).
-      const offset = s._cumOffset;
+      // Cumulative tracker: when currentTime regresses by more than ENTRY_RESET_THRESHOLD
+      // and the last entry had non-zero bufferedTime, the player evicted that entry and
+      // started a new one — accumulate the previous entry's bufferedTime into the offset.
+      let offset = s._cumOffset;
+      if (
+        raw.currentTime < s._lastCt - ENTRY_RESET_THRESHOLD &&
+        s._lastBt > 0
+      ) {
+        offset += s._lastBt;
+      }
       const cumCurrentTime = offset + raw.currentTime;
       const cumBufferedTime = offset + raw.bufferedTime;
       const cumDuration = offset + raw.duration;

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -183,17 +183,40 @@ export function usePlaybackHighlight(
   return usePlaybackStore(
     useShallow((s): PlaybackHighlight => {
       if (!item || s.playingItemId !== item.id) return EMPTY_HIGHLIGHT;
-      const text = textOverride ?? (item.formatted?.transcript || item.formatted?.text || '');
+      const originalText = item.formatted?.transcript || item.formatted?.text || '';
+      const renderedText = textOverride ?? originalText;
       const segments = item.formatted?.audioSegments;
-      return {
-        isPlaying: true,
-        highlightedChars: getHighlightedChars(
+      const usingSegments = !!(segments && segments.length > 0);
+
+      let highlightedChars: number;
+      if (usingSegments) {
+        // Segments carry textEnd values indexed against the original transcript.
+        // Pass originalText.length so the segment math is correct, then shift by
+        // the caller's leading-whitespace strip (if any) and clamp to the
+        // rendered text the caller will actually slice.
+        const rawIndex = getHighlightedChars(
           s.currentTime ?? 0,
           segments,
-          text.length,
+          originalText.length,
           s.progressRatio,
-        ),
-      };
+        );
+        let offset = 0;
+        if (textOverride && textOverride !== originalText) {
+          const idx = originalText.indexOf(textOverride);
+          if (idx > 0) offset = idx;
+        }
+        highlightedChars = Math.max(0, Math.min(rawIndex - offset, renderedText.length));
+      } else {
+        // Linear fallback indexes against textLength directly — no offset needed.
+        highlightedChars = getHighlightedChars(
+          s.currentTime ?? 0,
+          undefined,
+          renderedText.length,
+          s.progressRatio,
+        );
+      }
+
+      return { isPlaying: true, highlightedChars };
     }),
   );
 }

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -98,3 +98,34 @@ export const usePlaybackStore = create<PlaybackState>()(
     },
   })),
 );
+
+const r3 = (x: number) => Math.round(x * 1000) / 1000;
+const t3 = (x: number) => Math.trunc(x * 1000) / 1000;
+
+type RawProgress = { currentTime: number; duration: number; bufferedTime: number };
+
+function encodePlaybackForWire(s: {
+  playingItemId: string | null;
+  _raw: RawProgress | null;
+}): { i: string | null; c?: number | null; d?: number; b?: number } {
+  if (s.playingItemId === null) return { i: null };
+  if (s._raw === null) return { i: s.playingItemId, c: null };
+  return {
+    i: s.playingItemId,
+    c: r3(s._raw.currentTime),
+    d: r3(s._raw.duration),
+    b: r3(s._raw.bufferedTime),
+  };
+}
+
+function rawEqual(a: RawProgress | null, b: RawProgress | null): boolean {
+  if (a === null || b === null) return a === b;
+  return (
+    t3(a.currentTime) === t3(b.currentTime) &&
+    t3(a.duration) === t3(b.duration) &&
+    t3(a.bufferedTime) === t3(b.bufferedTime)
+  );
+}
+
+/** Internal exports for unit tests only. Do not consume from app code. */
+export const __internal__ = { encodePlaybackForWire, rawEqual };

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -1,0 +1,58 @@
+import { create } from 'zustand';
+import { subscribeWithSelector } from 'zustand/middleware';
+
+interface PlaybackPublic {
+  playingItemId: string | null;
+  currentTime: number | null;
+  progressRatio: number;
+}
+
+interface PlaybackInternal {
+  _cumOffset: number;
+  _lastBt: number;
+  _lastCt: number;
+  _maxProgress: number;
+  _raw: { currentTime: number; duration: number; bufferedTime: number } | null;
+}
+
+interface PlaybackActions {
+  setPlayingItem: (id: string | null) => void;
+  setProgress: (raw: { currentTime: number; duration: number; bufferedTime: number } | null) => void;
+}
+
+type PlaybackState = PlaybackPublic & PlaybackInternal & PlaybackActions;
+
+const DEFAULTS: PlaybackPublic & PlaybackInternal = {
+  playingItemId: null,
+  currentTime: null,
+  progressRatio: 0,
+  _cumOffset: 0,
+  _lastBt: 0,
+  _lastCt: 0,
+  _maxProgress: 0,
+  _raw: null,
+};
+
+export const usePlaybackStore = create<PlaybackState>()(
+  subscribeWithSelector((set, get) => ({
+    ...DEFAULTS,
+
+    setPlayingItem(id) {
+      if (get().playingItemId === id) return;
+      set({
+        playingItemId: id,
+        currentTime: id === null ? null : 0,
+        progressRatio: 0,
+        _cumOffset: 0,
+        _lastBt: 0,
+        _lastCt: 0,
+        _maxProgress: 0,
+        _raw: null,
+      });
+    },
+
+    setProgress(_raw) {
+      // Implemented in Task 3.
+    },
+  })),
+);

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -128,3 +128,20 @@ function rawEqual(a: RawProgress | null, b: RawProgress | null): boolean {
 
 /** Internal exports for unit tests only. Do not consume from app code. */
 export const __internal__ = { encodePlaybackForWire, rawEqual };
+
+export function getRawSnapshot(): RawProgress | null {
+  return usePlaybackStore.getState()._raw;
+}
+
+export type PlaybackWire = { i: string | null; c?: number | null; d?: number; b?: number };
+
+export function subscribePlaybackForPort(callback: (encoded: PlaybackWire) => void): () => void {
+  return usePlaybackStore.subscribe(
+    (s) => ({ playingItemId: s.playingItemId, _raw: s._raw }),
+    (next) => callback(encodePlaybackForWire(next)),
+    {
+      equalityFn: (a, b) =>
+        a.playingItemId === b.playingItemId && rawEqual(a._raw, b._raw),
+    },
+  );
+}

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -22,6 +22,8 @@ interface PlaybackActions {
 
 type PlaybackState = PlaybackPublic & PlaybackInternal & PlaybackActions;
 
+const ENTRY_RESET_THRESHOLD = 0.05; // seconds; matches MainPanel
+
 const DEFAULTS: PlaybackPublic & PlaybackInternal = {
   playingItemId: null,
   currentTime: null,
@@ -51,8 +53,34 @@ export const usePlaybackStore = create<PlaybackState>()(
       });
     },
 
-    setProgress(_raw) {
-      // Implemented in Task 3.
+    setProgress(raw) {
+      const s = get();
+      if (raw === null) {
+        // Implemented in Task 5.
+        return;
+      }
+      if (s.playingItemId === null) return;
+
+      // Cumulative tracker (Task 4 adds eviction handling; here it just passes through).
+      const offset = s._cumOffset;
+      const cumCurrentTime = offset + raw.currentTime;
+      const cumBufferedTime = offset + raw.bufferedTime;
+      const cumDuration = offset + raw.duration;
+
+      // Monotonic-clamped ratio.
+      const divisor = cumBufferedTime || cumDuration || 1;
+      const calculatedRatio = Math.min(cumCurrentTime / divisor, 1);
+      const progressRatio = Math.max(calculatedRatio, s._maxProgress);
+
+      set({
+        currentTime: cumCurrentTime,
+        progressRatio,
+        _cumOffset: offset,
+        _lastBt: raw.bufferedTime,
+        _lastCt: raw.currentTime,
+        _maxProgress: progressRatio,
+        _raw: raw,
+      });
     },
   })),
 );

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -135,6 +135,17 @@ export function getRawSnapshot(): RawProgress | null {
   return usePlaybackStore.getState()._raw;
 }
 
+/**
+ * Wire-encoded snapshot of the current playback state, suitable for
+ * forwarding over chrome.runtime.Port as the initial state-init payload.
+ * Returns null when nothing is playing.
+ */
+export function getWirePlaybackSnapshot(): PlaybackWire | null {
+  const state = usePlaybackStore.getState();
+  if (state.playingItemId === null) return null;
+  return encodePlaybackForWire(state);
+}
+
 export type PlaybackWire = { i: string | null; c?: number | null; d?: number; b?: number };
 
 export function subscribePlaybackForPort(callback: (encoded: PlaybackWire) => void): () => void {

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -1,5 +1,7 @@
 import { create } from 'zustand';
 import { subscribeWithSelector } from 'zustand/middleware';
+import { useShallow } from 'zustand/shallow';
+import { getHighlightedChars } from '../lib/playback/highlight';
 
 interface PlaybackPublic {
   playingItemId: string | null;
@@ -143,5 +145,43 @@ export function subscribePlaybackForPort(callback: (encoded: PlaybackWire) => vo
       equalityFn: (a, b) =>
         a.playingItemId === b.playingItemId && rawEqual(a._raw, b._raw),
     },
+  );
+}
+
+export interface PlaybackHighlight {
+  isPlaying: boolean;
+  highlightedChars: number;
+}
+
+const EMPTY_HIGHLIGHT: PlaybackHighlight = { isPlaying: false, highlightedChars: 0 };
+
+export function usePlaybackHighlight(
+  item:
+    | {
+        id: string;
+        formatted?: {
+          transcript?: string;
+          text?: string;
+          audioSegments?: Array<{ textEnd: number; audioEnd: number }>;
+        };
+      }
+    | null
+    | undefined,
+): PlaybackHighlight {
+  return usePlaybackStore(
+    useShallow((s): PlaybackHighlight => {
+      if (!item || s.playingItemId !== item.id) return EMPTY_HIGHLIGHT;
+      const text = item.formatted?.transcript || item.formatted?.text || '';
+      const segments = item.formatted?.audioSegments;
+      return {
+        isPlaying: true,
+        highlightedChars: getHighlightedChars(
+          s.currentTime ?? 0,
+          segments,
+          text.length,
+          s.progressRatio,
+        ),
+      };
+    }),
   );
 }

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -56,7 +56,13 @@ export const usePlaybackStore = create<PlaybackState>()(
     setProgress(raw) {
       const s = get();
       if (raw === null) {
-        // Implemented in Task 5.
+        // Preserve all derived trackers; only flip _raw to null so the port
+        // surface observes the pause transition. Avoids segment-based-provider
+        // chunk-gap flicker that currently affects MainPanel (improvement
+        // documented in the design spec).
+        if (s._raw !== null) {
+          set({ _raw: null });
+        }
         return;
       }
       if (s.playingItemId === null) return;

--- a/src/stores/playbackStore.ts
+++ b/src/stores/playbackStore.ts
@@ -167,11 +167,12 @@ export function usePlaybackHighlight(
       }
     | null
     | undefined,
+  textOverride?: string,
 ): PlaybackHighlight {
   return usePlaybackStore(
     useShallow((s): PlaybackHighlight => {
       if (!item || s.playingItemId !== item.id) return EMPTY_HIGHLIGHT;
-      const text = item.formatted?.transcript || item.formatted?.text || '';
+      const text = textOverride ?? (item.formatted?.transcript || item.formatted?.text || '');
       const segments = item.formatted?.audioSegments;
       return {
         isPlaying: true,

--- a/src/stores/playbackStore.usePlaybackHighlight.test.tsx
+++ b/src/stores/playbackStore.usePlaybackHighlight.test.tsx
@@ -104,4 +104,50 @@ describe('usePlaybackHighlight', () => {
     render(<Probe item={item as any} textOverride="Hello" />);
     expect(screen.getByTestId('chars').textContent).toBe('5');
   });
+
+  it('with audioSegments + textOverride, shifts indices by leading-trim offset', () => {
+    // Provider returned a transcript with leading whitespace AND
+    // per-segment audioSegments. Segment textEnd values index the original
+    // (untrimmed) string. The caller (SubtitleStream's CompactSpan) renders
+    // the trimmed copy, so highlightedChars must be relative to that.
+    const item = {
+      id: 'item_a',
+      formatted: {
+        text: '  Hello world',
+        audioSegments: [
+          { textEnd: 7, audioEnd: 1.0 },  // "  Hello" (original-indexed)
+          { textEnd: 13, audioEnd: 2.0 }, // "  Hello world"
+        ],
+      },
+    };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ currentTime: 1.5, progressRatio: 0 });
+    });
+    // 1.5s → 0.5/1.0 through seg 2 (width 6) → rawIndex = 7 + 3 = 10 in original.
+    // Override "Hello world" (11 chars) strips 2 leading spaces, so the rendered
+    // index is 10 - 2 = 8 → highlight covers "Hello wo".
+    render(<Probe item={item as any} textOverride="Hello world" />);
+    expect(screen.getByTestId('chars').textContent).toBe('8');
+  });
+
+  it('with audioSegments + textOverride, clamps index to rendered length', () => {
+    // Trailing whitespace stripped by trim should not produce out-of-range
+    // slice indices: rawIndex past renderedText.length is clamped.
+    const item = {
+      id: 'item_a',
+      formatted: {
+        text: 'Hello  ', // trailing whitespace
+        audioSegments: [{ textEnd: 7, audioEnd: 1.0 }],
+      },
+    };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ currentTime: 0.99, progressRatio: 0 });
+    });
+    // Just before audioEnd: rawIndex approaches 7 (full original length).
+    // Trimmed override "Hello" is 5 chars → clamp to 5.
+    render(<Probe item={item as any} textOverride="Hello" />);
+    expect(Number(screen.getByTestId('chars').textContent)).toBeLessThanOrEqual(5);
+  });
 });

--- a/src/stores/playbackStore.usePlaybackHighlight.test.tsx
+++ b/src/stores/playbackStore.usePlaybackHighlight.test.tsx
@@ -16,8 +16,8 @@ function resetStore() {
   });
 }
 
-function Probe({ item }: { item: any }) {
-  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+function Probe({ item, textOverride }: { item: any; textOverride?: string }) {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item, textOverride);
   const renders = useRef(0);
   renders.current += 1;
   return (
@@ -87,5 +87,21 @@ describe('usePlaybackHighlight', () => {
 
     const finalRenders = Number(screen.getByTestId('renders').textContent);
     expect(finalRenders).toBe(initialRenders);
+  });
+
+  it('uses textOverride length for indexing when provided', () => {
+    // Provider has leading whitespace in transcript; SubtitleStream renders
+    // a trimmed copy. The hook must index against what the caller renders.
+    const item = {
+      id: 'item_a',
+      formatted: { text: '  Hello' }, // 7 chars including 2 leading spaces
+    };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ progressRatio: 1.0, currentTime: 0 });
+    });
+    // With override 'Hello' (5 chars), full progress → 5
+    render(<Probe item={item as any} textOverride="Hello" />);
+    expect(screen.getByTestId('chars').textContent).toBe('5');
   });
 });

--- a/src/stores/playbackStore.usePlaybackHighlight.test.tsx
+++ b/src/stores/playbackStore.usePlaybackHighlight.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, act } from '@testing-library/react';
+import React, { useRef } from 'react';
+import { usePlaybackStore, usePlaybackHighlight } from './playbackStore';
+
+function resetStore() {
+  usePlaybackStore.setState({
+    playingItemId: null,
+    currentTime: null,
+    progressRatio: 0,
+    _cumOffset: 0,
+    _lastBt: 0,
+    _lastCt: 0,
+    _maxProgress: 0,
+    _raw: null,
+  });
+}
+
+function Probe({ item }: { item: any }) {
+  const { isPlaying, highlightedChars } = usePlaybackHighlight(item);
+  const renders = useRef(0);
+  renders.current += 1;
+  return (
+    <div>
+      <span data-testid="playing">{String(isPlaying)}</span>
+      <span data-testid="chars">{highlightedChars}</span>
+      <span data-testid="renders">{renders.current}</span>
+    </div>
+  );
+}
+
+describe('usePlaybackHighlight', () => {
+  beforeEach(resetStore);
+
+  it('returns isPlaying=false / 0 when item is null', () => {
+    render(<Probe item={null} />);
+    expect(screen.getByTestId('playing').textContent).toBe('false');
+    expect(screen.getByTestId('chars').textContent).toBe('0');
+  });
+
+  it('returns isPlaying=true with linear fallback when no audioSegments', () => {
+    const item = { id: 'item_a', formatted: { text: 'Hello world' } };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ progressRatio: 0.5, currentTime: 2.0 });
+    });
+    render(<Probe item={item} />);
+    expect(screen.getByTestId('playing').textContent).toBe('true');
+    expect(screen.getByTestId('chars').textContent).toBe('5'); // floor(11 * 0.5)
+  });
+
+  it('uses audioSegments when present', () => {
+    const item = {
+      id: 'item_a',
+      formatted: {
+        transcript: 'Hello world',
+        audioSegments: [
+          { textEnd: 5, audioEnd: 1.0 },
+          { textEnd: 11, audioEnd: 2.0 },
+        ],
+      },
+    };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_a');
+      usePlaybackStore.setState({ currentTime: 1.5, progressRatio: 0 });
+    });
+    render(<Probe item={item} />);
+    // 1.5s → 0.5/1.0 through seg 2 (textEnd 11, prev 5, width 6) → 5 + 3 = 8
+    expect(screen.getByTestId('chars').textContent).toBe('8');
+  });
+
+  it('non-playing item does not re-render on currentTime tick', () => {
+    const itemA = { id: 'item_a', formatted: { text: 'A' } };
+    act(() => {
+      usePlaybackStore.getState().setPlayingItem('item_b');
+      usePlaybackStore.setState({ currentTime: 1.0, progressRatio: 0.1 });
+    });
+    render(<Probe item={itemA} />);
+    const initialRenders = Number(screen.getByTestId('renders').textContent);
+
+    act(() => {
+      usePlaybackStore.setState({ currentTime: 1.1, progressRatio: 0.2 });
+    });
+    act(() => {
+      usePlaybackStore.setState({ currentTime: 1.2, progressRatio: 0.3 });
+    });
+
+    const finalRenders = Number(screen.getByTestId('renders').textContent);
+    expect(finalRenders).toBe(initialRenders);
+  });
+});

--- a/src/stores/playbackStore.usePlaybackHighlight.test.tsx
+++ b/src/stores/playbackStore.usePlaybackHighlight.test.tsx
@@ -46,7 +46,7 @@ describe('usePlaybackHighlight', () => {
     });
     render(<Probe item={item} />);
     expect(screen.getByTestId('playing').textContent).toBe('true');
-    expect(screen.getByTestId('chars').textContent).toBe('5'); // floor(11 * 0.5)
+    expect(screen.getByTestId('chars').textContent).toBe('6'); // round(11 * 0.5) = 6
   });
 
   it('uses audioSegments when present', () => {

--- a/src/stores/sessionPortMirror.test.ts
+++ b/src/stores/sessionPortMirror.test.ts
@@ -210,4 +210,24 @@ describe('sessionPortMirror — playback inbound', () => {
     onMessage({ type: 'state-init', payload: { items: [] } });
     expect(usePlaybackStore.getState().playingItemId).toBeNull();
   });
+
+  it('state-init with explicit playback:null clears stale playback state', () => {
+    // Simulates port reconnect: the iframe already had a prior playingItemId
+    // from a previous connection; the new state-init says the sidepanel is
+    // now idle. The mirror must clear, not silently leave stale state.
+    usePlaybackStore.getState().setPlayingItem('item_prior');
+    usePlaybackStore.getState().setProgress({
+      currentTime: 1.0,
+      duration: 5.0,
+      bufferedTime: 4.0,
+    });
+    expect(usePlaybackStore.getState().playingItemId).toBe('item_prior');
+
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'state-init', payload: { items: [], playback: null } });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+  });
 });

--- a/src/stores/sessionPortMirror.test.ts
+++ b/src/stores/sessionPortMirror.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { installSessionPortMirror } from './sessionPortMirror';
 import useSessionStore from './sessionStore';
 import useSettingsStore from './settingsStore';
+import { usePlaybackStore } from './playbackStore';
 
 // Mock SettingsService factory so settingsStore can be imported without
 // pulling audio worklet side-effects through ServiceFactory.
@@ -124,5 +125,89 @@ describe('sessionPortMirror', () => {
     const ps = state.getCurrentProviderSettings() as any;
     expect(ps?.sourceLanguage).toBe('fr');
     expect(ps?.targetLanguage).toBe('de');
+  });
+});
+
+describe('sessionPortMirror — playback inbound', () => {
+  let connectedPort: any;
+
+  beforeEach(() => {
+    usePlaybackStore.setState({
+      playingItemId: null,
+      currentTime: null,
+      progressRatio: 0,
+      _cumOffset: 0,
+      _lastBt: 0,
+      _lastCt: 0,
+      _maxProgress: 0,
+      _raw: null,
+    });
+    useSessionStore.setState({
+      items: [],
+      systemAudioItems: [],
+      isSessionActive: false,
+      sessionStartTime: null,
+    } as any);
+
+    connectedPort = {
+      name: 'sokuji-subtitle',
+      onMessage: { addListener: vi.fn(), removeListener: vi.fn() },
+      onDisconnect: { addListener: vi.fn(), removeListener: vi.fn() },
+      postMessage: vi.fn(),
+      disconnect: vi.fn(),
+    };
+    globalThis.chrome = {
+      runtime: { connect: vi.fn(() => connectedPort) },
+    };
+  });
+
+  it('applies playback message with full c/d/b', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'playback', i: 'item_a', c: 1.0, d: 5.0, b: 4.0 });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(1.0);
+    expect(s._raw).toEqual({ currentTime: 1.0, duration: 5.0, bufferedTime: 4.0 });
+  });
+
+  it('applies playback message with c:null (pause) preserving derived', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'playback', i: 'item_a', c: 1.0, d: 5.0, b: 4.0 });
+    onMessage({ type: 'playback', i: 'item_a', c: null });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(1.0);
+    expect(s._raw).toBeNull();
+  });
+
+  it('applies playback message with i:null (clear)', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'playback', i: 'item_a', c: 1.0, d: 5.0, b: 4.0 });
+    onMessage({ type: 'playback', i: null });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBeNull();
+    expect(s.currentTime).toBeNull();
+  });
+
+  it('state-init.payload.playback populates the store on connect', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({
+      type: 'state-init',
+      payload: { items: [], playback: { i: 'item_a', c: 0.5, d: 5, b: 4 } },
+    });
+    const s = usePlaybackStore.getState();
+    expect(s.playingItemId).toBe('item_a');
+    expect(s.currentTime).toBe(0.5);
+  });
+
+  it('state-init without playback leaves the playback store at defaults', () => {
+    installSessionPortMirror();
+    const onMessage = connectedPort.onMessage.addListener.mock.calls[0][0];
+    onMessage({ type: 'state-init', payload: { items: [] } });
+    expect(usePlaybackStore.getState().playingItemId).toBeNull();
   });
 });

--- a/src/stores/sessionPortMirror.ts
+++ b/src/stores/sessionPortMirror.ts
@@ -171,7 +171,16 @@ function handle(msg: Inbound): void {
         msg.payload.turnDetectionMode,
       );
     }
-    if (msg.payload.playback) applyPlayback(msg.payload.playback);
+    // `playback: null` is the explicit "nothing playing" signal — we must
+    // clear stale state on port reconnect (a truthy-only check would skip it
+    // and leave the iframe stuck on a prior playingItemId).
+    if ('playback' in msg.payload) {
+      if (msg.payload.playback === null) {
+        usePlaybackStore.getState().setPlayingItem(null);
+      } else if (msg.payload.playback) {
+        applyPlayback(msg.payload.playback);
+      }
+    }
   } else if (msg.type === 'playback') {
     applyPlayback(msg);
   } else if (msg.type === 'items') {

--- a/src/stores/sessionPortMirror.ts
+++ b/src/stores/sessionPortMirror.ts
@@ -1,5 +1,6 @@
 import useSessionStore from './sessionStore';
 import useSettingsStore from './settingsStore';
+import { usePlaybackStore } from './playbackStore';
 
 declare const chrome: any;
 
@@ -17,6 +18,7 @@ interface InboundStateInit {
     sourceLanguage?: string;
     targetLanguage?: string;
     turnDetectionMode?: string;
+    playback?: { i: string | null; c?: number | null; d?: number; b?: number } | null;
   };
 }
 interface InboundItems {
@@ -36,7 +38,14 @@ interface InboundConfig {
   targetLanguage: string;
   turnDetectionMode?: string;
 }
-type Inbound = InboundStateInit | InboundItems | InboundSession | InboundConfig;
+interface InboundPlayback {
+  type: 'playback';
+  i: string | null;
+  c?: number | null;
+  d?: number;
+  b?: number;
+}
+type Inbound = InboundStateInit | InboundItems | InboundSession | InboundConfig | InboundPlayback;
 
 /**
  * Installs the iframe-side mirror that forwards sessionStore state from the
@@ -127,6 +136,24 @@ function applyConfig(provider: string, sourceLanguage: string, targetLanguage: s
   });
 }
 
+function applyPlayback(msg: { i: string | null; c?: number | null; d?: number; b?: number }): void {
+  const playback = usePlaybackStore.getState();
+  if (msg.i === null) {
+    playback.setPlayingItem(null);
+    return;
+  }
+  playback.setPlayingItem(msg.i);
+  if (msg.c === null || msg.c === undefined) {
+    playback.setProgress(null);
+    return;
+  }
+  playback.setProgress({
+    currentTime: msg.c,
+    duration: msg.d ?? 0,
+    bufferedTime: msg.b ?? 0,
+  });
+}
+
 function handle(msg: Inbound): void {
   if (!msg || typeof msg !== 'object') return;
   if (msg.type === 'state-init') {
@@ -144,6 +171,9 @@ function handle(msg: Inbound): void {
         msg.payload.turnDetectionMode,
       );
     }
+    if (msg.payload.playback) applyPlayback(msg.payload.playback);
+  } else if (msg.type === 'playback') {
+    applyPlayback(msg);
   } else if (msg.type === 'items') {
     useSessionStore.setState({
       items: msg.items,

--- a/src/styles/karaoke.scss
+++ b/src/styles/karaoke.scss
@@ -1,0 +1,4 @@
+.karaoke-played {
+  color: var(--karaoke-played-color, #10a37f);
+  transition: color 80ms ease-out;
+}


### PR DESCRIPTION
## Summary

- Lifts MainPanel's `playingItemId` / `playbackProgress` state into a shared `playbackStore` so subtitle mode can read the same playback signal MainPanel uses for the existing karaoke highlight
- Wires both Electron (in-process subscribe) and Extension (sidepanel→iframe `chrome.runtime.Port`) paths through identical state machines and a single `usePlaybackHighlight(item)` hook
- Compact subtitle band gets per-item karaoke split via a new `CompactSpan` subcomponent; expanded mode reuses the existing `ConversationRow` split via a `SubtitleConversationRow` wrapper

Closes #232.

Spec: `docs/superpowers/specs/2026-05-19-subtitle-karaoke-highlight-design.md`
Plan: `docs/superpowers/plans/2026-05-19-subtitle-karaoke-highlight.md`

## Architecture

- New `src/lib/playback/highlight.ts` — `getHighlightedChars` extracted as pure module
- New `src/stores/playbackStore.ts` — Zustand store with cumulative-time + monotonic-clamp state machine (lifted from MainPanel's useMemo blocks); exposes `setPlayingItem` / `setProgress` actions, `usePlaybackHighlight(item, textOverride?)` selector hook, and `subscribePlaybackForPort` / `getWirePlaybackSnapshot` helpers for the extension wire protocol
- New `src/styles/karaoke.scss` — single source of the `.karaoke-played` class
- `MainPanel.tsx` net ~150 lines deleted — local state + derivation moved to the store
- `SubtitleStream.tsx` — `CompactSpan` + `SubtitleConversationRow`
- `ExtensionContentScriptSubtitleSurface.ts` + `sessionPortMirror.ts` — port forwarding + iframe decode using compact `{type:'playback', i, c?, d?, b?}` wire format with 3-decimal rounding and per-field dedup

## Wire Protocol

```
{ type: 'playback', i: 'item_abc', c: 1.234, d: 5.679, b: 6.789 }   // active tick
{ type: 'playback', i: 'item_abc', c: null }                         // paused, item still selected
{ type: 'playback', i: null }                                        // nothing playing
```

Sustained bandwidth ≈ 800 B/s @ 10 Hz (under the 1 KB/s ceiling from #232 acceptance).

## Intentional Improvement

`setProgress(null)` now preserves the derived `currentTime` / `progressRatio` during chunk gaps. Previously, segment-based providers (with `audioSegments`) would briefly snap the highlight back to character 0 when the player's progress state went null between chunks. The new behavior holds the last position through the gap.

## Test plan

- [x] Unit tests: 728/728 pass (39+ new tests covering `playbackStore`, `usePlaybackHighlight`, `getHighlightedChars`, wire helpers, `sessionPortMirror` inbound, surface forwarding/dedup)
- [x] Manual: Electron app — assistant message karaoke advances correctly in MainPanel + compact subtitle + expanded subtitle
- [x] Manual: chunk-gap behavior — no flicker-to-zero on segment-based providers
- [ ] Manual (deferred): Extension overlay on meet.google.com — confirm karaoke renders for an iframe joining mid-playback
- [ ] Manual (deferred): bandwidth measurement during continuous playback < 1 KB/s

## Known Limitations (Out of Scope, Documented)

- Mid-playback port reconnect: iframe's `_maxProgress` resets, causing a single ≤100ms visual snap-back. Acceptable per spec.
- Word-level timing not added (current data is character-based).
- Speaker (user) message highlight not added (only assistant playback gets highlighted, matching existing MainPanel behavior).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Karaoke-style subtitle highlighting with smooth color transitions in both compact and expanded subtitle views, synchronized to playback across app and extension/iframe.

* **Documentation**
  * Added design and implementation plans with verification and acceptance checklist.

* **Refactor**
  * Centralized playback state and moved per-item highlight logic into a shared mechanism to reduce flicker and unify rendering.

* **Tests**
  * Expanded coverage for highlighting, playback state transitions, port forwarding, and inbound playback handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/240?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->