### PR TITLE
feat: unify Settings/Logs panel chrome + resizable side panel

### DIFF
--- a/docs/superpowers/plans/2026-05-27-panel-chrome-unification.md
+++ b/docs/superpowers/plans/2026-05-27-panel-chrome-unification.md
@@ -1,0 +1,822 @@
+# Panel Chrome Unification Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bespoke headers of the Settings and Logs side panels with one shared `PanelBar`, formalize a small active-state token system, and fix the arrow-close / three-greens / three-rows defects — without changing MainPanel.
+
+**Architecture:** A new presentational `PanelBar` (`[tabs] ···· [actions] [collapse]`) is rendered by both `Settings` and `LogsPanel`. Settings lifts its category-tab state up from `AdvancedSettings` so the bar can own the tabs. Active-state styling is expressed through SCSS mixins in the existing `_variables.scss`; the only behavioral style change is neutralizing the TitleBar's active treatment (green outline → neutral pill; green outline reserved for `:focus-visible`).
+
+**Tech Stack:** React + TypeScript, SCSS (`@use` modules), lucide-react icons, react-i18next, Vitest + @testing-library/react (jsdom).
+
+**Spec:** `docs/superpowers/specs/2026-05-27-panel-chrome-unification-design.md`
+
+**Convention:** Every commit message ends with the trailer:
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+(Subject lines shown per step; append the trailer to each.)
+
+---
+
+## File Structure
+
+**Create:**
+- `src/components/Settings/shared/PanelBar.tsx` — shared panel bar (tabs slot + actions slot + collapse + Esc). One responsibility: panel-top chrome layout.
+- `src/components/Settings/shared/PanelBar.scss` — bar layout + relocated segmented `.mode-toggle` styles.
+- `src/components/Settings/shared/PanelBar.test.tsx` — unit tests.
+
+**Modify:**
+- `src/components/Settings/shared/_variables.scss` — add `state-selected-underline` / `state-selected-fill` mixins.
+- `src/components/Settings/shared/TabBar.scss` — use the underline mixin (no visual change).
+- `src/components/Settings/Settings.tsx` — own PanelBar + lifted `TABS` / `NAVIGATION_TAB_MAP` / `activeTab` / nav-effect; build mode-toggle as the actions slot; drop the header block.
+- `src/components/Settings/Settings.scss` — remove `.settings-header` / `.mode-toggle` / `.close-button` rules.
+- `src/components/Settings/AdvancedSettings/AdvancedSettings.tsx` — receive `activeTab` prop; drop its `TabBar`, `activeTab` state, nav effect, and the moved constants.
+- `src/components/LogsPanel/LogsPanel.tsx` — adopt PanelBar; remove bespoke header + arrow-close.
+- `src/components/LogsPanel/LogsPanel.scss` — remove header layout; keep action-button styles re-scoped.
+- `src/components/TitleBar/TitleBar.scss` — neutral active pill + `:focus-visible` outline.
+- `src/locales/en/translation.json` — add `common.collapsePanel`.
+
+---
+
+## Task 1: Audit selectors before deleting markup
+
+This task removes risk before any deletion. Several elements are removed in Tasks 5–6 (`.settings-header`, `.close-button`, `.mode-toggle` location, `.logs-panel-header`, `.close-logs-button`). Onboarding and tests may target them.
+
+**Files:** none modified (discovery only).
+
+- [ ] **Step 1: Grep the codebase for soon-to-change selectors**
+
+Run:
+```bash
+grep -rnE "settings-header|close-button|mode-toggle|mode-button|logs-panel-header|close-logs-button|header-actions" src/ \
+  --include=*.ts --include=*.tsx --include=*.js --include=*.json | grep -vE "\.scss"
+```
+
+- [ ] **Step 2: Grep onboarding specifically for any of the removed targets**
+
+Run:
+```bash
+grep -rnE "settings-button|logs-button|settings-header|close-button|tab-bar|mode-toggle|panel" src/components/Onboarding/
+```
+
+- [ ] **Step 3: Record findings as constraints**
+
+Write the hit list into a scratch note (or the PR description later). Decision rule:
+- `.settings-button` / `.logs-button` (TitleBar) — **preserved** by this plan; no action.
+- Any onboarding step or test targeting `.settings-header`, `.close-button`, `.mode-button`, `.tab-bar`, `.logs-panel-header` — note it; Tasks 5–6 must repoint it (e.g., to `.panel-bar`, `.panel-bar .tab-bar__tab`, or the TitleBar entry). If onboarding targets none of them, state that explicitly so Tasks 5–6 can delete freely.
+
+(No commit — discovery only.)
+
+---
+
+## Task 2: Active-state token mixins
+
+**Files:**
+- Modify: `src/components/Settings/shared/_variables.scss`
+- Modify: `src/components/Settings/shared/TabBar.scss`
+
+- [ ] **Step 1: Add the two state mixins to `_variables.scss`**
+
+Append after the existing `focus-ring` mixin (after line 116, the closing `}` of `@mixin focus-ring`):
+
+```scss
+// --- Selection state (mutually-exclusive sets) ---------------
+// green = the selected item. Form is fixed per control archetype:
+//   tabs        → underline
+//   segmented   → fill
+//   focus       → outline (focus-ring above; :focus-visible only)
+@mixin state-selected-underline {
+  color: $color-primary;
+  border-bottom: 2px solid $color-primary;
+}
+
+@mixin state-selected-fill {
+  background: $color-primary;
+  color: $text-primary;
+}
+```
+
+- [ ] **Step 2: Refactor TabBar's active rule to use the mixin (no visual change)**
+
+In `src/components/Settings/shared/TabBar.scss`, replace the `&--active` block:
+
+```scss
+    &--active {
+      color: vars.$color-primary;
+      border-bottom-color: vars.$color-primary;
+    }
+```
+
+with:
+
+```scss
+    &--active {
+      @include vars.state-selected-underline;
+    }
+```
+
+(The base `.tab-bar__tab` keeps `border-bottom: 2px solid transparent`; the mixin overrides color+width identically.)
+
+- [ ] **Step 3: Verify the project still builds (SCSS compiles)**
+
+Run: `npm run build`
+Expected: build succeeds, no SCSS errors. (CSS changes have no unit test; build is the gate.)
+
+- [ ] **Step 4: Run the test suite to confirm no regressions**
+
+Run: `npm run test`
+Expected: PASS (same set as before this task).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings/shared/_variables.scss src/components/Settings/shared/TabBar.scss
+git commit -m "style(settings): add active-state token mixins; TabBar uses underline token"
+```
+
+---
+
+## Task 3: PanelBar component (TDD)
+
+**Files:**
+- Create: `src/components/Settings/shared/PanelBar.tsx`
+- Create: `src/components/Settings/shared/PanelBar.scss`
+- Create: `src/components/Settings/shared/PanelBar.test.tsx`
+- Modify: `src/locales/en/translation.json`
+
+- [ ] **Step 1: Add the i18n key**
+
+In `src/locales/en/translation.json`, inside the top-level `"common"` object, add after the `"close": "Close",` on line 6:
+
+```json
+    "collapsePanel": "Close panel",
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `src/components/Settings/shared/PanelBar.test.tsx`:
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PanelBar from './PanelBar';
+import type { Tab } from './TabBar';
+
+const TABS: Tab[] = [
+  { id: 'general', labelKey: 'x.general', fallback: 'General' },
+  { id: 'audio', labelKey: 'x.audio', fallback: 'Audio' },
+];
+
+describe('PanelBar', () => {
+  it('renders tabs when provided', () => {
+    render(<PanelBar tabs={TABS} activeTab="general" onTabChange={() => {}} onClose={() => {}} />);
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+  });
+
+  it('renders no tabs when tabs is omitted', () => {
+    render(<PanelBar onClose={() => {}} />);
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  });
+
+  it('renders the actions slot', () => {
+    render(<PanelBar actions={<button>my-action</button>} onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: 'my-action' })).toBeInTheDocument();
+  });
+
+  it('calls onClose when the collapse button is clicked', () => {
+    const onClose = vi.fn();
+    render(<PanelBar onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close panel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = vi.fn();
+    render(<PanelBar onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores Escape when a dialog is open', () => {
+    const onClose = vi.fn();
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    document.body.appendChild(dialog);
+    render(<PanelBar onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+    document.body.removeChild(dialog);
+  });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm run test -- src/components/Settings/shared/PanelBar.test.tsx`
+Expected: FAIL — cannot resolve `./PanelBar` (module does not exist yet).
+
+- [ ] **Step 4: Implement `PanelBar.tsx`**
+
+Create `src/components/Settings/shared/PanelBar.tsx`:
+
+```tsx
+import React, { useEffect } from 'react';
+import { PanelRightClose } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import TabBar, { Tab } from './TabBar';
+import './PanelBar.scss';
+
+interface PanelBarProps {
+  /** Tab strip. Omit for tab-less panels (e.g. Settings Quick mode). */
+  tabs?: Tab[];
+  activeTab?: string;
+  onTabChange?: (id: string) => void;
+  /** Panel-specific controls, rendered in the right cluster left of close. */
+  actions?: React.ReactNode;
+  /** Collapse the panel. */
+  onClose: () => void;
+}
+
+const PanelBar: React.FC<PanelBarProps> = ({ tabs, activeTab, onTabChange, actions, onClose }) => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return;
+      // Don't steal Escape from an open modal/dialog or floating popover.
+      if (document.querySelector('[role="dialog"]')) return;
+      onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const hasTabs = tabs && activeTab !== undefined && onTabChange;
+
+  return (
+    <div className="panel-bar">
+      {hasTabs ? (
+        <TabBar tabs={tabs!} activeTab={activeTab!} onTabChange={onTabChange!} />
+      ) : (
+        <span className="panel-bar__spacer" />
+      )}
+      <div className="panel-bar__actions">
+        {actions}
+        <button
+          type="button"
+          className="panel-bar__close"
+          onClick={onClose}
+          title={t('common.collapsePanel', 'Close panel')}
+          aria-label={t('common.collapsePanel', 'Close panel')}
+        >
+          <PanelRightClose size={16} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PanelBar;
+```
+
+- [ ] **Step 5: Implement `PanelBar.scss`**
+
+Create `src/components/Settings/shared/PanelBar.scss`:
+
+```scss
+@use 'variables' as vars;
+
+.panel-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 15px;
+  border-bottom: 1px solid vars.$border-subtle;
+  flex-shrink: 0;
+
+  // TabBar provides its own item styling; the bar owns padding + the divider.
+  .tab-bar {
+    border-bottom: none;
+    padding: 0;
+    flex: 0 1 auto;
+  }
+
+  &__spacer {
+    flex: 1;
+  }
+
+  &__actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: vars.$space-3;
+    padding: vars.$space-2 0;
+  }
+
+  &__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    border-left: 1px solid vars.$border-subtle;
+    color: vars.$text-muted;
+    cursor: pointer;
+    padding: 6px 6px 6px 12px;
+    transition: color vars.$transition-fast;
+
+    &:hover { color: vars.$text-primary; }
+    &:focus-visible { @include vars.focus-ring; }
+  }
+
+  // Segmented mode toggle (relocated from Settings.scss).
+  .mode-toggle {
+    display: flex;
+    background: vars.$bg-page;
+    border-radius: vars.$radius-md;
+    padding: 2px;
+    gap: 2px;
+
+    .mode-button {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      background: transparent;
+      border: none;
+      border-radius: vars.$radius-sm;
+      color: vars.$text-muted;
+      font-size: vars.$font-caption;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all vars.$transition-fast;
+
+      svg { width: 14px; height: 14px; }
+
+      &:hover:not(:disabled):not(.active) {
+        color: vars.$text-secondary;
+        background: rgba(255, 255, 255, 0.05);
+      }
+
+      &.active { @include vars.state-selected-fill; }
+      &:disabled { @include vars.disabled-state; }
+      &:focus-visible { @include vars.focus-ring; }
+    }
+  }
+
+  @media (max-width: 768px) {
+    .mode-toggle .mode-button {
+      padding: 6px 8px;
+      span { display: none; }
+    }
+  }
+}
+```
+
+- [ ] **Step 6: Run the test to verify it passes**
+
+Run: `npm run test -- src/components/Settings/shared/PanelBar.test.tsx`
+Expected: PASS (all 6 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Settings/shared/PanelBar.tsx src/components/Settings/shared/PanelBar.scss src/components/Settings/shared/PanelBar.test.tsx src/locales/en/translation.json
+git commit -m "feat(settings): add shared PanelBar component with Esc-to-close"
+```
+
+---
+
+## Task 4: Neutralize the TitleBar active state
+
+**Files:**
+- Modify: `src/components/TitleBar/TitleBar.scss`
+
+- [ ] **Step 1: Replace the active rule and add a focus-visible outline**
+
+In `src/components/TitleBar/TitleBar.scss`, replace the `&.is-active` block inside `.title-bar__action`:
+
+```scss
+  &.is-active {
+    background: rgba(255, 255, 255, 0.12);
+    border-color: #10a37f;
+    color: #fff;
+  }
+```
+
+with (drop the green border; brighten the neutral pill; reserve green for focus):
+
+```scss
+  &.is-active {
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #10a37f;
+    outline-offset: -1px;
+  }
+```
+
+(The base `.title-bar__action` keeps `border: 1px solid transparent`, so layout is unchanged when the border color is no longer set.)
+
+- [ ] **Step 2: Verify build**
+
+Run: `npm run build`
+Expected: success, no SCSS errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/TitleBar/TitleBar.scss
+git commit -m "style(titlebar): neutral active pill; reserve green outline for focus"
+```
+
+---
+
+## Task 5: Settings adopts PanelBar (lift tab state)
+
+**Files:**
+- Modify: `src/components/Settings/Settings.tsx`
+- Modify: `src/components/Settings/Settings.scss`
+- Modify: `src/components/Settings/AdvancedSettings/AdvancedSettings.tsx`
+
+- [ ] **Step 1: Rewrite `Settings.tsx`**
+
+Replace the entire contents of `src/components/Settings/Settings.tsx` with:
+
+```tsx
+import React, { useState, useEffect } from 'react';
+import { LayoutGrid, Sliders, Settings as SettingsIcon, Headphones, Cpu } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { useUIMode, useSetUIMode, useNavigateToSettings, useSettingsNavigationTarget } from '../../stores/settingsStore';
+import { useIsSessionActive } from '../../stores/sessionStore';
+import { useAnalytics } from '../../lib/analytics';
+import SimpleSettings from './SimpleSettings/SimpleSettings';
+import AdvancedSettings from './AdvancedSettings/AdvancedSettings';
+import PanelBar from './shared/PanelBar';
+import type { Tab } from './shared/TabBar';
+import './Settings.scss';
+
+interface SettingsProps {
+  toggleSettings?: () => void;
+  /** External highlight section prop */
+  highlightSection?: string | null;
+}
+
+const TABS: Tab[] = [
+  { id: 'general', labelKey: 'settings.tabs.general', fallback: 'General', icon: SettingsIcon },
+  { id: 'audio', labelKey: 'settings.tabs.audio', fallback: 'Audio', icon: Headphones },
+  { id: 'provider', labelKey: 'settings.tabs.provider', fallback: 'Provider', icon: Cpu },
+];
+
+const NAVIGATION_TAB_MAP: Record<string, string> = {
+  'user-account': 'general',
+  'languages': 'general',
+  'microphone': 'audio',
+  'speaker': 'audio',
+  'system-audio': 'audio',
+  'participant': 'audio',
+  'provider': 'provider',
+  'system-instructions': 'provider',
+  'voice-settings': 'provider',
+  'turn-detection': 'provider',
+  'model-management': 'provider',
+  'model-asr': 'provider',
+  'model-translation': 'provider',
+  'model-tts': 'provider',
+};
+
+const Settings: React.FC<SettingsProps> = ({ toggleSettings, highlightSection }) => {
+  const { t } = useTranslation();
+  const { trackEvent } = useAnalytics();
+  const isSessionActive = useIsSessionActive();
+
+  const uiMode = useUIMode();
+  const setUIMode = useSetUIMode();
+  const settingsNavigationTarget = useSettingsNavigationTarget();
+  const navigateToSettings = useNavigateToSettings();
+
+  // 'basic' maps to Simple/Quick, 'advanced' maps to Advanced.
+  const isSimpleMode = uiMode === 'basic';
+
+  const [activeTab, setActiveTab] = useState('general');
+
+  // Advanced-only: switch to the target tab and scroll/highlight its section.
+  // Quick mode highlights via SimpleSettings' highlightSection instead.
+  useEffect(() => {
+    if (isSimpleMode) return;
+    if (settingsNavigationTarget) {
+      const targetTab = NAVIGATION_TAB_MAP[settingsNavigationTarget];
+      if (targetTab && targetTab !== activeTab) {
+        setActiveTab(targetTab);
+      }
+      setTimeout(() => {
+        const element = document.getElementById(`${settingsNavigationTarget}-section`);
+        if (element) {
+          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          element.classList.add('highlight');
+          setTimeout(() => {
+            element.classList.remove('highlight');
+            navigateToSettings(null);
+          }, 3000);
+        }
+      }, 150);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsNavigationTarget, navigateToSettings, isSimpleMode]);
+
+  const handleModeToggle = () => {
+    const newMode = isSimpleMode ? 'advanced' : 'basic';
+    setUIMode(newMode);
+    trackEvent('settings_mode_switched', {
+      from_mode: uiMode,
+      to_mode: newMode,
+      during_session: isSessionActive,
+    });
+  };
+
+  const modeToggle = (
+    <div className="mode-toggle">
+      <button
+        className={`mode-button ${isSimpleMode ? 'active' : ''}`}
+        onClick={() => !isSimpleMode && handleModeToggle()}
+        title={t('settings.simpleMode', 'Simple')}
+      >
+        <LayoutGrid size={14} />
+        <span>{t('settings.simple', 'Simple')}</span>
+      </button>
+      <button
+        className={`mode-button ${!isSimpleMode ? 'active' : ''}`}
+        onClick={() => isSimpleMode && handleModeToggle()}
+        title={t('settings.advancedMode', 'Advanced')}
+      >
+        <Sliders size={14} />
+        <span>{t('settings.advanced', 'Advanced')}</span>
+      </button>
+    </div>
+  );
+
+  return (
+    <div className="settings-container">
+      <PanelBar
+        tabs={isSimpleMode ? undefined : TABS}
+        activeTab={isSimpleMode ? undefined : activeTab}
+        onTabChange={isSimpleMode ? undefined : setActiveTab}
+        actions={modeToggle}
+        onClose={toggleSettings ?? (() => {})}
+      />
+
+      <div className="settings-body">
+        {isSimpleMode ? (
+          <SimpleSettings highlightSection={highlightSection || settingsNavigationTarget} />
+        ) : (
+          <AdvancedSettings toggleSettings={toggleSettings} activeTab={activeTab} />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default Settings;
+```
+
+- [ ] **Step 2: Remove the old header styles from `Settings.scss`**
+
+In `src/components/Settings/Settings.scss`, delete the entire `.settings-header { ... }` block (the block beginning `.settings-header {` and ending with its matching `}` — it contains `h2`, `.header-actions`, `.mode-toggle`, and `.close-button`). Keep `.settings-container`, `.settings-body`, and everything below.
+
+Then, in the responsive section at the bottom, delete the now-dangling `.header-actions .mode-toggle .mode-button` override (the `@media (max-width: 768px)` rule's `.settings-container .settings-header ...` nest), since that responsive behavior now lives in `PanelBar.scss`. Leave the `.language-pair-row` part of that media query intact.
+
+- [ ] **Step 3: Update `AdvancedSettings.tsx` to consume `activeTab` as a prop**
+
+Apply these edits to `src/components/Settings/AdvancedSettings/AdvancedSettings.tsx`:
+
+(a) Line 1 — drop `useEffect`:
+```tsx
+import React, { useState } from 'react';
+```
+
+(b) Line 2 — drop the tab icons (`Settings`, `Headphones`, `Cpu`), keep `AlertCircle`:
+```tsx
+import { AlertCircle } from 'lucide-react';
+```
+
+(c) In the settingsStore import block (lines 6–15) remove `useSettingsNavigationTarget` and `useNavigateToSettings` (they were only used by the moved effect). Result:
+```tsx
+import {
+  useProvider,
+  useAvailableModels,
+  useLoadingModels,
+  useFetchAvailableModels,
+  useGetProcessedSystemInstructions,
+  useCurrentTurnDetectionMode,
+} from '../../../stores/settingsStore';
+```
+
+(d) Remove the `TabBar` import (line 20). It is no longer used here.
+
+(e) Delete the `TABS` constant (lines 33–37) and the `NAVIGATION_TAB_MAP` constant (lines 39–54) — they moved to `Settings.tsx`.
+
+(f) Extend the props to accept `activeTab` and destructure it:
+```tsx
+interface AdvancedSettingsProps {
+  toggleSettings?: () => void;
+  activeTab: string;
+}
+
+const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings, activeTab }) => {
+```
+
+(g) Delete the local tab state line `const [activeTab, setActiveTab] = useState('general');` (line 107). Keep the other `useState` lines (`isPreviewExpanded`, `warningType`).
+
+(h) Delete the navigation `useEffect` block (lines 102–132: the `settingsNavigationTarget` / `navigateToSettings` consts and the whole effect).
+
+(i) Delete the `<TabBar tabs={TABS} ... />` line (line 149). The `settings-content` tabpanel `<div>` immediately below stays and still reads `activeTab` (now the prop).
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors. (Confirms `activeTab` prop wiring, removed imports, and that no dangling reference to `setActiveTab`/`TABS`/`NAVIGATION_TAB_MAP` remains in `AdvancedSettings`.)
+
+- [ ] **Step 5: Build + test**
+
+Run: `npm run build && npm run test`
+Expected: build succeeds; test suite PASS (PanelBar tests included; existing `settingsStore.providerSettings.test` unaffected).
+
+- [ ] **Step 6: Repoint any onboarding/test targets found in Task 1**
+
+If Task 1 found references to `.settings-header`, `.close-button`, or `.mode-toggle` (as a location target), update them now to `.panel-bar` / `.panel-bar .mode-toggle`. If Task 1 found none, skip.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Settings/Settings.tsx src/components/Settings/Settings.scss src/components/Settings/AdvancedSettings/AdvancedSettings.tsx
+git commit -m "refactor(settings): adopt PanelBar; lift tab state out of AdvancedSettings"
+```
+
+---
+
+## Task 6: LogsPanel adopts PanelBar
+
+**Files:**
+- Modify: `src/components/LogsPanel/LogsPanel.tsx`
+- Modify: `src/components/LogsPanel/LogsPanel.scss`
+
+- [ ] **Step 1: Swap imports in `LogsPanel.tsx`**
+
+Line 2 — remove `ArrowRight` (used only by the old close):
+```tsx
+import { Terminal, Trash2, ArrowUp, ArrowDown, FastForward, Mic, Users, ClipboardCopy } from 'lucide-react';
+```
+
+Line 3 — keep the `Tab` type but import `PanelBar` and stop importing `TabBar` as a value:
+```tsx
+import PanelBar from '../Settings/shared/PanelBar';
+import type { Tab } from '../Settings/shared/TabBar';
+```
+
+- [ ] **Step 2: Replace the header + standalone TabBar with PanelBar**
+
+In the `return` of `LogsPanel`, replace this block (the `.logs-panel-header` div through the `<TabBar ... />`, currently lines 266–299):
+
+```tsx
+      <div className="logs-panel-header">
+        <h2>{t('logsPanel.title')}</h2>
+        <div className="header-actions">
+          <button
+            className={`auto-scroll-button ${autoScroll ? 'active' : ''}`}
+            onClick={toggleAutoScroll}
+            title={autoScroll ? t('logsPanel.disableAutoScroll') : t('logsPanel.enableAutoScroll')}
+          >
+            <FastForward size={16} />
+            <span>{autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}</span>
+          </button>
+          {filteredLogs.length > 0 && (
+            <button className="copy-logs-button" onClick={handleCopyLogs}>
+              <ClipboardCopy size={16} />
+              <span>{copyLabel || t('logsPanel.copyLogs')}</span>
+            </button>
+          )}
+          {logs.length > 0 && (
+            <button className="clear-logs-button" onClick={clearLogs}>
+              <Trash2 size={16} />
+              <span>{t('common.clear')}</span>
+            </button>
+          )}
+          <button className="close-logs-button" onClick={toggleLogs}>
+            <ArrowRight size={16} />
+            <span>{t('common.close')}</span>
+          </button>
+        </div>
+      </div>
+      <TabBar
+        tabs={LOG_TABS}
+        activeTab={activeTab}
+        onTabChange={(id) => setActiveTab(id as ClientId)}
+      />
+```
+
+with:
+
+```tsx
+      <PanelBar
+        tabs={LOG_TABS}
+        activeTab={activeTab}
+        onTabChange={(id) => setActiveTab(id as ClientId)}
+        onClose={toggleLogs}
+        actions={
+          <div className="logs-actions">
+            <button
+              className={`auto-scroll-button ${autoScroll ? 'active' : ''}`}
+              onClick={toggleAutoScroll}
+              title={autoScroll ? t('logsPanel.disableAutoScroll') : t('logsPanel.enableAutoScroll')}
+            >
+              <FastForward size={16} />
+              <span>{autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}</span>
+            </button>
+            {filteredLogs.length > 0 && (
+              <button className="copy-logs-button" onClick={handleCopyLogs}>
+                <ClipboardCopy size={16} />
+                <span>{copyLabel || t('logsPanel.copyLogs')}</span>
+              </button>
+            )}
+            {logs.length > 0 && (
+              <button className="clear-logs-button" onClick={clearLogs}>
+                <Trash2 size={16} />
+                <span>{t('common.clear')}</span>
+              </button>
+            )}
+          </div>
+        }
+      />
+```
+
+- [ ] **Step 3: Re-scope the button styles in `LogsPanel.scss`**
+
+In `src/components/LogsPanel/LogsPanel.scss`:
+
+(a) Delete the `.logs-panel-header { ... }` block's outer wrapper rules (the `display/justify-content/padding/border-bottom` and the `h2` and `.header-actions` layout) **but keep** the three action-button style blocks (`.auto-scroll-button`, `.copy-logs-button`, `.clear-logs-button`). Move those three button blocks so they are nested under `.logs-panel .logs-actions` instead of `.logs-panel .logs-panel-header .header-actions`.
+
+(b) Delete the `.close-logs-button { ... }` block entirely (the collapse button now comes from `PanelBar`).
+
+(c) Add a small flex container rule for the relocated actions:
+```scss
+  .logs-actions {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+```
+
+(Keep `.auto-scroll-button.active` using its existing green; it represents a binary "on" toggle, consistent with `state-selected-fill`. Leaving it as-is is acceptable — no visual change required.)
+
+- [ ] **Step 4: Typecheck**
+
+Run: `npx tsc --noEmit`
+Expected: no errors (confirms `ArrowRight`/`TabBar` value import removed cleanly and `Tab` type still resolves for `LOG_TABS`).
+
+- [ ] **Step 5: Build + test**
+
+Run: `npm run build && npm run test`
+Expected: build succeeds; tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/LogsPanel/LogsPanel.tsx src/components/LogsPanel/LogsPanel.scss
+git commit -m "refactor(logs): adopt shared PanelBar; drop arrow-close header"
+```
+
+---
+
+## Task 7: Full verification & manual checklist
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Typecheck, build, and test the whole project**
+
+Run: `npx tsc --noEmit && npm run build && npm run test`
+Expected: all green.
+
+- [ ] **Step 2: Run the app and walk the manual checklist**
+
+Run: `npm run electron:dev` (or `npm run dev` for the extension build), open Settings, and verify:
+- **Settings · Advanced:** one row of tabs + `Quick/Advanced` toggle + collapse icon; only the active tab shows green (underline); TitleBar `Settings` entry is a neutral pill (no green outline).
+- **Settings · Quick:** no tabs on the left; the `Quick/Advanced` toggle + collapse icon are in the **same horizontal position** as in Advanced (toggle Quick⇄Advanced and confirm the right cluster does not move).
+- **Close:** the collapse icon closes the panel; **Esc** closes the panel; opening a WarningModal and pressing **Esc** closes the modal (not the panel).
+- **Deep-link:** trigger a "navigate to setting" path (e.g. from the footer/popover) and confirm Advanced switches to the right tab and scrolls/highlights; in Quick mode the section still highlights via `SimpleSettings`.
+- **Logs:** same PanelBar grammar — client tabs + autoscroll/copy/clear + collapse; copy/clear appear only when logs exist; collapse + Esc close it.
+- **Keyboard focus:** Tab through the TitleBar entries and panel controls; the green outline appears only on `:focus-visible`.
+- **Narrow width / mobile:** shrink below 768px — mode-button text labels hide (icon-only); the right cluster still fits.
+
+- [ ] **Step 3: Confirm onboarding still highlights valid targets**
+
+Restart onboarding (Settings → Help → restart onboarding) and confirm every step points at an element that still exists (especially any step that previously targeted the Settings header / mode toggle / tabs). Fix repointing if a step lands on nothing.
+
+- [ ] **Step 4: Final commit if any fixes were made in Steps 2–3**
+
+```bash
+git add -A
+git commit -m "fix(panel-chrome): address manual-verification findings"
+```
+
+(Skip if no changes were needed.)

--- a/docs/superpowers/plans/2026-05-28-settings-panel-resize.md
+++ b/docs/superpowers/plans/2026-05-28-settings-panel-resize.md
@@ -1,0 +1,415 @@
+# Resizable Side Panel Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the right-hand side panel (`.settings-panel-container`) horizontally resizable via a draggable seam, with clamped, persisted width and keyboard support — desktop-style splitter that composes with the existing container-query labels.
+
+**Architecture:** A pure width helper (`panelWidth.ts`) holds the constants, clamp, and persistence. A presentational `PanelResizer` (flex sibling between `.main-content` and `.settings-panel-container`) emits resize deltas. `MainLayout` owns the width state, clamps it (on drag, keypress, and window resize), applies it inline, and persists on commit.
+
+**Tech Stack:** React + TypeScript, Pointer Events, SCSS, Vitest + @testing-library/react.
+
+**Spec:** `docs/superpowers/specs/2026-05-28-settings-panel-resize-design.md`
+
+**Convention:** every commit message ends with the trailer:
+```
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+```
+
+---
+
+## File Structure
+
+**Create:**
+- `src/components/MainLayout/panelWidth.ts` — constants + `clampPanelWidth` / `readPanelWidth` / `savePanelWidth`. One responsibility: width math + persistence.
+- `src/components/MainLayout/panelWidth.test.ts` — unit tests for the above.
+- `src/components/MainLayout/PanelResizer.tsx` — the draggable separator (presentational).
+- `src/components/MainLayout/PanelResizer.scss` — seam styling + mobile hide + drag body class.
+- `src/components/MainLayout/PanelResizer.test.tsx` — role + keyboard tests.
+
+**Modify:**
+- `src/components/MainLayout/MainLayout.tsx` — width state, window-resize clamp, render resizer, inline width.
+- `src/components/MainLayout/MainLayout.scss` — drop the `max-width:450` cap, drop `.main-content.with-panel` border-right (resizer owns the seam).
+
+---
+
+## Task R1: Width helper (TDD)
+
+**Files:**
+- Create: `src/components/MainLayout/panelWidth.ts`
+- Create: `src/components/MainLayout/panelWidth.test.ts`
+
+- [ ] **Step 1: Write the failing test** — `src/components/MainLayout/panelWidth.test.ts`
+
+```ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  clampPanelWidth, readPanelWidth, savePanelWidth,
+  PANEL_MIN_WIDTH, PANEL_DEFAULT_WIDTH,
+} from './panelWidth';
+
+describe('clampPanelWidth', () => {
+  it('floors at the minimum', () => {
+    expect(clampPanelWidth(100, 1600)).toBe(PANEL_MIN_WIDTH);
+  });
+  it('caps at viewport minus the MainPanel minimum (360)', () => {
+    expect(clampPanelWidth(5000, 1000)).toBe(1000 - 360);
+  });
+  it('leaves an in-range width unchanged', () => {
+    expect(clampPanelWidth(500, 1600)).toBe(500);
+  });
+  it('floors at the minimum on a tiny viewport', () => {
+    expect(clampPanelWidth(400, 500)).toBe(PANEL_MIN_WIDTH);
+  });
+});
+
+describe('read/savePanelWidth', () => {
+  beforeEach(() => localStorage.clear());
+  it('returns the default when unset or garbage', () => {
+    expect(readPanelWidth()).toBe(PANEL_DEFAULT_WIDTH);
+    localStorage.setItem('panelState.settingsPanelWidth', 'abc');
+    expect(readPanelWidth()).toBe(PANEL_DEFAULT_WIDTH);
+  });
+  it('round-trips a saved width', () => {
+    savePanelWidth(523.6);
+    expect(localStorage.getItem('panelState.settingsPanelWidth')).toBe('524');
+    expect(readPanelWidth()).toBe(524);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `npm run test -- src/components/MainLayout/panelWidth.test.ts`
+Expected: FAIL — cannot resolve `./panelWidth`.
+
+- [ ] **Step 3: Implement** — `src/components/MainLayout/panelWidth.ts`
+
+```ts
+export const PANEL_MIN_WIDTH = 300;
+export const MAIN_CONTENT_MIN = 360;
+export const PANEL_DEFAULT_WIDTH = 450;
+
+const STORAGE_KEY = 'panelState.settingsPanelWidth';
+
+/** Clamp to [MIN, viewport − MAIN_CONTENT_MIN], floored at MIN for tiny viewports. */
+export function clampPanelWidth(width: number, viewportWidth: number): number {
+  const max = Math.max(PANEL_MIN_WIDTH, viewportWidth - MAIN_CONTENT_MIN);
+  return Math.min(Math.max(width, PANEL_MIN_WIDTH), max);
+}
+
+export function readPanelWidth(): number {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) ? n : PANEL_DEFAULT_WIDTH;
+}
+
+export function savePanelWidth(width: number): void {
+  localStorage.setItem(STORAGE_KEY, String(Math.round(width)));
+}
+```
+
+- [ ] **Step 4: Run, verify PASS**
+
+Run: `npm run test -- src/components/MainLayout/panelWidth.test.ts`
+Expected: PASS (6 assertions across 2 suites).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MainLayout/panelWidth.ts src/components/MainLayout/panelWidth.test.ts
+git commit -m "feat(layout): add panel width clamp + persistence helper"
+```
+
+---
+
+## Task R2: PanelResizer component (TDD)
+
+**Files:**
+- Create: `src/components/MainLayout/PanelResizer.tsx`
+- Create: `src/components/MainLayout/PanelResizer.scss`
+- Create: `src/components/MainLayout/PanelResizer.test.tsx`
+
+- [ ] **Step 1: Write the failing test** — `src/components/MainLayout/PanelResizer.test.tsx`
+
+```tsx
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PanelResizer from './PanelResizer';
+
+const base = { width: 450, min: 300, max: 900 };
+
+describe('PanelResizer', () => {
+  it('renders a vertical separator with aria values', () => {
+    render(<PanelResizer {...base} onResize={() => {}} onCommit={() => {}} />);
+    const sep = screen.getByRole('separator');
+    expect(sep).toHaveAttribute('aria-orientation', 'vertical');
+    expect(sep).toHaveAttribute('aria-valuenow', '450');
+    expect(sep).toHaveAttribute('aria-valuemin', '300');
+    expect(sep).toHaveAttribute('aria-valuemax', '900');
+  });
+
+  it('ArrowLeft widens by 16 (resize + commit)', () => {
+    const onResize = vi.fn(); const onCommit = vi.fn();
+    render(<PanelResizer {...base} onResize={onResize} onCommit={onCommit} />);
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowLeft' });
+    expect(onResize).toHaveBeenCalledWith(466);
+    expect(onCommit).toHaveBeenCalledWith(466);
+  });
+
+  it('ArrowRight narrows by 16 (resize + commit)', () => {
+    const onResize = vi.fn(); const onCommit = vi.fn();
+    render(<PanelResizer {...base} onResize={onResize} onCommit={onCommit} />);
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' });
+    expect(onResize).toHaveBeenCalledWith(434);
+    expect(onCommit).toHaveBeenCalledWith(434);
+  });
+});
+```
+
+- [ ] **Step 2: Run, verify FAIL**
+
+Run: `npm run test -- src/components/MainLayout/PanelResizer.test.tsx`
+Expected: FAIL — cannot resolve `./PanelResizer`.
+
+- [ ] **Step 3: Implement** — `src/components/MainLayout/PanelResizer.tsx`
+
+```tsx
+import React, { useCallback, useRef } from 'react';
+import './PanelResizer.scss';
+
+interface PanelResizerProps {
+  width: number;
+  min: number;
+  max: number;
+  /** Live updates during drag / keypress. Caller clamps. */
+  onResize: (next: number) => void;
+  /** On pointerup / keypress. Caller clamps + persists. */
+  onCommit: (next: number) => void;
+}
+
+const STEP = 16;
+
+const PanelResizer: React.FC<PanelResizerProps> = ({ width, min, max, onResize, onCommit }) => {
+  const drag = useRef<{ startX: number; startWidth: number } | null>(null);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    e.preventDefault();
+    drag.current = { startX: e.clientX, startWidth: width };
+    // Panel is docked on the right: dragging left (smaller clientX) widens it.
+    const widthFrom = (clientX: number) => drag.current!.startWidth + (drag.current!.startX - clientX);
+
+    const onMove = (ev: PointerEvent) => { if (drag.current) onResize(widthFrom(ev.clientX)); };
+    const onUp = (ev: PointerEvent) => {
+      if (drag.current) onCommit(widthFrom(ev.clientX));
+      drag.current = null;
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      document.body.classList.remove('is-resizing-panel');
+    };
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    document.body.classList.add('is-resizing-panel');
+  }, [width, onResize, onCommit]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    let next: number | null = null;
+    if (e.key === 'ArrowLeft') next = width + STEP;       // wider
+    else if (e.key === 'ArrowRight') next = width - STEP; // narrower
+    if (next !== null) {
+      e.preventDefault();
+      onResize(next);
+      onCommit(next);
+    }
+  }, [width, onResize, onCommit]);
+
+  return (
+    <div
+      className="panel-resizer"
+      role="separator"
+      aria-orientation="vertical"
+      aria-valuenow={Math.round(width)}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+export default PanelResizer;
+```
+
+- [ ] **Step 4: Implement** — `src/components/MainLayout/PanelResizer.scss`
+
+```scss
+.panel-resizer {
+  flex: 0 0 4px;
+  align-self: stretch;
+  cursor: col-resize;
+  background: #333;
+  transition: background 0.15s;
+
+  &:hover,
+  &:focus-visible {
+    background: #10a37f;
+  }
+  &:focus-visible {
+    outline: none;
+  }
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+
+body.is-resizing-panel {
+  cursor: col-resize;
+  user-select: none;
+}
+```
+
+- [ ] **Step 5: Run, verify PASS**
+
+Run: `npm run test -- src/components/MainLayout/PanelResizer.test.tsx`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MainLayout/PanelResizer.tsx src/components/MainLayout/PanelResizer.scss src/components/MainLayout/PanelResizer.test.tsx
+git commit -m "feat(layout): add PanelResizer separator (pointer + keyboard)"
+```
+
+---
+
+## Task R3: Wire into MainLayout + CSS
+
+**Files:**
+- Modify: `src/components/MainLayout/MainLayout.tsx`
+- Modify: `src/components/MainLayout/MainLayout.scss`
+
+- [ ] **Step 1: Imports + state in `MainLayout.tsx`**
+
+Add imports near the other component imports:
+```tsx
+import PanelResizer from './PanelResizer';
+import { clampPanelWidth, readPanelWidth, savePanelWidth, PANEL_MIN_WIDTH, MAIN_CONTENT_MIN } from './panelWidth';
+```
+
+Inside the `MainLayout` component, alongside the other `useState` hooks, add the width state:
+```tsx
+  const [panelWidth, setPanelWidth] = useState(() => clampPanelWidth(readPanelWidth(), window.innerWidth));
+```
+
+- [ ] **Step 2: Window-resize re-clamp + handlers**
+
+Add (near the other `useEffect`s):
+```tsx
+  // Re-clamp the saved/active width when the window shrinks so a wide panel
+  // can never strand MainPanel below its minimum.
+  useEffect(() => {
+    const onResize = () => setPanelWidth((w) => clampPanelWidth(w, window.innerWidth));
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const handlePanelResize = useCallback((next: number) => {
+    setPanelWidth(clampPanelWidth(next, window.innerWidth));
+  }, []);
+  const handlePanelResizeCommit = useCallback((next: number) => {
+    const clamped = clampPanelWidth(next, window.innerWidth);
+    setPanelWidth(clamped);
+    savePanelWidth(clamped);
+  }, []);
+```
+(`useEffect`, `useCallback`, `useState` are already imported in this file.)
+
+- [ ] **Step 3: Render the resizer + apply inline width**
+
+Replace the panel-render block:
+```tsx
+      {(showLogs || showSettings) && (
+        <div className="settings-panel-container">
+          {showLogs && <LogsPanel toggleLogs={toggleLogs} />}
+          {showSettings && (
+            <SettingsComponent
+              toggleSettings={toggleSettings}
+              highlightSection={settingsNavigationTarget}
+            />
+          )}
+        </div>
+      )}
+```
+with:
+```tsx
+      {(showLogs || showSettings) && (
+        <>
+          <PanelResizer
+            width={panelWidth}
+            min={PANEL_MIN_WIDTH}
+            max={Math.max(PANEL_MIN_WIDTH, window.innerWidth - MAIN_CONTENT_MIN)}
+            onResize={handlePanelResize}
+            onCommit={handlePanelResizeCommit}
+          />
+          <div className="settings-panel-container" style={{ width: panelWidth }}>
+            {showLogs && <LogsPanel toggleLogs={toggleLogs} />}
+            {showSettings && (
+              <SettingsComponent
+                toggleSettings={toggleSettings}
+                highlightSection={settingsNavigationTarget}
+              />
+            )}
+          </div>
+        </>
+      )}
+```
+
+- [ ] **Step 4: `MainLayout.scss` — drop the width cap and the duplicate seam**
+
+(a) In the base `.settings-panel-container` rule, remove the `max-width: 450px;` line. Keep `width: 450px;` (fallback) and `min-width: 300px;` and the `container-*` lines.
+
+(b) In `.main-content`, remove the `&.with-panel { border-right: 1px solid #333; }` seam (the resizer now draws it). If `.with-panel` then has no remaining declarations, delete the empty `&.with-panel { }` block.
+
+(Leave the `@media (max-width: 768px)` block untouched — its `width:100% !important` on the container still overrides the inline width on mobile, and the resizer is `display:none` there.)
+
+- [ ] **Step 5: Typecheck + build + test**
+
+Run: `npx tsc --noEmit 2>&1 | grep MainLayout` — Expected: no NEW MainLayout errors (the pre-existing `MainLayout.tsx(2,1) 'useTranslation' unused` may remain — do not "fix" it, it's out of scope).
+Run: `npm run build && npm run test`
+Expected: build OK; full suite PASS (now includes panelWidth + PanelResizer tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/MainLayout/MainLayout.tsx src/components/MainLayout/MainLayout.scss
+git commit -m "feat(layout): make the side panel resizable via a draggable seam"
+```
+
+---
+
+## Task R4: Verification & manual checklist
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full automated gate**
+
+Run: `npx tsc --noEmit && npm run build && npm run test` — confirm build OK, suite green, no NEW tsc errors vs. the pre-existing baseline.
+
+- [ ] **Step 2: Manual (Electron — `npm run electron:dev`)**
+
+Open Settings (and Logs) and verify:
+- Dragging the seam left/right resizes the panel live; MainPanel reflows to fill the rest.
+- Can't drag the panel below 300px or wide enough to leave MainPanel under ~360px.
+- Releasing persists: reload the app → the panel reopens at the chosen width.
+- Shrink the OS window very narrow → the panel re-clamps (never strands MainPanel).
+- As you widen the panel, the PanelBar labels (`Quick/Advanced`, Logs `auto-scroll/copy/clear`) reappear; narrowing collapses them again (container-query synergy).
+- Focus the seam (Tab) → Arrow Left/Right resize in steps; `aria-valuenow` updates.
+- Resize the window below 768px → layout stacks, the seam disappears, the panel is full-width.
+- During a drag, text doesn't get selected and the cursor stays `col-resize`.
+
+- [ ] **Step 3: Commit any manual-fix follow-ups (skip if none)**
+
+```bash
+git add -A && git commit -m "fix(panel-resize): address manual-verification findings"
+```

--- a/docs/superpowers/specs/2026-05-27-panel-chrome-unification-design.md
+++ b/docs/superpowers/specs/2026-05-27-panel-chrome-unification-design.md
@@ -1,0 +1,166 @@
+# Panel Chrome Unification (Settings + Logs) — Design
+
+**Date:** 2026-05-27
+**Status:** Draft
+**Scope:** Introduce a single shared `PanelBar` component for the Settings and Logs side panels, formalize a small active-state token system across the shell, and fix three concrete UX defects in the top-right region: (1) three competing green "active" treatments, (2) a `→`-arrow close button that sits directly under the window `✕`, and (3) three stacked horizontal navigation rows. MainPanel keeps its structure and only continues to share the same accent color.
+
+## Problem
+
+The Settings panel's top-right region (and, it turns out, the whole shell) suffers from chrome that was invented three separate times:
+
+- **Three greens fighting.** On one screen, "active" is expressed three different ways: the TitleBar `Settings` entry uses a green **outline** (`TitleBar.scss` `.is-active { border-color: #10a37f }`), the `Quick/Advanced` toggle uses a green **fill** (`Settings.scss` `.mode-button.active`), and the category tab uses green **text + underline** (`TabBar.scss` `.tab-bar__tab--active`). The green outline in particular reads like a focus/error ring. Nothing tells the user which green is "the" current location.
+- **A misleading close that's a mis-tap risk.** Both `Settings.tsx` (`.close-button`) and `LogsPanel.tsx:289` (`.close-logs-button`) render an `ArrowRight` icon + "Close". A right arrow conventionally means "forward/next", not "dismiss". Worse, this control sits one row directly below the window's `✕`, so a user aiming to close the panel can close the whole window.
+- **Three stacked nav rows.** TitleBar (`Subtitle/Settings/Logs`) → Settings header (`Settings` title + mode toggle + close) → TabBar (`General/Audio/Provider`). In a 300–450px side panel, navigation eats three rows of vertical space before any content appears. The word "Settings" also appears twice (TitleBar entry + `<h2>`).
+- **No shared panel chrome.** Settings, Logs, and MainPanel each built bespoke headers. The arrow-close bug is copy-pasted between Settings and Logs. Settings and Logs already share the `TabBar` component (`LogsPanel` imports it from `Settings/shared/TabBar`), which proves a shared header primitive is low-friction.
+
+## Goals
+
+1. One shared `PanelBar` grammar for both side panels: `[tabs (left)] ···· [panel-specific actions] [collapse]`.
+2. A documented active-state token system where **green = the selected item in a mutually-exclusive set**, with one fixed form per control archetype and a clear hierarchy so only one prominent "you are here" signal competes at a time.
+3. Replace the arrow-close with a semantically correct **"collapse panel"** affordance, visually distinct from the window `✕`, plus **Esc** to close.
+4. Collapse Settings from three nav rows to two (TitleBar + PanelBar); drop the duplicate `Settings`/`Logs` `<h2>`.
+5. The `Quick/Advanced` toggle never changes position when toggled.
+6. No regression to onboarding step targeting, the settings-navigation deep-link flow, or mobile/macOS/extension layouts.
+
+## Non-Goals
+
+- No structural change to **MainPanel** (`conversation-toolbar`, `control-footer`). It already uses the same `#10a37f` accent, so it stays as-is; this spec does not retrofit its buttons onto the new tokens.
+- No change to **what** the tabs are (Settings: General/Audio/Provider; Logs: per-client) or the panel contents.
+- No removal of the `Quick/Advanced` mode feature, and no moving it into an overflow menu.
+- No change to panel docking, width (`settings-panel-container: 450px`), or the side-by-side-with-MainPanel layout.
+- No new i18n copy beyond an optional `common.collapsePanel` aria-label key.
+- No relocation of `TabBar` out of `Settings/shared/` (a future cleanup, not this spec).
+
+## Design
+
+### Active-state token system (System A)
+
+The fix is **not** to make every control identical — it is to assign green a single meaning and pick the correct form per control type, weighting by hierarchy.
+
+| Control archetype | Where | Active form | Token |
+|---|---|---|---|
+| Tab strip | TabBar (Settings categories, Logs clients) | green text + 2px green bottom-border | `state-selected-underline` |
+| Segmented control | `Quick/Advanced` toggle | green fill + light text on active segment | `state-selected-fill` |
+| Panel switcher | TitleBar `Subtitle/Settings/Logs` active entry | **neutral pressed pill** — solid subtle fill + bright text, **no green** | (TitleBar-local) |
+| Keyboard focus (all) | any focusable control | green **outline**, `:focus-visible` only | `focus-ring` (exists) |
+
+Key point: most of this is already correct. `TabBar.scss` already does the underline; `Settings.scss .mode-button.active` already does the fill; `_variables.scss` already has a `focus-ring` mixin. **The only behavioral CSS change is the TitleBar**, which today borrows the green outline for "active" — that moves to a neutral pressed pill, and the green outline becomes focus-only. Net effect: on any screen there is exactly one prominent green location signal (the active tab), with the TitleBar receding to background context and the segmented control reading as a contained control.
+
+`_variables.scss` gains two mixins extracted from the existing patterns so future code references one source:
+
+```scss
+@mixin state-selected-underline {
+  color: $color-primary;
+  border-bottom: 2px solid $color-primary;
+}
+@mixin state-selected-fill {
+  background: $color-primary;
+  color: $text-primary;
+}
+// focus-ring already exists; reserve it for :focus-visible only.
+```
+
+`TabBar.scss` and the mode-toggle styles are refactored to `@include` these mixins (no visual change) so the tokens have real call sites.
+
+### Component: PanelBar
+
+New presentational component, placed at `src/components/Settings/shared/PanelBar.tsx` to sit beside the already-shared `TabBar`.
+
+**Props:**
+
+```ts
+interface PanelBarProps {
+  // Tab strip (optional — Settings Quick mode and any tab-less panel omit it)
+  tabs?: Tab[];
+  activeTab?: string;
+  onTabChange?: (id: string) => void;
+  // Panel-specific controls rendered in the right cluster, left of close.
+  // Settings: the Quick/Advanced toggle. Logs: auto-scroll / copy / clear.
+  actions?: React.ReactNode;
+  // Collapse the panel. Wired to the owning panel's existing toggle fn.
+  onClose: () => void;
+}
+```
+
+**Layout (single flex row):**
+
+```
+[ TabBar (or nothing) ]  → margin-left:auto →  [ actions ]  | divider |  [ collapse ]
+```
+
+- When `tabs` is provided, PanelBar renders `<TabBar>` internally; otherwise the left side is empty (Settings Quick mode). The actions+collapse cluster is right-anchored via `margin-left:auto`, so **it occupies the same pixels whether or not tabs are present** — toggling Quick⇄Advanced only adds/removes the left tabs; the right cluster never moves.
+- **Collapse control:** lucide `PanelRightClose` icon (the panel docks on the right; the icon depicts the side panel sliding shut), `aria-label`/`title` = `t('common.collapsePanel', 'Close panel')`, separated from the actions by a thin vertical divider. No visible text label.
+- **Esc to close:** PanelBar attaches a `keydown` listener while mounted; on `Escape`, if `!event.defaultPrevented` and there is no open modal/dialog (`document.querySelector('[role="dialog"]')` is null), it calls `onClose()`. This lets `WarningModal` and popovers keep their own Escape behavior. (Settings/Logs panels and Electron subtitle takeover are mutually exclusive, so there is no conflict with the subtitle ESC layering.)
+
+`PanelBar.scss` carries the bar container styles plus the relocated `.mode-toggle` segmented-control styles (moved out of `Settings.scss`), built on the state tokens. It keeps the existing `@media (max-width: 768px)` rule that hides the mode-button text labels on narrow widths (icon-only).
+
+### Settings integration
+
+`Settings.tsx` becomes the single owner of the panel bar and the category-tab state:
+
+- **Remove** the `.settings-header` block entirely (the `<h2>`, `.mode-toggle`, and `.close-button`).
+- **Lift** `activeTab`, the `TABS` constant, and the `settingsNavigationTarget → targetTab` effect up from `AdvancedSettings.tsx` into `Settings.tsx`. The lifted effect is **guarded to `!isSimpleMode`** so it only switches Advanced tabs — preserving today's behavior exactly (the effect currently lives in `AdvancedSettings`, which mounts only in Advanced). Quick mode keeps using `highlightSection` in `SimpleSettings`; navigation does **not** force a switch into Advanced.
+- Render `<PanelBar>` once:
+  - `tabs` / `activeTab` / `onTabChange` are passed **only in Advanced mode** (`!isSimpleMode`); omitted in Quick mode.
+  - `actions` = the `Quick/Advanced` segmented toggle (the existing `handleModeToggle` logic, markup moved into a small local `ModeToggle` element or kept inline).
+  - `onClose` = `toggleSettings`.
+- `AdvancedSettings` no longer renders `TabBar` or owns `activeTab`; it receives `activeTab` as a prop and renders only the matching tabpanel. The tabpanel a11y ids (`tabpanel-${id}` / `tab-${id}`) still match because `TabBar` (now inside `PanelBar`) emits the same ids and shares the same `activeTab`.
+- `Settings.scss`: delete `.settings-header`, `.mode-toggle`, `.mode-button`, `.close-button` rules (mode-toggle styles relocate to `PanelBar.scss`); keep the responsive section.
+
+Resulting Settings layout:
+
+- **Advanced:** `[General | Audio | Provider] ···· [Quick|Advanced] | [⇥▕]`
+- **Quick:** `(empty) ···· [Quick|Advanced] | [⇥▕]` — right cluster pixel-identical to Advanced.
+
+### Logs integration
+
+`LogsPanel.tsx`:
+
+- **Remove** `.logs-panel-header` (the `<h2>`, the `header-actions` wrapper) and the standalone `<TabBar>` call, plus the `ArrowRight` `.close-logs-button`.
+- Render `<PanelBar tabs={LOG_TABS} activeTab={activeTab} onTabChange={...} actions={<>auto-scroll / copy / clear</>} onClose={toggleLogs} />`.
+- The conditional visibility of copy (`filteredLogs.length > 0`) and clear (`logs.length > 0`) stays inside the `actions` JSX — the slot is plain `ReactNode`.
+- `LogsPanel.scss`: drop the header layout rules; the action-button styles either move into `PanelBar.scss` (if generic) or stay scoped to the buttons passed into the slot.
+
+### TitleBar change
+
+`TitleBar.scss` only:
+
+- `.title-bar__action.is-active`: remove `border-color: #10a37f`; keep the subtle background and brighten text (neutral pressed pill).
+- Add `.title-bar__action:focus-visible { outline: 2px solid #10a37f; outline-offset: -1px; }` so keyboard focus is the *only* place the green outline appears.
+
+`TitleBar.tsx` is unchanged — the `settings-button` / `logs-button` classes (onboarding targets) and window-control logic stay as-is.
+
+## Files
+
+**Create:**
+- `src/components/Settings/shared/PanelBar.tsx`
+- `src/components/Settings/shared/PanelBar.scss`
+- `src/components/Settings/shared/PanelBar.test.tsx`
+
+**Modify:**
+- `src/components/Settings/shared/_variables.scss` — add `state-selected-underline` / `state-selected-fill` mixins.
+- `src/components/Settings/shared/TabBar.scss` — `@include state-selected-underline` (no visual change).
+- `src/components/Settings/Settings.tsx` — own PanelBar + lifted tab state + nav-target effect; remove header block.
+- `src/components/Settings/Settings.scss` — remove header/mode/close rules.
+- `src/components/Settings/AdvancedSettings/AdvancedSettings.tsx` — receive `activeTab` prop; drop internal TabBar + tab state + nav effect.
+- `src/components/LogsPanel/LogsPanel.tsx` — adopt PanelBar; remove bespoke header + arrow-close.
+- `src/components/LogsPanel/LogsPanel.scss` — remove header rules.
+- `src/components/TitleBar/TitleBar.scss` — neutral active pill + focus-visible outline.
+- i18n locale files — add `common.collapsePanel` (English source; other locales fall back).
+
+## Edge cases & risks
+
+- **Onboarding selectors (highest risk).** Before deleting any markup, audit `src/components/Onboarding/` for selectors targeting removed elements (`.settings-header`, `.close-button`, `.mode-toggle`, `.mode-button`, `.logs-panel-header`, or `.tab-bar` if it expects a specific DOM position). The TitleBar `.settings-button` / `.logs-button` targets are preserved. Any onboarding step pointing at a removed node must be repointed (likely to the PanelBar tab or the TitleBar entry).
+- **Settings deep-link / navigation target.** `settingsNavigationTarget` both opens the panel (handled in `MainLayout`) and selects a tab (effect lifted into `Settings.tsx`, guarded to Advanced as above). Verify a deep-link still switches to the correct Advanced tab when already in Advanced, and that arriving in Quick mode still highlights the section via `SimpleSettings`/`highlightSection` (no behavior change).
+- **Esc handler conflicts.** Guard against closing while a `WarningModal`/dialog or floating popover is open (the `[role="dialog"]` check + `defaultPrevented`). Confirm no double-close with any global Esc handling.
+- **Mobile (`<768px`).** The panel goes full-width and the mode-button labels hide (icon-only). Confirm the right cluster still fits and the empty-left Quick bar looks intentional.
+- **macOS / extension TitleBar.** No in-app window controls there; the neutral-pill + focus-outline change is independent of window-control rendering and applies uniformly.
+- **Collapse-icon discoverability.** `PanelRightClose` is less universally understood than `✕`; the `title`/`aria-label` tooltip plus Esc mitigate this. Acceptable given the mis-tap risk of the current arrow-under-`✕` arrangement.
+
+## Testing
+
+- **PanelBar unit (`PanelBar.test.tsx`):** renders TabBar when `tabs` given and omits it when not; renders the `actions` slot; clicking the collapse button calls `onClose`; `Escape` calls `onClose`; `Escape` is a no-op when a `[role="dialog"]` is present.
+- **Settings:** PanelBar is present in both Quick and Advanced; `actions` (mode toggle) renders in both; switching modes does not unmount/remount the right cluster; Advanced shows tabs, Quick does not; existing `settingsStore.providerSettings.test` and `ModePicker.test` remain green.
+- **Logs:** PanelBar replaces the old header; copy/clear appear only under their existing conditions; collapse calls `toggleLogs`.
+- **TabBar.test.tsx:** unchanged behavior (component itself is untouched) — must still pass.
+- **Manual/visual:** right-cluster pixel alignment across Quick⇄Advanced; single green location signal per screen; `:focus-visible` outline appears on keyboard nav only; Esc closes each panel; onboarding walkthrough still highlights valid targets; narrow-width and macOS/extension renders.

--- a/docs/superpowers/specs/2026-05-28-settings-panel-resize-design.md
+++ b/docs/superpowers/specs/2026-05-28-settings-panel-resize-design.md
@@ -1,0 +1,118 @@
+# Resizable Side Panel — Design
+
+**Date:** 2026-05-28
+**Status:** Draft
+**Scope:** Make the right-hand side panel (`.settings-panel-container`, which hosts Settings or Logs) horizontally resizable via a draggable seam between it and MainPanel, in the side-by-side layout. Width is clamped, persists across sessions, and is keyboard-accessible. Builds directly on `2026-05-27-panel-chrome-unification-design.md` (same branch) — the panel is already a CSS query container, so widening it makes the PanelBar labels reappear for free.
+
+## Problem
+The side panel is fixed at `width: 450px` (`max-width: 450px`). After the panel-chrome unification, a 300–450px panel is tight: in Settings Advanced and in Logs the right-cluster labels collapse to icon-only because they don't fit. Desktop (Electron) users have a resizable window and plenty of horizontal room, but no way to give the panel more of it — to read logs comfortably or to see the full `Quick/Advanced` and `auto-scroll/copy/clear` labels.
+
+## Goals
+1. A full-height vertical drag handle on the seam between MainPanel and the side panel; drag left widens, right narrows.
+2. Width clamped to **[300px, viewportWidth − 360px]** (MainPanel keeps ≥360px); re-clamped on window resize so a saved wide width can't strand MainPanel.
+3. Width persists across sessions (`localStorage`, key `panelState.settingsPanelWidth`).
+4. Keyboard-accessible: the handle is a focusable `role="separator"`; Arrow Left/Right resize in 16px steps.
+5. Hidden and inert on mobile (`<768px`, where the layout stacks vertically and the panel is full-width).
+6. Composes with the existing container query — no extra label logic; widening reveals labels, narrowing collapses them.
+
+## Non-Goals
+- No direct resizing of `.main-content`/MainPanel (it stays `flex: 1`, the elastic member).
+- No vertical resize, no resizer in the stacked mobile layout.
+- No change to which panels exist, their content, or the 300px minimum.
+- No new runtime dependency — custom ~60-line implementation (the existing `useOverlayDragResize` hook is iframe/postMessage-specific and not reusable here).
+- No restructuring of the layout tree beyond inserting one sibling and relocating the 1px seam.
+
+## Layout context (from research)
+The only flex container is `.main-layout` (row; `flex-direction: column` under `@media (max-width: 768px)`). Its flex children, when a panel is open:
+- `.main-content` — `flex: 1` (elastic, holds MainPanel). `.with-panel` currently draws the `border-right` seam.
+- `.settings-panel-container` — fixed `width:450 / min:300 / max:450` (the member we size).
+- `<Onboarding>` — react-joyride, portals / `return null`, takes no flex space.
+
+`.settings-panel-container` is referenced only in `MainLayout.tsx`, `MainLayout.scss`, and `scrollbar.scss`; **no JS reads its width** and `450` is hardcoded only in `MainLayout.scss`. So driving its width is safe.
+
+## Design
+
+### Width helper — `src/components/MainLayout/panelWidth.ts`
+Pure, testable constants + functions (single source of truth, shared by MainLayout and PanelResizer):
+
+```ts
+export const PANEL_MIN_WIDTH = 300;
+export const MAIN_CONTENT_MIN = 360;
+export const PANEL_DEFAULT_WIDTH = 450;
+const STORAGE_KEY = 'panelState.settingsPanelWidth';
+
+/** Clamp to [MIN, viewport − MAIN_CONTENT_MIN], floored at MIN for tiny viewports. */
+export function clampPanelWidth(width: number, viewportWidth: number): number {
+  const max = Math.max(PANEL_MIN_WIDTH, viewportWidth - MAIN_CONTENT_MIN);
+  return Math.min(Math.max(width, PANEL_MIN_WIDTH), max);
+}
+export function readPanelWidth(): number {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) ? n : PANEL_DEFAULT_WIDTH;
+}
+export function savePanelWidth(width: number): void {
+  localStorage.setItem(STORAGE_KEY, String(Math.round(width)));
+}
+```
+
+### Component — `src/components/MainLayout/PanelResizer.tsx`
+A presentational flex sibling inserted **between `.main-content` and `.settings-panel-container`** (inside the existing `showLogs || showSettings` conditional, wrapped with the container in a fragment).
+
+Props:
+```ts
+interface PanelResizerProps {
+  width: number;                 // current panel width (for aria + drag origin)
+  min: number;                   // PANEL_MIN_WIDTH
+  max: number;                   // computed max (for aria)
+  onResize: (next: number) => void; // live, during drag/keys (caller clamps)
+  onCommit: (next: number) => void; // on pointerup / keypress (caller clamps + persists)
+}
+```
+
+Behavior:
+- Renders `<div className="panel-resizer" role="separator" aria-orientation="vertical" aria-valuenow={round(width)} aria-valuemin aria-valuemax tabIndex={0}>`.
+- **Pointer:** on `pointerdown`, record `startX`/`startWidth` and attach `pointermove`/`pointerup` to `window`; add `is-resizing-panel` to `document.body` (global `col-resize` cursor + `user-select:none`). Panel is docked right, so `next = startWidth + (startX − clientX)` (drag left → wider). Call `onResize(next)` on move, `onCommit(next)` on up, then detach listeners and remove the body class.
+- **Keyboard:** `ArrowLeft` → `onResize/onCommit(width + 16)` (wider), `ArrowRight` → `width − 16` (narrower); `preventDefault`.
+- Caller (MainLayout) is responsible for clamping `next`; `aria-valuenow` reflects the clamped `width` prop.
+
+### Wiring — `MainLayout.tsx`
+- `const [panelWidth, setPanelWidth] = useState(() => clampPanelWidth(readPanelWidth(), window.innerWidth));`
+- `useEffect` on mount: `resize` listener → `setPanelWidth(w => clampPanelWidth(w, window.innerWidth))`; cleanup on unmount.
+- `const handleResize = (w) => setPanelWidth(clampPanelWidth(w, window.innerWidth));`
+- `const handleCommit = (w) => { const c = clampPanelWidth(w, window.innerWidth); setPanelWidth(c); savePanelWidth(c); };`
+- In the conditional, render the resizer immediately before the container, and apply the inline width:
+```tsx
+{(showLogs || showSettings) && (
+  <>
+    <PanelResizer
+      width={panelWidth}
+      min={PANEL_MIN_WIDTH}
+      max={Math.max(PANEL_MIN_WIDTH, window.innerWidth - MAIN_CONTENT_MIN)}
+      onResize={handleResize}
+      onCommit={handleCommit}
+    />
+    <div className="settings-panel-container" style={{ width: panelWidth }}>
+      {showLogs && <LogsPanel toggleLogs={toggleLogs} />}
+      {showSettings && <SettingsComponent toggleSettings={toggleSettings} highlightSection={settingsNavigationTarget} />}
+    </div>
+  </>
+)}
+```
+
+### CSS — `MainLayout.scss` + new `PanelResizer.scss`
+- `.settings-panel-container`: **remove `max-width: 450px`** (the JS clamp governs the max; inline `width` sets the value). Keep `min-width: 300px` as the floor and `width: 450px` as a fallback. Keep `container-*`. The mobile `@media (max-width:768px)` rule already forces `width:100% !important`, which overrides the inline width — mobile unaffected.
+- `.main-content.with-panel`: **remove `border-right`** — the resizer now owns the seam.
+- New `PanelResizer.scss` (hardcoded hex to match MainLayout/TitleBar convention, not the Settings tokens): `.panel-resizer { flex: 0 0 4px; align-self: stretch; cursor: col-resize; background: #333; transition: background .15s; &:hover, &:focus-visible { background: #10a37f; } &:focus-visible { outline: none; } @media (max-width: 768px) { display: none; } }` plus `body.is-resizing-panel { cursor: col-resize; user-select: none; }`.
+
+## Edge cases & risks
+- **Tiny viewport** (`viewport − 360 < 300`): `clampPanelWidth` floors at 300; MainPanel may dip below 360 only on a genuinely small window — acceptable, and the mobile layout takes over below 768px anyway.
+- **Stale wide saved width** after the window shrank: re-clamped on mount and on every `resize` event.
+- **Mobile**: resizer `display:none`; container width `100% !important` wins over inline style. No JS branching needed.
+- **Drag selection/iframes**: `is-resizing-panel` sets `user-select:none` on body for the drag duration; `pointerup` always cleans up listeners + class even if the cursor leaves the window (listeners are on `window`).
+- **SSR/no-DOM**: not applicable (Electron/extension/browser runtime; `window`/`localStorage` always present).
+
+## Testing
+- **`panelWidth.test.ts`** (pure): `clampPanelWidth` — below min → 300; above max → `viewport−360`; within → unchanged; tiny viewport → 300. `readPanelWidth` → default when unset/garbage, parsed when set. `savePanelWidth` → writes rounded string. (Mock `localStorage`.)
+- **`PanelResizer.test.tsx`**: renders `role="separator"` with `aria-orientation` + aria-value attrs from props; `ArrowLeft` calls `onResize`+`onCommit` with `width+16`; `ArrowRight` with `width−16`.
+- **Manual** (Electron): drag widens/narrows live; release persists; reload restores width; shrinking the window re-clamps; widening reveals PanelBar labels; below 768px the handle disappears and the panel goes full-width; keyboard arrows on the focused seam resize.

--- a/src/components/LogsPanel/LogsPanel.scss
+++ b/src/components/LogsPanel/LogsPanel.scss
@@ -7,27 +7,11 @@
   overflow-x: hidden;
   font-size: 13px;
   
-  .logs-panel-header {
+  .logs-actions {
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    padding: 11.5px 15px;
-    border-bottom: 1px solid #333;
-    box-sizing: border-box;
-    width: 100%;
-    
-    h2 {
-      margin: 0;
-      font-size: 14px;
-      font-weight: 500;
-    }
-    
-    .header-actions {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-    }
-    
+    gap: 8px;
+
     .auto-scroll-button {
       display: flex;
       align-items: center;
@@ -38,27 +22,27 @@
       padding: 5px 10px;
       border-radius: 4px;
       transition: all 0.2s;
-      
+
       span {
         margin-left: 5px;
         font-size: 13px;
       }
-      
+
       &:hover {
         background-color: rgba(255, 255, 255, 0.1);
         color: white;
       }
-      
+
       &.active {
         background-color: rgba(16, 163, 127, 0.1);
         color: #10a37f;
-        
+
         &:hover {
           background-color: rgba(16, 163, 127, 0.2);
         }
       }
     }
-    
+
     .copy-logs-button {
       display: flex;
       align-items: center;
@@ -91,37 +75,15 @@
       padding: 5px 10px;
       border-radius: 4px;
       transition: all 0.2s;
-      
+
       span {
         margin-left: 5px;
         font-size: 13px;
       }
-      
+
       &:hover {
         background-color: rgba(255, 76, 76, 0.1);
         color: #ff4c4c;
-      }
-    }
-    
-    .close-logs-button {
-      display: flex;
-      align-items: center;
-      background: none;
-      border: none;
-      color: #888;
-      cursor: pointer;
-      padding: 6px 12px;
-      border-radius: 4px;
-      transition: all 0.2s;
-      
-      span {
-        margin-left: 5px;
-        font-size: 13px;
-      }
-      
-      &:hover {
-        background-color: rgba(255, 255, 255, 0.1);
-        color: white;
       }
     }
   }

--- a/src/components/LogsPanel/LogsPanel.tsx
+++ b/src/components/LogsPanel/LogsPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect, useMemo, useCallback, memo } from 'react';
-import { ArrowRight, Terminal, Trash2, ArrowUp, ArrowDown, FastForward, Mic, Users, ClipboardCopy } from 'lucide-react';
-import TabBar, { Tab } from '../Settings/shared/TabBar';
+import { Terminal, Trash2, ArrowUp, ArrowDown, FastForward, Mic, Users, ClipboardCopy } from 'lucide-react';
+import PanelBar from '../Settings/shared/PanelBar';
+import type { Tab } from '../Settings/shared/TabBar';
 import './LogsPanel.scss';
 import { useLogData, useLogActions } from '../../stores/logStore';
 import type { LogEntry, ClientId } from '../../stores/logStore';
@@ -263,39 +264,35 @@ const LogsPanel: React.FC<LogsPanelProps> = ({ toggleLogs }) => {
 
   return (
     <div className="logs-panel">
-      <div className="logs-panel-header">
-        <h2>{t('logsPanel.title')}</h2>
-        <div className="header-actions">
-          <button 
-            className={`auto-scroll-button ${autoScroll ? 'active' : ''}`} 
-            onClick={toggleAutoScroll}
-            title={autoScroll ? t('logsPanel.disableAutoScroll') : t('logsPanel.enableAutoScroll')}
-          >
-            <FastForward size={16} />
-            <span>{autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}</span>
-          </button>
-          {filteredLogs.length > 0 && (
-            <button className="copy-logs-button" onClick={handleCopyLogs}>
-              <ClipboardCopy size={16} />
-              <span>{copyLabel || t('logsPanel.copyLogs')}</span>
-            </button>
-          )}
-          {logs.length > 0 && (
-            <button className="clear-logs-button" onClick={clearLogs}>
-              <Trash2 size={16} />
-              <span>{t('common.clear')}</span>
-            </button>
-          )}
-          <button className="close-logs-button" onClick={toggleLogs}>
-            <ArrowRight size={16} />
-            <span>{t('common.close')}</span>
-          </button>
-        </div>
-      </div>
-      <TabBar
+      <PanelBar
         tabs={LOG_TABS}
         activeTab={activeTab}
         onTabChange={(id) => setActiveTab(id as ClientId)}
+        onClose={toggleLogs}
+        actions={
+          <div className="logs-actions">
+            <button
+              className={`auto-scroll-button ${autoScroll ? 'active' : ''}`}
+              onClick={toggleAutoScroll}
+              title={autoScroll ? t('logsPanel.disableAutoScroll') : t('logsPanel.enableAutoScroll')}
+            >
+              <FastForward size={16} />
+              <span>{autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}</span>
+            </button>
+            {filteredLogs.length > 0 && (
+              <button className="copy-logs-button" onClick={handleCopyLogs}>
+                <ClipboardCopy size={16} />
+                <span>{copyLabel || t('logsPanel.copyLogs')}</span>
+              </button>
+            )}
+            {logs.length > 0 && (
+              <button className="clear-logs-button" onClick={clearLogs}>
+                <Trash2 size={16} />
+                <span>{t('common.clear')}</span>
+              </button>
+            )}
+          </div>
+        }
       />
       <div
         className="logs-content"

--- a/src/components/LogsPanel/LogsPanel.tsx
+++ b/src/components/LogsPanel/LogsPanel.tsx
@@ -275,18 +275,29 @@ const LogsPanel: React.FC<LogsPanelProps> = ({ toggleLogs }) => {
               className={`auto-scroll-button ${autoScroll ? 'active' : ''}`}
               onClick={toggleAutoScroll}
               title={autoScroll ? t('logsPanel.disableAutoScroll') : t('logsPanel.enableAutoScroll')}
+              aria-label={autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}
             >
               <FastForward size={16} />
               <span>{autoScroll ? t('logsPanel.autoScrollOn') : t('logsPanel.autoScrollOff')}</span>
             </button>
             {filteredLogs.length > 0 && (
-              <button className="copy-logs-button" onClick={handleCopyLogs}>
+              <button
+                className="copy-logs-button"
+                onClick={handleCopyLogs}
+                title={copyLabel || t('logsPanel.copyLogs')}
+                aria-label={t('logsPanel.copyLogs')}
+              >
                 <ClipboardCopy size={16} />
                 <span>{copyLabel || t('logsPanel.copyLogs')}</span>
               </button>
             )}
             {logs.length > 0 && (
-              <button className="clear-logs-button" onClick={clearLogs}>
+              <button
+                className="clear-logs-button"
+                onClick={clearLogs}
+                title={t('common.clear')}
+                aria-label={t('common.clear')}
+              >
                 <Trash2 size={16} />
                 <span>{t('common.clear')}</span>
               </button>

--- a/src/components/MainLayout/MainLayout.scss
+++ b/src/components/MainLayout/MainLayout.scss
@@ -62,10 +62,6 @@
     min-width: 0; /* Allow content to shrink below its minimum content size */
     min-height: 0; /* Allow content to shrink for nested scrolling to work */
     
-    &.with-panel {
-      border-right: 1px solid #333;
-    }
-    
     &.full-width {
       width: 100%;
     }
@@ -80,9 +76,7 @@
   }
   
   .settings-panel-container {
-    width: 450px;
-    min-width: 300px;
-    max-width: 450px;
+    min-width: 300px; /* width is state-driven via inline style (see MainLayout.tsx) */
     overflow-y: auto; /* Changed to allow vertical scrolling */
     padding: 0;
     background-color: #252525;

--- a/src/components/MainLayout/MainLayout.scss
+++ b/src/components/MainLayout/MainLayout.scss
@@ -86,5 +86,10 @@
     overflow-y: auto; /* Changed to allow vertical scrolling */
     padding: 0;
     background-color: #252525;
+    /* Query container so PanelBar can collapse labels based on the panel's
+       own width, not the viewport's (the side panel stays narrow even when
+       the window is wide). */
+    container-type: inline-size;
+    container-name: panel-chrome;
   }
 }

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -6,6 +6,8 @@ import { Settings as SettingsComponent } from '../Settings';
 import Onboarding from '../Onboarding/Onboarding';
 import UserTypeSelection from '../UserTypeSelection/UserTypeSelection';
 import TitleBar from '../TitleBar/TitleBar';
+import PanelResizer from './PanelResizer';
+import { clampPanelWidth, maxPanelWidth, readPanelWidth, savePanelWidth, PANEL_MIN_WIDTH } from './panelWidth';
 import './MainLayout.scss';
 import { useAnalytics } from '../../lib/analytics';
 import { useProvider, useUIMode, useSetProvider, useSetUIMode, useSettingsNavigationTarget, useSubtitleModeActive } from '../../stores/settingsStore';
@@ -33,7 +35,7 @@ const MainLayout: React.FC = () => {
   const [showSettings, setShowSettings] = useState(() => {
     return sessionStorage.getItem('panelState.showSettings') === 'true';
   });
-
+  const [panelWidth, setPanelWidth] = useState(() => clampPanelWidth(readPanelWidth(), window.innerWidth));
 
   // Track panel view times
   const panelOpenTimeRef = useRef<number | null>(null);
@@ -101,6 +103,23 @@ const MainLayout: React.FC = () => {
     }
   };
 
+
+  // Re-clamp the saved/active width when the window shrinks so a wide panel
+  // can never strand MainPanel below its minimum.
+  useEffect(() => {
+    const onResize = () => setPanelWidth((w) => clampPanelWidth(w, window.innerWidth));
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  const handlePanelResize = useCallback((next: number) => {
+    setPanelWidth(clampPanelWidth(next, window.innerWidth));
+  }, []);
+  const handlePanelResizeCommit = useCallback((next: number) => {
+    const clamped = clampPanelWidth(next, window.innerWidth);
+    setPanelWidth(clamped);
+    savePanelWidth(clamped);
+  }, []);
 
   // Listen for navigation requests from settings context
   useEffect(() => {
@@ -187,15 +206,24 @@ const MainLayout: React.FC = () => {
         </div>
       </div>
       {(showLogs || showSettings) && (
-        <div className="settings-panel-container">
-          {showLogs && <LogsPanel toggleLogs={toggleLogs} />}
-          {showSettings && (
-            <SettingsComponent
-              toggleSettings={toggleSettings}
-              highlightSection={settingsNavigationTarget}
-            />
-          )}
-        </div>
+        <>
+          <PanelResizer
+            width={panelWidth}
+            min={PANEL_MIN_WIDTH}
+            max={maxPanelWidth(window.innerWidth)}
+            onResize={handlePanelResize}
+            onCommit={handlePanelResizeCommit}
+          />
+          <div className="settings-panel-container" style={{ width: panelWidth }}>
+            {showLogs && <LogsPanel toggleLogs={toggleLogs} />}
+            {showSettings && (
+              <SettingsComponent
+                toggleSettings={toggleSettings}
+                highlightSection={settingsNavigationTarget}
+              />
+            )}
+          </div>
+        </>
       )}
       <Onboarding />
     </div>

--- a/src/components/MainLayout/PanelResizer.scss
+++ b/src/components/MainLayout/PanelResizer.scss
@@ -1,15 +1,25 @@
 .panel-resizer {
-  flex: 0 0 4px;
+  position: relative;
+  z-index: 2;
+  flex: 0 0 1px;          // 1px visible seam (matches the old divider)
   align-self: stretch;
-  cursor: col-resize;
   background: #333;
+  cursor: col-resize;
   transition: background 0.15s;
 
-  &:hover,
-  &:focus-visible {
-    background: #10a37f;
+  // Wider invisible hit area straddling the 1px seam (7px total) so the thin
+  // seam is still easy to grab. Sits above the neighbours for pointer events.
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0 -3px;
+  }
+
+  &:hover {
+    background: #555;       // subtle neutral lift; the col-resize cursor is the main affordance
   }
   &:focus-visible {
+    background: #10a37f;
     outline: none;
   }
 
@@ -21,4 +31,9 @@
 body.is-resizing-panel {
   cursor: col-resize;
   user-select: none;
+
+  // Accent the seam only while a drag is actually in progress.
+  .panel-resizer {
+    background: #10a37f;
+  }
 }

--- a/src/components/MainLayout/PanelResizer.scss
+++ b/src/components/MainLayout/PanelResizer.scss
@@ -1,0 +1,24 @@
+.panel-resizer {
+  flex: 0 0 4px;
+  align-self: stretch;
+  cursor: col-resize;
+  background: #333;
+  transition: background 0.15s;
+
+  &:hover,
+  &:focus-visible {
+    background: #10a37f;
+  }
+  &:focus-visible {
+    outline: none;
+  }
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+}
+
+body.is-resizing-panel {
+  cursor: col-resize;
+  user-select: none;
+}

--- a/src/components/MainLayout/PanelResizer.test.tsx
+++ b/src/components/MainLayout/PanelResizer.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PanelResizer from './PanelResizer';
+
+const base = { width: 450, min: 300, max: 900 };
+
+describe('PanelResizer', () => {
+  it('renders a vertical separator with aria values', () => {
+    render(<PanelResizer {...base} onResize={() => {}} onCommit={() => {}} />);
+    const sep = screen.getByRole('separator');
+    expect(sep).toHaveAttribute('aria-orientation', 'vertical');
+    expect(sep).toHaveAttribute('aria-valuenow', '450');
+    expect(sep).toHaveAttribute('aria-valuemin', '300');
+    expect(sep).toHaveAttribute('aria-valuemax', '900');
+  });
+
+  it('ArrowLeft widens by 16 (resize + commit)', () => {
+    const onResize = vi.fn(); const onCommit = vi.fn();
+    render(<PanelResizer {...base} onResize={onResize} onCommit={onCommit} />);
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowLeft' });
+    expect(onResize).toHaveBeenCalledWith(466);
+    expect(onCommit).toHaveBeenCalledWith(466);
+  });
+
+  it('ArrowRight narrows by 16 (resize + commit)', () => {
+    const onResize = vi.fn(); const onCommit = vi.fn();
+    render(<PanelResizer {...base} onResize={onResize} onCommit={onCommit} />);
+    fireEvent.keyDown(screen.getByRole('separator'), { key: 'ArrowRight' });
+    expect(onResize).toHaveBeenCalledWith(434);
+    expect(onCommit).toHaveBeenCalledWith(434);
+  });
+
+  // Note: jsdom doesn't propagate clientX on synthetic pointer events, so this
+  // asserts the drag wiring + listener lifecycle, not the pixel arithmetic
+  // (the exact +/-16 math is covered by the keyboard tests above).
+  it('drag wires move->resize and up->commit, toggling the body class', () => {
+    const onResize = vi.fn(); const onCommit = vi.fn();
+    render(<PanelResizer {...base} onResize={onResize} onCommit={onCommit} />);
+    const sep = screen.getByRole('separator');
+    fireEvent.pointerDown(sep, { clientX: 1000 });
+    expect(document.body.classList.contains('is-resizing-panel')).toBe(true);
+    fireEvent.pointerMove(window, { clientX: 940 });
+    expect(onResize).toHaveBeenCalled();
+    fireEvent.pointerUp(window, { clientX: 920 });
+    expect(onCommit).toHaveBeenCalled();
+    expect(document.body.classList.contains('is-resizing-panel')).toBe(false);
+  });
+
+  it('does not keep resizing after unmount mid-drag', () => {
+    const onResize = vi.fn();
+    const { unmount } = render(<PanelResizer {...base} onResize={onResize} onCommit={() => {}} />);
+    fireEvent.pointerDown(screen.getByRole('separator'), { clientX: 1000 });
+    unmount();
+    expect(document.body.classList.contains('is-resizing-panel')).toBe(false);
+    onResize.mockClear();
+    fireEvent.pointerMove(window, { clientX: 900 });
+    expect(onResize).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/MainLayout/PanelResizer.tsx
+++ b/src/components/MainLayout/PanelResizer.tsx
@@ -25,6 +25,7 @@ const PanelResizer: React.FC<PanelResizerProps> = ({ width, min, max, onResize, 
   useEffect(() => () => cleanupRef.current?.(), []);
 
   const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (e.pointerType === 'mouse' && e.button !== 0) return; // primary button only
     if (drag.current) return; // ignore re-entrant pointerdowns (e.g. multi-touch)
     e.preventDefault();
     const start = { startX: e.clientX, startWidth: width };

--- a/src/components/MainLayout/PanelResizer.tsx
+++ b/src/components/MainLayout/PanelResizer.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback, useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import './PanelResizer.scss';
+
+interface PanelResizerProps {
+  width: number;
+  min: number;
+  max: number;
+  /** Live updates during drag / keypress. Caller clamps. */
+  onResize: (next: number) => void;
+  /** On pointerup / keypress. Caller clamps + persists. */
+  onCommit: (next: number) => void;
+}
+
+const STEP = 16;
+
+const PanelResizer: React.FC<PanelResizerProps> = ({ width, min, max, onResize, onCommit }) => {
+  const { t } = useTranslation();
+  const drag = useRef<{ startX: number; startWidth: number } | null>(null);
+  // Holds the teardown for an in-progress drag so we can run it on unmount.
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  // Abort any in-progress drag if the component unmounts mid-gesture, so the
+  // window listeners and the body class can never leak.
+  useEffect(() => () => cleanupRef.current?.(), []);
+
+  const handlePointerDown = useCallback((e: React.PointerEvent) => {
+    if (drag.current) return; // ignore re-entrant pointerdowns (e.g. multi-touch)
+    e.preventDefault();
+    const start = { startX: e.clientX, startWidth: width };
+    drag.current = start;
+    // Panel is docked on the right: dragging left (smaller clientX) widens it.
+    const widthFrom = (clientX: number) => start.startWidth + (start.startX - clientX);
+
+    const onMove = (ev: PointerEvent) => { if (drag.current) onResize(widthFrom(ev.clientX)); };
+    // Hoisted so onUp/onCancel below can reference it; only invoked on release.
+    function teardown() {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      window.removeEventListener('pointercancel', onCancel);
+      document.body.classList.remove('is-resizing-panel');
+      drag.current = null;
+      cleanupRef.current = null;
+    }
+    const onUp = (ev: PointerEvent) => { onCommit(widthFrom(ev.clientX)); teardown(); };
+    const onCancel = () => teardown();
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+    window.addEventListener('pointercancel', onCancel);
+    document.body.classList.add('is-resizing-panel');
+    cleanupRef.current = teardown;
+  }, [width, onResize, onCommit]);
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    let next: number | null = null;
+    if (e.key === 'ArrowLeft') next = width + STEP;       // wider
+    else if (e.key === 'ArrowRight') next = width - STEP; // narrower
+    if (next !== null) {
+      e.preventDefault();
+      onResize(next);
+      onCommit(next);
+    }
+  }, [width, onResize, onCommit]);
+
+  return (
+    <div
+      className="panel-resizer"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={t('common.resizePanel', 'Resize panel')}
+      aria-valuenow={Math.round(width)}
+      aria-valuemin={min}
+      aria-valuemax={max}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onKeyDown={handleKeyDown}
+    />
+  );
+};
+
+export default PanelResizer;

--- a/src/components/MainLayout/panelWidth.test.ts
+++ b/src/components/MainLayout/panelWidth.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  clampPanelWidth, readPanelWidth, savePanelWidth,
+  PANEL_MIN_WIDTH, PANEL_DEFAULT_WIDTH,
+} from './panelWidth';
+
+describe('clampPanelWidth', () => {
+  it('floors at the minimum', () => {
+    expect(clampPanelWidth(100, 1600)).toBe(PANEL_MIN_WIDTH);
+  });
+  it('caps at viewport minus the MainPanel minimum (360)', () => {
+    expect(clampPanelWidth(5000, 1000)).toBe(1000 - 360);
+  });
+  it('leaves an in-range width unchanged', () => {
+    expect(clampPanelWidth(500, 1600)).toBe(500);
+  });
+  it('floors at the minimum on a tiny viewport', () => {
+    expect(clampPanelWidth(400, 500)).toBe(PANEL_MIN_WIDTH);
+  });
+});
+
+describe('read/savePanelWidth', () => {
+  beforeEach(() => localStorage.clear());
+  it('returns the default when unset or garbage', () => {
+    expect(readPanelWidth()).toBe(PANEL_DEFAULT_WIDTH);
+    localStorage.setItem('panelState.settingsPanelWidth', 'abc');
+    expect(readPanelWidth()).toBe(PANEL_DEFAULT_WIDTH);
+  });
+  it('round-trips a saved width', () => {
+    savePanelWidth(523.6);
+    expect(localStorage.getItem('panelState.settingsPanelWidth')).toBe('524');
+    expect(readPanelWidth()).toBe(524);
+  });
+});

--- a/src/components/MainLayout/panelWidth.ts
+++ b/src/components/MainLayout/panelWidth.ts
@@ -1,0 +1,21 @@
+export const PANEL_MIN_WIDTH = 300;
+export const MAIN_CONTENT_MIN = 360;
+export const PANEL_DEFAULT_WIDTH = 450;
+
+const STORAGE_KEY = 'panelState.settingsPanelWidth';
+
+/** Clamp to [MIN, viewport − MAIN_CONTENT_MIN], floored at MIN for tiny viewports. */
+export function clampPanelWidth(width: number, viewportWidth: number): number {
+  const max = Math.max(PANEL_MIN_WIDTH, viewportWidth - MAIN_CONTENT_MIN);
+  return Math.min(Math.max(width, PANEL_MIN_WIDTH), max);
+}
+
+export function readPanelWidth(): number {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  const n = raw ? parseInt(raw, 10) : NaN;
+  return Number.isFinite(n) ? n : PANEL_DEFAULT_WIDTH;
+}
+
+export function savePanelWidth(width: number): void {
+  localStorage.setItem(STORAGE_KEY, String(Math.round(width)));
+}

--- a/src/components/MainLayout/panelWidth.ts
+++ b/src/components/MainLayout/panelWidth.ts
@@ -4,10 +4,14 @@ export const PANEL_DEFAULT_WIDTH = 450;
 
 const STORAGE_KEY = 'panelState.settingsPanelWidth';
 
+/** Widest the panel may be: leaves MainPanel at least MAIN_CONTENT_MIN, floored at MIN. */
+export function maxPanelWidth(viewportWidth: number): number {
+  return Math.max(PANEL_MIN_WIDTH, viewportWidth - MAIN_CONTENT_MIN);
+}
+
 /** Clamp to [MIN, viewport − MAIN_CONTENT_MIN], floored at MIN for tiny viewports. */
 export function clampPanelWidth(width: number, viewportWidth: number): number {
-  const max = Math.max(PANEL_MIN_WIDTH, viewportWidth - MAIN_CONTENT_MIN);
-  return Math.min(Math.max(width, PANEL_MIN_WIDTH), max);
+  return Math.min(Math.max(width, PANEL_MIN_WIDTH), maxPanelWidth(viewportWidth));
 }
 
 export function readPanelWidth(): number {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,7 +14,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" onClick={e => e.stopPropagation()}>
+      <div className="modal-content" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h3>{title}</h3>
           <button className="close-button" onClick={onClose}>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -14,7 +14,7 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children }) => {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal-content" role="dialog" aria-modal="true" onClick={e => e.stopPropagation()}>
+      <div className="modal-content" role="dialog" aria-modal="true" aria-label={title} onClick={e => e.stopPropagation()}>
         <div className="modal-header">
           <h3>{title}</h3>
           <button className="close-button" onClick={onClose}>

--- a/src/components/Settings/AdvancedSettings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings/AdvancedSettings.tsx
@@ -1,5 +1,5 @@
-import React, { useState, useEffect } from 'react';
-import { AlertCircle, Settings, Headphones, Cpu } from 'lucide-react';
+import React, { useState } from 'react';
+import { AlertCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useIsSessionActive, useLockedMode } from '../../../stores/sessionStore';
 import { useMode } from '../../../stores/audioStore';
@@ -9,15 +9,12 @@ import {
   useLoadingModels,
   useFetchAvailableModels,
   useGetProcessedSystemInstructions,
-  useSettingsNavigationTarget,
-  useNavigateToSettings,
   useCurrentTurnDetectionMode,
 } from '../../../stores/settingsStore';
 import { ProviderConfigFactory } from '../../../services/providers/ProviderConfigFactory';
 import { Provider } from '../../../types/Provider';
 import WarningModal from '../shared/WarningModal';
 import { WarningType } from '../shared/hooks';
-import TabBar, { Tab } from '../shared/TabBar';
 import {
   AccountSection,
   ProviderSection,
@@ -30,34 +27,12 @@ import {
 import ProviderSpecificSettings from '../sections/ProviderSpecificSettings';
 import './AdvancedSettings.scss';
 
-const TABS: Tab[] = [
-  { id: 'general', labelKey: 'settings.tabs.general', fallback: 'General', icon: Settings },
-  { id: 'audio', labelKey: 'settings.tabs.audio', fallback: 'Audio', icon: Headphones },
-  { id: 'provider', labelKey: 'settings.tabs.provider', fallback: 'Provider', icon: Cpu },
-];
-
-const NAVIGATION_TAB_MAP: Record<string, string> = {
-  'user-account': 'general',
-  'languages': 'general',
-  'microphone': 'audio',
-  'speaker': 'audio',
-  'system-audio': 'audio',
-  'participant': 'audio', // renamed section target — popover footer navigates here
-  'provider': 'provider',
-  'system-instructions': 'provider',
-  'voice-settings': 'provider',
-  'turn-detection': 'provider',
-  'model-management': 'provider',
-  'model-asr': 'provider',
-  'model-translation': 'provider',
-  'model-tts': 'provider',
-};
-
 interface AdvancedSettingsProps {
   toggleSettings?: () => void;
+  activeTab: string;
 }
 
-const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings }) => {
+const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings, activeTab }) => {
   const { t } = useTranslation();
   const isSessionActive = useIsSessionActive();
 
@@ -99,37 +74,9 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings }) =
     }
   }, [provider]);
 
-  // Navigation target for scroll-to-section
-  const settingsNavigationTarget = useSettingsNavigationTarget();
-  const navigateToSettings = useNavigateToSettings();
-
   // State
-  const [activeTab, setActiveTab] = useState('general');
   const [isPreviewExpanded, setIsPreviewExpanded] = useState(false);
   const [warningType, setWarningType] = useState<WarningType | null>(null);
-
-  // Handle scrolling and highlighting when settingsNavigationTarget changes
-  useEffect(() => {
-    if (settingsNavigationTarget) {
-      const targetTab = NAVIGATION_TAB_MAP[settingsNavigationTarget];
-      if (targetTab && targetTab !== activeTab) {
-        setActiveTab(targetTab);
-      }
-
-      // Wait for tab switch + DOM update before scrolling
-      setTimeout(() => {
-        const element = document.getElementById(`${settingsNavigationTarget}-section`);
-        if (element) {
-          element.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          element.classList.add('highlight');
-          setTimeout(() => {
-            element.classList.remove('highlight');
-            navigateToSettings(null);
-          }, 3000);
-        }
-      }, 150);
-    }
-  }, [settingsNavigationTarget, navigateToSettings]);
 
   return (
     <div className="advanced-settings">
@@ -145,8 +92,6 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings }) =
           <span>{t('settings.sessionActiveNotice', 'Settings are locked while session is active. Please end the session to modify settings.')}</span>
         </div>
       )}
-
-      <TabBar tabs={TABS} activeTab={activeTab} onTabChange={setActiveTab} />
 
       <div
         className="settings-content"

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -9,95 +9,6 @@
   overflow: hidden;
   color: vars.$text-primary;
 
-  .settings-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10.5px 15px;
-    border-bottom: 1px solid vars.$border-subtle;
-    box-sizing: border-box;
-    width: 100%;
-    flex-shrink: 0;
-
-    h2 {
-      margin: 0;
-      font-size: vars.$font-title;
-      font-weight: 500;
-      color: vars.$text-primary;
-      line-height: 32px;
-    }
-
-    .header-actions {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-
-      .mode-toggle {
-        display: flex;
-        background: vars.$bg-surface;
-        border-radius: vars.$radius-md;
-        padding: 2px;
-        gap: 2px;
-
-        .mode-button {
-          display: flex;
-          align-items: center;
-          gap: 6px;
-          padding: 6px 12px;
-          background: transparent;
-          border: none;
-          border-radius: vars.$radius-sm;
-          color: vars.$text-muted;
-          font-size: vars.$font-caption;
-          font-weight: 500;
-          cursor: pointer;
-          transition: all vars.$transition-fast;
-
-          svg {
-            width: 14px;
-            height: 14px;
-          }
-
-          &:hover:not(:disabled):not(.active) {
-            color: vars.$text-secondary;
-            background: rgba(255, 255, 255, 0.05);
-          }
-
-          &.active {
-            background: vars.$color-primary;
-            color: vars.$text-primary;
-          }
-
-          &:disabled {
-            @include vars.disabled-state;
-          }
-        }
-      }
-
-      .close-button {
-        display: flex;
-        align-items: center;
-        background: none;
-        border: none;
-        color: vars.$text-muted;
-        cursor: pointer;
-        padding: 6px 12px;
-        border-radius: vars.$radius-sm;
-        transition: all 0.2s;
-
-        span {
-          margin-left: 5px;
-          font-size: vars.$font-body;
-        }
-
-        &:hover {
-          background-color: rgba(255, 255, 255, 0.1);
-          color: vars.$text-primary;
-        }
-      }
-    }
-  }
-
   .settings-body {
     flex: 1;
     overflow: hidden;
@@ -1612,22 +1523,6 @@
 
 // Responsive
 @media (max-width: 768px) {
-  .settings-container {
-    .settings-header {
-      .header-actions {
-        .mode-toggle {
-          .mode-button {
-            padding: 6px 8px;
-
-            span {
-              display: none;
-            }
-          }
-        }
-      }
-    }
-  }
-
   .language-pair-row {
     grid-template-columns: 1fr;
     gap: 12px;

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -97,6 +97,7 @@ const Settings: React.FC<SettingsProps> = ({ toggleSettings, highlightSection })
         className={`mode-button ${isSimpleMode ? 'active' : ''}`}
         onClick={() => !isSimpleMode && handleModeToggle()}
         title={t('settings.simpleMode', 'Simple')}
+        aria-label={t('settings.simple', 'Simple')}
       >
         <LayoutGrid size={14} />
         <span>{t('settings.simple', 'Simple')}</span>
@@ -105,6 +106,7 @@ const Settings: React.FC<SettingsProps> = ({ toggleSettings, highlightSection })
         className={`mode-button ${!isSimpleMode ? 'active' : ''}`}
         onClick={() => isSimpleMode && handleModeToggle()}
         title={t('settings.advancedMode', 'Advanced')}
+        aria-label={t('settings.advanced', 'Advanced')}
       >
         <Sliders size={14} />
         <span>{t('settings.advanced', 'Advanced')}</span>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -66,18 +66,22 @@ const Settings: React.FC<SettingsProps> = ({ toggleSettings, highlightSection })
     // Wait for the tab switch + DOM update before scrolling. Cancel the
     // pending scroll on cleanup so flipping modes mid-navigation doesn't
     // fire into an unmounted/stale DOM.
+    let highlightTimer: ReturnType<typeof setTimeout> | undefined;
     const scrollTimer = setTimeout(() => {
       const element = document.getElementById(`${settingsNavigationTarget}-section`);
       if (element) {
         element.scrollIntoView({ behavior: 'smooth', block: 'start' });
         element.classList.add('highlight');
-        setTimeout(() => {
+        highlightTimer = setTimeout(() => {
           element.classList.remove('highlight');
           navigateToSettings(null);
         }, 3000);
       }
     }, 150);
-    return () => clearTimeout(scrollTimer);
+    return () => {
+      clearTimeout(scrollTimer);
+      if (highlightTimer) clearTimeout(highlightTimer);
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [settingsNavigationTarget, navigateToSettings, isSimpleMode]);
 

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect } from 'react';
-import { ArrowRight, Save, Check, AlertCircle, AlertTriangle, Info, LayoutGrid, Sliders } from 'lucide-react';
+import { LayoutGrid, Sliders, Settings as SettingsIcon, Headphones, Cpu } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useUIMode, useSetUIMode, useNavigateToSettings, useSettingsNavigationTarget } from '../../stores/settingsStore';
 import { useIsSessionActive } from '../../stores/sessionStore';
 import { useAnalytics } from '../../lib/analytics';
 import SimpleSettings from './SimpleSettings/SimpleSettings';
 import AdvancedSettings from './AdvancedSettings/AdvancedSettings';
+import PanelBar from './shared/PanelBar';
+import type { Tab } from './shared/TabBar';
 import './Settings.scss';
 
 interface SettingsProps {
@@ -14,20 +16,70 @@ interface SettingsProps {
   highlightSection?: string | null;
 }
 
+const TABS: Tab[] = [
+  { id: 'general', labelKey: 'settings.tabs.general', fallback: 'General', icon: SettingsIcon },
+  { id: 'audio', labelKey: 'settings.tabs.audio', fallback: 'Audio', icon: Headphones },
+  { id: 'provider', labelKey: 'settings.tabs.provider', fallback: 'Provider', icon: Cpu },
+];
+
+const NAVIGATION_TAB_MAP: Record<string, string> = {
+  'user-account': 'general',
+  'languages': 'general',
+  'microphone': 'audio',
+  'speaker': 'audio',
+  'system-audio': 'audio',
+  'participant': 'audio',
+  'provider': 'provider',
+  'system-instructions': 'provider',
+  'voice-settings': 'provider',
+  'turn-detection': 'provider',
+  'model-management': 'provider',
+  'model-asr': 'provider',
+  'model-translation': 'provider',
+  'model-tts': 'provider',
+};
+
 const Settings: React.FC<SettingsProps> = ({ toggleSettings, highlightSection }) => {
   const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
   const isSessionActive = useIsSessionActive();
 
-  // UI mode from settings store
   const uiMode = useUIMode();
   const setUIMode = useSetUIMode();
   const settingsNavigationTarget = useSettingsNavigationTarget();
   const navigateToSettings = useNavigateToSettings();
 
-  // Determine if we're in simple or advanced mode
-  // 'basic' maps to Simple, 'advanced' maps to Advanced
+  // 'basic' maps to Simple/Quick, 'advanced' maps to Advanced.
   const isSimpleMode = uiMode === 'basic';
+
+  const [activeTab, setActiveTab] = useState('general');
+
+  // Advanced-only: switch to the target tab and scroll/highlight its section.
+  // Quick mode highlights via SimpleSettings' highlightSection instead.
+  useEffect(() => {
+    if (isSimpleMode) return;
+    if (!settingsNavigationTarget) return;
+    const targetTab = NAVIGATION_TAB_MAP[settingsNavigationTarget];
+    if (targetTab && targetTab !== activeTab) {
+      setActiveTab(targetTab);
+    }
+    // Wait for the tab switch + DOM update before scrolling. Cancel the
+    // pending scroll on cleanup so flipping modes mid-navigation doesn't
+    // fire into an unmounted/stale DOM.
+    const scrollTimer = setTimeout(() => {
+      const element = document.getElementById(`${settingsNavigationTarget}-section`);
+      if (element) {
+        element.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        element.classList.add('highlight');
+        setTimeout(() => {
+          element.classList.remove('highlight');
+          navigateToSettings(null);
+        }, 3000);
+      }
+    }, 150);
+    return () => clearTimeout(scrollTimer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [settingsNavigationTarget, navigateToSettings, isSimpleMode]);
 
   const handleModeToggle = () => {
     const newMode = isSimpleMode ? 'advanced' : 'basic';
@@ -35,48 +87,46 @@ const Settings: React.FC<SettingsProps> = ({ toggleSettings, highlightSection })
     trackEvent('settings_mode_switched', {
       from_mode: uiMode,
       to_mode: newMode,
-      during_session: isSessionActive
+      during_session: isSessionActive,
     });
   };
 
+  const modeToggle = (
+    <div className="mode-toggle">
+      <button
+        className={`mode-button ${isSimpleMode ? 'active' : ''}`}
+        onClick={() => !isSimpleMode && handleModeToggle()}
+        title={t('settings.simpleMode', 'Simple')}
+      >
+        <LayoutGrid size={14} />
+        <span>{t('settings.simple', 'Simple')}</span>
+      </button>
+      <button
+        className={`mode-button ${!isSimpleMode ? 'active' : ''}`}
+        onClick={() => isSimpleMode && handleModeToggle()}
+        title={t('settings.advancedMode', 'Advanced')}
+      >
+        <Sliders size={14} />
+        <span>{t('settings.advanced', 'Advanced')}</span>
+      </button>
+    </div>
+  );
+
   return (
     <div className="settings-container">
-      <div className="settings-header">
-        <h2>{t('settings.title')}</h2>
-        <div className="header-actions">
-          {/* Mode Toggle */}
-          <div className="mode-toggle">
-            <button
-              className={`mode-button ${isSimpleMode ? 'active' : ''}`}
-              onClick={() => !isSimpleMode && handleModeToggle()}
-              title={t('settings.simpleMode', 'Simple')}
-            >
-              <LayoutGrid size={14} />
-              <span>{t('settings.simple', 'Simple')}</span>
-            </button>
-            <button
-              className={`mode-button ${!isSimpleMode ? 'active' : ''}`}
-              onClick={() => isSimpleMode && handleModeToggle()}
-              title={t('settings.advancedMode', 'Advanced')}
-            >
-              <Sliders size={14} />
-              <span>{t('settings.advanced', 'Advanced')}</span>
-            </button>
-          </div>
-
-          {/* Close Button */}
-          <button className="close-button" onClick={toggleSettings}>
-            <ArrowRight size={16} />
-            <span>{t('common.close')}</span>
-          </button>
-        </div>
-      </div>
+      <PanelBar
+        tabs={isSimpleMode ? undefined : TABS}
+        activeTab={isSimpleMode ? undefined : activeTab}
+        onTabChange={isSimpleMode ? undefined : setActiveTab}
+        actions={modeToggle}
+        onClose={toggleSettings ?? (() => {})}
+      />
 
       <div className="settings-body">
         {isSimpleMode ? (
           <SimpleSettings highlightSection={highlightSection || settingsNavigationTarget} />
         ) : (
-          <AdvancedSettings toggleSettings={toggleSettings} />
+          <AdvancedSettings toggleSettings={toggleSettings} activeTab={activeTab} />
         )}
       </div>
     </div>

--- a/src/components/Settings/shared/PanelBar.scss
+++ b/src/components/Settings/shared/PanelBar.scss
@@ -1,0 +1,90 @@
+@use 'variables' as vars;
+
+.panel-bar {
+  display: flex;
+  align-items: center;
+  padding: 0 15px;
+  border-bottom: 1px solid vars.$border-subtle;
+  flex-shrink: 0;
+
+  // TabBar provides its own item styling; the bar owns padding + the divider.
+  .tab-bar {
+    border-bottom: none;
+    padding: 0;
+    flex: 0 1 auto;
+  }
+
+  &__spacer {
+    flex: 1;
+  }
+
+  &__actions {
+    margin-left: auto;
+    display: flex;
+    align-items: center;
+    gap: vars.$space-3;
+    padding: vars.$space-2 0;
+  }
+
+  &__close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: none;
+    border: none;
+    border-left: 1px solid vars.$border-subtle;
+    color: vars.$text-muted;
+    cursor: pointer;
+    padding: 6px 6px 6px 12px;
+    transition: color vars.$transition-fast;
+
+    &:hover { color: vars.$text-primary; }
+    &:focus-visible { @include vars.focus-ring; }
+  }
+
+  // Segmented mode toggle. Applied to a `.mode-toggle` element a consumer
+  // passes via the `actions` slot (see Settings.tsx for the markup shape).
+  // Relocated from Settings.scss, with the track intentionally deepened to
+  // $bg-page (vs the old $bg-surface) so it reads as a recessed segmented
+  // track against the $bg-surface panel rather than two loose buttons.
+  .mode-toggle {
+    display: flex;
+    background: vars.$bg-page;
+    border-radius: vars.$radius-md;
+    padding: 2px;
+    gap: 2px;
+
+    .mode-button {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 12px;
+      background: transparent;
+      border: none;
+      border-radius: vars.$radius-sm;
+      color: vars.$text-muted;
+      font-size: vars.$font-caption;
+      font-weight: 500;
+      cursor: pointer;
+      transition: all vars.$transition-fast;
+
+      svg { width: 14px; height: 14px; }
+
+      &:hover:not(:disabled):not(.active) {
+        color: vars.$text-secondary;
+        background: rgba(255, 255, 255, 0.05);
+      }
+
+      &.active { @include vars.state-selected-fill; }
+      &:disabled { @include vars.disabled-state; }
+      &:focus-visible { @include vars.focus-ring; }
+    }
+  }
+
+  @media (max-width: 768px) {
+    .mode-toggle .mode-button {
+      padding: 6px 8px;
+      span { display: none; }
+    }
+  }
+}

--- a/src/components/Settings/shared/PanelBar.scss
+++ b/src/components/Settings/shared/PanelBar.scss
@@ -8,22 +8,30 @@
   flex-shrink: 0;
 
   // TabBar provides its own item styling; the bar owns padding + the divider.
+  // min-width:0 + overflow lets the tab strip give way first so the right
+  // cluster (and its collapse button) is never pushed off-screen.
   .tab-bar {
     border-bottom: none;
     padding: 0;
     flex: 0 1 auto;
+    min-width: 0;
+    overflow: hidden;
   }
 
   &__spacer {
     flex: 1;
   }
 
+  // Right cluster never shrinks — the collapse button must always stay
+  // reachable, and nothing here wraps to a second line.
   &__actions {
     margin-left: auto;
+    flex-shrink: 0;
     display: flex;
     align-items: center;
     gap: vars.$space-3;
     padding: vars.$space-2 0;
+    white-space: nowrap;
   }
 
   &__close {
@@ -65,6 +73,7 @@
       color: vars.$text-muted;
       font-size: vars.$font-caption;
       font-weight: 500;
+      white-space: nowrap;
       cursor: pointer;
       transition: all vars.$transition-fast;
 
@@ -81,10 +90,33 @@
     }
   }
 
-  @media (max-width: 768px) {
-    .mode-toggle .mode-button {
+  // When the bar carries tabs (Settings Advanced, all of Logs) the tabs eat
+  // the horizontal room, so the right-cluster controls collapse to icon-only
+  // (their `title`/`aria-label` carry the meaning). With no tabs (Settings
+  // Quick) there is room, so the labels stay visible.
+  &--has-tabs {
+    .panel-bar__actions .mode-button {
       padding: 6px 8px;
-      span { display: none; }
     }
+    .panel-bar__actions span {
+      display: none;
+    }
+  }
+}
+
+// Tab labels are the last thing to go — only on a genuinely tiny panel. Use an
+// sr-only collapse (not display:none) so the accessible name survives while the
+// visual width drops to just the icon.
+@container panel-chrome (max-width: 360px) {
+  .panel-bar .tab-bar__tab span {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
   }
 }

--- a/src/components/Settings/shared/PanelBar.test.tsx
+++ b/src/components/Settings/shared/PanelBar.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import PanelBar from './PanelBar';
+import type { Tab } from './TabBar';
+
+const TABS: Tab[] = [
+  { id: 'general', labelKey: 'x.general', fallback: 'General' },
+  { id: 'audio', labelKey: 'x.audio', fallback: 'Audio' },
+];
+
+describe('PanelBar', () => {
+  it('renders tabs when provided', () => {
+    render(<PanelBar tabs={TABS} activeTab="general" onTabChange={() => {}} onClose={() => {}} />);
+    expect(screen.getAllByRole('tab')).toHaveLength(2);
+  });
+
+  it('renders no tabs when tabs is omitted', () => {
+    render(<PanelBar onClose={() => {}} />);
+    expect(screen.queryAllByRole('tab')).toHaveLength(0);
+  });
+
+  it('renders the actions slot', () => {
+    render(<PanelBar actions={<button>my-action</button>} onClose={() => {}} />);
+    expect(screen.getByRole('button', { name: 'my-action' })).toBeInTheDocument();
+  });
+
+  it('calls onClose when the collapse button is clicked', () => {
+    const onClose = vi.fn();
+    render(<PanelBar onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close panel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onClose on Escape', () => {
+    const onClose = vi.fn();
+    render(<PanelBar onClose={onClose} />);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores Escape when a dialog is open', () => {
+    const onClose = vi.fn();
+    const dialog = document.createElement('div');
+    dialog.setAttribute('role', 'dialog');
+    document.body.appendChild(dialog);
+    try {
+      render(<PanelBar onClose={onClose} />);
+      fireEvent.keyDown(document, { key: 'Escape' });
+      expect(onClose).not.toHaveBeenCalled();
+    } finally {
+      document.body.removeChild(dialog);
+    }
+  });
+
+  it('does not call onClose after unmount', () => {
+    const onClose = vi.fn();
+    const { unmount } = render(<PanelBar onClose={onClose} />);
+    unmount();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Settings/shared/PanelBar.tsx
+++ b/src/components/Settings/shared/PanelBar.tsx
@@ -32,7 +32,7 @@ const PanelBar: React.FC<PanelBarProps> = ({ tabs, activeTab, onTabChange, actio
   const hasTabs = tabs && activeTab !== undefined && onTabChange;
 
   return (
-    <div className="panel-bar">
+    <div className={`panel-bar${hasTabs ? ' panel-bar--has-tabs' : ''}`}>
       {hasTabs ? (
         <TabBar tabs={tabs!} activeTab={activeTab!} onTabChange={onTabChange!} />
       ) : (

--- a/src/components/Settings/shared/PanelBar.tsx
+++ b/src/components/Settings/shared/PanelBar.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect } from 'react';
+import { PanelRightClose } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import TabBar, { Tab } from './TabBar';
+import './PanelBar.scss';
+
+interface PanelBarProps {
+  /** Tab strip. Omit for tab-less panels (e.g. Settings Quick mode). */
+  tabs?: Tab[];
+  activeTab?: string;
+  onTabChange?: (id: string) => void;
+  /** Panel-specific controls, rendered in the right cluster left of close. */
+  actions?: React.ReactNode;
+  /** Collapse the panel. */
+  onClose: () => void;
+}
+
+const PanelBar: React.FC<PanelBarProps> = ({ tabs, activeTab, onTabChange, actions, onClose }) => {
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape' || e.defaultPrevented) return;
+      // Don't steal Escape from an open modal/dialog or floating popover.
+      if (document.querySelector('[role="dialog"]')) return;
+      onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
+
+  const hasTabs = tabs && activeTab !== undefined && onTabChange;
+
+  return (
+    <div className="panel-bar">
+      {hasTabs ? (
+        <TabBar tabs={tabs!} activeTab={activeTab!} onTabChange={onTabChange!} />
+      ) : (
+        <span className="panel-bar__spacer" />
+      )}
+      <div className="panel-bar__actions">
+        {actions}
+        <button
+          type="button"
+          className="panel-bar__close"
+          onClick={onClose}
+          title={t('common.collapsePanel', 'Close panel')}
+          aria-label={t('common.collapsePanel', 'Close panel')}
+        >
+          <PanelRightClose size={16} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default PanelBar;

--- a/src/components/Settings/shared/TabBar.scss
+++ b/src/components/Settings/shared/TabBar.scss
@@ -28,8 +28,7 @@
     }
 
     &--active {
-      color: vars.$color-primary;
-      border-bottom-color: vars.$color-primary;
+      @include vars.state-selected-underline;
     }
 
     &:focus-visible {

--- a/src/components/Settings/shared/_variables.scss
+++ b/src/components/Settings/shared/_variables.scss
@@ -115,6 +115,21 @@ $toggle-bg-on:    $color-primary;
   outline-offset: $focus-ring-offset;
 }
 
+// --- Selection state (mutually-exclusive sets) ---------------
+// green = the selected item. Form is fixed per control archetype:
+//   tabs        → underline
+//   segmented   → fill
+//   focus       → outline (focus-ring above; :focus-visible only)
+@mixin state-selected-underline {
+  color: $color-primary;
+  border-bottom: 2px solid $color-primary;
+}
+
+@mixin state-selected-fill {
+  background: $color-primary;
+  color: $text-primary;
+}
+
 @mixin control-base {
   background: $bg-control;
   border: 1px solid $border-default;

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -68,9 +68,13 @@
   }
 
   &.is-active {
-    background: rgba(255, 255, 255, 0.12);
-    border-color: #10a37f;
+    background: rgba(255, 255, 255, 0.16);
     color: #fff;
+  }
+
+  &:focus-visible {
+    outline: 2px solid #10a37f;
+    outline-offset: -1px;
   }
 
   &:disabled {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -4,6 +4,7 @@
     "cancel": "Cancel",
     "save": "Save",
     "close": "Close",
+    "collapsePanel": "Close panel",
     "settings": "Settings",
     "help": "Help",
     "loading": "Loading...",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -5,6 +5,7 @@
     "save": "Save",
     "close": "Close",
     "collapsePanel": "Close panel",
+    "resizePanel": "Resize panel",
     "settings": "Settings",
     "help": "Help",
     "loading": "Loading...",


### PR DESCRIPTION
## Summary

Reworks the side-panel chrome (the top-right region of the app) into one shared, consistent system, and makes the panel resizable.

**Panel chrome unification**
- New shared `PanelBar` (`[tabs] ···· [actions] [collapse]`) used by **both** Settings and Logs — previously each panel hand-rolled its own header.
- Active-state token system: tabs = green underline, segmented (`Quick/Advanced`) = green fill, focus = green outline (`:focus-visible` only). TitleBar active entry **neutralized** (was a green outline that read like an error/focus ring).
- Replaced the misleading `→ Close` (an `ArrowRight`) in **both** Settings and Logs with a `PanelRightClose` collapse icon + **Esc-to-close** (guarded so an open modal keeps Esc).
- Dropped the duplicate `Settings`/`Logs` `<h2>` titles; lifted the Settings category-tab state out of `AdvancedSettings` so `PanelBar` owns the tabs (onboarding/deep-link tab switching preserved).
- a11y: `Modal` now `role="dialog" aria-modal="true"` so the Esc guard respects open warning modals.

**Narrow-panel fit (responsive labels)**
- The panel is now a CSS query container; when the bar carries tabs the right-cluster labels collapse to icon-only (with tooltips/aria-labels), so nothing wraps or clips in the 300–450px panel. The collapse button is `flex-shrink:0` and can never be pushed off-screen.

**Resizable side panel**
- Draggable 1px seam (wide invisible hit area) between MainPanel and the panel; pointer + keyboard (Arrow ←/→), `role="separator"`.
- Width clamped to `[300px, viewport − 360px]`, re-clamped on window resize, persisted to `localStorage`. Hidden on mobile (<768px stacked). Composes with the container query — widening reveals labels.

MainPanel structure is untouched (out of scope by design).

## Test Plan
- [x] `npm run build` + `npm run test` (839 tests pass; no new `tsc` errors vs. baseline)
- [ ] Settings Advanced/Quick + Logs: one-row PanelBar, collapse icon never clipped, labels collapse/expand by width
- [ ] Esc closes the panel; Esc with a WarningModal open closes the modal, not the panel
- [ ] Deep-link / onboarding still switches to the correct Settings tab
- [ ] Drag-resize: live resize, min/max clamp, persists across reload, re-clamps on window shrink
- [ ] Keyboard resize on the focused seam; hidden + full-width below 768px
- [ ] Keyboard focus shows green outline only on `:focus-visible`

Specs & plans under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Unified header for Settings and Logs panels for consistent controls.
  * Horizontally resizable Settings/Logs panel with drag handle, keyboard Arrow resizing, and persisted width.
  * Escape and keyboard interactions standardized for panel collapse; resize control hidden on small screens.

* **Accessibility**
  * Improved focus/aria behavior for dialogs and panel controls; new accessible labels for collapse and resize.

* **Style**
  * Harmonized active/focus visual treatments across panel chrome.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->