### PR TITLE
fix(audio): silence mic passthrough when the mic is muted

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -58,7 +58,7 @@ import { isDevelopment } from '../../config/analytics';
 import { v4 as uuidv4 } from 'uuid';
 import { Provider, isOpenAICompatible } from '../../types/Provider';
 import AudioFeedbackWarning from '../AudioFeedbackWarning/AudioFeedbackWarning';
-import { getSafeAudioConfiguration } from '../../utils/audioUtils';
+import { getSafeAudioConfiguration, isPassthroughActive } from '../../utils/audioUtils';
 import { useAuth } from '../../lib/auth/hooks';
 import { useUserProfile } from '../../contexts/UserProfileContext';
 import { isExtension, isElectron, isLoopbackPlatform, getEnvironment } from '../../utils/environment';
@@ -721,9 +721,12 @@ const MainPanel: React.FC<MainPanelProps> = () => {
 
     const isPushToTranslate = currentTurnDetectionMode === 'Push-to-Translate';
 
-    const enabled = isPushToTranslate
-      ? !isRecording                    // mute only while user is holding the key
-      : isRealVoicePassthroughEnabled;  // legacy: user-controlled toggle
+    const enabled = isPassthroughActive({
+      mode: currentTurnDetectionMode,
+      isRecording,
+      isMicMuted,
+      legacyPassthroughEnabled: isRealVoicePassthroughEnabled,
+    });
 
     const volume = isPushToTranslate
       ? 1.0                             // self-contained, ignore 0-60% cap
@@ -737,6 +740,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   }, [
     currentTurnDetectionMode,
     isRecording,
+    isMicMuted,
     isRealVoicePassthroughEnabled,
     realVoicePassthroughVolume,
     selectedInputDevice,

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -710,6 +710,20 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     };
   }, []);
 
