### PR TITLE
refactor(workers): share transformers/ORT/vad-web chunks across workers

### DIFF
--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -4,6 +4,7 @@ import { viteStaticCopy } from 'vite-plugin-static-copy'
 import path from 'path'
 import fs from 'fs'
 import pkg from '../package.json' with { type: 'json' }
+import { workerManualChunks } from '../vite.worker-chunks'
 
 /**
  * Rollup emits ort-wasm-*.wasm into assets/ because onnxruntime-web uses
@@ -129,19 +130,7 @@ export default defineConfig(({ mode }) => {
     worker: {
       format: 'es',
       rollupOptions: {
-        output: {
-          manualChunks(id) {
-            if (id.includes('node_modules/@huggingface/transformers')) {
-              return 'hf-transformers'
-            }
-            if (id.includes('node_modules/onnxruntime-web')) {
-              return 'onnxruntime-web'
-            }
-            if (id.includes('node_modules/@ricky0123/vad-web')) {
-              return 'vad-web'
-            }
-          },
-        },
+        output: { manualChunks: workerManualChunks },
       },
     },
     resolve: {

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -126,6 +126,24 @@ export default defineConfig(({ mode }) => {
         },
       },
     },
+    worker: {
+      format: 'es',
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules/@huggingface/transformers')) {
+              return 'hf-transformers'
+            }
+            if (id.includes('node_modules/onnxruntime-web')) {
+              return 'onnxruntime-web'
+            }
+            if (id.includes('node_modules/@ricky0123/vad-web')) {
+              return 'vad-web'
+            }
+          },
+        },
+      },
+    },
     resolve: {
       extensions: ['.js', '.jsx', '.ts', '.tsx'],
       alias: {

--- a/src/lib/local-inference/workers/_shared/onnxruntime-all.ts
+++ b/src/lib/local-inference/workers/_shared/onnxruntime-all.ts
@@ -1,0 +1,24 @@
+/**
+ * Barrel shim for onnxruntime-web — pins the import surface via a top-level
+ * side-effect so per-worker tree-shaking produces identical chunks.
+ *
+ * Vite bundles each worker as its own Rollup build, so manualChunks runs
+ * per-worker. Without this shim each worker tree-shakes a different subset
+ * of ORT, producing distinct chunks per consumer. The pin assignment below
+ * is a real side effect that references every binding via the namespace
+ * import, forcing them to be retained in every consumer's bundle.
+ *
+ * Bindings are re-exported directly from `onnxruntime-web` so they carry
+ * both value and type (classes live in both namespaces, e.g. consumers can
+ * use `InferenceSession.SessionOptions` as a namespace too).
+ */
+
+import * as ORT from 'onnxruntime-web';
+
+(self as { __ortPin?: unknown }).__ortPin = [
+  ORT.InferenceSession,
+  ORT.Tensor,
+  ORT.env,
+];
+
+export { InferenceSession, Tensor, env } from 'onnxruntime-web';

--- a/src/lib/local-inference/workers/_shared/transformers-all.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-all.ts
@@ -1,0 +1,55 @@
+/**
+ * Barrel shim for @huggingface/transformers — pins the full import surface
+ * so every worker bundles an identical chunk, allowing Vite to emit a single
+ * shared `hf-transformers-*.js` instead of one per worker.
+ *
+ * Vite bundles each worker as its own Rollup build, so manualChunks runs
+ * per-worker. Without this shim each worker tree-shakes a different subset
+ * of transformers (whisper needs AutomaticSpeechRecognitionPipeline, granite
+ * needs GraniteSpeechForConditionalGeneration, etc.), producing 7+ distinct
+ * chunks with overlapping content (~2.8 MB total).
+ *
+ * The pin assignment below is a real side effect that references every
+ * concrete class via the namespace import, forcing them to be retained in
+ * every consumer's bundle. Identical chunk content → identical content hash
+ * → Vite emits one file shared by all workers.
+ *
+ * Bindings are re-exported directly from `@huggingface/transformers` so they
+ * carry both value and type (classes live in both namespaces).
+ */
+
+import * as T from '@huggingface/transformers';
+
+(self as { __transformersPin?: unknown }).__transformersPin = [
+  T.pipeline,
+  T.env,
+  T.AutoProcessor,
+  T.TextStreamer,
+  T.BaseStreamer,
+  T.GraniteSpeechForConditionalGeneration,
+  T.VoxtralRealtimeForConditionalGeneration,
+  T.VoxtralRealtimeProcessor,
+  T.VoxtralForConditionalGeneration,
+  T.VoxtralProcessor,
+  T.Qwen3_5ForConditionalGeneration,
+];
+
+export {
+  pipeline,
+  env,
+  AutoProcessor,
+  TextStreamer,
+  BaseStreamer,
+  GraniteSpeechForConditionalGeneration,
+  VoxtralRealtimeForConditionalGeneration,
+  VoxtralRealtimeProcessor,
+  VoxtralForConditionalGeneration,
+  VoxtralProcessor,
+  Qwen3_5ForConditionalGeneration,
+} from '@huggingface/transformers';
+
+export type {
+  AutomaticSpeechRecognitionPipeline,
+  ProgressInfo,
+  TranslationPipeline,
+} from '@huggingface/transformers';

