### PR TITLE
Add Jitsi Meet to supported platforms

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -93,7 +93,8 @@
         "https://app.v2.gather.town/*",
         "https://whereby.com/*",
         "https://discord.com/*",
-        "https://app.slack.com/*"
+        "https://app.slack.com/*",
+        "https://meet.jit.si/*"
       ]
     }
   ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -45,7 +45,7 @@
   },
   "content_scripts": [
     {
-      "matches": ["https://meet.google.com/*", "https://teams.live.com/*", "https://teams.microsoft.com/*", "https://teams.cloud.microsoft/*", "https://app.gather.town/*", "https://app.v2.gather.town/*", "https://whereby.com/*", "https://discord.com/*", "https://app.slack.com/*"],
+      "matches": ["https://meet.google.com/*", "https://teams.live.com/*", "https://teams.microsoft.com/*", "https://teams.cloud.microsoft/*", "https://app.gather.town/*", "https://app.v2.gather.town/*", "https://whereby.com/*", "https://discord.com/*", "https://app.slack.com/*", "https://meet.jit.si/*"],
       "js": ["content.js", "subtitle-overlay-content.js"],
       "run_at": "document_start"
     },


### PR DESCRIPTION
Added https://meet.jit.si/* to content script matches. Jitsi Meet is a popular open-source video conferencing platform used by many in Europe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended extension compatibility to support Jitsi Meet conferencing (works on meet.jit.si).
  * Enables extension scripts and required resources to run and be available on Jitsi Meet pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/256?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->