### PR TITLE
fix(layout): readable narrow-viewport layout when a side panel is open

### DIFF
--- a/docs/superpowers/plans/2026-05-29-narrow-layout-panel.md
+++ b/docs/superpowers/plans/2026-05-29-narrow-layout-panel.md
@@ -1,0 +1,212 @@
+# Narrow-layout panel readability — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When the viewport is narrow and a Settings/Logs panel is open, give the panel the space and pin a slim, readable control bar at the bottom — instead of crushing the conversation into an unreadable clipped sliver.
+
+**Architecture:** A single responsive stylesheet change in `MainLayout.scss`. At `≤768px` with a panel open, the page stacks: panel on top (full width, scrolls), and `MainPanel` collapses to its `.control-footer` pinned at the bottom via a flex `order` swap. The transcript is hidden with `display:none` (MainPanel stays mounted, so the active session survives). The dead rules targeting stale class names (`.conversation-container`, `.audio-visualization`) are removed.
+
+**Tech Stack:** SCSS (Sass), CSS flexbox, React (Vite dev server). No new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md`
+
+---
+
+## File Structure
+
+- **Modify:** `src/components/MainLayout/MainLayout.scss` — replace the entire `@media (max-width: 768px)` block (currently lines ~11–56). This is the only file that changes.
+
+No other files are touched. The new rules deliberately reach into `MainPanel`'s class names (the same cross-file pattern that already exists); a comment documents that contract so a future rename in `MainPanel` is caught rather than silently no-op'ing (the root cause of the original bug).
+
+**Resolved facts (no need to re-verify during implementation):**
+- `.control-footer` already has `border-top: 1px solid #333` (in `MainPanel.scss`) → the pinned bar's separator is free; do **not** add another border.
+- `Onboarding` renders `null` when inactive and uses portaled, absolutely-positioned `react-joyride` overlays (`z-index ≥ 10000`) when active → it never sits in the `.main-layout` flex flow, so the `order` swap is safe and needs no special-casing.
+- Confirmed `MainPanel` class names this change depends on: `.main-content.with-panel`, `.main-panel-container`, `.main-panel-wrapper`, `.main-panel`, and the transcript elements `.conversation-toolbar`, `.conversation-display`, `.text-input-section`. The `.control-footer` (and everything inside it — ModePicker, waveforms, Start/Stop, push-to-talk, debug) is **not** touched: it renders unchanged and adapts to narrow widths via its own `@container (max-width: 768px)` styles.
+
+---
+
+## Task 1: Replace the narrow-viewport layout block
+
+This is a pure-CSS change with no meaningful jsdom unit test (media-query layout needs a real browser). The TDD red→green cycle is done by **observing the broken state, applying the change, then observing the fixed state** in a browser.
+
+**Files:**
+- Modify: `src/components/MainLayout/MainLayout.scss` (the `@media (max-width: 768px)` block)
+
+- [ ] **Step 1: Start the dev server and observe the BROKEN (red) state**
+
+Run:
+```bash
+npm run dev
+```
+Open `http://localhost:5173`. If a "user type" / onboarding gate appears, pick any option (e.g. regular) to reach the main layout. Narrow the window to **under 768px** (or use DevTools device toolbar at ~400px wide). Click the **Settings** (⚙) toggle in the title bar.
+
+Expected (the bug): the conversation area is crushed into a ~60px clipped sliver at the top; the transcript is unreadable. This is the state we are fixing.
+
+- [ ] **Step 2: Replace the `@media (max-width: 768px)` block**
+
+In `src/components/MainLayout/MainLayout.scss`, **delete** the entire current block (the comment `/* For small screens... */` plus the `@media (max-width: 768px) { ... }` it precedes — currently lines ~11–56):
+
+```scss
+  /* For small screens, change to a vertical layout with panel taking full width */
+  @media (max-width: 768px) {
+    flex-direction: column;
+    
+    .settings-panel-container {
+      width: 100% !important;
+      min-width: 100% !important;
+      max-width: 100% !important;
+      height: calc(100vh - 120px); /* Full height minus header and audio controls */
+      border-top: 1px solid #333;
+      border-right: none;
+    }
+    
+    .main-content {
+      height: auto;
+      
+      &.with-panel {
+        height: 120px; /* Enough for the header and audio controls */
+        min-height: 120px;
+        border-right: none;
+        
+        .main-panel-container {
+          display: block; /* Show the main panel content for audio controls */
+          height: 60px; /* Just enough for the audio visualization and controls */
+          overflow: hidden; /* Hide everything else */
+          
+          /* Ensure the audio visualization is visible */
+          .main-panel {
+            height: 100%;
+            
+            /* Hide the conversation container when panel is open */
+            .conversation-container {
+              display: none;
+            }
+            
+            /* Ensure audio visualization is positioned correctly */
+            .audio-visualization {
+              position: relative;
+              bottom: auto;
+              margin-top: 10px;
+            }
+          }
+        }
+      }
+    }
+  }
+```
+
+**Replace** it with:
+
+```scss
+  /* Narrow viewports: stack vertically. When a side panel (Settings/Logs) is
+     open, the panel takes the space and MainPanel collapses to its control
+     footer, pinned as a bar at the bottom; the footer renders unchanged (its
+     own @container styles handle narrow widths).
+     See docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md.
+
+     CONTRACT: the rules below reach into MainPanel's class names
+     (.conversation-toolbar, .conversation-display, .text-input-section) to hide
+     the transcript. If those names change in MainPanel, update them here too —
+     a stale selector silently matches nothing (this is exactly what broke the
+     previous version). */
+  @media (max-width: 768px) {
+    flex-direction: column;
+
+    .panel-resizer { display: none; } /* meaningless when stacked */
+
+    .settings-panel-container {
+      order: 1; /* panel on top */
+      width: 100% !important;
+      min-width: 100% !important;
+      max-width: 100% !important;
+      flex: 1 1 auto;
+      min-height: 0; /* allow internal scrolling */
+      overflow-y: auto;
+      border-top: none;
+      border-right: none;
+    }
+
+    .main-content.with-panel {
+      order: 2; /* control footer pinned below the panel */
+      flex: 0 0 auto; /* size to the footer, not a flex-grow region */
+      height: auto;
+      min-height: 0;
+      border-right: none;
+
+      .main-panel-container {
+        height: auto;
+        overflow: visible;
+      }
+
+      .main-panel-wrapper,
+      .main-panel {
+        height: auto;
+        min-height: 0;
+      }
+
+      /* Hide the transcript while a panel is open. MainPanel stays mounted
+         (display:none, NOT unmounted) so the active session survives. The
+         .control-footer is intentionally left untouched — it renders exactly
+         as in the normal layout and adapts via its own @container styles. */
+      .conversation-toolbar,
+      .conversation-display,
+      .text-input-section {
+        display: none;
+      }
+    }
+  }
+```
+
+Save the file. The Vite dev server hot-reloads the styles.
+
+- [ ] **Step 3: Observe the FIXED (green) state — manual verification**
+
+With the window still under 768px, run through this checklist (each should pass):
+
+1. **Settings open:** the Settings panel fills the area under the title bar and scrolls internally; a slim one-line bar is pinned at the bottom showing the status dot, the Start/Stop button, and the `EN → JA`-style language pair. No transcript sliver; nothing clipped.
+2. **Logs open:** click the Logs (📋) toggle — same behavior (Logs panel on top, slim bar pinned at bottom).
+3. **Advanced mode:** open Settings → switch UI mode to **advanced** (or relaunch and pick the "experienced" user type). With a panel open and narrow, confirm the control footer renders **normally** pinned at the bottom — ModePicker, waveforms, Start/Stop and language all present — adapting to the narrow width via its own `@container` styles (e.g. collapsed button labels). It is not stripped down.
+4. **Close restores transcript:** click the open panel's toggle to close it → the full conversation transcript returns at full height.
+5. **Widen restores side-by-side:** drag the window wider than 768px with a panel open → the layout returns to side-by-side (main content left, panel right, `PanelResizer` visible between them).
+6. **Session not interrupted (lightweight):** this is guaranteed because `MainPanel` is only `display`-toggled, never unmounted. If a provider/API key is configured, optionally start a session, open a panel, confirm the session keeps running and Start/Stop in the slim bar ends it.
+
+If any check fails, fix the CSS and re-run this step before committing.
+
+- [ ] **Step 4: Build to confirm SCSS compiles**
+
+Run:
+```bash
+npm run build
+```
+Expected: build succeeds with no Sass errors referencing `MainLayout.scss`. (Sass deprecation warnings are silenced project-wide and are not failures.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/MainLayout/MainLayout.scss
+git commit -m "fix(layout): readable narrow-viewport layout when a panel is open
+
+When narrow and a side panel is open, give the panel the space and pin a
+slim control bar (status + Start/Stop + language) at the bottom instead of
+crushing the conversation into a clipped sliver. Hide the transcript via
+display:none (MainPanel stays mounted, session survives). Remove the dead
+rules that targeted stale class names (.conversation-container,
+.audio-visualization)."
+```
+
+(Optionally include the spec and plan docs in the same or a preceding commit:
+`git add docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md docs/superpowers/plans/2026-05-29-narrow-layout-panel.md`.)
+
+---
+
+## Optional follow-up (not required)
+
+A Playwright responsive snapshot (narrow viewport, panel open) would guard against regressions, but Playwright is not currently configured as a test runner in this repo (tests use Vitest + jsdom, which can't evaluate media-query layout). Skip unless/until a browser-based test setup is added.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Every spec section maps to Task 1 — vertical stack + panel-on-top + scroll (Step 2 `.settings-panel-container`), transcript hidden / session preserved (Step 2 `display:none`, verified Step 3.4/3.6), control footer left unchanged and pinned (no `.control-footer` rules; verified Step 3.3), reorder without `:has()` (Step 2 `order`), remove dead selectors (Step 2 deletion), no-panel-narrow untouched (only `.with-panel` targeted), breakpoint 768px (unchanged), separator reused not re-added (File Structure note). Edge cases (banners/warnings stay visible, Onboarding overlay) resolved in File Structure.
+- **Placeholder scan:** none — full before/after CSS shown, exact commands and expected results given.
+- **Type/name consistency:** class names used in the CSS (`.panel-resizer`, `.settings-panel-container`, `.main-content.with-panel`, `.main-panel-container`, `.main-panel-wrapper`, `.main-panel`, `.conversation-toolbar`, `.conversation-display`, `.text-input-section`) match the verified names in the spec's File Structure facts. The footer's internal classes are no longer referenced (the footer is left unchanged).

--- a/docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md
+++ b/docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md
@@ -167,6 +167,24 @@ Ensure a 1px top border on the pinned bar so it reads as distinct from the
 panel above it. Reuse `.control-footer`'s existing top border if present;
 otherwise add `border-top: 1px solid #333;` to `.main-content.with-panel`.
 
+### Accessibility trade-off (accepted)
+
+The bottom-pinned bar is produced with CSS flex `order` (panel `order: 1`,
+main-content `order: 2`). `order` changes visual position only, not DOM/focus
+order — so in the narrow + panel-open state, keyboard and screen-reader users
+traverse the footer (Start/Stop, language) **before** the panel, the reverse of
+the visual top→bottom (WCAG 2.4.3 Focus Order / 1.3.2 Meaningful Sequence).
+
+This is **accepted, not fixed**: the mismatch is confined to one state, the
+reordered-first region (the footer) holds only a few controls, and the clean
+alternatives each cost more — a top-pinned bar abandons the chosen
+bottom-bar ergonomics, and a JS/`matchMedia` DOM reorder re-couples a responsive
+concern to React that this CSS-only design deliberately avoids. If WCAG focus
+order later becomes a priority for this viewport, reorder the DOM in
+`MainLayout.tsx` (render the panel before `.main-content` when narrow +
+panel-open) and drop the `order` swap. (Raised in PR #254 review by Gemini Code
+Assist.)
+
 ## Edge cases & verification items
 
 - **`UpdateBanner` / `UpdateDialog` / `AudioFeedbackWarning`** live inside

--- a/docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md
+++ b/docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md
@@ -1,0 +1,216 @@
+# Narrow-layout readability when a side panel is open
+
+**Date:** 2026-05-29
+**Status:** Approved design — ready for implementation plan
+**Area:** `src/components/MainLayout/` (responsive layout)
+
+## Summary
+
+On narrow viewports, opening the Settings or Logs panel crushes the main
+conversation area into a clipped, unreadable sliver. This spec replaces that
+behavior: when the viewport is narrow **and** a side panel is open, the panel
+takes the available space and the conversation transcript is cleanly hidden,
+while the control footer — rendered exactly as it normally is — stays pinned at
+the bottom so the session remains controllable. Closing the panel restores the
+transcript; widening the viewport restores the side-by-side layout.
+
+The change is confined to one stylesheet — `MainLayout.scss` — and does not
+alter `MainPanel`'s markup or behavior.
+
+## Problem
+
+`.main-layout` is a flex **row** by default: `.main-content` (the `MainPanel`,
+i.e. conversation + control footer) on the left, `.settings-panel-container`
+(Settings or Logs) on the right, with a `PanelResizer` between them.
+
+At `@media (max-width: 768px)` it flips to `flex-direction: column`. When a
+panel is open, the current rules force:
+
+- `.main-content.with-panel { height: 120px; min-height: 120px; }`
+- `.main-panel-container { height: 60px; overflow: hidden; }`
+
+This squeezes the entire `MainPanel` (toolbar + scrolling transcript + control
+footer) into ~60px and clips it — the "上下很窄、不可读" (vertically tiny,
+unreadable) state.
+
+### Root cause
+
+Two compounding issues:
+
+1. **The squeeze itself** — the hard `120px` / `60px` height caps on
+   `.main-content.with-panel` and `.main-panel-container`.
+2. **Dead selectors** — the rules that were *supposed* to hide the transcript
+   target `.conversation-container` and `.audio-visualization`, but `MainPanel`
+   now renders `.conversation-display` and `.control-footer`. Those old class
+   names exist nowhere in the rendered component, so the rules silently match
+   nothing. Nothing is hidden; it is merely clipped by `overflow: hidden`.
+
+The original intent behind reserving 60–120px was to keep the **session
+controls** (Start/Stop, status) reachable while a panel is open. The new design
+preserves that intent without crushing the transcript.
+
+## Goals
+
+- On narrow viewports with a panel open, both the panel and the session
+  controls are fully usable; nothing is clipped.
+- Start/Stop and connection status remain reachable while a panel is open.
+- The active session is never interrupted by opening/closing a panel
+  (`MainPanel` stays mounted).
+- Wide-viewport (side-by-side) behavior is unchanged.
+- Change stays localized; remove the dead/stale CSS.
+
+## Non-goals
+
+- No redesign of the wide-screen side-by-side layout or the `PanelResizer`.
+- No changes to `MainPanel`'s component structure, props, or rendering logic.
+- No bottom-sheet/drawer gestures or animations (considered and rejected as
+  more code than this fix warrants — see Alternatives).
+
+## Design
+
+Chosen direction: **Panel takeover with the control footer pinned as a bar at
+the bottom — rendered unchanged.**
+
+> **Decision update (2026-05-29):** an earlier revision slimmed the footer in
+> narrow mode (hiding ModePicker / waveforms / push-to-talk / debug). That was
+> dropped: the footer is left exactly as it renders normally. The footer's own
+> `@container (max-width: 768px)` styles already adapt it to narrow widths, so a
+> parallel slim variant added coupling and a horizontal-overflow risk for no
+> real gain.
+
+### Target behavior — narrow (`≤768px`) AND a panel open
+
+1. `.main-layout` stays `flex-direction: column`.
+2. **Settings/Logs panel** is on top, full width, `flex: 1`, scrolls
+   internally — the prime space directly under the `TitleBar`.
+3. **Transcript hidden, session preserved**: `.conversation-toolbar`,
+   `.conversation-display`, and `.text-input-section` are set to
+   `display: none`. `MainPanel` is **not** unmounted, so the active session
+   survives. Closing the panel restores the transcript.
+4. **Control footer pinned at the bottom**: the existing `.control-footer`
+   renders **unchanged** (basic or advanced, including its ModePicker and
+   waveforms), full width, below the panel. Its own
+   `@container (max-width: 768px)` styles already adapt it to narrow widths.
+
+### Ordering (bar at the bottom)
+
+The bar lives inside `.main-content`, which is the **first** flex child in DOM
+order. To render it below the panel, swap flex `order`. `:has()` is **not**
+needed because `.settings-panel-container` is only rendered when a panel is open:
+
+- `.settings-panel-container { order: 1; }` → top
+- `.main-content.with-panel { order: 2; }` → bottom
+- `.panel-resizer { display: none; }` → meaningless when stacked
+
+### Control footer: unchanged
+
+The footer is **not** modified in narrow mode — no controls are stripped. It
+renders exactly as in the normal (wide / full-height) layout, in both its
+`.control-footer.basic` and `.control-footer.advanced` variants. The footer
+already carries its own `@container (max-width: 768px)` rules (e.g. collapsing
+button labels), so it adapts to a narrow bar on its own. Consequently the
+narrow-mode rules reach into `MainPanel` only to hide the transcript
+(`.conversation-toolbar`, `.conversation-display`, `.text-input-section`) — not
+the footer's internals.
+
+### CSS sketch (single file: `MainLayout.scss`)
+
+Replace the current `@media (max-width: 768px)` block with:
+
+```scss
+@media (max-width: 768px) {
+  flex-direction: column;
+
+  .panel-resizer { display: none; }            // meaningless when stacked
+
+  .settings-panel-container {
+    order: 1;                                   // panel on top
+    width: 100% !important;
+    min-width: 100% !important;
+    max-width: 100% !important;
+    flex: 1 1 auto;
+    min-height: 0;                              // allow internal scroll
+    overflow-y: auto;
+    border-top: none;
+    border-right: none;
+  }
+
+  .main-content.with-panel {
+    order: 2;                                   // slim bar pinned below
+    flex: 0 0 auto;                             // size to the footer
+    height: auto;
+    min-height: 0;
+    border-right: none;
+
+    .main-panel-container { height: auto; overflow: visible; }
+    .main-panel-wrapper,
+    .main-panel { height: auto; min-height: 0; }
+
+    // Hide the transcript while a panel is open. MainPanel stays mounted
+    // (display:none, not unmounted) so the active session survives.
+    // The .control-footer is intentionally left untouched.
+    .conversation-toolbar,
+    .conversation-display,
+    .text-input-section { display: none; }
+  }
+}
+```
+
+A comment will document that these descendant selectors depend on `MainPanel`'s
+class names — the contract whose drift (`.conversation-container` →
+`.conversation-display`) caused the original bug. This keeps the next renamer
+aware of the cross-file coupling.
+
+### Separator
+
+Ensure a 1px top border on the pinned bar so it reads as distinct from the
+panel above it. Reuse `.control-footer`'s existing top border if present;
+otherwise add `border-top: 1px solid #333;` to `.main-content.with-panel`.
+
+## Edge cases & verification items
+
+- **`UpdateBanner` / `UpdateDialog` / `AudioFeedbackWarning`** live inside
+  `.main-panel-wrapper` / `.main-panel` and remain visible (transient and
+  important). Acceptable; revisit only if they visibly crowd the slim bar.
+- **`Onboarding`** is a sibling inside `.main-layout`. Implementation must
+  verify it is an overlay (fixed/absolute or portal) so the flex `order` swap
+  does not misposition it. If it is in normal flow, give it `order: 0` or
+  otherwise exclude it from the reordering.
+- **No-panel narrow** (`.main-content.full-width`) is untouched: `MainPanel`
+  renders normally at full height.
+- **Breakpoint** stays at `768px`. The browser-extension side panel is
+  typically narrower than this, so it is effectively always in column mode —
+  the takeover is its normal state there, which is intended.
+
+## Alternatives considered
+
+- **B · Proportional split** (conversation + panel both visible, each scrolls):
+  rejected — comfortable only when the narrow view is also tall; cramped on
+  short viewports, and shows a partial transcript that competes with the panel.
+- **C · Bottom-sheet drawer** (panel slides up over the conversation): rejected
+  — most mobile-native feel but the most new code (gesture/animation, overlay
+  z-index, focus management) for little gain over A.
+
+## Testing / verification
+
+Primary verification is a manual responsive check (CSS media-query layout is
+not meaningfully testable in jsdom):
+
+1. Narrow the viewport below 768px. Open **Settings**, then **Logs**:
+   - Panel fills the space above and scrolls internally.
+   - The control footer is pinned at the bottom and renders normally (basic or
+     advanced — ModePicker, waveforms, Start/Stop, language all present),
+     adapting to the narrow width via its own `@container` styles.
+   - Nothing is clipped; no transcript sliver.
+2. Start a session, then open a panel → session persists and Start/Stop works.
+   Stop from the slim bar → session ends.
+3. Close the panel → transcript returns at full height.
+4. Widen past 768px → side-by-side layout (with `PanelResizer`) restored.
+
+A Playwright responsive snapshot is optional. No new unit tests are warranted
+for a pure-CSS change.
+
+## Files touched
+
+- `src/components/MainLayout/MainLayout.scss` — replace the
+  `@media (max-width: 768px)` block (the only required change).

--- a/src/components/MainLayout/MainLayout.scss
+++ b/src/components/MainLayout/MainLayout.scss
@@ -24,6 +24,15 @@
 
     .panel-resizer { display: none; } /* meaningless when stacked */
 
+    /* A11y trade-off (WCAG 2.4.3 Focus Order / 1.3.2 Meaningful Sequence):
+       `order` reflows the layout visually but NOT the DOM/focus order. So in
+       this narrow + panel-open state, keyboard and screen-reader users reach
+       the footer (inside .main-content, order: 2) BEFORE the panel — the
+       reverse of the visual top→bottom. Accepted: the mismatch is confined to
+       this one state and the footer holds only a few controls. If WCAG focus
+       order becomes a priority for this viewport, reorder the DOM in
+       MainLayout.tsx (render the panel before .main-content when narrow +
+       panel-open) and drop the `order` swap. Raised in PR #254 review. */
     .settings-panel-container {
       order: 1; /* panel on top */
       width: 100% !important;

--- a/src/components/MainLayout/MainLayout.scss
+++ b/src/components/MainLayout/MainLayout.scss
@@ -8,49 +8,60 @@
   color: white;
   overflow: hidden; /* Prevent overflow from causing scrollbars on the body */
   
-  /* For small screens, change to a vertical layout with panel taking full width */
+  /* Narrow viewports: stack vertically. When a side panel (Settings/Logs) is
+     open, the panel takes the space and MainPanel collapses to its control
+     footer, pinned as a bar at the bottom; the footer renders unchanged (its
+     own @container styles handle narrow widths).
+     See docs/superpowers/specs/2026-05-29-narrow-layout-panel-design.md.
+
+     CONTRACT: the rules below reach into MainPanel's class names
+     (.conversation-toolbar, .conversation-display, .text-input-section) to hide
+     the transcript. If those names change in MainPanel, update them here too —
+     a stale selector silently matches nothing (this is exactly what broke the
+     previous version). */
   @media (max-width: 768px) {
     flex-direction: column;
-    
+
+    .panel-resizer { display: none; } /* meaningless when stacked */
+
     .settings-panel-container {
+      order: 1; /* panel on top */
       width: 100% !important;
       min-width: 100% !important;
       max-width: 100% !important;
-      height: calc(100vh - 120px); /* Full height minus header and audio controls */
-      border-top: 1px solid #333;
+      flex: 1 1 auto;
+      min-height: 0; /* allow internal scrolling */
+      overflow-y: auto;
+      border-top: none;
       border-right: none;
     }
-    
-    .main-content {
+
+    .main-content.with-panel {
+      order: 2; /* control footer pinned below the panel */
+      flex: 0 0 auto; /* size to the footer, not a flex-grow region */
       height: auto;
-      
-      &.with-panel {
-        height: 120px; /* Enough for the header and audio controls */
-        min-height: 120px;
-        border-right: none;
-        
-        .main-panel-container {
-          display: block; /* Show the main panel content for audio controls */
-          height: 60px; /* Just enough for the audio visualization and controls */
-          overflow: hidden; /* Hide everything else */
-          
-          /* Ensure the audio visualization is visible */
-          .main-panel {
-            height: 100%;
-            
-            /* Hide the conversation container when panel is open */
-            .conversation-container {
-              display: none;
-            }
-            
-            /* Ensure audio visualization is positioned correctly */
-            .audio-visualization {
-              position: relative;
-              bottom: auto;
-              margin-top: 10px;
-            }
-          }
-        }
+      min-height: 0;
+      border-right: none;
+
+      .main-panel-container {
+        height: auto;
+        overflow: visible;
+      }
+
+      .main-panel-wrapper,
+      .main-panel {
+        height: auto;
+        min-height: 0;
+      }
+
+      /* Hide the transcript while a panel is open. MainPanel stays mounted
+         (display:none, NOT unmounted) so the active session survives. The
+         .control-footer is intentionally left untouched — it renders exactly
+         as in the normal layout and adapts via its own @container styles. */
+      .conversation-toolbar,
+      .conversation-display,
+      .text-input-section {
+        display: none;
       }
     }
   }


### PR DESCRIPTION
## Problem

On narrow viewports (≤768px) with a Settings/Logs side panel open, the layout flips to a vertical stack, but the conversation area was hard-capped at ~120px and clipped into an unreadable sliver. The rules meant to *hide* the transcript targeted stale class names (`.conversation-container`, `.audio-visualization`) that `MainPanel` no longer renders, so they silently matched nothing.

## Fix

When the viewport is narrow **and** a panel is open:

- The Settings/Logs panel takes the top — full width, scrolls internally.
- `MainPanel` collapses to its **control footer**, pinned as a bar at the bottom (via a flex `order` swap — no `:has()` needed, since the panel container only renders when a panel is open).
- The transcript (`.conversation-toolbar`, `.conversation-display`, `.text-input-section`) is hidden with `display:none`. `MainPanel` stays **mounted**, so an active translation session is never interrupted by opening/closing a panel.
- The control footer renders **unchanged**, adapting to narrow widths via its own existing `@container` styles (no parallel "slim" variant).
- Removed the dead `.conversation-container` / `.audio-visualization` rules.

Single source file changed: `src/components/MainLayout/MainLayout.scss` (the `@media (max-width: 768px)` block).

## Testing

- `npm run build` passes (SCSS compiles cleanly).
- Manual responsive check (recommended before merge): narrow below 768px → open Settings, then Logs (panel fills the top and scrolls, control footer pinned at the bottom, nothing clipped); close the panel → transcript returns; widen past 768px → side-by-side layout restored; advanced mode → footer renders normally at the bottom.

## Docs

Design spec and implementation plan added under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved narrow-viewport readability when Settings/Logs panel is open: the side panel now stacks above main content, becomes scrollable, the control footer stays pinned, and transcript/input elements are hidden while preserving session state. A visible separator is retained for clarity.

* **Documentation**
  * Added implementation plan and design spec with verification steps and checklist.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/254?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->