--- a/src/lib/local-inference/workers/_shared/transformers-all.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-all.ts
@@ -1,7 +1,14 @@
 /**
- * Barrel shim for @huggingface/transformers — pins the full import surface
- * so every worker bundles an identical chunk, allowing Vite to emit a single
- * shared `hf-transformers-*.js` instead of one per worker.
+ * Barrel shim for @huggingface/transformers — pins the worker-shared import
+ * surface so every worker bundles an identical chunk, allowing Vite to emit
+ * a single shared `hf-transformers-*.js` instead of one per worker.
+ *
+ * The surface listed below is the *union of what every transformers-using
+ * worker in this repo imports today*. It is not the complete transformers
+ * API. When adding a new worker that needs a class not yet listed here,
+ * add it to both the pin array and the `export { … }` block — otherwise
+ * that worker's tree-shake will diverge and Vite will emit a separate
+ * hf-transformers chunk for it.
  *
  * Vite bundles each worker as its own Rollup build, so manualChunks runs
  * per-worker. Without this shim each worker tree-shakes a different subset

--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -18,8 +18,8 @@ import {
   env,
   type AutomaticSpeechRecognitionPipeline,
   type ProgressInfo,
-} from '@huggingface/transformers';
-import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+} from './_shared/transformers-all';
+import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -17,8 +17,8 @@ import {
   GraniteSpeechForConditionalGeneration,
   TextStreamer,
   env,
-} from '@huggingface/transformers';
-import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+} from './_shared/transformers-all';
+import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 

--- a/src/lib/local-inference/workers/hy-mt-translation.worker.ts
+++ b/src/lib/local-inference/workers/hy-mt-translation.worker.ts
@@ -12,7 +12,7 @@
  * filler/native-name reinforcement designed for general-purpose LLMs.
  */
 
-import { pipeline, env } from '@huggingface/transformers';
+import { pipeline, env } from './_shared/transformers-all';
 
 // Disable WASM proxy (we're already in a worker).
 // wasmPaths is set in the init handler from the main thread's resolved URL.

--- a/src/lib/local-inference/workers/qwen-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen-translation.worker.ts
@@ -6,7 +6,7 @@
  * (same pattern as the Opus-MT translation worker).
  */
 
-import { pipeline, env } from '@huggingface/transformers';
+import { pipeline, env } from './_shared/transformers-all';
 import { buildDefaultLocalPrompt } from '../prompts';
 
 // Disable WASM proxy (we're already in a worker).

--- a/src/lib/local-inference/workers/qwen35-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen35-translation.worker.ts
@@ -11,7 +11,7 @@ import {
   Qwen3_5ForConditionalGeneration,
   TextStreamer,
   env,
-} from '@huggingface/transformers';
+} from './_shared/transformers-all';
 import { buildDefaultLocalPrompt } from '../prompts';
 
 // Disable WASM proxy (we're already in a worker).

--- a/src/lib/local-inference/workers/supertonic-tts.worker.ts
+++ b/src/lib/local-inference/workers/supertonic-tts.worker.ts
@@ -12,7 +12,7 @@
  * Output messages: TtsWorkerOutMessage (ready | status | result | error | disposed)
  */
 
