### PR TITLE
fix(subtitle): strip heavy replay fields from overlay port payload

### DIFF
--- a/src/components/Subtitle/SubtitleBar.test.tsx
+++ b/src/components/Subtitle/SubtitleBar.test.tsx
@@ -43,7 +43,9 @@ vi.mock('./useOverlayDragResize', () => ({
 // Stub the child components so we only assert SubtitleBar's own controls and
 // don't pull conversationDisplayStore / ServiceFactory transitively.
 vi.mock('../MainPanel/DisplayModeButton', () => ({ default: () => null }));
-vi.mock('../MainPanel/ExportButton', () => ({ default: () => null }));
+vi.mock('../MainPanel/ExportButton', () => ({
+  default: () => require('react').createElement('div', { 'data-testid': 'export-button' }),
+}));
 vi.mock('../Display/DisplaySettingsPopover', () => ({ default: () => null }));
 
 const baseProps = {
@@ -88,5 +90,20 @@ describe('SubtitleBar fullscreen button', () => {
     expect(btn.classList.contains('active')).toBe(true);
     fireEvent.click(btn);
     expect(setSubtitleFullscreen).toHaveBeenCalledWith(false);
+  });
+});
+
+describe('SubtitleBar export button', () => {
+  // In the extension overlay the forwarded items are windowed to the recent
+  // tail, so export there would silently omit older messages. Export is only
+  // offered on the Electron surface, where the overlay shares the full store.
+  it('renders the export button on the electron surface', () => {
+    render(<SubtitleBar {...baseProps} surface="electron" />);
+    expect(screen.getByTestId('export-button')).toBeInTheDocument();
+  });
+
+  it('does NOT render the export button on the extension-overlay surface', () => {
+    render(<SubtitleBar {...baseProps} surface="extension-overlay" />);
+    expect(screen.queryByTestId('export-button')).not.toBeInTheDocument();
   });
 });

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -162,7 +162,12 @@ const SubtitleBar: React.FC<Props> = ({
         >
           {subtitle.compactMode ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
         </button>
-        <ExportButton {...exportProps} />
+        {/* In the extension overlay the wire is capped to the recent tail
+            (MAX_FORWARDED_ITEMS), so an export here would silently omit older
+            messages. The side panel holds the full conversation and is the
+            export source of truth — only offer export on the Electron surface,
+            where the overlay shares the full session store. */}
+        {surface === 'electron' && <ExportButton {...exportProps} />}
         <button
           type="button"
           className="subtitle-bar__btn"

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
@@ -15,6 +15,11 @@ vi.mock('../../../services/ServiceFactory', () => ({
 
 declare const globalThis: any;
 
+// Items forwarding is trailing-throttled (ITEMS_THROTTLE_MS = 120ms in the
+// surface). After mutating sessionStore.items, wait past that window for the
+// coalesced 'items' message to be posted. state-init is NOT throttled.
+const waitThrottle = () => new Promise((r) => setTimeout(r, 160));
+
 describe('ExtensionContentScriptSubtitleSurface', () => {
   let listeners: { onConnect: Function[]; onRemoved: Function[]; onUpdated: Function[]; onMessage: Function[] };
   let sendMessage: ReturnType<typeof vi.fn>;
@@ -88,19 +93,67 @@ describe('ExtensionContentScriptSubtitleSurface', () => {
     expect(useSettingsStore.getState().subtitleModeActive).toBe(false);
   });
 
-  it('port reconnect does not leak Zustand subscriptions', async () => {
+  it('port reconnect unsubscribes the prior generation of store subscriptions', async () => {
     // Regression: meeting-tab reload destroys the iframe, which disconnects
     // the port. The surface intentionally doesn't tearDown on disconnect
     // (the content script re-mounts on subsequent subtitle:enter). But
     // before, installStoreSubscriptions() overwrote `this.subscriptions`
     // without unsubscribing the prior ones, leaving old listeners alive on
-    // the Zustand stores. Each store change would then fan out to N copies.
+    // the Zustand stores and accumulating on every reload.
+    //
+    // We assert the cleanup directly (not via message count): the items
+    // forwarding is now trailing-throttled at the instance level, so a leaked
+    // duplicate subscription would be coalesced and wouldn't change the number
+    // of posted messages — only the count of live store subscriptions.
     const { default: useSessionStore } = await import('../../../stores/sessionStore');
     useSessionStore.setState({ items: [], participantItems: [], isSessionActive: false } as any);
 
-    const surface = new ExtensionContentScriptSubtitleSurface();
-    await surface.enter();
+    // Wrap each subscribe's returned unsubscribe in a spy to detect tear-down.
+    const realSubscribe = useSessionStore.subscribe.bind(useSessionStore);
+    const unsubSpies: ReturnType<typeof vi.fn>[] = [];
+    const subSpy = vi
+      .spyOn(useSessionStore, 'subscribe')
+      .mockImplementation((...args: any[]) => {
+        const realUnsub = (realSubscribe as any)(...args);
+        const spy = vi.fn(() => realUnsub());
+        unsubSpies.push(spy);
+        return spy as any;
+      });
 
+    try {
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+
+      const makePort = () => ({
+        name: 'sokuji-subtitle',
+        onMessage: { addListener: vi.fn() },
+        onDisconnect: { addListener: vi.fn() },
+        postMessage: vi.fn(),
+        disconnect: vi.fn(),
+      });
+      const handleConnect = listeners.onConnect[0];
+
+      // Gen 1 — installs the first generation of sessionStore subscriptions.
+      const port1 = makePort();
+      handleConnect(port1);
+      await new Promise((r) => setTimeout(r, 0));
+      const gen1Unsubs = unsubSpies.slice();
+      expect(gen1Unsubs.length).toBeGreaterThanOrEqual(2); // items + session
+
+      // Tab reload: port1 disconnects, port2 connects → gen2 installs, which
+      // must first unsubscribe gen1.
+      port1.onDisconnect.addListener.mock.calls[0][0]();
+      const port2 = makePort();
+      handleConnect(port2);
+      await new Promise((r) => setTimeout(r, 0));
+
+      for (const u of gen1Unsubs) expect(u).toHaveBeenCalled();
+    } finally {
+      subSpy.mockRestore();
+    }
+  });
+
+  describe('strips heavy replay fields from forwarded items (memory-leak guard)', () => {
     const makePort = () => ({
       name: 'sokuji-subtitle',
       onMessage: { addListener: vi.fn() },
@@ -109,34 +162,198 @@ describe('ExtensionContentScriptSubtitleSurface', () => {
       disconnect: vi.fn(),
     });
 
-    const handleConnect = listeners.onConnect[0];
+    // An item as the provider clients build it: carries retained PCM audio
+    // (formatted.audio / content[].audio) AND a generated WAV blob
+    // (formatted.file) for the replay/download feature. The subtitle overlay
+    // never reads any of them, yet the surface used to forward them verbatim —
+    // formatted.audio grew until a single message blew past Chrome's 64MiB port
+    // limit and crashed the app; formatted.file (multi-MB) re-cloned per delta
+    // pegged the page. Both must be stripped on the wire.
+    const makeAudioItem = (id: string) => ({
+      id,
+      role: 'assistant',
+      type: 'message',
+      status: 'completed',
+      formatted: {
+        transcript: 'hello world',
+        audioSegments: [{ textEnd: 5, audioEnd: 1.2 }],
+        audioTextEnd: 5,
+        audio: new Int16Array(1024).fill(7),
+        file: { blob: 'x'.repeat(5000), mimeType: 'audio/wav' },
+      },
+      content: [{ type: 'audio', transcript: 'hello world', audio: new Int16Array(512) }],
+    });
 
-    // First connect — installs initial subscriptions
-    const port1 = makePort();
-    handleConnect(port1);
-    // Let the lazily-imported installStoreSubscriptions() resolve.
-    await new Promise((r) => setTimeout(r, 0));
+    const expectStripped = (item: any) => {
+      expect(item.formatted.audio).toBeUndefined();
+      expect(item.formatted.file).toBeUndefined();
+      expect(item.content?.[0]?.audio).toBeUndefined();
+      // Metadata the overlay actually uses must survive.
+      expect(item.formatted.transcript).toBe('hello world');
+      expect(item.formatted.audioSegments).toEqual([{ textEnd: 5, audioEnd: 1.2 }]);
+    };
 
-    // Capture port1's onDisconnect callback before "tab reload" tears it down.
-    const port1Disconnect = port1.onDisconnect.addListener.mock.calls[0][0];
-    port1Disconnect();
+    it('state-init payload omits audio + file but keeps text + timing metadata', async () => {
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({
+        items: [makeAudioItem('a')],
+        participantItems: [makeAudioItem('p')],
+        isSessionActive: true,
+      } as any);
 
-    // Second connect — would previously stack a second set of subscriptions
-    const port2 = makePort();
-    handleConnect(port2);
-    await new Promise((r) => setTimeout(r, 0));
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
 
-    port2.postMessage.mockClear();
+      const init = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'state-init',
+      );
+      expect(init).toBeDefined();
+      expectStripped(init![0].payload.items[0]);
+      expectStripped(init![0].payload.participantItems[0]);
+    });
 
-    // Mutate sessionStore.items → exactly ONE 'items' message should reach
-    // port2 (was 2 before the fix: one from each generation of subscription).
-    useSessionStore.setState({ items: [{ id: 'x' }] } as any);
-    await new Promise((r) => setTimeout(r, 0));
+    it('items message omits audio + file but keeps text + timing metadata', async () => {
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({ items: [], participantItems: [], isSessionActive: true } as any);
 
-    const itemsMessages = port2.postMessage.mock.calls.filter(
-      (call: any[]) => call[0]?.type === 'items',
-    );
-    expect(itemsMessages.length).toBe(1);
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+      port.postMessage.mockClear();
+
+      useSessionStore.setState({ items: [makeAudioItem('b')] } as any);
+      await waitThrottle();
+
+      const msg = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'items',
+      );
+      expect(msg).toBeDefined();
+      expectStripped(msg![0].items[0]);
+    });
+  });
+
+  describe('windows forwarded items to the recent tail (perf cap)', () => {
+    const makePort = () => ({
+      name: 'sokuji-subtitle',
+      onMessage: { addListener: vi.fn() },
+      onDisconnect: { addListener: vi.fn() },
+      postMessage: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    const makeItems = (n: number) =>
+      Array.from({ length: n }, (_, i) => ({
+        id: String(i),
+        role: 'user',
+        type: 'message',
+        status: 'completed',
+        formatted: { transcript: `t${i}` },
+      }));
+
+    it('state-init forwards only the last 15 items (newest tail)', async () => {
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({
+        items: makeItems(150),
+        participantItems: makeItems(130),
+        isSessionActive: true,
+      } as any);
+
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+
+      const init = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'state-init',
+      );
+      expect(init).toBeDefined();
+      expect(init![0].payload.items).toHaveLength(15);
+      expect(init![0].payload.items[0].id).toBe('135'); // 150 items → keep ids 135..149
+      expect(init![0].payload.items[14].id).toBe('149');
+      expect(init![0].payload.participantItems).toHaveLength(15);
+      expect(init![0].payload.participantItems[14].id).toBe('129');
+    });
+
+    it('items message forwards only the last 15 items (newest tail)', async () => {
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({ items: [], participantItems: [], isSessionActive: true } as any);
+
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+      port.postMessage.mockClear();
+
+      useSessionStore.setState({ items: makeItems(150) } as any);
+      await waitThrottle();
+
+      const msg = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'items',
+      );
+      expect(msg).toBeDefined();
+      expect(msg![0].items).toHaveLength(15);
+      expect(msg![0].items[14].id).toBe('149');
+    });
+
+    it('forwards the array unchanged when under the cap', async () => {
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({ items: makeItems(10), participantItems: [], isSessionActive: true } as any);
+
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+
+      const init = port.postMessage.mock.calls.find(
+        (call: any[]) => call[0]?.type === 'state-init',
+      );
+      expect(init![0].payload.items).toHaveLength(10);
+      expect(init![0].payload.items[0].id).toBe('0');
+    });
+  });
+
+  describe('throttles items forwarding (coalesces bursts)', () => {
+    const makePort = () => ({
+      name: 'sokuji-subtitle',
+      onMessage: { addListener: vi.fn() },
+      onDisconnect: { addListener: vi.fn() },
+      postMessage: vi.fn(),
+      disconnect: vi.fn(),
+    });
+
+    it('collapses a burst of items updates into one trailing message with the latest items', async () => {
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({ items: [], participantItems: [], isSessionActive: true } as any);
+
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const port = makePort();
+      listeners.onConnect[0](port);
+      await new Promise((r) => setTimeout(r, 0));
+      port.postMessage.mockClear();
+
+      // Three rapid updates inside the throttle window (mimics streaming deltas).
+      useSessionStore.setState({ items: [{ id: 'a' }] } as any);
+      useSessionStore.setState({ items: [{ id: 'a' }, { id: 'b' }] } as any);
+      useSessionStore.setState({ items: [{ id: 'a' }, { id: 'b' }, { id: 'c' }] } as any);
+
+      // Synchronously, before the window elapses: nothing posted yet.
+      expect(port.postMessage.mock.calls.filter((c: any[]) => c[0]?.type === 'items')).toHaveLength(0);
+
+      await waitThrottle();
+
+      const itemsMsgs = port.postMessage.mock.calls.filter((c: any[]) => c[0]?.type === 'items');
+      expect(itemsMsgs).toHaveLength(1); // coalesced
+      expect(itemsMsgs[0][0].items.map((i: any) => i.id)).toEqual(['a', 'b', 'c']); // latest snapshot
+    });
   });
 
   describe('playback forwarding', () => {

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.test.ts
@@ -354,6 +354,40 @@ describe('ExtensionContentScriptSubtitleSurface', () => {
       expect(itemsMsgs).toHaveLength(1); // coalesced
       expect(itemsMsgs[0][0].items.map((i: any) => i.id)).toEqual(['a', 'b', 'c']); // latest snapshot
     });
+
+    it('reconnect cancels a pending throttle timer (no stale post to the new port)', async () => {
+      // A throttle timer scheduled by the prior port's subscription must not
+      // fire after a reconnect and post a stale pendingItems snapshot to the
+      // new port. installStoreSubscriptions must reset the throttle state, the
+      // same way tearDown does.
+      const { default: useSessionStore } = await import('../../../stores/sessionStore');
+      useSessionStore.setState({ items: [], participantItems: [], isSessionActive: true } as any);
+
+      const surface = new ExtensionContentScriptSubtitleSurface();
+      await surface.enter();
+      const handleConnect = listeners.onConnect[0];
+
+      // Gen 1 connects.
+      const port1 = makePort();
+      handleConnect(port1);
+      await new Promise((r) => setTimeout(r, 0));
+
+      // Items change → schedules a throttle timer holding this snapshot. Do NOT
+      // wait for it to fire.
+      useSessionStore.setState({ items: [{ id: 'stale' }] } as any);
+
+      // Tab reload: port1 disconnects, port2 connects → gen2 installs.
+      port1.onDisconnect.addListener.mock.calls[0][0]();
+      const port2 = makePort();
+      handleConnect(port2);
+      await new Promise((r) => setTimeout(r, 0));
+      port2.postMessage.mockClear();
+
+      // Past the throttle window: the carried-over gen1 timer must not post.
+      await waitThrottle();
+      const itemsMsgs = port2.postMessage.mock.calls.filter((c: any[]) => c[0]?.type === 'items');
+      expect(itemsMsgs).toHaveLength(0);
+    });
   });
 
   describe('playback forwarding', () => {

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
@@ -19,6 +19,71 @@ function isSupportedUrl(url: string | undefined): boolean {
 }
 
 /**
+ * Cap how many trailing items cross the port. The overlay is a live tail, not a
+ * scrollback log: compact mode only ever renders ~BUCKET_MAX_CHARS of the
+ * newest text. Bounding to the most recent N keeps the per-message clone and
+ * the iframe's per-render work (re-sort / filter / Map-rebuild) O(N) regardless
+ * of how long the session runs. Full history stays on the side panel (the
+ * source of truth) for export. Defensive bound — the dominant cost was the
+ * heavy per-item fields (see stripHeavyItemFields), not item count.
+ */
+const MAX_FORWARDED_ITEMS = 15;
+
+// Coalesce items forwarding to this cadence. Streaming deltas mutate the items
+// array many times/sec; posting each one (structured clone + cross-process IPC
+// + an iframe re-render) is wasteful for a live subtitle. ~8 refreshes/sec
+// reads perfectly smoothly. Roughly matches the 100ms playback/karaoke cadence
+// so text and highlight stay in step.
+const ITEMS_THROTTLE_MS = 120;
+
+function recentItems(items: any[] | undefined): any[] {
+  if (!items) return [];
+  return items.length > MAX_FORWARDED_ITEMS
+    ? items.slice(-MAX_FORWARDED_ITEMS)
+    : items;
+}
+
+/**
+ * Drop the heavy replay-only fields from items before they cross the
+ * chrome.runtime port: `formatted.audio` (raw PCM `Int16Array`),
+ * `formatted.file` (a generated WAV blob for the download/replay button), and
+ * `content[].audio`.
+ *
+ * Provider clients keep this audio on each conversation item to power replay,
+ * but the subtitle overlay never reads any of it — it renders text and uses
+ * only the small `audioSegments`/`audioTextEnd` timing metadata for the
+ * karaoke highlight. Forwarding these fields was catastrophic because the items
+ * subscription re-posts the whole array on every streaming delta and port
+ * messages are structured-cloned in full:
+ *   - `formatted.audio` grew until one message exceeded Chrome's 64MiB port
+ *     limit and `postMessage` threw synchronously inside the Zustand notify,
+ *     crashing the app.
+ *   - `formatted.file` (the WAV, even larger than the PCM) reached multiple MB
+ *     per item and, re-cloned on every delta, pegged the page (measured: a
+ *     single item at 5.4MB, total payload 12MB).
+ * Stripping them keeps the wire payload tiny and bounded to text.
+ */
+function stripHeavyItemFields(items: any[] | undefined): any[] {
+  if (!items) return [];
+  return items.map((item) => {
+    if (!item || typeof item !== 'object') return item;
+    const next: any = { ...item };
+    if (item.formatted && typeof item.formatted === 'object') {
+      const { audio: _audio, file: _file, ...formattedRest } = item.formatted;
+      next.formatted = formattedRest;
+    }
+    if (Array.isArray(item.content)) {
+      next.content = item.content.map((part: any) => {
+        if (!part || typeof part !== 'object') return part;
+        const { audio: _partAudio, ...partRest } = part;
+        return partRest;
+      });
+    }
+    return next;
+  });
+}
+
+/**
  * Thrown when the meeting tab has no content-script receiver. Most common
  * cause: the user reloaded the extension after the meeting tab was already
  * open, so the (now-current) content script was never injected into it. The
@@ -30,6 +95,9 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
   private targetTabId: number | null = null;
   private port: any = null;
   private subscriptions: (() => void)[] = [];
+  // Trailing throttle state for items forwarding (see ITEMS_THROTTLE_MS).
+  private itemsThrottleTimer: ReturnType<typeof setTimeout> | null = null;
+  private pendingItems: { items: any[]; participantItems: any[] } | null = null;
 
   private handleConnect = (p: any) => {
     if (p.name !== 'sokuji-subtitle') return;
@@ -124,6 +192,11 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     chrome.runtime.onConnect.removeListener(this.handleConnect);
     chrome.tabs.onRemoved.removeListener(this.handleTabRemoved);
     chrome.tabs.onUpdated.removeListener(this.handleTabUpdated);
+    if (this.itemsThrottleTimer != null) {
+      clearTimeout(this.itemsThrottleTimer);
+      this.itemsThrottleTimer = null;
+    }
+    this.pendingItems = null;
     this.subscriptions.forEach((u) => u());
     this.subscriptions = [];
     this.port?.disconnect();
@@ -181,8 +254,8 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     this.port.postMessage({
       type: 'state-init',
       payload: {
-        items: session.items,
-        participantItems: session.participantItems,
+        items: stripHeavyItemFields(recentItems(session.items)),
+        participantItems: stripHeavyItemFields(recentItems(session.participantItems)),
         isSessionActive: session.isSessionActive,
         sessionStartTime: session.sessionStartTime,
         provider: lastConfig.provider,
@@ -194,21 +267,34 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     });
 
     // Subscribe to subsequent changes.
-    const unsubItems = useSessionStore.subscribe(
+    const subs: (() => void)[] = [];
+
+    subs.push(useSessionStore.subscribe(
       (s) => ({ items: s.items, participantItems: s.participantItems }),
       (next) => {
-        this.port?.postMessage({
-          type: 'items',
-          items: next.items,
-          participantItems: next.participantItems,
-        });
+        // Trailing throttle: keep only the latest snapshot and post it at
+        // most once per ITEMS_THROTTLE_MS. Bursts of streaming deltas
+        // collapse into one message instead of one-per-delta.
+        this.pendingItems = { items: next.items, participantItems: next.participantItems };
+        if (this.itemsThrottleTimer != null) return;
+        this.itemsThrottleTimer = setTimeout(() => {
+          this.itemsThrottleTimer = null;
+          const p = this.pendingItems;
+          this.pendingItems = null;
+          if (!p || !this.port) return;
+          this.port.postMessage({
+            type: 'items',
+            items: stripHeavyItemFields(recentItems(p.items)),
+            participantItems: stripHeavyItemFields(recentItems(p.participantItems)),
+          });
+        }, ITEMS_THROTTLE_MS);
       },
       {
         equalityFn: (a, b) =>
           a.items === b.items && a.participantItems === b.participantItems,
       },
-    );
-    const unsubSession = useSessionStore.subscribe(
+    ));
+    subs.push(useSessionStore.subscribe(
       (s) => ({ isSessionActive: s.isSessionActive, sessionStartTime: s.sessionStartTime }),
       (next) => {
         this.port?.postMessage({
@@ -222,7 +308,7 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
           a.isSessionActive === b.isSessionActive &&
           a.sessionStartTime === b.sessionStartTime,
       },
-    );
+    ));
 
     // Forward provider + language pair + turn detection mode whenever they
     // change in the side panel. We listen to the full state (rather than a
@@ -254,13 +340,13 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
       lastConfig = next;
       this.port.postMessage({ type: 'config', ...next });
     };
-    const unsubConfig = useSettingsStore.subscribe(pushConfigIfChanged);
+    subs.push(useSettingsStore.subscribe(pushConfigIfChanged));
 
-    const unsubPlayback = subscribePlaybackForPort((encoded) => {
+    subs.push(subscribePlaybackForPort((encoded) => {
       this.port?.postMessage({ type: 'playback', ...encoded });
-    });
+    }));
 
-    this.subscriptions = [unsubItems, unsubSession, unsubConfig, unsubPlayback];
+    this.subscriptions = subs;
   }
 }
 

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
@@ -210,9 +210,16 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     // when the meeting tab reloads (iframe re-mounts → new port), and
     // without this cleanup the previous generation of Zustand listeners
     // would stay alive, fan messages to the new port too, and accumulate
-    // on every reload.
+    // on every reload. Reset the items throttle too (same as tearDown): a
+    // timer scheduled by the prior generation must not fire after reconnect
+    // and post its stale pendingItems snapshot to the new port.
     this.subscriptions.forEach((u) => u());
     this.subscriptions = [];
+    if (this.itemsThrottleTimer != null) {
+      clearTimeout(this.itemsThrottleTimer);
+      this.itemsThrottleTimer = null;
+    }
+    this.pendingItems = null;
 
     // Lazy dynamic import keeps the surface module testable in environments
     // that don't want to pull in sessionStore (and its audio dependencies)


### PR DESCRIPTION
## Problem

The extension's subtitle overlay forwards conversation items from the extension page to the meeting-tab iframe over a `chrome.runtime` port, re-posting the array on **every streaming delta** (structured-cloned in full each time). It was forwarding replay-only fields the overlay never reads:

1. **`formatted.audio`** (raw PCM `Int16Array`) grew until a single message exceeded Chrome's **64MiB port limit**, so `postMessage` threw synchronously inside the Zustand notify and **crashed the app** (`Message exceeded maximum allowed size of 64MiB`).
2. **`formatted.file`** (a multi-MB WAV blob built in `MainPanel.tsx` for the download/replay button) was re-cloned on every delta — measured **5.4MB on a single item, 12MB total payload** — pegging CPU (**20% → 130%+**) and climbing memory over long meetings.

The overlay only renders text and uses the small `audioSegments` / `audioTextEnd` timing metadata for the karaoke highlight; it never reads `formatted.audio` or `formatted.file`.

## Fix

All in `ExtensionContentScriptSubtitleSurface.ts`:

- **`stripHeavyItemFields()`** — drop `formatted.audio`, `formatted.file`, and `content[].audio` before posting. Payload drops from **~12MB to a few KB**.
- **`recentItems()`** — cap the wire to the last **15** items (live tail). Full history stays in the side panel as the source of truth for export.
- **Trailing throttle (`ITEMS_THROTTLE_MS = 120`)** — coalesce streaming-delta bursts into ~8 posts/sec instead of one per delta.

## How it was diagnosed

Controlled elimination, since reading the code repeatedly pointed at the wrong cause:

| Step | Result | Conclusion |
|------|--------|------------|
| strip `formatted.audio` | crash gone, lag remained | not (only) audio |
| cap items to 15 | no effect | not message size |
| throttle to ~8/sec | no effect | not message rate |
| disable forwarding channels one by one | subtitle OFF = fine; items channel = culprit | it's items forwarding |
| send a fixed tiny payload | smooth | it's the payload, not the machinery |
| dump per-key byte sizes | `formatted.file` = 5.4MB | exact field |

## Tests

- `formatted.audio` + `formatted.file` stripped from both `state-init` and `items` messages (timing metadata preserved).
- Windowing to the last 15 items.
- Throttle coalesces a burst of updates into one trailing message with the latest snapshot.
- Existing port-reconnect / playback-forwarding tests updated for the throttle. Full subtitle + port suite: **92 passing**.

## Out of scope (separate, non-subtitle issues surfaced during debugging)

- `logStore` is unbounded with an O(n)-per-event array copy (O(n²) over a session).
- The side panel still retains `formatted.audio`/`formatted.file` on its own items for the whole session (replay feature) — independent of subtitle mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export control now appears only in the Electron surface.

* **Bug Fixes**
  * Fixed subscription lifecycle to avoid leaks on port reconnects and cleared pending throttled messages on reconnect/teardown.
  * Ensured throttled updates coalesce into a single latest snapshot.

* **Chores**
  * Limit forwarded recent items and strip large replay/audio fields from forwarded payloads.
  * Expanded tests for subscription, throttling, and payload-forwarding behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->