+  // Whether raw-mic passthrough is currently audible to the outputs. Shared by
+  // the passthrough setup, the feedback-warning effect, and the warning UI so
+  // they never drift (mute always wins; see isPassthroughActive).
+  const passthroughActive = useMemo(
+    () =>
+      isPassthroughActive({
+        mode: currentTurnDetectionMode,
+        isRecording,
+        isMicMuted,
+        legacyPassthroughEnabled: isRealVoicePassthroughEnabled,
+      }),
+    [currentTurnDetectionMode, isRecording, isMicMuted, isRealVoicePassthroughEnabled]
+  );
+
   /**
    * Update passthrough settings when they change.
    * Push-to-translate mode hijacks passthrough: on @ 100% during idle,
@@ -721,12 +735,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
 
     const isPushToTranslate = currentTurnDetectionMode === 'Push-to-Translate';
 
-    const enabled = isPassthroughActive({
-      mode: currentTurnDetectionMode,
-      isRecording,
-      isMicMuted,
-      legacyPassthroughEnabled: isRealVoicePassthroughEnabled,
-    });
+    const enabled = passthroughActive;
 
     const volume = isPushToTranslate
       ? 1.0                             // self-contained, ignore 0-60% cap
@@ -739,12 +748,10 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     }
   }, [
     currentTurnDetectionMode,
-    isRecording,
-    isMicMuted,
-    isRealVoicePassthroughEnabled,
+    passthroughActive,
     realVoicePassthroughVolume,
-    selectedInputDevice,
-    selectedMonitorDevice,
+    selectedInputDevice?.deviceId,
+    selectedMonitorDevice?.deviceId,
     isMonitorMuted,
   ]);
 
@@ -770,8 +777,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
    * in addition to the user-controlled isRealVoicePassthroughEnabled.
    */
   useEffect(() => {
-    const isPushToTranslate = currentTurnDetectionMode === 'Push-to-Translate';
-    const effectivePassthroughEnabled = isPushToTranslate || isRealVoicePassthroughEnabled;
+    const effectivePassthroughEnabled = passthroughActive;
 
     if (feedbackWarningDismissed || !effectivePassthroughEnabled || isMonitorMuted) {
       setShowFeedbackWarning(false);
@@ -790,8 +796,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       setShowFeedbackWarning(false);
     }
   }, [
-    currentTurnDetectionMode,
-    isRealVoicePassthroughEnabled,
+    passthroughActive,
     selectedInputDevice,
     selectedMonitorDevice,
     feedbackWarningDismissed,
@@ -3481,14 +3486,14 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             getSafeAudioConfiguration(
               selectedInputDevice,
               selectedMonitorDevice,
-              isRealVoicePassthroughEnabled
+              passthroughActive
             ).recommendedAction
           }
           feedbackRisk={
             getSafeAudioConfiguration(
               selectedInputDevice,
               selectedMonitorDevice,
-              isRealVoicePassthroughEnabled
+              passthroughActive
             ).feedbackRisk
           }
           onDismiss={() => {

--- a/src/utils/audioUtils.test.ts
+++ b/src/utils/audioUtils.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { isPassthroughActive } from './audioUtils';
+
+/**
+ * isPassthroughActive decides whether the raw-mic passthrough should currently
+ * be audible to the outputs (monitor / virtual mic / meeting tab).
+ *
+ * The critical invariant: muting the mic must silence passthrough too. The
+ * mic-mute is a "soft mute" (the recorder keeps running and only the AI-bound
+ * tap is gated), so the passthrough path must honor mute independently or the
+ * user's voice keeps leaking to participants. This is most visible in
+ * Push-to-Translate mode, where passthrough is auto-enabled @ 100% while idle.
+ */
+describe('isPassthroughActive', () => {
+  it('is on during Push-to-Translate idle when not muted', () => {
+    expect(
+      isPassthroughActive({
+        mode: 'Push-to-Translate',
+        isRecording: false,
+        isMicMuted: false,
+        legacyPassthroughEnabled: false,
+      })
+    ).toBe(true);
+  });
+
+  it('is off during Push-to-Translate while holding the key (recording)', () => {
+    expect(
+      isPassthroughActive({
+        mode: 'Push-to-Translate',
+        isRecording: true,
+        isMicMuted: false,
+        legacyPassthroughEnabled: false,
+      })
+    ).toBe(false);
+  });
+
+  it('is off during Push-to-Translate idle when the mic is muted', () => {
+    // The bug: previously stayed true here, so a muted mic still leaked voice.
+    expect(
+      isPassthroughActive({
+        mode: 'Push-to-Translate',
+        isRecording: false,
+        isMicMuted: true,
+        legacyPassthroughEnabled: false,
+      })
+    ).toBe(false);
+  });
+
+  it('follows the legacy toggle in non-P2T modes when not muted', () => {
+    expect(
+      isPassthroughActive({
+        mode: 'Normal',
+        isRecording: false,
+        isMicMuted: false,
+        legacyPassthroughEnabled: true,
+      })
+    ).toBe(true);
+
+    expect(
+      isPassthroughActive({
+        mode: 'Normal',
+        isRecording: false,
+        isMicMuted: false,
+        legacyPassthroughEnabled: false,
+      })
+    ).toBe(false);
+  });
+
+  it('is off in legacy passthrough modes when the mic is muted', () => {
+    expect(
+      isPassthroughActive({
+        mode: 'Normal',
+        isRecording: false,
+        isMicMuted: true,
+        legacyPassthroughEnabled: true,
+      })
+    ).toBe(false);
+  });
+});

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -152,19 +152,24 @@ export const isLikelyToGenerateFeedback = (
  * - Push-to-Translate → on while idle, off while the user holds the key (recording).
  * - Other modes → follow the user's legacy passthrough toggle.
  */
-export const isPassthroughActive = (params: {
+export const isPassthroughActive = ({
+  mode,
+  isRecording,
+  isMicMuted,
+  legacyPassthroughEnabled,
+}: {
   mode: string;
   isRecording: boolean;
   isMicMuted: boolean;
   legacyPassthroughEnabled: boolean;
 }): boolean => {
-  if (params.isMicMuted) {
+  if (isMicMuted) {
     return false;
   }
-  if (params.mode === 'Push-to-Translate') {
-    return !params.isRecording;
+  if (mode === 'Push-to-Translate') {
+    return !isRecording;
   }
-  return params.legacyPassthroughEnabled;
+  return legacyPassthroughEnabled;
 };
 
 /**

--- a/src/utils/audioUtils.ts
+++ b/src/utils/audioUtils.ts
@@ -138,6 +138,36 @@ export const isLikelyToGenerateFeedback = (
 };
 
 /**
+ * Decide whether the raw-mic passthrough should currently be audible to the
+ * outputs (local monitor, virtual mic, meeting tab).
+ *
+ * Mute is a "soft mute": the recorder keeps running and only the AI-bound tap is
+ * gated per-frame. The passthrough path is a *separate* output, so it must honor
+ * mute here independently — otherwise a muted mic still leaks the user's voice to
+ * participants. This is most visible in Push-to-Translate, where passthrough is
+ * auto-enabled at full volume while idle.
+ *
+ * Rules:
+ * - Muted always wins → no passthrough (voice must not leave the machine).
+ * - Push-to-Translate → on while idle, off while the user holds the key (recording).
+ * - Other modes → follow the user's legacy passthrough toggle.
+ */
+export const isPassthroughActive = (params: {
+  mode: string;
+  isRecording: boolean;
+  isMicMuted: boolean;
+  legacyPassthroughEnabled: boolean;
+}): boolean => {
+  if (params.isMicMuted) {
+    return false;
+  }
+  if (params.mode === 'Push-to-Translate') {
+    return !params.isRecording;
+  }
+  return params.legacyPassthroughEnabled;
+};
+
+/**
  * Get safe audio device configuration to prevent feedback
  */
 export const getSafeAudioConfiguration = (


### PR DESCRIPTION
## Problem

Muting the mic is a "soft mute": the recorder keeps running and only the **AI-bound audio tap** is gated per frame. The **passthrough output** (local monitor, virtual mic, meeting tab) was never gated on mute.

In **Push-to-Translate**, passthrough is auto-enabled at 100% while idle, so muting the mic only stopped audio going to the AI — the user's raw voice still leaked to meeting participants. Reproduced in the Electron app. Legacy real-voice passthrough had the same gap.

## Fix

- Add a pure, tested `isPassthroughActive()` helper in `audioUtils.ts` where **mute always wins**:
  - muted → off
  - Push-to-Translate → on while idle, off while holding the key
  - other modes → follow the user's legacy passthrough toggle
- Route the passthrough `useEffect` in `MainPanel` through the helper, and add `isMicMuted` to the effect deps so toggling mute re-runs `setupPassthrough()`.
- Passthrough **volume** is unchanged (user-set percentage in legacy mode, 100% in P2T) — only the on/off gate is affected.

## Testing

- `src/utils/audioUtils.test.ts` — 6 cases covering P2T idle/holding/muted and legacy on/off/muted (all green via vitest).
- `tsc --noEmit`: no new type errors in the touched files.
- Manually verified in the Electron app: muting the mic in Push-to-Translate now stops the voice reaching participants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Passthrough audio now reliably respects microphone mute and is disabled during active recording in push-to-translate mode, preventing unintended audio leakage.

* **New Features**
  * Audio feedback warnings now reflect the effective passthrough state so recommendations match real audible behavior.

* **Tests**
  * Added tests covering passthrough behavior across modes, recording, and mute states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kizuna-ai-lab/sokuji/pull/258?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->