-import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
 
 import type {
   SupertonicTtsInitMessage,

--- a/src/lib/local-inference/workers/translategemma-translation.worker.ts
+++ b/src/lib/local-inference/workers/translategemma-translation.worker.ts
@@ -10,7 +10,7 @@
  * the translation prompt.
  */
 
-import { pipeline, env } from '@huggingface/transformers';
+import { pipeline, env } from './_shared/transformers-all';
 
 // Disable WASM proxy (we're already in a worker).
 // wasmPaths is set in the init handler from the main thread's resolved URL.

--- a/src/lib/local-inference/workers/translation.worker.ts
+++ b/src/lib/local-inference/workers/translation.worker.ts
@@ -7,8 +7,7 @@
  * network requests to HuggingFace Hub.
  */
 
-import { pipeline, env } from '@huggingface/transformers';
-import type { TranslationPipeline } from '@huggingface/transformers';
+import { pipeline, env, type TranslationPipeline } from './_shared/transformers-all';
 
 // Disable WASM proxy (we're already in a worker).
 // wasmPaths is set in the init handler from the main thread's resolved URL.

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -23,8 +23,8 @@ import {
   TextStreamer,
   env,
   type ProgressInfo,
-} from '@huggingface/transformers';
-import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+} from './_shared/transformers-all';
+import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -19,8 +19,8 @@ import {
   VoxtralRealtimeProcessor,
   env,
   type ProgressInfo,
-} from '@huggingface/transformers';
-import { InferenceSession, Tensor, env as ortEnv } from 'onnxruntime-web';
+} from './_shared/transformers-all';
+import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -15,9 +15,9 @@
 import {
   pipeline,
   env,
-  AutomaticSpeechRecognitionPipeline,
-} from '@huggingface/transformers';
-import {InferenceSession, Tensor, env as ortEnv} from 'onnxruntime-web';
+  type AutomaticSpeechRecognitionPipeline,
+} from './_shared/transformers-all';
+import {InferenceSession, Tensor, env as ortEnv} from './_shared/onnxruntime-all';
 import {FrameProcessor, Message} from '@ricky0123/vad-web';
 import type {FrameProcessorEvent} from '@ricky0123/vad-web/dist/frame-processor';
 

