### PR TITLE
feat(subtitle): true fullscreen mode for subtitle presentation

### DIFF
--- a/docs/superpowers/plans/2026-05-27-subtitle-fullscreen.md
+++ b/docs/superpowers/plans/2026-05-27-subtitle-fullscreen.md
@@ -1,0 +1,772 @@
+# Subtitle True Fullscreen Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an Electron-only true-fullscreen toggle to subtitle mode (taskbar/dock hidden), driven by a visible subtitle-bar button, with layered ESC (fullscreen → windowed → exit).
+
+**Architecture:** A new `subtitle:set-fullscreen` IPC calls `BrowserWindow.setFullScreen()`. An ephemeral `subtitleFullscreen` flag in `settingsStore` is the single source of truth, applied live through a new `SubtitleSurface.setFullscreen()` method. The main process forwards OS fullscreen changes back so the flag stays in sync. The flag always resets to `false` on enter (start windowed) and exit.
+
+**Tech Stack:** Electron (main + preload IPC), React + TypeScript, Zustand, Vitest + jsdom, react-i18next, lucide-react.
+
+**Design doc:** `docs/superpowers/specs/2026-05-26-subtitle-fullscreen-design.md`
+
+---
+
+## File Structure
+
+**Main process (no unit tests; manual QA + verified by build):**
+- Modify `electron/subtitle-window.js` — add `subtitle:set-fullscreen` handler; force-exit fullscreen in `subtitle:exit`; forward `enter/leave-full-screen`; guard the bounds broadcaster against fullscreen geometry.
+- Modify `electron/preload.js` — whitelist the new invoke + receive channels.
+
+**Renderer:**
+- Modify `src/components/Subtitle/surfaces/SubtitleSurface.ts` — add `setFullscreen` to the interface.
+- Modify `src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts` — implement `setFullscreen` (IPC).
+- Modify `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts` — implement `setFullscreen` (no-op).
+- Modify `src/stores/settingsStore.ts` — `subtitleFullscreen` state, `setSubtitleFullscreen`, `__syncSubtitleFullscreen`, reset on enter/exit, selector hooks.
+- Modify `src/components/Subtitle/SubtitleBar.tsx` — Electron-only fullscreen toggle button.
+- Modify `src/components/Subtitle/SubtitleApp.tsx` — layered ESC + `subtitle:fullscreen-changed` sync effect.
+- Modify `src/locales/en/translation.json` — two new `subtitle.bar` keys.
+
+**Tests:**
+- Modify `src/stores/settingsStore.subtitle.test.ts` — fullscreen action tests.
+- Modify `src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts` — `setFullscreen` invokes IPC.
+- Create `src/components/Subtitle/SubtitleBar.test.tsx` — button render/toggle.
+
+**Build order rationale:** interface → surfaces (with tests) → store (with tests) → UI button (with test) → ESC/sync wiring → main process IPC → i18n. Each task is independently committable; the renderer compiles at every step because the IPC channels are referenced only through the surface, and the surface no-ops until the main handler exists.
+
+---
+
+## Task 1: Add `setFullscreen` to the surface interface + both implementations
+
+**Files:**
+- Modify: `src/components/Subtitle/surfaces/SubtitleSurface.ts`
+- Modify: `src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts`
+- Modify: `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts`
+- Test: `src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append this test inside the existing `describe('ElectronSubtitleSurface', …)` block in `ElectronSubtitleSurface.test.ts` (before its closing `});`):
+
+```ts
+  it('setFullscreen(true) invokes subtitle:set-fullscreen with true', async () => {
+    const surface = new ElectronSubtitleSurface();
+    await surface.setFullscreen(true);
+    expect(invoke).toHaveBeenCalledWith('subtitle:set-fullscreen', true);
+  });
+
+  it('setFullscreen(false) invokes subtitle:set-fullscreen with false', async () => {
+    const surface = new ElectronSubtitleSurface();
+    await surface.setFullscreen(false);
+    expect(invoke).toHaveBeenCalledWith('subtitle:set-fullscreen', false);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts`
+Expected: FAIL — `surface.setFullscreen is not a function`.
+
+- [ ] **Step 3: Add `setFullscreen` to the interface**
+
+In `src/components/Subtitle/surfaces/SubtitleSurface.ts`, replace the whole file with:
+
+```ts
+export interface SubtitleSurface {
+  /** Open subtitle mode. Must be called inside a user gesture. */
+  enter(): Promise<void>;
+  /** Exit subtitle mode. Idempotent. */
+  exit(): Promise<void>;
+  /**
+   * Toggle OS-level fullscreen for the subtitle surface. Electron-only;
+   * other surfaces implement this as a no-op.
+   */
+  setFullscreen(flag: boolean): Promise<void>;
+}
+```
+
+- [ ] **Step 4: Implement in `ElectronSubtitleSurface`**
+
+In `src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts`, add this method inside the class, after `exit()`:
+
+```ts
+  async setFullscreen(flag: boolean): Promise<void> {
+    await window.electron?.invoke('subtitle:set-fullscreen', flag);
+  }
+```
+
+- [ ] **Step 5: Implement no-op in `ExtensionContentScriptSubtitleSurface`**
+
+In `src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts`, add this method inside the class, after `exit()` (before the private `tearDown()`):
+
+```ts
+  // Fullscreen is an Electron-window concept; the extension overlay lives
+  // inside the host page and has no equivalent. No-op by design.
+  async setFullscreen(_flag: boolean): Promise<void> {
+    /* no-op */
+  }
+```
+
+- [ ] **Step 6: Update the `NoopSubtitleSurface` so it still satisfies the interface**
+
+In `src/components/Subtitle/surfaces/getSubtitleSurface.ts`, add a `setFullscreen` method to the `NoopSubtitleSurface` class, after its `exit()`:
+
+```ts
+  async setFullscreen(): Promise<void> { /* no-op */ }
+```
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `npm run test -- src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts`
+Expected: PASS (all, including the 2 new).
+Run: `npx tsc --noEmit`
+Expected: no errors (all three `SubtitleSurface` implementers now have `setFullscreen`).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/Subtitle/surfaces/SubtitleSurface.ts \
+        src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts \
+        src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts \
+        src/components/Subtitle/surfaces/getSubtitleSurface.ts \
+        src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts
+git commit -m "feat(subtitle): add setFullscreen to subtitle surface abstraction"
+```
+
+---
+
+## Task 2: Add `subtitleFullscreen` state + actions to `settingsStore`
+
+**Files:**
+- Modify: `src/stores/settingsStore.ts`
+- Test: `src/stores/settingsStore.subtitle.test.ts`
+
+Context: `getSubtitleSurface` is already imported at the top of `settingsStore.ts` (line 22). The state interface has `subtitleModeActive: boolean;` at line 407; actions `enterSubtitleMode`/`exitSubtitleMode`/`__notifySubtitleSurfaceExited` are declared at lines 417-425 and implemented at lines 913-953.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append these tests inside the existing `describe('settingsStore subtitle actions', …)` block in `settingsStore.subtitle.test.ts`, before its closing `});`:
+
+```ts
+  it('setSubtitleFullscreen(true) sets the flag and invokes subtitle:set-fullscreen', async () => {
+    const invokeMock = (window as any).electron.invoke;
+    invokeMock.mockClear();
+    await useSettingsStore.getState().setSubtitleFullscreen(true);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(true);
+    expect(invokeMock).toHaveBeenCalledWith('subtitle:set-fullscreen', true);
+  });
+
+  it('setSubtitleFullscreen rolls back the flag if the surface rejects', async () => {
+    const invokeMock = (window as any).electron.invoke;
+    invokeMock.mockImplementationOnce(async (channel: string) => {
+      if (channel === 'subtitle:set-fullscreen') throw new Error('boom');
+      return { ok: true };
+    });
+    await useSettingsStore.getState().setSubtitleFullscreen(true);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
+  it('enterSubtitleMode resets subtitleFullscreen to false (always start windowed)', async () => {
+    useSessionStore.setState({ isSessionActive: true } as any);
+    useSettingsStore.setState({ subtitleFullscreen: true });
+    await useSettingsStore.getState().enterSubtitleMode();
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
+  it('exitSubtitleMode resets subtitleFullscreen to false', async () => {
+    useSettingsStore.setState({ subtitleModeActive: true, subtitleFullscreen: true });
+    await useSettingsStore.getState().exitSubtitleMode();
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
+  it('__syncSubtitleFullscreen sets state only and does not call the surface', () => {
+    const invokeMock = (window as any).electron.invoke;
+    invokeMock.mockClear();
+    useSettingsStore.getState().__syncSubtitleFullscreen(true);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(true);
+    expect(invokeMock).not.toHaveBeenCalled();
+  });
+```
+
+Also reset the new flag in the block's existing `beforeEach` — change line 47 from:
+
+```ts
+    useSettingsStore.setState({ subtitleModeActive: false });
+```
+
+to:
+
+```ts
+    useSettingsStore.setState({ subtitleModeActive: false, subtitleFullscreen: false });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/stores/settingsStore.subtitle.test.ts`
+Expected: FAIL — `subtitleFullscreen` is `undefined` and `setSubtitleFullscreen`/`__syncSubtitleFullscreen` are not functions.
+
+- [ ] **Step 3: Declare the state + actions on the interface**
+
+In `src/stores/settingsStore.ts`, change the subtitle state line (407) from:
+
+```ts
+  // Subtitle runtime flag (lifecycle only — subtitle settings live in subtitleStore)
+  subtitleModeActive: boolean;
+```
+
+to:
+
+```ts
+  // Subtitle runtime flags (lifecycle only — subtitle settings live in subtitleStore)
+  subtitleModeActive: boolean;
+  // Ephemeral: true while subtitle mode is in OS fullscreen. Never persisted;
+  // always reset to false on enter (start windowed) and exit. Electron-only.
+  subtitleFullscreen: boolean;
+```
+
+Then add the action declarations directly after `exitSubtitleMode: () => Promise<void>;` (line 418):
+
+```ts
+  /** Toggle OS fullscreen for the active subtitle surface (Electron-only). */
+  setSubtitleFullscreen: (flag: boolean) => Promise<void>;
+  /**
+   * Internal: invoked when the OS fullscreen state changes outside of our
+   * setSubtitleFullscreen() call (app menu, F11, macOS gesture). Updates the
+   * flag only — does NOT re-invoke the surface, which would loop.
+   */
+  __syncSubtitleFullscreen: (flag: boolean) => void;
+```
+
+- [ ] **Step 4: Initialize the state default**
+
+Find the initial-state object that sets `subtitleModeActive: false` (line ~793) and add the new flag right after it:
+
+```ts
+    subtitleModeActive: false,
+    subtitleFullscreen: false,
+```
+
+- [ ] **Step 5: Implement the actions + reset on enter/exit**
+
+In `src/stores/settingsStore.ts`, in `enterSubtitleMode` (line 924), change:
+
+```ts
+      set({ subtitleModeActive: true });
+```
+
+to:
+
+```ts
+      set({ subtitleModeActive: true, subtitleFullscreen: false });
+```
+
+In `exitSubtitleMode` (line 943), change:
+
+```ts
+      set({ subtitleModeActive: false });
+```
+
+to:
+
+```ts
+      set({ subtitleModeActive: false, subtitleFullscreen: false });
+```
+
+Then add the two new actions immediately after the `__notifySubtitleSurfaceExited` action (after line 953):
+
+```ts
+    setSubtitleFullscreen: async (flag) => {
+      const previous = get().subtitleFullscreen;
+      if (previous === flag) return;
+      set({ subtitleFullscreen: flag });
+      try {
+        await getSubtitleSurface().setFullscreen(flag);
+      } catch (error) {
+        console.error('[SettingsStore] setSubtitleFullscreen failed:', error);
+        set({ subtitleFullscreen: previous });
+      }
+    },
+
+    __syncSubtitleFullscreen: (flag) => {
+      set({ subtitleFullscreen: flag });
+    },
+```
+
+- [ ] **Step 6: Add selector hooks**
+
+In the selector-hook cluster near the bottom of `settingsStore.ts` (around line 1620+), `useSubtitleModeActive` is at ~1625 and `useExitSubtitleMode` at ~1627. Add the two new hooks immediately after `useExitSubtitleMode`:
+
+```ts
+export const useSubtitleFullscreen = () =>
+  useSettingsStore((state) => state.subtitleFullscreen);
+export const useSetSubtitleFullscreen = () =>
+  useSettingsStore((state) => state.setSubtitleFullscreen);
+```
+
+- [ ] **Step 7: Run tests + typecheck**
+
+Run: `npm run test -- src/stores/settingsStore.subtitle.test.ts`
+Expected: PASS (existing + 5 new).
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/stores/settingsStore.ts src/stores/settingsStore.subtitle.test.ts
+git commit -m "feat(subtitle): add ephemeral subtitleFullscreen state and actions"
+```
+
+---
+
+## Task 3: Add the fullscreen toggle button to `SubtitleBar`
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleBar.tsx`
+- Modify: `src/locales/en/translation.json`
+- Test: `src/components/Subtitle/SubtitleBar.test.tsx` (create)
+
+Context: `SubtitleBar` renders an Electron-only `Pin` (always-on-top) button gated by `surface === 'electron'` at lines 178-188, followed by the `Lock` and `X` buttons. Icons are imported from `lucide-react` at the top (line 4-7).
+
+- [ ] **Step 1: Add the i18n strings**
+
+In `src/locales/en/translation.json`, inside `subtitle.bar`, add two keys (after `"alwaysOnTop"`):
+
+```json
+    "fullscreen": "Fullscreen",
+    "exitFullscreen": "Exit fullscreen",
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/components/Subtitle/SubtitleBar.test.tsx`:
+
+```tsx
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import SubtitleBar from './SubtitleBar';
+
+// i18n: return the default string passed to t(key, default).
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}));
+
+// The fullscreen flag + setter come from settingsStore.
+const setSubtitleFullscreen = vi.fn(async () => {});
+let fullscreenValue = false;
+vi.mock('../../stores/settingsStore', () => ({
+  __esModule: true,
+  default: { getState: () => ({}) },
+  useExitSubtitleMode: () => vi.fn(),
+  useSubtitleFullscreen: () => fullscreenValue,
+  useSetSubtitleFullscreen: () => setSubtitleFullscreen,
+}));
+
+// subtitleStore: provide the settings object + the action hooks SubtitleBar uses.
+vi.mock('../../stores/subtitleStore', () => ({
+  useSubtitleSettings: () => ({
+    fontSize: 24, compactMode: false, positionLocked: false, alwaysOnTop: false,
+  }),
+  useSetSubtitleFontSize: () => vi.fn(),
+  useSetSubtitleCompactMode: () => vi.fn(),
+  useToggleSubtitleAlwaysOnTop: () => vi.fn(),
+  useToggleSubtitlePositionLocked: () => vi.fn(),
+  useSubtitleSpeakerDisplayMode: () => 'both',
+  useSubtitleParticipantDisplayMode: () => 'both',
+  useSetSubtitleSpeakerDisplayMode: () => vi.fn(),
+  useSetSubtitleParticipantDisplayMode: () => vi.fn(),
+  FONT_SIZE_MIN: 12,
+  FONT_SIZE_MAX: 64,
+}));
+
+// Drag/resize hook is irrelevant here.
+vi.mock('./useOverlayDragResize', () => ({
+  useOverlayDragResize: () => ({ dragHandleProps: {}, resizeHandleProps: {} }),
+}));
+
+// Stub the child components so we only assert SubtitleBar's own controls and
+// don't pull conversationDisplayStore / ServiceFactory transitively.
+vi.mock('../MainPanel/DisplayModeButton', () => ({ default: () => null }));
+vi.mock('../MainPanel/ExportButton', () => ({ default: () => null }));
+vi.mock('../Display/DisplaySettingsPopover', () => ({ default: () => null }));
+
+const baseProps = {
+  sessionElapsedMs: 0,
+  sourceLanguageCode: 'EN',
+  targetLanguageCode: 'ZH',
+  onClearConversation: vi.fn(),
+  speakerActive: false,
+  participantActive: false,
+  exportProps: {} as any,
+};
+
+beforeEach(() => {
+  cleanup();
+  setSubtitleFullscreen.mockClear();
+  fullscreenValue = false;
+});
+
+describe('SubtitleBar fullscreen button', () => {
+  it('renders the fullscreen button on the electron surface', () => {
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('does NOT render the fullscreen button on the extension-overlay surface', () => {
+    render(<SubtitleBar {...baseProps} surface="extension-overlay" />);
+    expect(screen.queryByLabelText('Fullscreen')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Exit fullscreen')).not.toBeInTheDocument();
+  });
+
+  it('clicking the button enters fullscreen when currently windowed', () => {
+    fullscreenValue = false;
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    fireEvent.click(screen.getByLabelText('Fullscreen'));
+    expect(setSubtitleFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the exit-fullscreen affordance and exits when already fullscreen', () => {
+    fullscreenValue = true;
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    fireEvent.click(screen.getByLabelText('Exit fullscreen'));
+    expect(setSubtitleFullscreen).toHaveBeenCalledWith(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -- src/components/Subtitle/SubtitleBar.test.tsx`
+Expected: FAIL — `getByLabelText('Fullscreen')` finds nothing (button not implemented).
+
+- [ ] **Step 4: Import the icons + hooks**
+
+In `src/components/Subtitle/SubtitleBar.tsx`, add `Maximize, Minimize` to the existing `lucide-react` import (line 4-7). The block becomes:
+
+```tsx
+import {
+  AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown,
+  Pin, Lock, X, Settings, Trash2, Maximize, Minimize,
+} from 'lucide-react';
+```
+
+Add the settings-store hooks to the existing import from `../../stores/settingsStore` (currently `import { useExitSubtitleMode } from '../../stores/settingsStore';`):
+
+```tsx
+import {
+  useExitSubtitleMode,
+  useSubtitleFullscreen,
+  useSetSubtitleFullscreen,
+} from '../../stores/settingsStore';
+```
+
+- [ ] **Step 5: Read the hooks in the component body**
+
+In `SubtitleBar`, after `const exitSubtitleMode = useExitSubtitleMode();` (line 71), add:
+
+```tsx
+  const fullscreen = useSubtitleFullscreen();
+  const setFullscreen = useSetSubtitleFullscreen();
+```
+
+- [ ] **Step 6: Render the button (Electron-only), next to the Pin button**
+
+In `SubtitleBar.tsx`, find the Electron-only `Pin` button block (the `{surface === 'electron' && ( … <Pin size={14} /> … )}` at lines 178-188). Insert this new block immediately **before** that `{surface === 'electron' && (` line:
+
+```tsx
+        {surface === 'electron' && (
+          <button
+            type="button"
+            className={`subtitle-bar__btn ${fullscreen ? 'active' : ''}`}
+            onClick={() => void setFullscreen(!fullscreen)}
+            title={fullscreen
+              ? t('subtitle.bar.exitFullscreen', 'Exit fullscreen')
+              : t('subtitle.bar.fullscreen', 'Fullscreen')}
+            aria-label={fullscreen
+              ? t('subtitle.bar.exitFullscreen', 'Exit fullscreen')
+              : t('subtitle.bar.fullscreen', 'Fullscreen')}
+          >
+            {fullscreen ? <Minimize size={14} /> : <Maximize size={14} />}
+          </button>
+        )}
+```
+
+- [ ] **Step 7: Run test + typecheck**
+
+Run: `npm run test -- src/components/Subtitle/SubtitleBar.test.tsx`
+Expected: PASS (4 tests).
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleBar.tsx \
+        src/components/Subtitle/SubtitleBar.test.tsx \
+        src/locales/en/translation.json
+git commit -m "feat(subtitle): add fullscreen toggle button to subtitle bar"
+```
+
+---
+
+## Task 4: Layered ESC + OS-sync effect in `SubtitleApp`
+
+**Files:**
+- Modify: `src/components/Subtitle/SubtitleApp.tsx`
+
+Context: `SubtitleApp` currently has an ESC effect at lines 182-190 that always calls `requestExit()`. It already imports hooks from `settingsStore` (line 7-13) and computes `surface` from props. The root element ref (`rootRef`) is used to find the owner document for keyboard listeners.
+
+This task has no new unit test: the ESC layering and the IPC receive wiring depend on `window.electron` + a full component render that the existing `SubtitleApp.test.tsx` (pure-function only) doesn't set up, and the underlying branch logic (`setSubtitleFullscreen` vs `requestExit`) is already covered by the store tests in Task 2. It is verified by typecheck + the manual QA matrix.
+
+- [ ] **Step 1: Import the fullscreen hooks**
+
+In `src/components/Subtitle/SubtitleApp.tsx`, add to the existing `settingsStore` import (lines 7-13):
+
+```tsx
+  useSubtitleFullscreen,
+  useSetSubtitleFullscreen,
+```
+
+so the import reads (keep the other existing names):
+
+```tsx
+import useSettingsStore, {
+  useExitSubtitleMode,
+  useProvider,
+  useCurrentProviderSettings,
+  useLocalInferenceSettings,
+  useCurrentTurnDetectionMode,
+  useSubtitleFullscreen,
+  useSetSubtitleFullscreen,
+} from '../../stores/settingsStore';
+```
+
+- [ ] **Step 2: Read the hooks in the component body**
+
+Near the other hook calls at the top of `SubtitleApp` (after `const exitSubtitleMode = useExitSubtitleMode();`, line 82), add:
+
+```tsx
+  const fullscreen = useSubtitleFullscreen();
+  const setFullscreen = useSetSubtitleFullscreen();
+```
+
+- [ ] **Step 3: Make ESC layered**
+
+Replace the existing ESC effect (lines 182-190):
+
+```tsx
+  // ESC to exit subtitle mode
+  useEffect(() => {
+    const target = rootRef.current?.ownerDocument ?? document;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') requestExit();
+    };
+    target.addEventListener('keydown', onKey);
+    return () => target.removeEventListener('keydown', onKey);
+  }, [requestExit]);
+```
+
+with:
+
+```tsx
+  // ESC is layered: if we're in fullscreen, the first ESC drops back to the
+  // windowed bar; otherwise (or on the next ESC) it exits subtitle mode.
+  useEffect(() => {
+    const target = rootRef.current?.ownerDocument ?? document;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      if (fullscreen) {
+        void setFullscreen(false);
+      } else {
+        requestExit();
+      }
+    };
+    target.addEventListener('keydown', onKey);
+    return () => target.removeEventListener('keydown', onKey);
+  }, [requestExit, fullscreen, setFullscreen]);
+```
+
+- [ ] **Step 4: Sync OS-driven fullscreen changes back into the store (Electron only)**
+
+Add this effect immediately after the ESC effect:
+
+```tsx
+  // The OS fullscreen state can change outside our button (app menu, F11,
+  // macOS gesture). Mirror it into the store so the bar button + layered ESC
+  // stay correct. Electron surface only.
+  useEffect(() => {
+    if (surface !== 'electron') return;
+    if (!window.electron?.receive) return;
+    const handler = (flag: boolean) => {
+      useSettingsStore.getState().__syncSubtitleFullscreen(Boolean(flag));
+    };
+    window.electron.receive('subtitle:fullscreen-changed', handler);
+    return () => {
+      window.electron?.removeListener?.('subtitle:fullscreen-changed', handler);
+    };
+  }, [surface]);
+```
+
+- [ ] **Step 5: Typecheck + run the full subtitle test suite**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+Run: `npm run test -- src/components/Subtitle`
+Expected: PASS (existing SubtitleApp/SubtitleStream tests + the new SubtitleBar test).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Subtitle/SubtitleApp.tsx
+git commit -m "feat(subtitle): layered ESC and OS fullscreen sync in SubtitleApp"
+```
+
+---
+
+## Task 5: Main-process IPC — `subtitle:set-fullscreen`, exit cleanup, event forwarding, bounds guard
+
+**Files:**
+- Modify: `electron/subtitle-window.js`
+- Modify: `electron/preload.js`
+
+Context (`electron/subtitle-window.js`): `getLiveWindow()` returns the active window or null; `beginTransition()` sets a 600 ms blackout; the `subtitle:exit` handler is at lines 76-99; `setupSubtitleHandlers(mainWindow)` at lines 115-151 wires the resize/move broadcaster (`onChange`, which checks `transitionUntil`) and the `closed` handler. No unit tests for the main process — verified by `npm run build` (no syntax errors) + the manual QA matrix in Task 6.
+
+- [ ] **Step 1: Add the `subtitle:set-fullscreen` IPC handler**
+
+In `electron/subtitle-window.js`, add this handler immediately after the `subtitle:set-locked` handler (it ends at line 113, `});`):
+
+```js
+ipcMain.handle('subtitle:set-fullscreen', (_event, flag) => {
+  const win = getLiveWindow();
+  if (!win) return { ok: false };
+  // Suppress the resize/move broadcaster while the WM animates in/out of
+  // fullscreen, so the fullscreen geometry is never persisted as the bar's
+  // windowBounds. The isFullScreen() guard added to onChange backs this up.
+  beginTransition();
+  win.setFullScreen(Boolean(flag));
+  return { ok: true };
+});
+```
+
+- [ ] **Step 2: Force-exit fullscreen on `subtitle:exit` before restoring bounds**
+
+In the `subtitle:exit` handler, add the fullscreen reset right after the `if (!win) return { ok: false };` line (currently line 78) and before `const restore = …`:
+
+```js
+  // If the user exits subtitle mode while fullscreen, drop fullscreen first;
+  // otherwise setBounds() fights the fullscreen state and the window can be
+  // left stuck. Safe to call unconditionally, but guard to avoid a needless
+  // transition on the common (windowed) path.
+  if (win.isFullScreen()) win.setFullScreen(false);
+```
+
+- [ ] **Step 3: Forward OS fullscreen changes + guard the bounds broadcaster**
+
+In `setupSubtitleHandlers(mainWindow)`, locate the `onChange` function (the debounced broadcaster, lines 128-136). Add an `isFullScreen()` short-circuit as its first statement:
+
+```js
+  const onChange = () => {
+    if (mainWindow.isFullScreen()) return; // never persist fullscreen geometry as bar bounds
+    if (Date.now() < transitionUntil) return;
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      if (!mainWindow.isDestroyed() && Date.now() >= transitionUntil) {
+        mainWindow.webContents.send('subtitle:window-bounds-changed', mainWindow.getBounds());
+      }
+    }, 200);
+  };
+```
+
+Then, immediately after the existing `mainWindow.on('resize', onChange);` / `mainWindow.on('move', onChange);` lines (137-138), add the fullscreen-event forwarders:
+
+```js
+  const onFullScreen = () =>
+    mainWindow.webContents.send('subtitle:fullscreen-changed', true);
+  const onLeaveFullScreen = () =>
+    mainWindow.webContents.send('subtitle:fullscreen-changed', false);
+  mainWindow.on('enter-full-screen', onFullScreen);
+  mainWindow.on('leave-full-screen', onLeaveFullScreen);
+```
+
+- [ ] **Step 4: Whitelist the new invoke channel in preload**
+
+In `electron/preload.js`, in the `invoke` `validChannels` array, add `'subtitle:set-fullscreen'` to the Subtitle mode IPC group (after `'subtitle:set-locked'`, line 141):
+
+```js
+        'subtitle:set-always-on-top',
+        'subtitle:set-locked',
+        'subtitle:set-fullscreen',
+        'subtitle:get-screen-bounds',
+```
+
+- [ ] **Step 5: Whitelist the new receive channel in preload**
+
+In `electron/preload.js`, in `validReceiveChannels` (lines 57-65), add `'subtitle:fullscreen-changed'` after `'subtitle:window-bounds-changed'`:
+
+```js
+  // Subtitle window bounds change events
+  'subtitle:window-bounds-changed',
+  'subtitle:fullscreen-changed',
+```
+
+- [ ] **Step 6: Build to verify no syntax errors**
+
+Run: `npm run build`
+Expected: build succeeds (Vite builds the renderer; the Electron JS is plain CommonJS — confirm no syntax error by `node --check`):
+Run: `node --check electron/subtitle-window.js && node --check electron/preload.js`
+Expected: no output (both parse cleanly).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add electron/subtitle-window.js electron/preload.js
+git commit -m "feat(subtitle): add subtitle:set-fullscreen IPC and fullscreen event sync"
+```
+
+---
+
+## Task 6: Full verification + manual QA
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Run the whole test suite**
+
+Run: `npm run test`
+Expected: PASS (no regressions; new tests from Tasks 1-3 green).
+
+- [ ] **Step 2: Typecheck the project**
+
+Run: `npx tsc --noEmit`
+Expected: no errors.
+
+- [ ] **Step 3: Manual QA in the Electron app**
+
+Run: `npm run electron:dev`
+
+Verify (repeat the bullets on Linux, then Windows, then macOS where available):
+- [ ] Start a session, enter subtitle mode → it opens **windowed** (bar at bottom), not fullscreen.
+- [ ] Click the new ⤢ button → window goes **true fullscreen**, taskbar/dock hidden; the bar auto-hides ~1.5 s after the mouse leaves, leaving only captions.
+- [ ] Move the mouse → bar reappears; the button now shows the Minimize icon / "Exit fullscreen" label.
+- [ ] Click ⤢ again (or press **ESC**) → returns to the **windowed bar** at its previous size/position (does NOT exit subtitle mode).
+- [ ] Press **ESC** again from windowed → exits subtitle mode back to the normal app window.
+- [ ] Enter subtitle mode → fullscreen → press the bar's **✕** → exits cleanly to the normal window (not stuck fullscreen, correct pre-subtitle size).
+- [ ] Resize the windowed bar, exit and re-enter subtitle mode → the bar keeps your resized geometry (a fullscreen round-trip did NOT overwrite `windowBounds`).
+- [ ] (If reachable) Trigger OS fullscreen via the app menu / F11 / macOS gesture while in subtitle mode → the bar button label and ESC behavior stay correct.
+- [ ] macOS only: compare `win.setFullScreen(true)` vs `win.setSimpleFullScreen(true)` — if the native-Space animation is jarring or fights always-on-top, switch the `subtitle:set-fullscreen` handler to `setSimpleFullScreen` on `process.platform === 'darwin'` and re-verify.
+
+- [ ] **Step 4: Commit any QA-driven fix (e.g. macOS simpleFullScreen)**
+
+If a fix was needed:
+
+```bash
+git add electron/subtitle-window.js
+git commit -m "fix(subtitle): use setSimpleFullScreen on macOS for in-place fullscreen"
+```
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** every spec section maps to a task — surface method (T1), settingsStore flag/actions/reset/hooks (T2), bar button + i18n (T3), layered ESC + OS-sync effect (T4), main IPC + exit cleanup + event forwarding + bounds guard + preload whitelists (T5), test matrix incl. manual QA (T1-T3 unit, T6 manual). Non-goals (extension fullscreen, persistence, F11 entry, kiosk) are respected: extension surface no-ops (T1), flag is ephemeral and reset on enter/exit (T2), toggle is button + ESC only with OS-sync tolerance (T4).
+- **Type consistency:** `setFullscreen(flag: boolean): Promise<void>` is identical across the interface and all implementers; `setSubtitleFullscreen`/`__syncSubtitleFullscreen` and the hooks `useSubtitleFullscreen`/`useSetSubtitleFullscreen` are named identically wherever referenced; IPC channels `subtitle:set-fullscreen` (invoke) and `subtitle:fullscreen-changed` (receive) match across preload, main, surface, and SubtitleApp.
+- **Placeholder scan:** no TBD/TODO; every code step shows complete code; the macOS `setSimpleFullScreen` choice is a bounded, optional QA-driven refinement (T6 Step 3/4), not a placeholder.

--- a/docs/superpowers/specs/2026-05-26-subtitle-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-05-26-subtitle-fullscreen-design.md
@@ -1,0 +1,148 @@
+# Subtitle — True Fullscreen Mode
+
+**Date:** 2026-05-26
+**Status:** Design approved, ready for implementation plan
+**Scope:** Electron desktop only
+
+## Problem
+
+Subtitle mode is meant for projecting live captions onto a big screen during classes, training sessions, and speaking contests. Today a user can get close to a clean presentation:
+
+1. Enter subtitle mode (the captions button in the title bar).
+2. Adjust font size (`A− / A+`) and background/opacity/text colors (the gear popover).
+3. Double-click the subtitle bar's drag region — the OS **maximizes** the frameless window so the captions fill the screen.
+4. Move the mouse away — the control bar auto-hides after ~1.5 s, leaving only the source/translated text.
+
+The gap: step 3 is **window maximize**, not true fullscreen. The window fills the work area, but the **OS taskbar/dock at the bottom is still visible**, so the result isn't a fully immersive, distraction-free projection. The maximize gesture is also an undiscoverable OS behavior (double-clicking a drag region), which is why users don't realize a near-fullscreen presentation is already possible.
+
+This feature adds a real, taskbar-free fullscreen toggle to subtitle mode.
+
+## Goals & Non-Goals
+
+**Goals**
+- Add a one-click **true fullscreen** toggle to subtitle mode that hides the taskbar/dock entirely (`BrowserWindow.setFullScreen`).
+- Make it discoverable: a visible button in the subtitle bar, alongside the existing Pin / Lock controls.
+- Layered exit that protects a live class: in fullscreen, ESC returns to the windowed bar; only a second ESC (from windowed) exits subtitle mode.
+- Fullscreen is an intentional, in-the-moment action: entering subtitle mode always starts windowed.
+- Keep the saved subtitle bar geometry (`windowBounds`) intact across a fullscreen round-trip.
+
+**Non-Goals**
+- The browser extension overlay. "Fullscreen" there is a fundamentally different mechanism (the Web Fullscreen API on the host tab, user-gesture constraints) and is out of scope. The extension surface keeps its current behavior; the fullscreen button is not rendered there.
+- Persisting the fullscreen state across subtitle sessions. It is ephemeral by design (see "always start windowed").
+- A second keybinding (e.g. F11). Toggle is the bar button; exit is ESC. F11/menu-driven toggles are still *tolerated* and synced (see edge cases) but not a designed entry point.
+- Changing the existing double-click-to-maximize behavior, font/color controls, auto-hide bar, or the windowed bar geometry.
+- Kiosk mode (`setKiosk`). Too locked-down for a classroom toggle and easy to trap a non-technical user.
+
+## Background — how subtitle mode works today
+
+- Subtitle mode **reuses the main `BrowserWindow`**. `electron/subtitle-window.js` handles `subtitle:enter` by snapshotting the current ("normal") bounds, then resizing the window to a bar (80% width × 200 px, bottom-center), setting always-on-top / resizable, and hiding the macOS traffic lights. `subtitle:exit` restores the snapshot.
+- Existing subtitle IPC: `subtitle:enter`, `subtitle:exit`, `subtitle:set-always-on-top`, `subtitle:set-locked`, `subtitle:get-screen-bounds`, plus the `subtitle:window-bounds-changed` event (renderer ← main).
+- A resize/move broadcaster persists the user's bar geometry as `windowBounds`. It is guarded by a `TRANSITION_BLACKOUT_MS = 600` window (`beginTransition()`) so WM-settling intermediate sizes aren't saved.
+- **Note discovered during design:** `subtitle:set-always-on-top` / `subtitle:set-locked` are registered in the main process and whitelisted in preload, but **no renderer code currently invokes them** — `alwaysOnTop` / `positionLocked` are applied only at `subtitle:enter` via the payload. There is therefore no existing "live-apply mid-session" path to copy; fullscreen introduces the first one.
+- The subtitle surface abstraction (`SubtitleSurface { enter(); exit() }`) has two implementations selected by `getSubtitleSurface()`: `ElectronSubtitleSurface` and `ExtensionContentScriptSubtitleSurface`.
+- Persisted subtitle preferences live in `subtitleStore` (colors, font size, `alwaysOnTop`, `positionLocked`, `windowBounds`). Subtitle **session/lifecycle** state (`subtitleModeActive`, enter/exit orchestration) lives in `settingsStore`.
+
+## Design
+
+### Where the fullscreen flag lives
+
+An ephemeral `subtitleFullscreen: boolean` in **`settingsStore`**, next to `subtitleModeActive` — **not** in `subtitleStore`.
+
+Rationale:
+- It is session/lifecycle state, not a persisted preference (contrast with colors / alwaysOnTop, which persist).
+- `settingsStore` already owns the subtitle lifecycle and imports `getSubtitleSurface()`, so the live-apply call has a natural, cycle-free home. (`subtitleStore` is imported *by* `ElectronSubtitleSurface`, so having `subtitleStore` reach back to the surface would create an import cycle.)
+- It must reset to `false` on every `enterSubtitleMode` — the "always start windowed" requirement.
+
+### Components & responsibilities
+
+1. **`electron/subtitle-window.js`** — the real mechanism
+   - New `ipcMain.handle('subtitle:set-fullscreen', (_event, flag) => …)`: resolve the live window (`getLiveWindow()`); if none, return `{ ok: false }` (same contract as the other handlers); else `beginTransition()` then `win.setFullScreen(Boolean(flag))`, return `{ ok: true }`.
+   - `subtitle:exit`: if `win.isFullScreen()`, call `win.setFullScreen(false)` **before** restoring the bounds snapshot, so exit never leaves a "normal-size window stuck in a fullscreen Space" state.
+   - `setupSubtitleHandlers(mainWindow)`: forward `mainWindow.on('enter-full-screen' | 'leave-full-screen')` to the renderer as `subtitle:fullscreen-changed(boolean)`; and add `if (mainWindow.isFullScreen()) return;` at the top of the bounds-changed broadcaster (`onChange`) so a fullscreen-sized geometry is never persisted as the bar's `windowBounds`.
+
+2. **`electron/preload.js`** — whitelist `subtitle:set-fullscreen` (invoke) and `subtitle:fullscreen-changed` (receive).
+
+3. **`src/components/Subtitle/surfaces/SubtitleSurface.ts`** — add `setFullscreen(flag: boolean): Promise<void>`.
+   - `ElectronSubtitleSurface.setFullscreen` → `window.electron?.invoke('subtitle:set-fullscreen', flag)`.
+   - `ExtensionContentScriptSubtitleSurface.setFullscreen` → no-op (Electron-only scope).
+
+4. **`src/stores/settingsStore.ts`**
+   - State: `subtitleFullscreen: boolean` (ephemeral, default `false`).
+   - `setSubtitleFullscreen(flag)`: optimistic `set({ subtitleFullscreen: flag })`, then `await getSubtitleSurface().setFullscreen(flag)`; revert the flag on rejection.
+   - `__syncSubtitleFullscreen(flag)`: state-only setter for the OS-driven `subtitle:fullscreen-changed` event — **does not** call the surface (prevents an IPC feedback loop).
+   - Reset `subtitleFullscreen = false` in **both** `enterSubtitleMode` (start windowed) and `exitSubtitleMode` (clean teardown).
+   - Selector hooks: `useSubtitleFullscreen`, `useSetSubtitleFullscreen`.
+
+5. **`src/components/Subtitle/SubtitleBar.tsx`** — an Electron-only Maximize/Minimize toggle button beside the Pin/Lock buttons (gated on `surface === 'electron'`). Reads `useSubtitleFullscreen`; `onClick` → `setSubtitleFullscreen(!current)`; icon and `aria-label` reflect enter-vs-exit.
+
+6. **`src/components/Subtitle/SubtitleApp.tsx`**
+   - Layered ESC: if `subtitleFullscreen` → `setSubtitleFullscreen(false)`; else → `requestExit()` (today's behavior).
+   - Electron-surface effect: subscribe to `subtitle:fullscreen-changed` → `__syncSubtitleFullscreen(flag)`; clean up on unmount.
+
+7. **i18n** — `subtitle.bar.fullscreen` / `subtitle.bar.exitFullscreen` in `en/translation.json`. English fallback covers the other locales (existing convention).
+
+### State machine (within an active subtitle session)
+
+```
+                 ┌─────────────────────── ESC ◄─────────────────────┐
+                 ▼                                                   │
+        ┌──────────────────┐  ⤢ button / setFullscreen(true)   ┌──────────────────┐
+        │  WINDOWED bar    │ ───────────────────────────────►  │   FULLSCREEN     │
+        │ (80%×200 bottom) │ ◄───────────────────────────────  │ (setFullScreen)  │
+        └──────────────────┘  ⤢ button / ESC / setFullscreen(false) └─────────────┘
+                 │ ESC (windowed)                                       │
+                 ▼                                                      │
+        ┌──────────────────┐                                           │
+        │ subtitle EXITED   │ ◄── exit always forces setFullScreen(false)
+        │ (normal window)   │
+        └──────────────────┘
+```
+
+- Enter subtitle mode → always **WINDOWED** (`subtitleFullscreen` reset on enter).
+- **⤢ button** toggles WINDOWED ⇄ FULLSCREEN.
+- **ESC**: FULLSCREEN → WINDOWED; WINDOWED → EXITED.
+- **✕ / exit** from any state → EXITED; `subtitle:exit` forces `setFullScreen(false)` first, then restores pre-subtitle bounds.
+
+### Data flow — entering fullscreen (button click)
+
+1. `SubtitleBar` ⤢ click → `setSubtitleFullscreen(true)`.
+2. Store optimistically sets `subtitleFullscreen = true`, then `await getSubtitleSurface().setFullscreen(true)`.
+3. `ElectronSubtitleSurface` → `invoke('subtitle:set-fullscreen', true)`.
+4. Main: `beginTransition()` → `win.setFullScreen(true)`. The 600 ms blackout + `isFullScreen()` guard prevent the fullscreen geometry from being persisted as the bar bounds.
+5. Window emits `enter-full-screen` → main sends `subtitle:fullscreen-changed(true)` → `SubtitleApp` effect → `__syncSubtitleFullscreen(true)` (state-only; idempotent here).
+6. Auto-hide bar fades after ~1.5 s → only captions on the chosen background fill the screen; taskbar/dock gone.
+
+Exiting fullscreen runs the same path with `false`; Electron restores the previous (bar) bounds; `leave-full-screen` keeps the button state correct.
+
+### Edge cases
+
+- **OS-initiated fullscreen toggle** (app menu `togglefullscreen`, macOS gesture, F11): caught by `enter/leave-full-screen` → `__syncSubtitleFullscreen` keeps the flag and button label correct, without re-invoking the IPC (no loop).
+- **Exit subtitle mode while fullscreen** (✕ or second ESC): `subtitle:exit` forces `setFullScreen(false)` before restoring bounds — no stuck state.
+- **Bounds persistence**: `beginTransition()` on every toggle + `if (isFullScreen()) return;` in the broadcaster guarantee `windowBounds` keeps the bar geometry, never fullscreen geometry.
+- **Window recreated / `activeWindow` null** (macOS dock-close/reopen): `set-fullscreen` returns `{ ok: false }`; the optimistic store update reverts.
+- **macOS**: `setFullScreen(true)` uses a native Space with animation. Evaluate `setSimpleFullScreen(true)` as a macOS refinement (instant, in-place, plays nicer with always-on-top) during implementation/QA; baseline is `setFullScreen` cross-platform.
+- **always-on-top / lock / resize while fullscreen**: moot (OS owns the window); buttons remain but have no harmful effect. No special handling.
+- **Extension surface**: `setFullscreen` is a no-op and the ⤢ button isn't rendered, so nothing changes there.
+
+## Testing
+
+Renderer/unit tests (Vitest + jsdom, colocated `*.test.tsx`); the main-process IPC is verified by manual QA. Mock `window.electron` and the surface.
+
+1. **`settingsStore`**
+   - `setSubtitleFullscreen(true)` sets the flag and calls `surface.setFullscreen(true)`.
+   - On surface rejection, the flag reverts.
+   - `enterSubtitleMode` and `exitSubtitleMode` both reset `subtitleFullscreen` to `false`.
+   - `__syncSubtitleFullscreen(flag)` sets state only; does not call the surface.
+
+2. **`SubtitleBar`**
+   - ⤢ button renders only when `surface === 'electron'` (absent for `extension-overlay`).
+   - Click toggles via `setSubtitleFullscreen(!current)`; icon/`aria-label` reflect Maximize vs Minimize.
+
+3. **`SubtitleApp`**
+   - ESC with `subtitleFullscreen=true` → `setSubtitleFullscreen(false)`, does not exit subtitle mode.
+   - ESC while windowed → `requestExit()` (unchanged).
+   - `subtitle:fullscreen-changed` event drives `__syncSubtitleFullscreen`.
+
+4. **`ElectronSubtitleSurface`** — `setFullscreen(flag)` invokes `'subtitle:set-fullscreen'` with the flag; the extension surface's `setFullscreen` is a no-op.
+
+**Manual QA matrix** (Linux / Windows / macOS): enter/exit fullscreen via the button; ESC layering (FULLSCREEN → WINDOWED → EXITED); exit-from-fullscreen via ✕; confirm the taskbar/dock is hidden in fullscreen; confirm the bar returns to its prior size/position on exit; confirm `windowBounds` is unchanged after a fullscreen round-trip. macOS: compare `setFullScreen` vs `setSimpleFullScreen`.

--- a/docs/superpowers/specs/2026-05-26-subtitle-fullscreen-design.md
+++ b/docs/superpowers/specs/2026-05-26-subtitle-fullscreen-design.md
@@ -83,7 +83,7 @@ Rationale:
 
 ### State machine (within an active subtitle session)
 
-```
+```text
                  ┌─────────────────────── ESC ◄─────────────────────┐
                  ▼                                                   │
         ┌──────────────────┐  ⤢ button / setFullscreen(true)   ┌──────────────────┐

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -62,6 +62,7 @@ const validReceiveChannels = [
   'update-progress',
   // Subtitle window bounds change events
   'subtitle:window-bounds-changed',
+  'subtitle:fullscreen-changed',
 ];
 
 // Expose protected methods that allow the renderer process to use
@@ -139,6 +140,7 @@ contextBridge.exposeInMainWorld(
         'subtitle:exit',
         'subtitle:set-always-on-top',
         'subtitle:set-locked',
+        'subtitle:set-fullscreen',
         'subtitle:get-screen-bounds',
       ];
       if (validChannels.includes(channel)) {

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -79,11 +79,16 @@ ipcMain.handle('subtitle:exit', (_event, payload) => {
   // If the user exits subtitle mode while fullscreen, drop fullscreen first;
   // otherwise setBounds() fights the fullscreen state and the window can be
   // left stuck. Guarded to avoid a needless transition on the common path.
-  // macOS caveat: setFullScreen(false) animates asynchronously, so the
-  // synchronous setBounds() below can land before the Space transition ends
-  // and be overridden. If macOS QA shows wrong bounds on this exit path,
-  // switch the darwin fullscreen calls to setSimpleFullScreen (synchronous,
-  // in-place) — see the design doc's macOS note and Task 6 QA.
+  //
+  // KNOWN, ACCEPTED limitation (macOS): setFullScreen(false) animates
+  // asynchronously, so the synchronous setBounds() below can land before the
+  // Space transition finishes, leaving the window slightly mis-sized when
+  // exiting subtitle mode DIRECTLY from fullscreen via the ✕ button. The
+  // layered-ESC path (fullscreen → windowed → exit) is unaffected. We keep
+  // native setFullScreen (not setSimpleFullScreen) because it emits
+  // enter/leave-full-screen, which the subtitle:fullscreen-changed sync relies
+  // on. If revisited, defer setBounds to the leave-full-screen event rather
+  // than switching fullscreen modes.
   if (win.isFullScreen()) win.setFullScreen(false);
   const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
   beginTransition();
@@ -146,6 +151,9 @@ function setupSubtitleHandlers(mainWindow) {
   // user's intended bounds.
   let debounceTimer = null;
   const onChange = () => {
+    // resize/move can fire synchronously during window teardown; isFullScreen()
+    // throws on a destroyed window, so bail before touching it.
+    if (mainWindow.isDestroyed()) return;
     if (mainWindow.isFullScreen()) return; // never persist fullscreen geometry as bar bounds
     if (Date.now() < transitionUntil) return;
     if (debounceTimer) clearTimeout(debounceTimer);

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -76,6 +76,15 @@ ipcMain.handle('subtitle:enter', (_event, payload) => {
 ipcMain.handle('subtitle:exit', (_event, payload) => {
   const win = getLiveWindow();
   if (!win) return { ok: false };
+  // If the user exits subtitle mode while fullscreen, drop fullscreen first;
+  // otherwise setBounds() fights the fullscreen state and the window can be
+  // left stuck. Guarded to avoid a needless transition on the common path.
+  // macOS caveat: setFullScreen(false) animates asynchronously, so the
+  // synchronous setBounds() below can land before the Space transition ends
+  // and be overridden. If macOS QA shows wrong bounds on this exit path,
+  // switch the darwin fullscreen calls to setSimpleFullScreen (synchronous,
+  // in-place) — see the design doc's macOS note and Task 6 QA.
+  if (win.isFullScreen()) win.setFullScreen(false);
   const restore = payload?.restoreBounds ?? normalBoundsSnapshot ?? { width: 1200, height: 800 };
   beginTransition();
   if (restore.x !== undefined && restore.y !== undefined) {
@@ -112,6 +121,17 @@ ipcMain.handle('subtitle:set-locked', (_event, locked) => {
   return { ok: true };
 });
 
+ipcMain.handle('subtitle:set-fullscreen', (_event, flag) => {
+  const win = getLiveWindow();
+  if (!win) return { ok: false };
+  // Suppress the resize/move broadcaster while the WM animates in/out of
+  // fullscreen, so the fullscreen geometry is never persisted as the bar's
+  // windowBounds. The isFullScreen() guard added to onChange backs this up.
+  beginTransition();
+  win.setFullScreen(Boolean(flag));
+  return { ok: true };
+});
+
 function setupSubtitleHandlers(mainWindow) {
   // Rebind the active window. Resize/move listeners are per-window and need
   // to be attached on every createWindow() call.
@@ -126,6 +146,7 @@ function setupSubtitleHandlers(mainWindow) {
   // user's intended bounds.
   let debounceTimer = null;
   const onChange = () => {
+    if (mainWindow.isFullScreen()) return; // never persist fullscreen geometry as bar bounds
     if (Date.now() < transitionUntil) return;
     if (debounceTimer) clearTimeout(debounceTimer);
     debounceTimer = setTimeout(() => {
@@ -136,6 +157,12 @@ function setupSubtitleHandlers(mainWindow) {
   };
   mainWindow.on('resize', onChange);
   mainWindow.on('move', onChange);
+  const onEnterFullScreen = () =>
+    mainWindow.webContents.send('subtitle:fullscreen-changed', true);
+  const onLeaveFullScreen = () =>
+    mainWindow.webContents.send('subtitle:fullscreen-changed', false);
+  mainWindow.on('enter-full-screen', onEnterFullScreen);
+  mainWindow.on('leave-full-screen', onLeaveFullScreen);
   mainWindow.on('closed', () => {
     if (debounceTimer) {
       clearTimeout(debounceTimer);

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -10,6 +10,12 @@
   // Positioning context for the SubtitleBar, which floats above the
   // subtitle area so the bar's footprint isn't permanently reserved.
   position: relative;
+
+  // In fullscreen the window fills the screen, so the rounded corners would
+  // expose the transparent window (the desktop) behind them. Square them.
+  &.fullscreen {
+    border-radius: 0;
+  }
 }
 
 // Resize affordance for the extension-overlay surface — 4 corners + 4

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -176,6 +176,11 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
     if (hideTimer.current) clearTimeout(hideTimer.current);
     hideTimer.current = setTimeout(() => setBarVisible(false), AUTO_HIDE_MS);
   };
+  // Clear the pending auto-hide timer on unmount so it can't fire after the
+  // component is gone (movement-based revealBar arms one frequently).
+  useEffect(() => () => {
+    if (hideTimer.current) clearTimeout(hideTimer.current);
+  }, []);
 
   // Centralised exit request. In the extension-overlay surface we don't have
   // direct access to the side panel's settingsStore.exitSubtitleMode; instead

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -162,10 +162,16 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
   // Auto-hide bar
   const [barVisible, setBarVisible] = useState(true);
   const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const onMouseEnter = () => {
+  // Reveal the bar and (re)arm an inactivity timer that hides it after
+  // AUTO_HIDE_MS. Driven by mouse MOVEMENT, not just enter/leave: in
+  // fullscreen the root fills the entire screen, so the pointer never
+  // "leaves" and a leave-only hide would keep the bar stuck visible.
+  // Movement-based inactivity hides correctly in both windowed and fullscreen.
+  const revealBar = useCallback(() => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
     setBarVisible(true);
-  };
+    hideTimer.current = setTimeout(() => setBarVisible(false), AUTO_HIDE_MS);
+  }, []);
   const onMouseLeave = () => {
     if (hideTimer.current) clearTimeout(hideTimer.current);
     hideTimer.current = setTimeout(() => setBarVisible(false), AUTO_HIDE_MS);
@@ -270,9 +276,10 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
   return (
     <div
       ref={rootRef}
-      className="subtitle-app"
+      className={`subtitle-app${fullscreen ? ' fullscreen' : ''}`}
       style={rootStyle}
-      onMouseEnter={onMouseEnter}
+      onMouseEnter={revealBar}
+      onMouseMove={revealBar}
       onMouseLeave={onMouseLeave}
     >
       <SubtitleBar

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -10,6 +10,8 @@ import useSettingsStore, {
   useCurrentProviderSettings,
   useLocalInferenceSettings,
   useCurrentTurnDetectionMode,
+  useSubtitleFullscreen,
+  useSetSubtitleFullscreen,
 } from '../../stores/settingsStore';
 import {
   useSubtitleSettings,
@@ -80,6 +82,8 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
   const { t } = useTranslation();
   const subtitle = useSubtitleSettings();
   const exitSubtitleMode = useExitSubtitleMode();
+  const fullscreen = useSubtitleFullscreen();
+  const setFullscreen = useSetSubtitleFullscreen();
   const saveBounds = useSaveSubtitleWindowBounds();
   const items = useItems();
   const participantItems = useParticipantItems();
@@ -179,15 +183,36 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
     }
   }, [surface, exitSubtitleMode]);
 
-  // ESC to exit subtitle mode
+  // ESC is layered: if we're in fullscreen, the first ESC drops back to the
+  // windowed bar; otherwise (or on the next ESC) it exits subtitle mode.
   useEffect(() => {
     const target = rootRef.current?.ownerDocument ?? document;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') requestExit();
+      if (e.key !== 'Escape') return;
+      if (fullscreen) {
+        void setFullscreen(false);
+      } else {
+        requestExit();
+      }
     };
     target.addEventListener('keydown', onKey);
     return () => target.removeEventListener('keydown', onKey);
-  }, [requestExit]);
+  }, [requestExit, fullscreen, setFullscreen]);
+
+  // The OS fullscreen state can change outside our button (app menu, F11,
+  // macOS gesture). Mirror it into the store so the bar button + layered ESC
+  // stay correct. Electron surface only.
+  useEffect(() => {
+    if (surface !== 'electron') return;
+    if (!window.electron?.receive) return;
+    const handler = (flag: boolean) => {
+      useSettingsStore.getState().__syncSubtitleFullscreen(Boolean(flag));
+    };
+    window.electron.receive('subtitle:fullscreen-changed', handler);
+    return () => {
+      window.electron?.removeListener?.('subtitle:fullscreen-changed', handler);
+    };
+  }, [surface]);
 
   // Bounds-changed listener (debounced 500 ms before persistence).
   // The main process emits this for any resize/move regardless of mode, so

--- a/src/components/Subtitle/SubtitleBar.test.tsx
+++ b/src/components/Subtitle/SubtitleBar.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import SubtitleBar from './SubtitleBar';
+
+// i18n: return the default string passed to t(key, default).
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}));
+
+// The fullscreen flag + setter come from settingsStore.
+const setSubtitleFullscreen = vi.fn(async () => {});
+let fullscreenValue = false;
+vi.mock('../../stores/settingsStore', () => ({
+  __esModule: true,
+  default: { getState: () => ({}) },
+  useExitSubtitleMode: () => vi.fn(),
+  useSubtitleFullscreen: () => fullscreenValue,
+  useSetSubtitleFullscreen: () => setSubtitleFullscreen,
+}));
+
+// subtitleStore: provide the settings object + the action hooks SubtitleBar uses.
+vi.mock('../../stores/subtitleStore', () => ({
+  useSubtitleSettings: () => ({
+    fontSize: 24, compactMode: false, positionLocked: false, alwaysOnTop: false,
+  }),
+  useSetSubtitleFontSize: () => vi.fn(),
+  useSetSubtitleCompactMode: () => vi.fn(),
+  useToggleSubtitleAlwaysOnTop: () => vi.fn(),
+  useToggleSubtitlePositionLocked: () => vi.fn(),
+  useSubtitleSpeakerDisplayMode: () => 'both',
+  useSubtitleParticipantDisplayMode: () => 'both',
+  useSetSubtitleSpeakerDisplayMode: () => vi.fn(),
+  useSetSubtitleParticipantDisplayMode: () => vi.fn(),
+  FONT_SIZE_MIN: 12,
+  FONT_SIZE_MAX: 64,
+}));
+
+// Drag/resize hook is irrelevant here.
+vi.mock('./useOverlayDragResize', () => ({
+  useOverlayDragResize: () => ({ dragHandleProps: {}, resizeHandleProps: {} }),
+}));
+
+// Stub the child components so we only assert SubtitleBar's own controls and
+// don't pull conversationDisplayStore / ServiceFactory transitively.
+vi.mock('../MainPanel/DisplayModeButton', () => ({ default: () => null }));
+vi.mock('../MainPanel/ExportButton', () => ({ default: () => null }));
+vi.mock('../Display/DisplaySettingsPopover', () => ({ default: () => null }));
+
+const baseProps = {
+  sessionElapsedMs: 0,
+  sourceLanguageCode: 'EN',
+  targetLanguageCode: 'ZH',
+  onClearConversation: vi.fn(),
+  speakerActive: false,
+  participantActive: false,
+  exportProps: {} as any,
+};
+
+beforeEach(() => {
+  cleanup();
+  setSubtitleFullscreen.mockClear();
+  fullscreenValue = false;
+});
+
+describe('SubtitleBar fullscreen button', () => {
+  it('renders the fullscreen button on the electron surface', () => {
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    expect(screen.getByLabelText('Fullscreen')).toBeInTheDocument();
+  });
+
+  it('does NOT render the fullscreen button on the extension-overlay surface', () => {
+    render(<SubtitleBar {...baseProps} surface="extension-overlay" />);
+    expect(screen.queryByLabelText('Fullscreen')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Exit fullscreen')).not.toBeInTheDocument();
+  });
+
+  it('clicking the button enters fullscreen when currently windowed', () => {
+    fullscreenValue = false;
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    fireEvent.click(screen.getByLabelText('Fullscreen'));
+    expect(setSubtitleFullscreen).toHaveBeenCalledWith(true);
+  });
+
+  it('shows the exit-fullscreen affordance and exits when already fullscreen', () => {
+    fullscreenValue = true;
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    const btn = screen.getByLabelText('Exit fullscreen');
+    expect(btn.classList.contains('active')).toBe(true);
+    fireEvent.click(btn);
+    expect(setSubtitleFullscreen).toHaveBeenCalledWith(false);
+  });
+});

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -3,14 +3,18 @@ import React, { useCallback, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown,
-  Pin, Lock, X, Settings, Trash2,
+  Pin, Lock, X, Settings, Trash2, Maximize, Minimize,
 } from 'lucide-react';
 import {
   useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
 } from '@floating-ui/react';
 import DisplayModeButton from '../MainPanel/DisplayModeButton';
 import ExportButton from '../MainPanel/ExportButton';
-import { useExitSubtitleMode } from '../../stores/settingsStore';
+import {
+  useExitSubtitleMode,
+  useSubtitleFullscreen,
+  useSetSubtitleFullscreen,
+} from '../../stores/settingsStore';
 import {
   useSubtitleSettings,
   useSetSubtitleFontSize,
@@ -69,6 +73,12 @@ const SubtitleBar: React.FC<Props> = ({
   const setSpeakerMode = useSetSpeakerDisplayMode();
   const setParticipantMode = useSetParticipantDisplayMode();
   const exitSubtitleMode = useExitSubtitleMode();
+  const fullscreen = useSubtitleFullscreen();
+  const setFullscreen = useSetSubtitleFullscreen();
+  // Single source for both title + aria-label so they can't drift apart.
+  const fullscreenLabel = fullscreen
+    ? t('subtitle.bar.exitFullscreen', 'Exit fullscreen')
+    : t('subtitle.bar.fullscreen', 'Fullscreen');
   // See SubtitleApp.requestExit — in the extension-overlay surface we forward
   // the exit intent to the side panel via a window event instead of calling
   // the local (no-op) settings store action.
@@ -175,6 +185,17 @@ const SubtitleBar: React.FC<Props> = ({
         >
           <Settings size={14} />
         </button>
+        {surface === 'electron' && (
+          <button
+            type="button"
+            className={`subtitle-bar__btn ${fullscreen ? 'active' : ''}`}
+            onClick={() => void setFullscreen(!fullscreen)}
+            title={fullscreenLabel}
+            aria-label={fullscreenLabel}
+          >
+            {fullscreen ? <Minimize size={14} /> : <Maximize size={14} />}
+          </button>
+        )}
         {surface === 'electron' && (
           <button
             type="button"

--- a/src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts
+++ b/src/components/Subtitle/surfaces/ElectronSubtitleSurface.test.ts
@@ -68,4 +68,16 @@ describe('ElectronSubtitleSurface', () => {
     await surface.exit();
     expect(invoke).toHaveBeenCalledWith('subtitle:exit', {});
   });
+
+  it('setFullscreen(true) invokes subtitle:set-fullscreen with true', async () => {
+    const surface = new ElectronSubtitleSurface();
+    await surface.setFullscreen(true);
+    expect(invoke).toHaveBeenCalledWith('subtitle:set-fullscreen', true);
+  });
+
+  it('setFullscreen(false) invokes subtitle:set-fullscreen with false', async () => {
+    const surface = new ElectronSubtitleSurface();
+    await surface.setFullscreen(false);
+    expect(invoke).toHaveBeenCalledWith('subtitle:set-fullscreen', false);
+  });
 });

--- a/src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts
@@ -20,4 +20,8 @@ export class ElectronSubtitleSurface implements SubtitleSurface {
     // normal mode.
     await window.electron?.invoke('subtitle:exit', {});
   }
+
+  async setFullscreen(flag: boolean): Promise<void> {
+    await window.electron?.invoke('subtitle:set-fullscreen', flag);
+  }
 }

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
@@ -114,6 +114,12 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     this.tearDown();
   }
 
+  // Fullscreen is an Electron-window concept; the extension overlay lives
+  // inside the host page and has no equivalent. No-op by design.
+  async setFullscreen(_flag: boolean): Promise<void> {
+    /* no-op */
+  }
+
   private tearDown() {
     chrome.runtime.onConnect.removeListener(this.handleConnect);
     chrome.tabs.onRemoved.removeListener(this.handleTabRemoved);

--- a/src/components/Subtitle/surfaces/SubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/SubtitleSurface.ts
@@ -3,4 +3,9 @@ export interface SubtitleSurface {
   enter(): Promise<void>;
   /** Exit subtitle mode. Idempotent. */
   exit(): Promise<void>;
+  /**
+   * Toggle OS-level fullscreen for the subtitle surface. Electron-only;
+   * other surfaces implement this as a no-op.
+   */
+  setFullscreen(flag: boolean): Promise<void>;
 }

--- a/src/components/Subtitle/surfaces/getSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/getSubtitleSurface.ts
@@ -9,6 +9,7 @@ class NoopSubtitleSurface implements SubtitleSurface {
     throw new Error('Subtitle mode is not supported in this context');
   }
   async exit(): Promise<void> { /* no-op */ }
+  async setFullscreen(_flag: boolean): Promise<void> { /* no-op */ }
 }
 
 let cached: SubtitleSurface | null = null;

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -945,6 +945,8 @@
       "clear": "Clear conversation",
       "settings": "Subtitle settings",
       "alwaysOnTop": "Always on top",
+      "fullscreen": "Fullscreen",
+      "exitFullscreen": "Exit fullscreen",
       "lock": "Lock position and size",
       "exit": "Exit subtitle mode"
     },

--- a/src/stores/settingsStore.subtitle.test.ts
+++ b/src/stores/settingsStore.subtitle.test.ts
@@ -147,6 +147,13 @@ describe('settingsStore subtitle actions', () => {
     expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
   });
 
+  it('__notifySubtitleSurfaceExited resets subtitleFullscreen (external exit)', () => {
+    useSettingsStore.setState({ subtitleModeActive: true, subtitleFullscreen: true });
+    useSettingsStore.getState().__notifySubtitleSurfaceExited();
+    expect(useSettingsStore.getState().subtitleModeActive).toBe(false);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
   it('__syncSubtitleFullscreen sets state only and does not call the surface', () => {
     const invokeMock = (window as any).electron.invoke;
     invokeMock.mockClear();

--- a/src/stores/settingsStore.subtitle.test.ts
+++ b/src/stores/settingsStore.subtitle.test.ts
@@ -44,7 +44,7 @@ const { default: useSessionStore } = await import('./sessionStore');
 
 describe('settingsStore subtitle actions', () => {
   beforeEach(() => {
-    useSettingsStore.setState({ subtitleModeActive: false });
+    useSettingsStore.setState({ subtitleModeActive: false, subtitleFullscreen: false });
   });
 
   it('enterSubtitleMode is a no-op when session is not active', async () => {
@@ -114,6 +114,45 @@ describe('settingsStore subtitle actions', () => {
     });
     await expect(useSettingsStore.getState().enterSubtitleMode()).rejects.toThrow(/boom/);
     expect(useSettingsStore.getState().subtitleModeActive).toBe(false);
+  });
+
+  it('setSubtitleFullscreen(true) sets the flag and invokes subtitle:set-fullscreen', async () => {
+    const invokeMock = (window as any).electron.invoke;
+    invokeMock.mockClear();
+    await useSettingsStore.getState().setSubtitleFullscreen(true);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(true);
+    expect(invokeMock).toHaveBeenCalledWith('subtitle:set-fullscreen', true);
+  });
+
+  it('setSubtitleFullscreen rolls back the flag if the surface rejects', async () => {
+    const invokeMock = (window as any).electron.invoke;
+    invokeMock.mockImplementationOnce(async (channel: string) => {
+      if (channel === 'subtitle:set-fullscreen') throw new Error('boom');
+      return { ok: true };
+    });
+    await useSettingsStore.getState().setSubtitleFullscreen(true);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
+  it('enterSubtitleMode resets subtitleFullscreen to false (always start windowed)', async () => {
+    useSessionStore.setState({ isSessionActive: true } as any);
+    useSettingsStore.setState({ subtitleFullscreen: true });
+    await useSettingsStore.getState().enterSubtitleMode();
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
+  it('exitSubtitleMode resets subtitleFullscreen to false', async () => {
+    useSettingsStore.setState({ subtitleModeActive: true, subtitleFullscreen: true });
+    await useSettingsStore.getState().exitSubtitleMode();
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(false);
+  });
+
+  it('__syncSubtitleFullscreen sets state only and does not call the surface', () => {
+    const invokeMock = (window as any).electron.invoke;
+    invokeMock.mockClear();
+    useSettingsStore.getState().__syncSubtitleFullscreen(true);
+    expect(useSettingsStore.getState().subtitleFullscreen).toBe(true);
+    expect(invokeMock).not.toHaveBeenCalled();
   });
 
   // NOTE: setSubtitleFontSize / setSubtitleBgOpacity / etc. moved to subtitleStore in Task 5.

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -961,7 +961,7 @@ const useSettingsStore = create<SettingsStore>()(
     },
 
     __notifySubtitleSurfaceExited: () => {
-      set({ subtitleModeActive: false });
+      set({ subtitleModeActive: false, subtitleFullscreen: false });
     },
 
     setSubtitleFullscreen: async (flag) => {

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -403,8 +403,11 @@ interface SettingsStore {
   speakerDisplayMode: DisplayMode;
   participantDisplayMode: DisplayMode;
 
-  // Subtitle runtime flag (lifecycle only — subtitle settings live in subtitleStore)
+  // Subtitle runtime flags (lifecycle only — subtitle settings live in subtitleStore)
   subtitleModeActive: boolean;
+  // Ephemeral: true while subtitle mode is in OS fullscreen. Never persisted;
+  // always reset to false on enter (start windowed) and exit. Electron-only.
+  subtitleFullscreen: boolean;
 
   // === Actions ===
   // Common settings actions
@@ -423,6 +426,14 @@ interface SettingsStore {
    * Resets the flag without re-entering the exit path.
    */
   __notifySubtitleSurfaceExited: () => void;
+  /** Toggle OS fullscreen for the active subtitle surface (Electron-only). */
+  setSubtitleFullscreen: (flag: boolean) => Promise<void>;
+  /**
+   * Internal: invoked when the OS fullscreen state changes outside of our
+   * setSubtitleFullscreen() call (app menu, F11, macOS gesture). Updates the
+   * flag only — does NOT re-invoke the surface, which would loop.
+   */
+  __syncSubtitleFullscreen: (flag: boolean) => void;
   setSystemInstructions: (instructions: string) => void;
   setTemplateSystemInstructions: (instructions: string) => void;
   setUseTemplateMode: (useTemplate: boolean) => void;
@@ -791,6 +802,7 @@ const useSettingsStore = create<SettingsStore>()(
 
     settingsLoaded: false,
     subtitleModeActive: false,
+    subtitleFullscreen: false,
 
     // === Common Settings Actions ===
     setProvider: async (provider) => {
@@ -921,7 +933,7 @@ const useSettingsStore = create<SettingsStore>()(
       // racing into a second surface.enter(). On the Electron path the
       // second IPC would otherwise overwrite normalBoundsSnapshot with
       // the already-shrunk subtitle bounds — same bug class as 8f9aea85.
-      set({ subtitleModeActive: true });
+      set({ subtitleModeActive: true, subtitleFullscreen: false });
       try {
         await getSubtitleSurface().enter();
       } catch (error) {
@@ -940,7 +952,7 @@ const useSettingsStore = create<SettingsStore>()(
       // first so a re-entrant exit() short-circuits. The original
       // `finally` already set the flag false on the way out; the only
       // observable difference is concurrent callers, which we want.
-      set({ subtitleModeActive: false });
+      set({ subtitleModeActive: false, subtitleFullscreen: false });
       try {
         await getSubtitleSurface().exit();
       } catch (error) {
@@ -950,6 +962,25 @@ const useSettingsStore = create<SettingsStore>()(
 
     __notifySubtitleSurfaceExited: () => {
       set({ subtitleModeActive: false });
+    },
+
+    setSubtitleFullscreen: async (flag) => {
+      const previous = get().subtitleFullscreen;
+      if (previous === flag) return;
+      set({ subtitleFullscreen: flag });
+      try {
+        await getSubtitleSurface().setFullscreen(flag);
+      } catch (error) {
+        // Swallow (unlike enterSubtitleMode, which re-throws so the entry
+        // button can toast): a fullscreen-toggle failure is non-actionable
+        // for the caller, and reverting the flag re-syncs the bar button.
+        console.error('[SettingsStore] setSubtitleFullscreen failed:', error);
+        set({ subtitleFullscreen: previous });
+      }
+    },
+
+    __syncSubtitleFullscreen: (flag) => {
+      set({ subtitleFullscreen: flag });
     },
 
     // === Provider Settings Actions ===
@@ -1625,6 +1656,10 @@ export const useParticipantDisplayMode = () => useSettingsStore((state) => state
 export const useSubtitleModeActive = () => useSettingsStore((state) => state.subtitleModeActive);
 export const useEnterSubtitleMode = () => useSettingsStore((state) => state.enterSubtitleMode);
 export const useExitSubtitleMode = () => useSettingsStore((state) => state.exitSubtitleMode);
+export const useSubtitleFullscreen = () =>
+  useSettingsStore((state) => state.subtitleFullscreen);
+export const useSetSubtitleFullscreen = () =>
+  useSettingsStore((state) => state.setSubtitleFullscreen);
 export const useNotifySubtitleSurfaceExited = () =>
   useSettingsStore((state) => state.__notifySubtitleSurfaceExited);
 export const useSystemInstructions = () => useSettingsStore((state) => state.systemInstructions);


### PR DESCRIPTION
## Summary

Adds an **Electron-only true fullscreen toggle** to subtitle mode, for distraction-free projection (classrooms, speaking contests). Today the closest a user can get is double-click-to-maximize, which still leaves the OS taskbar/dock visible. This adds real, taskbar-free fullscreen.

- A visible ⤢ toggle button in the subtitle bar (Electron surface only) enters/exits OS fullscreen via `BrowserWindow.setFullScreen`.
- **Layered ESC:** in fullscreen, ESC drops back to the windowed bar; a second ESC exits subtitle mode (protects a live session from an accidental full exit).
- Fullscreen is **ephemeral** — entering subtitle mode always starts windowed; the flag is never persisted.
- OS-initiated fullscreen changes (app menu, F11, macOS gesture) are synced back so the button + ESC stay correct, with no IPC feedback loop.
- The browser-extension overlay surface is intentionally unaffected (`setFullscreen` is a no-op; button not rendered).

## How it works

`SubtitleBar` button / ESC → `settingsStore.setSubtitleFullscreen` → `SubtitleSurface.setFullscreen` → IPC `subtitle:set-fullscreen` → `win.setFullScreen()`. The main process forwards `enter/leave-full-screen` as `subtitle:fullscreen-changed` → `__syncSubtitleFullscreen` (state-only). `beginTransition()` + an `isFullScreen()` guard keep the saved bar geometry (`windowBounds`) intact across a fullscreen round-trip.

Design + plan: `docs/superpowers/specs/2026-05-26-subtitle-fullscreen-design.md`, `docs/superpowers/plans/2026-05-27-subtitle-fullscreen.md`.

## Test Plan

Automated: 820/820 unit tests pass; build clean. New tests cover the surface IPC dispatch, the store action (set + rollback-on-reject + reset-on-enter/exit + state-only sync), and the bar button (electron-only gating, label/icon toggle).

Manual QA (Electron app, `npm run electron:dev`):
- [x] Enter subtitle mode → opens windowed (not fullscreen).
- [x] ⤢ button → true fullscreen, taskbar/dock hidden; bar fades ~1.5s after the mouse stops, reappears on movement.
- [x] All four screen corners are solid in fullscreen (no desktop bleed).
- [x] ESC in fullscreen → windowed bar (keeps prior size/position); ESC again → exits subtitle mode.
- [x] ✕ from fullscreen → exits cleanly to the normal window.
- [x] Resize the windowed bar, fullscreen round-trip → bar geometry preserved.
- [x] macOS: verify exit-from-fullscreen lands at the correct bounds; if not, switch the darwin path to `setSimpleFullScreen` (documented in `electron/subtitle-window.js`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Electron-only fullscreen for subtitles with a subtitle-bar toggle, ESC exits fullscreen first, and OS taskbar/dock are hidden in fullscreen.
  * Host-initiated fullscreen changes are reflected in the subtitle UI.

* **Bug Fixes**
  * Fixed rounded-corner styling so fullscreen subtitle window is squared off.

* **Documentation**
  * Added design spec and end-to-end implementation plan with QA checklist.

* **Tests**
  * Added unit/component tests covering fullscreen controls and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/249?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->