--- a/src/lib/modern-audio/gtcrn/gtcrn-worker.ts
+++ b/src/lib/modern-audio/gtcrn/gtcrn-worker.ts
@@ -1,4 +1,4 @@
-import * as ort from 'onnxruntime-web';
+import { InferenceSession, Tensor, env as ortEnv } from '../../local-inference/workers/_shared/onnxruntime-all';
 import {
   GTCRN_SAMPLE_RATE,
   GTCRN_N_FFT,
@@ -16,13 +16,13 @@ import {
 // ORT WASM paths — set from main thread during init (relative paths don't work in workers)
 const INPUT_SAMPLE_RATE = 48000;
 
-let session: ort.InferenceSession | null = null;
+let session: InferenceSession | null = null;
 let win: Float32Array;
 
 // RNN state tensors (persist across frames)
-let convCache: ort.Tensor;
-let traCache: ort.Tensor;
-let interCache: ort.Tensor;
+let convCache: Tensor;
+let traCache: Tensor;
+let interCache: Tensor;
 
 // Ring buffer for accumulating input samples at 16kHz
 let inputBuffer: Float32Array = new Float32Array(0);
@@ -31,19 +31,19 @@ let inputBuffer: Float32Array = new Float32Array(0);
 let prevFrame: Float32Array = new Float32Array(GTCRN_N_FFT);
 
 function initStates(): void {
-  convCache = new ort.Tensor('float32', new Float32Array(2 * 1 * 16 * 16 * 33), [2, 1, 16, 16, 33]);
-  traCache = new ort.Tensor('float32', new Float32Array(2 * 3 * 1 * 1 * 16), [2, 3, 1, 1, 16]);
-  interCache = new ort.Tensor('float32', new Float32Array(2 * 1 * 33 * 16), [2, 1, 33, 16]);
+  convCache = new Tensor('float32', new Float32Array(2 * 1 * 16 * 16 * 33), [2, 1, 16, 16, 33]);
+  traCache = new Tensor('float32', new Float32Array(2 * 3 * 1 * 1 * 16), [2, 3, 1, 1, 16]);
+  interCache = new Tensor('float32', new Float32Array(2 * 1 * 33 * 16), [2, 1, 33, 16]);
   prevFrame = new Float32Array(GTCRN_N_FFT);
 }
 
 async function init(ortWasmBaseUrl: string, modelUrl: string): Promise<void> {
   try {
     // Set ORT WASM paths from main thread's resolved URL
-    ort.env.wasm.wasmPaths = ortWasmBaseUrl;
-    ort.env.wasm.proxy = false; // Already in a worker
+    ortEnv.wasm.wasmPaths = ortWasmBaseUrl;
+    ortEnv.wasm.proxy = false; // Already in a worker
 
-    session = await ort.InferenceSession.create(modelUrl, {
+    session = await InferenceSession.create(modelUrl, {
       executionProviders: ['wasm'],
       graphOptimizationLevel: 'all',
     });
@@ -66,9 +66,9 @@ async function processFrame(frameRe: Float32Array, frameIm: Float32Array): Promi
     mixData[i * 2] = frameRe[i];
     mixData[i * 2 + 1] = frameIm[i];
   }
-  const mixTensor = new ort.Tensor('float32', mixData, [1, GTCRN_FREQ_BINS, 1, 2]);
+  const mixTensor = new Tensor('float32', mixData, [1, GTCRN_FREQ_BINS, 1, 2]);
 
-  const feeds: Record<string, ort.Tensor> = {
+  const feeds: Record<string, Tensor> = {
     mix: mixTensor,
     conv_cache: convCache,
     tra_cache: traCache,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,7 @@ import electron from 'vite-plugin-electron/simple'
 import path from 'path'
 import fs from 'fs'
 import pkg from './package.json' with { type: 'json' }
+import { workerManualChunks } from './vite.worker-chunks'
 
 /**
  * Dev-only plugin: serve model-packs/tts/ files at /model-packs/tts/ URLs.
@@ -157,19 +158,7 @@ export default defineConfig(({ command, mode }) => {
     worker: {
       format: 'es',
       rollupOptions: {
-        output: {
-          manualChunks(id) {
-            if (id.includes('node_modules/@huggingface/transformers')) {
-              return 'hf-transformers'
-            }
-            if (id.includes('node_modules/onnxruntime-web')) {
-              return 'onnxruntime-web'
-            }
-            if (id.includes('node_modules/@ricky0123/vad-web')) {
-              return 'vad-web'
-            }
-          },
-        },
+        output: { manualChunks: workerManualChunks },
       },
     },
     base: './',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -154,6 +154,24 @@ export default defineConfig(({ command, mode }) => {
       assetsDir: 'static',
       sourcemap: true
     },
+    worker: {
+      format: 'es',
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules/@huggingface/transformers')) {
+              return 'hf-transformers'
+            }
+            if (id.includes('node_modules/onnxruntime-web')) {
+              return 'onnxruntime-web'
+            }
+            if (id.includes('node_modules/@ricky0123/vad-web')) {
+              return 'vad-web'
+            }
+          },
+        },
+      },
+    },
     base: './',
     define: {
       global: 'globalThis',

--- a/vite.worker-chunks.ts
+++ b/vite.worker-chunks.ts
@@ -1,0 +1,28 @@
+/**
+ * Manual-chunk strategy for Vite worker builds, shared by the Electron
+ * (root `vite.config.ts`) and browser-extension (`extension/vite.config.ts`)
+ * builds.
+ *
+ * Buckets `@huggingface/transformers`, `onnxruntime-web`, and
+ * `@ricky0123/vad-web` into named chunks so multiple workers in the same
+ * build can share them. Combined with the side-effect "pin" shims under
+ * `src/lib/local-inference/workers/_shared/`, this lets Vite deduplicate
+ * ~6 MB of transformer / ORT code across the 12 worker bundles.
+ *
+ * Path matching uses `[\\/]` so it works under both POSIX and Windows
+ * module IDs — on Windows Rollup hands us paths with backslashes, and a
+ * plain `includes('node_modules/…')` check silently misses, regressing
+ * Windows worker bundles to the un-shared layout.
+ */
+export function workerManualChunks(id: string): string | undefined {
+  if (/[\\/]node_modules[\\/]@huggingface[\\/]transformers[\\/]/.test(id)) {
+    return 'hf-transformers'
+  }
+  if (/[\\/]node_modules[\\/]onnxruntime-web[\\/]/.test(id)) {
+    return 'onnxruntime-web'
+  }
+  if (/[\\/]node_modules[\\/]@ricky0123[\\/]vad-web[\\/]/.test(id)) {
+    return 'vad-web'
+  }
+  return undefined
+}


### PR DESCRIPTION
## Summary

Configure Vite's worker build with `manualChunks` to extract `@huggingface/transformers`, `onnxruntime-web`, and `@ricky0123/vad-web` into named shared chunks across all 12 local-inference / audio workers, plus add barrel shims that force per-worker tree-shaking to produce identical chunks Vite can deduplicate on disk.

Related to but does not subsume #242 — that issue's source-side helper extraction (`hfRangeFix`, `vadDefaults`, `blobUrlCache`, `ortSetup`) is orthogonal and still worth doing on top.

## Bundle impact

| Build | Before | After | Reduction |
|---|---|---|---|
| Electron (`build/static/`) | 9.36 MB | **2.24 MB** | **−76.0 %** |
| Extension (`extension/dist/`) | 12.73 MB | **2.79 MB** | **−78.1 %** |

Chunk layout after this change:

- **5 ASR-WebGPU workers** (whisper, voxtral, voxtral-3b, cohere-transcribe, granite-speech) share one ~408 KB `hf-transformers-*.js` + one ~904 KB `onnxruntime-web-*.js` (full WebGPU build) + one ~22 KB `vad-web-*.js`.
- **5 transformers.js translation workers** (translation/opus-mt, qwen, qwen35, hy-mt, translategemma) share one ~408 KB `hf-transformers-*.js` + one ~112 KB `onnxruntime-web-*.js` (basic WASM only).
- **gtcrn + supertonic-tts** share one ~400 KB `onnxruntime-web-*.js` (basic WASM, no transformers).
- Worker stubs themselves are now 2–8 KB each.

There are still two `hf-transformers-*.js` chunks (one for ASR, one for translation) because they embed different ORT chunk URLs. Merging them would force translation workers to also load the 904 KB WebGPU ORT — net +4 MB, not worth it.

## How it works

1. `vite.config.ts` and `extension/vite.config.ts` get a `worker.rollupOptions.output.manualChunks` rule that buckets the three heavy node_modules into named chunks.

2. Two new barrel shims under `src/lib/local-inference/workers/_shared/`:
   - `transformers-all.ts` re-exports the 11 transformers classes any worker uses
   - `onnxruntime-all.ts` re-exports `InferenceSession`, `Tensor`, `env`

   Each shim has a top-level side effect — `(self as { __pin?: unknown }).__pin = [T.classA, T.classB, ...]` — that references every binding via the namespace import. Rollup cannot eliminate side effects, so every consumer's tree-shake retains the same set of bindings → identical chunk content → identical content hash → Vite emits one file shared across workers.

3. The 12 worker source files swap `from '@huggingface/transformers'` / `from 'onnxruntime-web'` for the shim paths.

## Why a side effect instead of `export const _pin = [...]`

A plain exported array that no consumer imports is dead-code-eliminated. The side-effect assignment to `self.__pin` is observable behavior the bundler must preserve, and because it references each class, those classes stay reachable.

## Test plan

- [x] `npx tsc --noEmit` — no new errors in `workers/`
- [x] `npm test` — 785/785 pass
- [x] `npm run build` — Electron build succeeds, expected chunk layout
- [x] `npm run extension:build` — extension build succeeds, expected chunk layout
- [ ] Manual smoke test: load Electron app, run one ASR model (e.g. Whisper WebGPU) end-to-end through Sokuji session
- [ ] Manual smoke test: load Electron app, run one translation model (e.g. Opus-MT) end-to-end
- [ ] Manual smoke test: load Electron app, run Supertonic TTS
- [ ] Manual smoke test: load Electron app with GTCRN noise suppression enabled, verify audio passthrough still works
- [ ] Manual smoke test: load browser extension, repeat the above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved web-worker bundling and dependency handling via shared entry points and targeted chunking for core ML/audio libraries, resulting in more consistent worker builds, faster model startup and loading, reduced memory/overhead, and more reliable cross-platform behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->