### PR TITLE
feat(native): Cohere Transcribe ASR (non-gated, GPU bf16) + download/delete UX fixes

### DIFF
--- a/docs/superpowers/plans/2026-06-24-native-asr-cohere.md
+++ b/docs/superpowers/plans/2026-06-24-native-asr-cohere.md
@@ -1,0 +1,580 @@
+# Cohere Transcribe Native (GPU Sidecar) ASR — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Cohere Transcribe (`CohereLabs/cohere-transcribe-03-2026`) as a GPU-native ASR in the Python sidecar — the full-precision bf16/CUDA twin of the existing LOCAL_INFERENCE WebGPU model — so existing Cohere users get the same model, faster and at higher quality.
+
+**Architecture:** A new `CohereAsrBackend` that mirrors the shipped `Qwen3AsrBackend` (transformers speech model, GPU bf16, `.to(device)` with no `accelerate`, `local_files_only=True`). It is wired through the same four seams as Granite/Qwen3: the `accel` resolver self-gate, the sidecar `catalog`, `native_models.download_specs`, and the renderer `nativeCatalog`. Cohere is `recommended` and sorted **first**.
+
+**Tech Stack:** Python sidecar (`sokuji_sidecar`, pytest), transformers 5.13.0.dev0 + torch 2.11.0+cu128, React/TypeScript renderer (vitest).
+
+## Global Constraints
+
+- **Checkpoint:** `CohereLabs/cohere-transcribe-03-2026` (safetensors, bf16, ~4.13 GB). Apache 2.0.
+- **Runtime class:** `from transformers import CohereAsrForConditionalGeneration, AutoProcessor` — mainline (`transformers.models.cohere_asr`), already present in our venv (5.13.0.dev0). No `trust_remote_code`, no `accelerate`, no new pip deps.
+- **Backend NAME:** `cohereasr`. **GPU-only:** raise `BackendLoadError("cohereasr is GPU-only")` when `device == "cpu"`. Load with `.to(device).eval()` (never `device_map`). Pass `local_files_only=True` to **both** `from_pretrained` calls.
+- **Conformer, not a speech-LLM:** the source language is passed via `processor(..., language=lang)` — NO chat template, NO input-prompt slicing on the generated tokens.
+- **Languages (14, verbatim):** `en, de, fr, it, es, pt, el, nl, pl, ar, vi, zh, ja, ko`.
+- **Positioning:** `recommended=True` and sorted **first** — `sort_order`/`sortOrder = 0`; the existing ASR rows shift +1 in **both** catalogs, relative order preserved. (`sort_order` is advisory and not sent over the wire; the two catalogs' integers stay independent — only "Cohere first" must hold in both.)
+- **Explicit language:** Cohere has no auto-detect. The renderer already hides the `auto` source option for `LOCAL_NATIVE` (`LanguageSection.tsx:522`), so the requirement is met at the UI; the backend additionally defaults a missing/`"auto"` language to `"en"`.
+- **Comments:** English only. **Commits:** Conventional Commits. **Gates:** `pytest` (sidecar) + `vitest` (renderer), NOT `tsc`; `npm run build` for renderer wiring.
+
+## Deviation from the spec (resolved during planning)
+
+Spec §5.3 proposed a `requiresExplicitLanguage` flag on the native catalog plus a `LanguageSection` guard. **This is already done in existing code** — `LanguageSection.tsx:522` renders the `auto` source option only when the provider is neither `LOCAL_INFERENCE` nor `LOCAL_NATIVE`, so native never offers `auto`. Adding the flag would be unused. This plan therefore **omits** the flag and the `LanguageSection` change, and instead defends the backend against a stale `auto`/empty language value (Task 1). No renderer-logic change is needed beyond the catalog row (Task 4).
+
+---
+
+## Task 1: `CohereAsrBackend` + tests + GPU smoke
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/backends.py` (append a new backend class after `Qwen3AsrBackend`, which ends at line ~223)
+- Test: `sidecar/tests/test_backends.py` (append fakes + tests)
+
+**Interfaces:**
+- Consumes: `register_backend`, `BackendLoadError`, `AsrResult`, `TARGET_RATE` (all defined at the top of `backends.py`); `make_backend(name)`.
+- Produces: a backend registered under `NAME = "cohereasr"` with `load(model_ref, device, compute_type)`, `transcribe(samples, language) -> AsrResult`, `unload()`, `is_loaded` — the same contract Granite/Qwen3 expose.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_backends.py`:
+
+```python
+def test_cohereasr_is_gpu_only():
+    b = backends.make_backend("cohereasr")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("CohereLabs/cohere-transcribe-03-2026", "cpu", "bfloat16")
+
+
+def _install_fake_cohere(monkeypatch, *, decoded="hello world"):
+    cap = {}
+
+    class FakeFeat:
+        def to(self, dtype):
+            cap["feat_dtype"] = dtype
+            return self
+
+    class FakeBatch(dict):
+        def to(self, device):
+            cap["inp_device"] = device
+            return self
+
+    class FakeProc:
+        # Cohere processor: positional audio + sampling_rate + language (no chat template)
+        def __call__(self, samples, sampling_rate, return_tensors, language):
+            cap["sr"] = sampling_rate
+            cap["language"] = language
+            b = FakeBatch()
+            b["input_features"] = FakeFeat()
+            return b
+        def batch_decode(self, seq, skip_special_tokens):
+            cap["decoded_seq"] = seq
+            return [decoded]
+
+    class FakeModel:
+        def to(self, device):
+            cap["model_device"] = device
+            return self
+        def eval(self):
+            return self
+        def generate(self, **kw):
+            cap["gen_kw"] = kw
+            return "OUT"
+
+    class FakeAutoProcessor:
+        @staticmethod
+        def from_pretrained(repo, local_files_only=False):
+            cap["proc_repo"] = repo
+            cap["proc_local_files_only"] = local_files_only
+            return FakeProc()
+
+    class FakeCohere:
+        @staticmethod
+        def from_pretrained(repo, dtype, local_files_only=False):
+            cap["repo"] = repo
+            cap["dtype"] = dtype
+            cap["model_local_files_only"] = local_files_only
+            return FakeModel()
+
+    tmod = types.ModuleType("transformers")
+    tmod.AutoProcessor = FakeAutoProcessor
+    tmod.CohereAsrForConditionalGeneration = FakeCohere
+    monkeypatch.setitem(sys.modules, "transformers", tmod)
+
+    torch_mod = types.ModuleType("torch")
+    torch_mod.bfloat16 = "BF16"
+    torch_mod.float16 = "F16"
+    torch_mod.inference_mode = contextlib.nullcontext
+    torch_mod.cuda = types.SimpleNamespace(empty_cache=lambda: None, is_available=lambda: True)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    return cap
+
+
+def test_cohereasr_load_and_transcribe(monkeypatch):
+    cap = _install_fake_cohere(monkeypatch)
+    b = backends.make_backend("cohereasr")
+    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    assert b.is_loaded
+    assert cap["repo"] == "CohereLabs/cohere-transcribe-03-2026"
+    assert cap["dtype"] == "BF16" and cap["model_device"] == "cuda"
+    assert cap["proc_local_files_only"] is True
+    assert cap["model_local_files_only"] is True
+    r = b.transcribe(np.zeros(16000, np.float32), "ja")
+    assert r.text == "hello world"            # decoded + stripped, no prefix logic
+    assert cap["feat_dtype"] == "BF16"          # input_features cast to model dtype
+    assert cap["sr"] == 16000                   # TARGET_RATE
+    assert cap["language"] == "ja"              # explicit language passed through
+    assert cap["gen_kw"]["do_sample"] is False
+    b.unload()
+    assert not b.is_loaded
+
+
+def test_cohereasr_defaults_missing_language_to_english(monkeypatch):
+    cap = _install_fake_cohere(monkeypatch)
+    b = backends.make_backend("cohereasr")
+    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    b.transcribe(np.zeros(16000, np.float32), "")        # empty → en
+    assert cap["language"] == "en"
+    b.transcribe(np.zeros(16000, np.float32), "auto")    # stale 'auto' value → en
+    assert cap["language"] == "en"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k cohere -v`
+Expected: FAIL — `make_backend("cohereasr")` raises `BackendLoadError("unknown backend: cohereasr")` (not yet registered).
+
+- [ ] **Step 3: Implement the backend**
+
+Append to `sidecar/sokuji_sidecar/backends.py` (after `Qwen3AsrBackend`):
+
+```python
+@register_backend
+class CohereAsrBackend:
+    """Cohere Transcribe (Fast-Conformer ASR) via native transformers
+    (CohereAsrForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
+    loaded with .to(device) (no accelerate). A Conformer encoder-decoder, NOT a
+    chat-template speech-LLM: the source language is passed through the processor and
+    generate() returns only the transcription (no input-prompt slicing). Cohere has no
+    auto-detect, so a missing/'auto' language defaults to English."""
+    NAME = "cohereasr"
+
+    def __init__(self):
+        self._model = None
+        self._proc = None
+        self._device = "cpu"
+        self._dtype = None
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._proc = None
+        if device == "cpu":
+            raise BackendLoadError("cohereasr is GPU-only")
+        try:
+            import torch
+            from transformers import CohereAsrForConditionalGeneration, AutoProcessor
+            self._dtype = torch.bfloat16 if compute_type in ("bfloat16", "auto") else torch.float16
+            self._proc = AutoProcessor.from_pretrained(model_ref, local_files_only=True)
+            self._model = CohereAsrForConditionalGeneration.from_pretrained(
+                model_ref, dtype=self._dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing cohere_asr module, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language) -> AsrResult:
+        import torch
+        lang = language if language and language != "auto" else "en"  # no auto-detect
+        inp = self._proc(samples, sampling_rate=TARGET_RATE, return_tensors="pt",
+                         language=lang).to(self._device)
+        if "input_features" in inp:  # features are float32, model is bf16
+            inp["input_features"] = inp["input_features"].to(self._dtype)
+        with torch.inference_mode():
+            out = self._model.generate(**inp, max_new_tokens=256, do_sample=False)
+        text = self._proc.batch_decode(out, skip_special_tokens=True)[0]
+        return AsrResult(text.strip(), language)
+
+    def unload(self) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k cohere -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Add the GPU validation smoke (the de-risker)**
+
+Append to `sidecar/tests/test_backends.py`:
+
+```python
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads CohereLabs/cohere-transcribe-03-2026 ~4GB; needs CUDA)")
+def test_cohereasr_real_gpu_smoke():
+    # Real flow: manager downloads first, backend loads from cache.
+    from huggingface_hub import snapshot_download
+    snapshot_download("CohereLabs/cohere-transcribe-03-2026")
+    b = backends.make_backend("cohereasr")
+    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    assert b.is_loaded
+    clip = np.zeros(16000 * 3, np.float32)   # 3 s silence — exercises the full path
+    t0 = time.perf_counter()
+    r = b.transcribe(clip, "en")
+    rtf = (time.perf_counter() - t0) / 3.0
+    assert isinstance(r.text, str)           # may be empty for silence; must not raise
+    print(f"cohere-transcribe-03-2026 RTF={rtf:.4f}")
+    b.unload()
+    # coexistence regression: Granite + Qwen3 still load after Cohere unload + empty_cache
+    import torch
+    torch.cuda.empty_cache()
+    g = backends.make_backend("transformers")
+    g.load("ibm-granite/granite-speech-4.1-2b", "cuda", "bfloat16")
+    assert g.is_loaded
+    g.unload()
+    q = backends.make_backend("qwen3asr")
+    q.load("bezzam/Qwen3-ASR-1.7B", "cuda", "bfloat16")
+    assert q.is_loaded
+    q.unload()
+```
+
+Run (skips without the env var): `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k cohere -v`
+Expected: the 3 unit tests PASS, `test_cohereasr_real_gpu_smoke` SKIPPED.
+
+> **Controller note (run the smoke to validate reality):** before approving this task, run
+> `cd sidecar && SOKUJI_RUN_GPU=1 .venv/bin/python -m pytest tests/test_backends.py::test_cohereasr_real_gpu_smoke -v -s`.
+> Confirm: a non-raising transcribe, a sane RTF print, and Granite + Qwen3 still load after.
+> **If the real processor differs from the Qwen3-mirror assumption** — e.g. it needs `CohereAsrProcessor`
+> instead of `AutoProcessor`, a different call signature, slicing of the generated tokens, or a decoded
+> prefix to strip — fix `transcribe()`/`load()` and the matching fake in Step 1, then re-run.
+
+- [ ] **Step 6: Run the whole sidecar suite + commit**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: all pass, GPU smoke skipped.
+
+```bash
+git add sidecar/sokuji_sidecar/backends.py sidecar/tests/test_backends.py
+git commit -m "feat(sidecar): CohereAsrBackend (Cohere Transcribe, GPU bf16)"
+```
+
+---
+
+## Task 2: Resolver self-gate (`accel._installed`)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/accel.py:60-67` (the `_installed()` `mods` dict)
+- Test: `sidecar/tests/test_accel.py` (append)
+
+**Interfaces:**
+- Consumes: `accel._installed()`, `accel._has_mod`, `accel.resolve_deployments(model, machine)`, `accel.Machine`, `accel.Gpu`, `catalog.asr_model(id)`.
+- Produces: `"cohereasr"` present in `_installed()` iff `transformers.models.cohere_asr` is importable; a Cohere catalog row resolves a `cuda` plan on an NVIDIA machine that has the runtime, and `[]` without it.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_cohereasr_resolves_gpu_on_nvidia_with_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"cohereasr", "transformers"}),
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("cohere-transcribe-03-2026"), m)
+    assert [p.device for p in plans] == ["cuda"]
+    assert plans[0].backend == "cohereasr" and plans[0].compute_type == "bfloat16"
+
+
+def test_cohereasr_model_unavailable_without_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"ctranslate2", "sherpa", "transformers"}),  # no cohereasr
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("cohere-transcribe-03-2026"), m)
+    assert plans == []     # gated off: no usable deployment
+
+
+def test_cohereasr_gated_on_cohere_asr_module(monkeypatch):
+    import importlib.util as iu
+    from sokuji_sidecar import accel
+    real = iu.find_spec
+
+    def fake_find_spec(name, *a, **k):
+        if name == "transformers.models.cohere_asr":
+            return None
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", fake_find_spec)
+    assert "cohereasr" not in accel._installed()
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_accel.py -k cohere -v`
+Expected: `test_cohereasr_resolves_gpu_on_nvidia_with_runtime` FAILS (the catalog row does not exist yet → `asr_model(...)` returns `None` → `resolve_deployments(None, m)` raises) and `test_cohereasr_gated_on_cohere_asr_module` FAILS (`cohereasr` not in `_installed()` because the mods entry is absent).
+
+> Note: the catalog row lands in Task 3. To unblock the two resolver tests here, this task adds **only** the `_installed()` entry; the row-dependent tests (`*_with_runtime`, `*_without_runtime`) will pass once Task 3 adds the row. Run them again at the end of Task 3. Implement Step 3 now; the `gated_on_cohere_asr_module` test passes immediately.
+
+- [ ] **Step 3: Add the gate entry**
+
+In `sidecar/sokuji_sidecar/accel.py`, extend the `mods` dict in `_installed()` (the dict currently ending with the `qwen3asr` entry):
+
+```python
+def _installed() -> frozenset:
+    mods = {"ctranslate2": "faster_whisper", "sherpa": "sherpa_onnx",
+            "onnx": "onnxruntime", "llamacpp": "llama_cpp", "mlx": "mlx_lm",
+            "transformers": "transformers",
+            # qwen3asr needs the native qwen3_asr model (transformers 5.13.x+); until
+            # then it is "not installed" so resolve()/models_catalog exclude it.
+            "qwen3asr": "transformers.models.qwen3_asr",
+            # cohereasr needs the native cohere_asr model (mainline since transformers
+            # 5.4); present in our 5.13 venv. Same self-gate as qwen3asr.
+            "cohereasr": "transformers.models.cohere_asr"}
+    return frozenset(b for b, mod in mods.items() if _has_mod(mod))
+```
+
+- [ ] **Step 4: Run the module-gate test**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_accel.py::test_cohereasr_gated_on_cohere_asr_module -v`
+Expected: PASS. (The two row-dependent tests still fail until Task 3 — that is expected and resolved there.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/accel.py sidecar/tests/test_accel.py
+git commit -m "feat(sidecar): self-gate cohereasr on transformers.models.cohere_asr"
+```
+
+---
+
+## Task 3: Catalog row (first) + download spec
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/catalog.py:34-62` (insert the Cohere row first; bump every existing `sort_order` +1)
+- Modify: `sidecar/sokuji_sidecar/native_models.py:24-43` (add a `download_specs` branch)
+- Test: `sidecar/tests/test_catalog.py` (add the row test, extend the allowed-backend set, update the Qwen3 `sort_order` assertion)
+- Test: `sidecar/tests/test_native_models.py` (add a `download_specs` assertion — create the file if absent)
+
+**Interfaces:**
+- Consumes: `AsrModel`, `Deployment` (`catalog.py`); `catalog.asr_model(id)`; `native_models.download_specs(model_id)`.
+- Produces: `catalog.asr_model("cohere-transcribe-03-2026")` with `recommended=True`, `sort_order=0`, the 14 languages, one `cohereasr/gpu-cuda/bfloat16` deployment; `download_specs("cohere-transcribe-03-2026") == {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}`. This row makes Task 2's `*_with_runtime` / `*_without_runtime` tests pass.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `sidecar/tests/test_catalog.py`, extend the allowed-backend set in `test_models_have_deployments_and_languages` (currently `{"ctranslate2", "sherpa", "transformers", "qwen3asr"}`) to include `"cohereasr"`, update the Qwen3 row test's `sort_order` from `7` to `8`, and append the Cohere row test:
+
+```python
+def test_cohere_asr_row():
+    m = catalog.asr_model("cohere-transcribe-03-2026")
+    assert m is not None
+    assert m.languages == ("en", "de", "fr", "it", "es", "pt", "el",
+                           "nl", "pl", "ar", "vi", "zh", "ja", "ko")
+    assert m.recommended is True
+    assert m.sort_order == 0          # sorted first
+    d = m.deployments[0]
+    assert (d.backend, d.tier, d.compute_type, d.artifact) == \
+        ("cohereasr", "gpu-cuda", "bfloat16", "CohereLabs/cohere-transcribe-03-2026")
+
+
+def test_cohere_is_first_qwen3_shifted():
+    ids = [m.id for m in catalog.asr_models()]
+    assert ids[0] == "cohere-transcribe-03-2026"           # inserted first in the list
+    assert catalog.asr_model("qwen3-asr-1.7b").sort_order == 8   # shifted +1 from 7
+    assert catalog.asr_model("sense-voice").sort_order == 1      # shifted +1 from 0
+```
+
+In `sidecar/tests/test_native_models.py` (create it if it does not exist, with `from sokuji_sidecar import native_models` at the top), append:
+
+```python
+def test_download_specs_cohere():
+    assert native_models.download_specs("cohere-transcribe-03-2026") == \
+        {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py tests/test_native_models.py -v`
+Expected: FAIL — `asr_model("cohere-transcribe-03-2026")` is `None`; `download_specs` returns the fallthrough `{"repos": ["cohere-transcribe-03-2026"], "urls": []}`; the Qwen3 `sort_order` is still 7.
+
+- [ ] **Step 3: Insert the catalog row first and shift the rest +1**
+
+In `sidecar/sokuji_sidecar/catalog.py`, make the Cohere row the **first** entry of `ASR_MODELS` and add +1 to every existing `sort_order` (0→1, 1→2, …, 7→8):
+
+```python
+ASR_MODELS: list[AsrModel] = [
+    AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe",
+             ("en", "de", "fr", "it", "es", "pt", "el",
+              "nl", "pl", "ar", "vi", "zh", "ja", "ko"),
+             (Deployment("cohereasr", "gpu-cuda", "bfloat16",
+                         "CohereLabs/cohere-transcribe-03-2026", 1.0),),
+             recommended=True, sort_order=0),
+    AsrModel("sense-voice", "SenseVoice", ("zh", "en", "ja", "ko", "yue"),
+             (Deployment("sherpa", "cpu", "int8", SENSE_VOICE_REPO, 1.0),),
+             recommended=True, sort_order=1),
+    AsrModel("whisper-large-v3", "Whisper large-v3", ("multi",),
+             (Deployment("ctranslate2", "gpu-cuda", "float16", "large-v3", 1.0),
+              Deployment("ctranslate2", "cpu", "int8", "large-v3", 1.0)), sort_order=2),
+    AsrModel("whisper-base", "Whisper base", ("multi",),
+             (Deployment("ctranslate2", "gpu-cuda", "float16", "base", 1.0),
+              Deployment("ctranslate2", "cpu", "int8", "base", 1.0)),
+             recommended=True, sort_order=3),
+    AsrModel("whisper-small", "Whisper small", ("multi",),
+             (Deployment("ctranslate2", "gpu-cuda", "float16", "small", 1.0),
+              Deployment("ctranslate2", "cpu", "int8", "small", 1.0)), sort_order=4),
+    AsrModel("whisper-tiny", "Whisper tiny", ("multi",),
+             (Deployment("ctranslate2", "gpu-cuda", "float16", "tiny", 1.0),
+              Deployment("ctranslate2", "cpu", "int8", "tiny", 1.0)), sort_order=5),
+    AsrModel("granite-speech-4.1-2b", "Granite Speech 4.1 (2B)", ("en", "fr", "de", "es", "pt", "ja"),
+             (Deployment("transformers", "gpu-cuda", "bfloat16", "ibm-granite/granite-speech-4.1-2b", 1.0),),
+             sort_order=6),
+    AsrModel("granite-speech-4.1-2b-plus", "Granite Speech 4.1 (2B+)", ("en", "fr", "de", "es", "pt"),
+             (Deployment("transformers", "gpu-cuda", "bfloat16", "ibm-granite/granite-speech-4.1-2b-plus", 1.0),),
+             sort_order=7),
+    AsrModel("qwen3-asr-1.7b", "Qwen3-ASR 1.7B",
+             ("zh", "en", "ja", "ko", "yue", "ar", "de", "es",
+              "fr", "it", "pt", "ru", "th", "vi", "hi", "id"),
+             (Deployment("qwen3asr", "gpu-cuda", "bfloat16", "bezzam/Qwen3-ASR-1.7B", 1.0),),
+             recommended=True, sort_order=8),
+]
+```
+
+- [ ] **Step 4: Add the download spec**
+
+In `sidecar/sokuji_sidecar/native_models.py`, add a branch in `download_specs` **before** the final `return {"repos": [model_id], "urls": []}` fallthrough (right after the `qwen3-asr-1.7b` branch at line ~42):
+
+```python
+    if model_id == "cohere-transcribe-03-2026":
+        return {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
+```
+
+- [ ] **Step 5: Run the catalog/download tests + the Task-2 resolver tests**
+
+Run:
+```bash
+cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py tests/test_native_models.py \
+  tests/test_accel.py -k "cohere or row or catalog or download or qwen3" -v
+```
+Expected: PASS — including Task 2's `test_cohereasr_resolves_gpu_on_nvidia_with_runtime` and `test_cohereasr_model_unavailable_without_runtime` (now that the row exists), and the updated `test_qwen3_asr_row` (sort_order 8).
+
+- [ ] **Step 6: Run the whole sidecar suite + commit**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: all pass, GPU smoke skipped.
+
+```bash
+git add sidecar/sokuji_sidecar/catalog.py sidecar/sokuji_sidecar/native_models.py \
+        sidecar/tests/test_catalog.py sidecar/tests/test_native_models.py
+git commit -m "feat(sidecar): cohere-transcribe-03-2026 catalog row (recommended, first) + download spec"
+```
+
+---
+
+## Task 4: Renderer catalog row (first)
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts:22-31` (insert the Cohere row first in `NATIVE_ASR`; bump every existing `sortOrder` +1)
+- Test: `src/lib/local-inference/native/nativeCatalog.test.ts` (add the Cohere row test; update the assertions that assumed sense-voice / whisper-base lead)
+
+**Interfaces:**
+- Consumes: `NATIVE_ASR`, `compatibleNativeAsr(src)`, `nativeAsrCards(src)`, `nativeAsrForLanguage(src, cur)`, `byRecommendedThenOrder` (all in `nativeCatalog.ts`).
+- Produces: a Cohere `NativeModelOption` (`recommended: true`, `sortOrder: 0`, 14 languages) that leads `compatibleNativeAsr` / `nativeAsrCards` for every language it supports (en/de/fr/it/es/pt/el/nl/pl/ar/vi/zh/ja/ko).
+
+- [ ] **Step 1: Update + add the failing tests**
+
+In `src/lib/local-inference/native/nativeCatalog.test.ts`, make these edits (Cohere now leads for languages it supports — `zh`, `de`, `ja`, etc. — while `yue`, which Cohere does not support, still leads with sense-voice):
+
+1. In the `'language compatibility + ASR auto-select'` test, change:
+   - `expect(compatibleNativeAsr('zh').map((m) => m.id)[0]).toBe('sense-voice');` → `.toBe('cohere-transcribe-03-2026');`
+   - `expect(compatibleNativeAsr('de')[0].id).toBe('whisper-base');` → `.toBe('cohere-transcribe-03-2026');`
+   - `expect(nativeAsrForLanguage('de', 'sense-voice')).toBe('whisper-base');` → `.toBe('cohere-transcribe-03-2026');`
+   - Leave `nativeAsrForLanguage('zh', 'sense-voice')` as `'sense-voice'` (sense-voice still supports zh, so a still-compatible current choice is kept).
+
+2. In `'includes whisper-large-v3 as an available, non-recommended ASR option'`, change:
+   - `expect(compatibleNativeAsr('de')[0].id).toBe('whisper-base');` → `.toBe('cohere-transcribe-03-2026');`
+
+3. In `'exposes Granite speech-LLM ASR options with language-specific gating'`, change:
+   - `expect(compatibleNativeAsr('de')[0].id).toBe('whisper-base');` → `.toBe('cohere-transcribe-03-2026');`
+
+4. Replace the body of `'includes Qwen3-ASR 1.7B as a recommended GPU option with verbatim sidecar languages'`'s last two assertions:
+   - `expect(q!.sortOrder).toBe(7);` → `expect(q!.sortOrder).toBe(8);`
+   - `expect(nativeAsrCards('zh')[0].selectId).toBe('sense-voice');` → `.toBe('cohere-transcribe-03-2026');`
+   - `expect(nativeAsrCards('de')[0].selectId).toBe('whisper-base');` → `.toBe('cohere-transcribe-03-2026');`
+
+5. Add a new test:
+
+```javascript
+  it('includes Cohere Transcribe as the first (recommended) ASR with its 14 languages', () => {
+    const c = NATIVE_ASR.find((m) => m.id === 'cohere-transcribe-03-2026');
+    expect(c).toBeTruthy();
+    expect(c!.languages).toEqual(['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko']);
+    expect(c!.recommended).toBe(true);
+    expect(c!.sortOrder).toBe(0);
+    // Cohere leads for every language it supports...
+    expect(nativeAsrCards('zh')[0].selectId).toBe('cohere-transcribe-03-2026');
+    expect(nativeAsrCards('ja')[0].selectId).toBe('cohere-transcribe-03-2026');
+    expect(nativeAsrCards('de')[0].selectId).toBe('cohere-transcribe-03-2026');
+    // ...but not for Cantonese (yue), which Cohere does not support → sense-voice still leads
+    expect(nativeAsrCards('yue')[0].selectId).toBe('sense-voice');
+  });
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: FAIL — the new test and the edited assertions reference `cohere-transcribe-03-2026`, which is not in `NATIVE_ASR` yet (Cohere absent → sense-voice/whisper-base still lead).
+
+- [ ] **Step 3: Insert the renderer row first and shift the rest +1**
+
+In `src/lib/local-inference/native/nativeCatalog.ts`, make Cohere the first `NATIVE_ASR` entry and add +1 to every existing `sortOrder`:
+
+```typescript
+export const NATIVE_ASR: NativeModelOption[] = [
+  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe', languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'], recommended: true, sortOrder: 0 },
+  { id: 'sense-voice', label: 'SenseVoice', languages: ['zh', 'en', 'ja', 'ko', 'yue'], recommended: true, sortOrder: 1 },
+  { id: 'whisper-base', label: 'Whisper base', languages: ['multi'], recommended: true, sortOrder: 2 },
+  { id: 'whisper-small', label: 'Whisper small', languages: ['multi'], sortOrder: 3 },
+  { id: 'whisper-tiny', label: 'Whisper tiny', languages: ['multi'], sortOrder: 4 },
+  { id: 'whisper-large-v3', label: 'Whisper large-v3', languages: ['multi'], sortOrder: 5 },
+  { id: 'granite-speech-4.1-2b', label: 'Granite Speech 4.1 (2B)', languages: ['en', 'fr', 'de', 'es', 'pt', 'ja'], sortOrder: 6 },
+  { id: 'granite-speech-4.1-2b-plus', label: 'Granite Speech 4.1 (2B+)', languages: ['en', 'fr', 'de', 'es', 'pt'], sortOrder: 7 },
+  { id: 'qwen3-asr-1.7b', label: 'Qwen3-ASR 1.7B', languages: ['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id'], recommended: true, sortOrder: 8 },
+];
+```
+
+- [ ] **Step 4: Run the renderer tests + build**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS (the new Cohere test + all updated assertions).
+
+Run: `npm run build`
+Expected: `✓ built` with no errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(native): Cohere Transcribe renderer catalog row (recommended, first)"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §5.1 `CohereAsrBackend` → Task 1. §5.2 catalog row → Task 3; `accel` gate → Task 2; `download_specs` → Task 3. §5.3 renderer row → Task 4; the explicit-language gate is satisfied by existing code (see Deviation) and the backend default (Task 1). §6 validation spike → Task 1 Step 5 (GPU smoke + controller note). §7 testing → tasks' mocked unit tests + the catalog/accel/renderer tests. §8 YAGNI (no GGUF/ONNX/CPU, no timestamps) → nothing added. §4 decisions: recommended+first → Tasks 3 & 4; explicit language → Deviation + Task 1.
+- **Gap check:** the only spec item not implemented verbatim is §5.3's `requiresExplicitLanguage` flag, deliberately dropped (already-satisfied; see Deviation). No other gaps.
+
+**Placeholder scan:** none — every code step carries complete code and exact commands.
+
+**Type/value consistency:** backend `NAME = "cohereasr"`, checkpoint `CohereLabs/cohere-transcribe-03-2026`, gate module `transformers.models.cohere_asr`, the 14-language tuple/array, `sort_order`/`sortOrder = 0` with existing rows +1, and the Qwen3 `sort_order` 7→8 update are identical across Tasks 1–4 and both catalogs. The Cohere-first ordering is asserted in both `test_catalog.py` (`test_cohere_is_first_qwen3_shifted`) and `nativeCatalog.test.ts`.

--- a/docs/superpowers/specs/2026-06-24-native-asr-cohere-design.md
+++ b/docs/superpowers/specs/2026-06-24-native-asr-cohere-design.md
@@ -1,0 +1,210 @@
+# Native ASR: Cohere Transcribe (GPU sidecar) — Design
+
+**Status:** Approved design — ready for implementation plan.
+**Branch:** `feat/native-asr-cohere` (from `native-sidecar`).
+**Date:** 2026-06-24.
+
+## 1. Goal
+
+Run **the same Cohere Transcribe model our browser users already use** in the LOCAL_NATIVE
+Python sidecar, full-precision **bf16 on CUDA**, instead of today's 4-bit `q4f16` ONNX/WebGPU
+path. The win is parity + hardware: existing Cohere users get the identical model, faster and
+at higher quality (no 4-bit weight quantization), by exploiting the GPU.
+
+This is **not** a "should we add a new model" decision — Cohere Transcribe already ships in
+LOCAL_INFERENCE (`src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts`, model
+`onnx-community/cohere-transcribe-03-2026-ONNX`) and has many users. This design is the
+GPU-native port of that existing, popular feature.
+
+## 2. Context: what we already have
+
+- **LOCAL_INFERENCE (browser):** `cohere-transcribe-webgpu` runs the model via Transformers.js
+  `pipeline('automatic-speech-recognition', …, { device:'webgpu', dtype:'q4f16' })`, Silero VAD,
+  batch-per-segment, token streaming. It **requires an explicit source language** (the worker
+  throws "Cohere Transcribe requires an explicit source language") — there is no auto-detect.
+- **LOCAL_NATIVE (sidecar):** the `AsrBackend` adapter pattern (`load`/`transcribe`/`unload`),
+  a `@register_backend` registry, the `accel.py` resolver with a `_installed()` self-gate, the
+  `catalog.py` model registry, `native_models.download_specs`, and the renderer
+  `nativeCatalog.ts` + `NativeModelManagementSection`. We already shipped two GPU speech-LLM
+  ASRs through this path: **Granite Speech 4.1** (`TransformersBackend`) and **Qwen3-ASR**
+  (`Qwen3AsrBackend`).
+
+## 3. Verified facts (de-risking complete)
+
+Confirmed by live execution in the actual sidecar venv (`sidecar/.venv`, transformers 5.13.0.dev0):
+
+- `from transformers import CohereAsrForConditionalGeneration` → **OK**, resolves to
+  `transformers.models.cohere_asr.modeling_cohere_asr`.
+- `importlib.util.find_spec("transformers.models.cohere_asr")` → **present**.
+- `Qwen3ASRForConditionalGeneration`, `AutoModelForSpeechSeq2Seq`, `AutoProcessor` all still
+  import on the **same** transformers → Cohere **coexists** with Granite + Qwen3 in one venv.
+
+Why there is **no Qwen3-style trap:** `CohereAsr` was merged into transformers **mainline**
+(shipped in v5.4.0). It is a first-class class, **not** a separate pip package, so there is no
+version pin that could break Granite (unlike `qwen-asr==4.57.6`). The module is already on disk
+in our venv because the Qwen3-ASR fork branched from main *after* the Cohere merge. **No venv
+changes, no new transformers, no `accelerate`, no `trust_remote_code`.**
+
+Model facts (HuggingFace model card + release blog, `CohereLabs/cohere-transcribe-03-2026`):
+
+| Property | Value |
+|---|---|
+| Checkpoint | `CohereLabs/cohere-transcribe-03-2026` |
+| Weights | safetensors, ~4.13 GB, bf16 |
+| Architecture | ~2B, Fast-Conformer encoder (>90% of params) + lightweight Transformer decoder — **a Conformer ASR, not a chat-template speech-LLM** |
+| Languages (14) | en, de, fr, it, es, pt, el, nl, pl, ar, vi, zh, ja, ko |
+| License | Apache 2.0 |
+| Audio | resampled to 16 kHz, multi-channel averaged, log-Mel internally |
+| Source language | **required** via `processor(language=…)` — no auto-detect |
+| English accuracy | #1 on the Open ASR Leaderboard at release (5.42 WER) |
+| VRAM | ~5 GB bf16 — fits the 4070 SUPER 12 GB with margin |
+
+## 4. Decisions
+
+1. **Positioning — recommended and sorted first.** Mark Cohere `recommended=True` in both the
+   sidecar catalog and the renderer catalog, alongside Qwen3-ASR (which stays recommended), and
+   place Cohere **first** in the ASR list — above the recommended CPU defaults (sense-voice,
+   whisper-base). Since the renderer sorts `recommended` first then `sortOrder` ascending, Cohere
+   takes `sort_order = 0` and the existing ASR rows shift +1 (sense-voice → 1, whisper rows and
+   Granite follow, Qwen3 → 8) in **both** catalogs. This reflects Cohere's existing popularity
+   with our users. (`sort_order` is advisory and not sent over the wire, so the two catalogs'
+   values stay independent — only the relative "Cohere first" ordering must match.)
+2. **Explicit source language required.** Cohere has no auto-detect. When Cohere is the selected
+   native ASR, the source-language `auto` option is hidden (the user must pick a language) —
+   exact parity with the LOCAL_INFERENCE worker.
+
+## 5. Architecture
+
+### 5.1 `CohereAsrBackend` (`sidecar/sokuji_sidecar/backends.py`)
+
+A new `@register_backend` class, `NAME = "cohereasr"`, GPU-only, mirroring `Qwen3AsrBackend`.
+The one structural difference from Granite/Qwen3: Cohere is a Conformer ASR, so there is **no
+conversation/chat template** — the source language goes through the *processor*, not a prompt.
+
+```python
+@register_backend
+class CohereAsrBackend:
+    """Cohere Transcribe (Fast-Conformer ASR) via native transformers
+    (CohereAsrForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
+    loaded with .to(device) (no accelerate). Conformer, not a speech-LLM: the source
+    language is passed through the processor, not a chat template."""
+    NAME = "cohereasr"
+
+    def load(self, model_ref, device, compute_type):
+        self._model = None; self._proc = None
+        if device == "cpu":
+            raise BackendLoadError("cohereasr is GPU-only")
+        try:
+            import torch
+            from transformers import CohereAsrForConditionalGeneration, AutoProcessor
+            self._dtype = torch.bfloat16 if compute_type in ("bfloat16", "auto") else torch.float16
+            self._proc = AutoProcessor.from_pretrained(model_ref, local_files_only=True)
+            self._model = CohereAsrForConditionalGeneration.from_pretrained(
+                model_ref, dtype=self._dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:   # missing cohere_asr module, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language):
+        import torch
+        lang = language or "en"   # UI guarantees an explicit language (§5.3); defensive default
+        inp = self._proc(samples, sampling_rate=TARGET_RATE, return_tensors="pt",
+                         language=lang).to(self._device)
+        if "input_features" in inp:                 # the Qwen3 lesson: cast to model dtype
+            inp["input_features"] = inp["input_features"].to(self._dtype)
+        with torch.inference_mode():
+            out = self._model.generate(**inp, max_new_tokens=256, do_sample=False)
+        text = self._proc.batch_decode(out, skip_special_tokens=True)[0]
+        return AsrResult(text.strip(), language)    # prefix-strip helper added only if the spike shows one
+```
+
+Open items confirmed by the spike (§6), not assumed: exact processor signature
+(`AutoProcessor` vs `CohereAsrProcessor`; whether `input_features` is the right key), whether
+the decoded output carries any prefix to strip, and the accepted `language` code form.
+
+### 5.2 Registry wiring (three one-line touches, identical to Qwen3)
+
+- **`catalog.py`** — new row:
+  ```python
+  AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe",
+           ("en","de","fr","it","es","pt","el","nl","pl","ar","vi","zh","ja","ko"),
+           (Deployment("cohereasr", "gpu-cuda", "bfloat16",
+                       "CohereLabs/cohere-transcribe-03-2026", 1.0),),
+           recommended=True, sort_order=0)   # first in the list; existing rows shift +1
+  ```
+- **`accel.py` `_installed()`** — add `"cohereasr": "transformers.models.cohere_asr"` to the
+  `mods` dict. Present on 5.13 → the model lights up immediately; the `_has_mod` self-gate still
+  protects builds where the module is absent.
+- **`native_models.py` `download_specs`** — before the fallthrough:
+  ```python
+  if model_id == "cohere-transcribe-03-2026":
+      return {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
+  ```
+
+### 5.3 Renderer (`src/lib/local-inference/native/nativeCatalog.ts` + `LanguageSection.tsx`)
+
+- **Catalog row** (no change to `NativeModelManagementSection`, which renders it):
+  ```ts
+  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe',
+    languages: ['en','de','fr','it','es','pt','el','nl','pl','ar','vi','zh','ja','ko'],
+    recommended: true, sortOrder: 0, requiresExplicitLanguage: true }   // first; existing rows shift +1
+  ```
+  Add the optional `requiresExplicitLanguage?: boolean` field to the `NativeModelOption` type.
+- **Explicit-language gate** (`LanguageSection.tsx`): the source-language render already hides
+  the `auto` option for `LOCAL_INFERENCE`. Extend that guard to also hide `auto` when the
+  provider is `LOCAL_NATIVE` **and** the currently selected native ASR row has
+  `requiresExplicitLanguage` (via a small selector, e.g. `nativeAsrRequiresExplicitLanguage(id)`
+  in `nativeCatalog.ts`). This keeps the rule data-driven so a future no-auto-detect model only
+  needs the flag.
+
+## 6. Validation spike (de-risker — run first)
+
+A GPU-gated smoke (`SOKUJI_RUN_GPU`, like the Qwen3 smoke) that mirrors the real flow — download
+first, then load from cache — and resolves the unknowns the import test could not:
+
+1. `AutoProcessor.from_pretrained(ref, local_files_only=True)` (after a `snapshot_download(ref)`).
+2. `CohereAsrForConditionalGeneration.from_pretrained(ref, dtype=torch.bfloat16,
+   local_files_only=True).to("cuda").eval()`.
+3. `proc(samples_f32_16k, sampling_rate=16000, return_tensors="pt", language="en")` →
+   `model.generate(**inputs, max_new_tokens=256)` → `proc.batch_decode(out, skip_special_tokens=True)`.
+
+Assert / observe: a plausible transcript on a real clip (verify the **output format** — any
+prefix to strip?); our **language codes** are accepted (`en`, `ja`, …); **RTF and VRAM** on the
+4070; and — the coexistence regression — **Granite and Qwen3 still load** after Cohere
+`unload()` + `torch.cuda.empty_cache()`.
+
+## 7. Testing
+
+- **Mocked unit tests** (`sidecar/tests/test_backends.py`): a fake processor + model (mirroring
+  the Qwen3 fakes) asserting the bf16 dtype cast, `language=` is passed through, the GPU-only
+  guard raises `BackendLoadError` on `cpu`, and the decode path. Plus the
+  `SOKUJI_RUN_GPU`-gated real smoke from §6.
+- **Catalog** (`test_catalog.py`): the new row — `recommended is True`, `sort_order == 8`, the
+  14 languages, backend `cohereasr`. Add `"cohereasr"` to the allowed-backend set.
+- **Resolver** (`test_accel.py`): `cohereasr` gated on `transformers.models.cohere_asr`; present
+  → resolves a GPU plan on an NVIDIA machine.
+- **Renderer** (`nativeCatalog.test.ts`): the Cohere row (recommended, `sortOrder` 0, languages)
+  and `requiresExplicitLanguage` truthy; **Cohere now leads the ASR list** (assert it sorts
+  ahead of sense-voice / whisper-base), and the existing rows keep their relative order.
+- Gates: `pytest` (sidecar) + `vitest` (renderer) are the correctness gates (not `tsc`);
+  `npm run build` for renderer wiring.
+
+## 8. Out of scope (YAGNI)
+
+- No GGUF / ONNX / CPU path — the GPU bf16 path **is** the upgrade; CPU is already covered by
+  Whisper (`ctranslate2`) and SenseVoice (`sherpa`).
+- No word timestamps / diarization / code-switching — the model does not provide them.
+- No changes to Qwen3-ASR or Granite, and no new pip dependencies (the GPU path needs nothing
+  beyond what Granite/Qwen3 already pull in; `sentencepiece` is already in `requirements.txt`).
+
+## 9. Files touched
+
+- `sidecar/sokuji_sidecar/backends.py` — `CohereAsrBackend`.
+- `sidecar/sokuji_sidecar/catalog.py` — the `cohere-transcribe-03-2026` row.
+- `sidecar/sokuji_sidecar/accel.py` — `_installed()` gate entry.
+- `sidecar/sokuji_sidecar/native_models.py` — `download_specs` branch.
+- `sidecar/tests/test_backends.py`, `test_catalog.py`, `test_accel.py` — tests + GPU smoke.
+- `src/lib/local-inference/native/nativeCatalog.ts` — row + `requiresExplicitLanguage` +
+  selector.
+- `src/lib/local-inference/native/nativeCatalog.test.ts` — row test.
+- `src/components/Settings/sections/LanguageSection.tsx` — extend the `auto`-hiding guard.

--- a/docs/superpowers/specs/2026-06-24-native-asr-cohere-design.md
+++ b/docs/superpowers/specs/2026-06-24-native-asr-cohere-design.md
@@ -1,8 +1,38 @@
 # Native ASR: Cohere Transcribe (GPU sidecar) — Design
 
-**Status:** Approved design — ready for implementation plan.
+**Status:** IMPLEMENTED on `feat/native-asr-cohere` — see "Implementation Outcome" for what actually shipped (the key change: a non-gated source, so no HF_TOKEN).
 **Branch:** `feat/native-asr-cohere` (from `native-sidecar`).
 **Date:** 2026-06-24.
+
+## Implementation Outcome (shipped) — supersedes the gated/HF_TOKEN parts of the design below
+
+- **Backend renamed** `cohereasr` → **`cohere_transformers`** (it's the PyTorch-transformers
+  runtime); catalog display **"Cohere Transcribe (Transformers)"**. The "(Transformers)" tag was
+  forward-looking for a possible ONNX sibling — see the Plan-B note.
+- **Non-gated source — no HF_TOKEN.** `CohereLabs/cohere-transcribe-03-2026` is gated, but
+  **`AEmotionStudio/cohere-transcribe-03-2026-models`** is a non-gated re-upload of the **same
+  weights** — verified **byte-identical**: all **2152 tensors match by SHA256**, config
+  identical, and it loads with the native `CohereAsr` class (no `trust_remote_code`, so only the
+  weights are used — none of the mirror's Python runs). The catalog artifact + `download_specs`
+  point at it, so Cohere downloads with **no authentication** (browser parity, no per-user
+  token). The HF_TOKEN / gated-401 handling from the original design was therefore dropped; the
+  general "surface a download error on the card" UX was kept.
+- **`librosa` is a required dependency** — `CohereAsrFeatureExtractor` imports it at load time
+  (the backend crashed without it; mocked tests couldn't catch it). Added to `sidecar/setup.sh`.
+- **Performance (RTX 4070 SUPER, bf16/CUDA):** ~**101–154× realtime** (RTF ~0.006–0.010),
+  ~80 ms/utterance, 4.17 GB VRAM — verified with CUDA-event timing on real clips. The headline
+  multiple is high simply because the GPU decodes ~420 tok/s while speech is ~3 tok/s.
+- **"Plan B" (onnxruntime-GPU ONNX backend) investigated and rejected.** The non-gated
+  `onnx-community` ONNX export runs its encoder on CUDA (62 ms) but its decoder's
+  `GroupQueryAttention` op is rejected by the onnxruntime-CUDA kernel (it doesn't accept the
+  `position_ids` the transformers.js-style export feeds it), so the decoder is **CPU-only** → a
+  ~7× hybrid vs the transformers path's ~100×. Once the non-gated *transformers* mirror was
+  found, B added nothing (slower, an `onnxruntime-gpu` dep, a hand-rolled decode loop) and was
+  dropped. (HF also has sherpa-onnx / GGUF / NVFP4 / CoreML / MLX re-exports; none was needed.)
+
+The sections below are the original design (gated source + HF_TOKEN) — kept as the record.
+
+---
 
 ## 1. Goal
 

--- a/sidecar/setup.sh
+++ b/sidecar/setup.sh
@@ -40,7 +40,7 @@ esac
 # cannot shift the installed code under us (unlike a mutable branch archive). Swap to a
 # released 'transformers>=5.13' from PyPI once huggingface/transformers PR #43838 merges.
 TRANSFORMERS_REF="git+https://github.com/mbtariq82/transformers@a2ec912647e42dee56eb89e64b0ec539ad9e7b65"
-"$PY" -m pip install -q "$TRANSFORMERS_REF" sherpa-onnx faster-whisper sacremoses
+"$PY" -m pip install -q "$TRANSFORMERS_REF" sherpa-onnx faster-whisper sacremoses librosa
 
 if [ "${1:-}" = "--no-models" ]; then
   echo "[setup] deps installed; skipping models (--no-models). Done."

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -64,9 +64,9 @@ def _installed() -> frozenset:
             # qwen3asr needs the native qwen3_asr model (transformers 5.13.x+); until
             # then it is "not installed" so resolve()/models_catalog exclude it.
             "qwen3asr": "transformers.models.qwen3_asr",
-            # cohereasr needs the native cohere_asr model (mainline since transformers
-            # 5.4); present in our 5.13 venv. Same self-gate as qwen3asr.
-            "cohereasr": "transformers.models.cohere_asr"}
+            # cohere_transformers needs the native cohere_asr model (mainline since
+            # transformers 5.4); present in our 5.13 venv. Same self-gate as qwen3asr.
+            "cohere_transformers": "transformers.models.cohere_asr"}
     return frozenset(b for b, mod in mods.items() if _has_mod(mod))
 
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -63,7 +63,10 @@ def _installed() -> frozenset:
             "transformers": "transformers",
             # qwen3asr needs the native qwen3_asr model (transformers 5.13.x+); until
             # then it is "not installed" so resolve()/models_catalog exclude it.
-            "qwen3asr": "transformers.models.qwen3_asr"}
+            "qwen3asr": "transformers.models.qwen3_asr",
+            # cohereasr needs the native cohere_asr model (mainline since transformers
+            # 5.4); present in our 5.13 venv. Same self-gate as qwen3asr.
+            "cohereasr": "transformers.models.cohere_asr"}
     return frozenset(b for b, mod in mods.items() if _has_mod(mod))
 
 

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -83,6 +83,10 @@ class AsrEngine:
              vad_threshold=None, vad_min_silence=None, vad_min_speech=None, device="auto"):
         from . import accel
         t0 = time.time()
+        # Free any previously-loaded model BEFORE loading the next. The engine is a
+        # process singleton reused across sessions; without this, re-init piles a second
+        # model into VRAM (PyTorch's caching allocator never returns it) and usage climbs.
+        self.close()
         self._init_vad(sample_rate, vad_threshold, vad_min_silence, vad_min_speech)
         # Resolve the fastest available backend+device; CPU floor guaranteed.
         plans = accel.resolve(model_id or "sense-voice", override=device or "auto")
@@ -102,6 +106,17 @@ class AsrEngine:
               + (f" rtf={rtf:.3f} (~{1 / rtf:.0f}x realtime)" if rtf else "")
               + f"  [requested device={device or 'auto'}]", file=sys.stderr, flush=True)
         return int((time.time() - t0) * 1000)
+
+    def close(self):
+        """Free the loaded ASR model and its GPU memory. Idempotent — called at the start
+        of each init() and when a session connection closes, so VRAM never accumulates."""
+        backend = self._backend
+        self._backend = None
+        if backend is not None:
+            try:
+                backend.unload()
+            except Exception:
+                pass
 
     def _drain(self):
         out = []

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -93,6 +93,14 @@ class AsrEngine:
                          "computeType": plan.compute_type}
         if rtf is not None:
             self.resolved["rtf"] = round(rtf, 3)
+        # Surface the ACTUAL backend/device the session resolved to. A non-'auto'
+        # compute-device choice only reorders plans, so a GPU-only model still loads
+        # on CUDA even when 'cpu' was requested — this line makes that visible.
+        import sys
+        print(f"[sokuji-sidecar] ASR ready: model={model_id or 'sense-voice'} "
+              f"backend={plan.backend} device={plan.device} compute={plan.compute_type}"
+              + (f" rtf={rtf:.3f} (~{1 / rtf:.0f}x realtime)" if rtf else "")
+              + f"  [requested device={device or 'auto'}]", file=sys.stderr, flush=True)
         return int((time.time() - t0) * 1000)
 
     def _drain(self):

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -221,3 +221,61 @@ class Qwen3AsrBackend:
     @property
     def is_loaded(self) -> bool:
         return self._model is not None
+
+
+@register_backend
+class CohereAsrBackend:
+    """Cohere Transcribe (Fast-Conformer ASR) via native transformers
+    (CohereAsrForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
+    loaded with .to(device) (no accelerate). A Conformer encoder-decoder, NOT a
+    chat-template speech-LLM: the source language is passed through the processor and
+    generate() returns only the transcription (no input-prompt slicing). Cohere has no
+    auto-detect, so a missing/'auto' language defaults to English."""
+    NAME = "cohereasr"
+
+    def __init__(self):
+        self._model = None
+        self._proc = None
+        self._device = "cpu"
+        self._dtype = None
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._proc = None
+        if device == "cpu":
+            raise BackendLoadError("cohereasr is GPU-only")
+        try:
+            import torch
+            from transformers import CohereAsrForConditionalGeneration, AutoProcessor
+            self._dtype = torch.bfloat16 if compute_type in ("bfloat16", "auto") else torch.float16
+            self._proc = AutoProcessor.from_pretrained(model_ref, local_files_only=True)
+            self._model = CohereAsrForConditionalGeneration.from_pretrained(
+                model_ref, dtype=self._dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing cohere_asr module, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language) -> AsrResult:
+        import torch
+        lang = language if language and language != "auto" else "en"  # no auto-detect
+        inp = self._proc(samples, sampling_rate=TARGET_RATE, return_tensors="pt",
+                         language=lang).to(self._device)
+        if "input_features" in inp:  # features are float32, model is bf16
+            inp["input_features"] = inp["input_features"].to(self._dtype)
+        with torch.inference_mode():
+            out = self._model.generate(**inp, max_new_tokens=256, do_sample=False)
+        text = self._proc.batch_decode(out, skip_special_tokens=True)[0]
+        return AsrResult(text.strip(), language)
+
+    def unload(self) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -224,14 +224,14 @@ class Qwen3AsrBackend:
 
 
 @register_backend
-class CohereAsrBackend:
+class CohereTransformersBackend:
     """Cohere Transcribe (Fast-Conformer ASR) via native transformers
     (CohereAsrForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
     loaded with .to(device) (no accelerate). A Conformer encoder-decoder, NOT a
     chat-template speech-LLM: the source language is passed through the processor and
     generate() returns only the transcription (no input-prompt slicing). Cohere has no
     auto-detect, so a missing/'auto' language defaults to English."""
-    NAME = "cohereasr"
+    NAME = "cohere_transformers"
 
     def __init__(self):
         self._model = None
@@ -243,7 +243,7 @@ class CohereAsrBackend:
         self._model = None
         self._proc = None
         if device == "cpu":
-            raise BackendLoadError("cohereasr is GPU-only")
+            raise BackendLoadError("cohere_transformers is GPU-only")
         try:
             import torch
             from transformers import CohereAsrForConditionalGeneration, AutoProcessor

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -11,7 +11,7 @@ SENSE_VOICE_REPO = os.environ.get(
 
 @dataclass(frozen=True)
 class Deployment:
-    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohereasr"
+    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohere_transformers"
     tier: str           # "cpu" (Phase 0); "gpu-cuda"/... later
     compute_type: str   # "int8" | ...
     artifact: str       # backend.load() model_ref: whisper size, or sherpa repo id
@@ -32,10 +32,10 @@ class AsrModel:
 # (NativeModelInfo omits it); the renderer owns card ordering via nativeCatalog.ts.
 # So renderer and sidecar sort_order values may differ harmlessly.
 ASR_MODELS: list[AsrModel] = [
-    AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe",
+    AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe (Transformers)",
              ("en", "de", "fr", "it", "es", "pt", "el",
               "nl", "pl", "ar", "vi", "zh", "ja", "ko"),
-             (Deployment("cohereasr", "gpu-cuda", "bfloat16",
+             (Deployment("cohere_transformers", "gpu-cuda", "bfloat16",
                          "CohereLabs/cohere-transcribe-03-2026", 1.0),),
              recommended=True, sort_order=0),
     AsrModel("sense-voice", "SenseVoice", ("zh", "en", "ja", "ko", "yue"),

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -32,7 +32,7 @@ class AsrModel:
 # (NativeModelInfo omits it); the renderer owns card ordering via nativeCatalog.ts.
 # So renderer and sidecar sort_order values may differ harmlessly.
 ASR_MODELS: list[AsrModel] = [
-    AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe (Transformers)",
+    AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe",
              ("en", "de", "fr", "it", "es", "pt", "el",
               "nl", "pl", "ar", "vi", "zh", "ja", "ko"),
              (Deployment("cohere_transformers", "gpu-cuda", "bfloat16",

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -11,7 +11,7 @@ SENSE_VOICE_REPO = os.environ.get(
 
 @dataclass(frozen=True)
 class Deployment:
-    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr"
+    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohereasr"
     tier: str           # "cpu" (Phase 0); "gpu-cuda"/... later
     compute_type: str   # "int8" | ...
     artifact: str       # backend.load() model_ref: whisper size, or sherpa repo id
@@ -32,33 +32,39 @@ class AsrModel:
 # (NativeModelInfo omits it); the renderer owns card ordering via nativeCatalog.ts.
 # So renderer and sidecar sort_order values may differ harmlessly.
 ASR_MODELS: list[AsrModel] = [
+    AsrModel("cohere-transcribe-03-2026", "Cohere Transcribe",
+             ("en", "de", "fr", "it", "es", "pt", "el",
+              "nl", "pl", "ar", "vi", "zh", "ja", "ko"),
+             (Deployment("cohereasr", "gpu-cuda", "bfloat16",
+                         "CohereLabs/cohere-transcribe-03-2026", 1.0),),
+             recommended=True, sort_order=0),
     AsrModel("sense-voice", "SenseVoice", ("zh", "en", "ja", "ko", "yue"),
              (Deployment("sherpa", "cpu", "int8", SENSE_VOICE_REPO, 1.0),),
-             recommended=True, sort_order=0),
+             recommended=True, sort_order=1),
     AsrModel("whisper-large-v3", "Whisper large-v3", ("multi",),
              (Deployment("ctranslate2", "gpu-cuda", "float16", "large-v3", 1.0),
-              Deployment("ctranslate2", "cpu", "int8", "large-v3", 1.0)), sort_order=1),
+              Deployment("ctranslate2", "cpu", "int8", "large-v3", 1.0)), sort_order=2),
     AsrModel("whisper-base", "Whisper base", ("multi",),
              (Deployment("ctranslate2", "gpu-cuda", "float16", "base", 1.0),
               Deployment("ctranslate2", "cpu", "int8", "base", 1.0)),
-             recommended=True, sort_order=2),
+             recommended=True, sort_order=3),
     AsrModel("whisper-small", "Whisper small", ("multi",),
              (Deployment("ctranslate2", "gpu-cuda", "float16", "small", 1.0),
-              Deployment("ctranslate2", "cpu", "int8", "small", 1.0)), sort_order=3),
+              Deployment("ctranslate2", "cpu", "int8", "small", 1.0)), sort_order=4),
     AsrModel("whisper-tiny", "Whisper tiny", ("multi",),
              (Deployment("ctranslate2", "gpu-cuda", "float16", "tiny", 1.0),
-              Deployment("ctranslate2", "cpu", "int8", "tiny", 1.0)), sort_order=4),
+              Deployment("ctranslate2", "cpu", "int8", "tiny", 1.0)), sort_order=5),
     AsrModel("granite-speech-4.1-2b", "Granite Speech 4.1 (2B)", ("en", "fr", "de", "es", "pt", "ja"),
              (Deployment("transformers", "gpu-cuda", "bfloat16", "ibm-granite/granite-speech-4.1-2b", 1.0),),
-             sort_order=5),
+             sort_order=6),
     AsrModel("granite-speech-4.1-2b-plus", "Granite Speech 4.1 (2B+)", ("en", "fr", "de", "es", "pt"),
              (Deployment("transformers", "gpu-cuda", "bfloat16", "ibm-granite/granite-speech-4.1-2b-plus", 1.0),),
-             sort_order=6),
+             sort_order=7),
     AsrModel("qwen3-asr-1.7b", "Qwen3-ASR 1.7B",
              ("zh", "en", "ja", "ko", "yue", "ar", "de", "es",
               "fr", "it", "pt", "ru", "th", "vi", "hi", "id"),
              (Deployment("qwen3asr", "gpu-cuda", "bfloat16", "bezzam/Qwen3-ASR-1.7B", 1.0),),
-             recommended=True, sort_order=7),
+             recommended=True, sort_order=8),
 ]
 
 

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -36,7 +36,7 @@ ASR_MODELS: list[AsrModel] = [
              ("en", "de", "fr", "it", "es", "pt", "el",
               "nl", "pl", "ar", "vi", "zh", "ja", "ko"),
              (Deployment("cohere_transformers", "gpu-cuda", "bfloat16",
-                         "CohereLabs/cohere-transcribe-03-2026", 1.0),),
+                         "AEmotionStudio/cohere-transcribe-03-2026-models", 1.0),),
              recommended=True, sort_order=0),
     AsrModel("sense-voice", "SenseVoice", ("zh", "en", "ja", "ko", "yue"),
              (Deployment("sherpa", "cpu", "int8", SENSE_VOICE_REPO, 1.0),),

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -41,7 +41,7 @@ def download_specs(model_id):
     if model_id == "qwen3-asr-1.7b":
         return {"repos": ["bezzam/Qwen3-ASR-1.7B"], "urls": []}
     if model_id == "cohere-transcribe-03-2026":
-        return {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
+        return {"repos": ["AEmotionStudio/cohere-transcribe-03-2026-models"], "urls": []}
     return {"repos": [model_id], "urls": []}
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -137,9 +137,8 @@ async def download(model_id, send, should_cancel=None):
     import asyncio
     from huggingface_hub import HfApi, hf_hub_download
     cancelled = (lambda: bool(should_cancel and should_cancel()))
-    tok = os.environ.get("HF_TOKEN")
     specs = download_specs(model_id)
-    api = HfApi(token=tok)
+    api = HfApi()
     files = []
     for repo in specs["repos"]:
         try:
@@ -157,15 +156,7 @@ async def download(model_id, send, should_cancel=None):
     for repo, fname in files:
         if cancelled():
             return "cancelled"
-        try:
-            await asyncio.to_thread(hf_hub_download, repo, fname, token=tok)
-        except Exception as e:
-            m = str(e).lower()
-            if any(k in m for k in ("gated", "restricted", "401", "unauthorized")):
-                raise RuntimeError(
-                    f"Access to {repo} is restricted (gated on HuggingFace). "
-                    f"Set the HF_TOKEN environment variable to download.")
-            raise
+        await asyncio.to_thread(hf_hub_download, repo, fname)
         done += 1
         await send({"type": "model_progress", "model": model_id, "downloaded": done, "total": total})
     for url in specs["urls"]:

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -40,6 +40,8 @@ def download_specs(model_id):
         return {"repos": [os.environ.get("SOKUJI_ASR_REPO", SENSE_VOICE_REPO)], "urls": [VAD_URL]}
     if model_id == "qwen3-asr-1.7b":
         return {"repos": ["bezzam/Qwen3-ASR-1.7B"], "urls": []}
+    if model_id == "cohere-transcribe-03-2026":
+        return {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
     return {"repos": [model_id], "urls": []}
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -137,8 +137,9 @@ async def download(model_id, send, should_cancel=None):
     import asyncio
     from huggingface_hub import HfApi, hf_hub_download
     cancelled = (lambda: bool(should_cancel and should_cancel()))
+    tok = os.environ.get("HF_TOKEN")
     specs = download_specs(model_id)
-    api = HfApi()
+    api = HfApi(token=tok)
     files = []
     for repo in specs["repos"]:
         try:
@@ -156,7 +157,15 @@ async def download(model_id, send, should_cancel=None):
     for repo, fname in files:
         if cancelled():
             return "cancelled"
-        await asyncio.to_thread(hf_hub_download, repo, fname)
+        try:
+            await asyncio.to_thread(hf_hub_download, repo, fname, token=tok)
+        except Exception as e:
+            m = str(e).lower()
+            if any(k in m for k in ("gated", "restricted", "401", "unauthorized")):
+                raise RuntimeError(
+                    f"Access to {repo} is restricted (gated on HuggingFace). "
+                    f"Set the HF_TOKEN environment variable to download.")
+            raise
         done += 1
         await send({"type": "model_progress", "model": model_id, "downloaded": done, "total": total})
     for url in specs["urls"]:

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -80,10 +80,13 @@ def model_status(model_id):
             # snapshot_download(local_files_only=True) is satisfied by a PARTIAL cache — offline
             # it can't know the repo's full file list, so an interrupted download (e.g. a session
             # started mid-fetch) reads back as 'ready' and then fails to load. A half-fetched blob
-            # leaves a '*.incomplete' file in blobs/ — treat its presence as not-ready.
+            # leaves a '<sha>.<etag>.incomplete' in blobs/. But a *stale* leftover can coexist with
+            # the finalized '<sha>' blob (a later resume re-fetched under a different temp name), so
+            # only treat it as not-ready when the finalized blob is actually missing.
             blobs = os.path.join(HF_HUB_CACHE, f"models--{repo.replace('/', '--')}", "blobs")
-            if glob.glob(os.path.join(blobs, "*.incomplete")):
-                return "absent"
+            for inc in glob.glob(os.path.join(blobs, "*.incomplete")):
+                if not os.path.exists(os.path.join(blobs, os.path.basename(inc).split(".")[0])):
+                    return "absent"
         for _url in specs["urls"]:
             if not os.path.exists(_vad_cache_path()):
                 return "absent"

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -69,12 +69,21 @@ def model_size(model_id):
 
 
 def model_status(model_id):
-    """'ready' if every repo + url for this model is cached locally, else 'absent'."""
+    """'ready' only if every repo + url is cached locally AND complete, else 'absent'."""
+    import glob
     from huggingface_hub import snapshot_download
+    from huggingface_hub.constants import HF_HUB_CACHE
     specs = download_specs(model_id)
     try:
         for repo in specs["repos"]:
             snapshot_download(repo_id=repo, local_files_only=True)
+            # snapshot_download(local_files_only=True) is satisfied by a PARTIAL cache — offline
+            # it can't know the repo's full file list, so an interrupted download (e.g. a session
+            # started mid-fetch) reads back as 'ready' and then fails to load. A half-fetched blob
+            # leaves a '*.incomplete' file in blobs/ — treat its presence as not-ready.
+            blobs = os.path.join(HF_HUB_CACHE, f"models--{repo.replace('/', '--')}", "blobs")
+            if glob.glob(os.path.join(blobs, "*.incomplete")):
+                return "absent"
         for _url in specs["urls"]:
             if not os.path.exists(_vad_cache_path()):
                 return "absent"

--- a/sidecar/sokuji_sidecar/server.py
+++ b/sidecar/sokuji_sidecar/server.py
@@ -30,32 +30,44 @@ async def handle_message(state, raw, binary_in=None, conn=None):
 async def _conn(state, ws):
     conn = Conn(ws)
     pending_binary = None
-    async for raw in ws:
-        if isinstance(raw, (bytes, bytearray)):
-            data = bytes(raw)
-            feeder = conn.ctx.get("on_binary")   # ASR streaming: process immediately
-            if feeder is not None:
-                try:
-                    for out in feeder(data):
-                        await conn.send(out)
-                except Exception as e:  # feeder error must not kill the connection
-                    await conn.send({"type": "error", "message": str(e)})
-            else:
-                pending_binary = data            # set_voice: buffer for next control msg
-            continue
-        try:
-            reply, binary = await handle_message(state, raw, pending_binary, conn)
-        except Exception as e:  # never drop the connection on a single bad request
+    try:
+        async for raw in ws:
+            if isinstance(raw, (bytes, bytearray)):
+                data = bytes(raw)
+                feeder = conn.ctx.get("on_binary")   # ASR streaming: process immediately
+                if feeder is not None:
+                    try:
+                        for out in feeder(data):
+                            await conn.send(out)
+                    except Exception as e:  # feeder error must not kill the connection
+                        await conn.send({"type": "error", "message": str(e)})
+                else:
+                    pending_binary = data            # set_voice: buffer for next control msg
+                continue
             try:
-                _mid = json.loads(raw).get("id")
-            except Exception:
-                _mid = None
-            reply, binary = {"type": "error", "id": _mid, "message": str(e)}, None
-        pending_binary = None
-        if binary is not None:
-            await ws.send(binary)
-        if reply is not None:
-            await ws.send(json.dumps(reply))
+                reply, binary = await handle_message(state, raw, pending_binary, conn)
+            except Exception as e:  # never drop the connection on a single bad request
+                try:
+                    _mid = json.loads(raw).get("id")
+                except Exception:
+                    _mid = None
+                reply, binary = {"type": "error", "id": _mid, "message": str(e)}, None
+            pending_binary = None
+            if binary is not None:
+                await ws.send(binary)
+            if reply is not None:
+                await ws.send(json.dumps(reply))
+    finally:
+        # A session connection closing is "stop": free the ASR model from VRAM. Only a
+        # connection that started ASR streaming (on_binary set) owns the engine; the
+        # model-management connection has no on_binary, so it leaves the model alone.
+        if conn.ctx.get("on_binary") is not None:
+            eng = state.get("asr_engine")
+            if eng is not None:
+                try:
+                    eng.close()
+                except Exception:
+                    pass
 
 
 async def serve(state=None, host="127.0.0.1", port=0):

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -388,6 +388,29 @@ def test_installed_find_spec_raise_does_not_nuke_whole_set(monkeypatch):
     assert "transformers" in result      # … but other present backends survive
 
 
+def test_cohereasr_resolves_gpu_on_nvidia_with_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"cohereasr", "transformers"}),
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("cohere-transcribe-03-2026"), m)
+    assert [p.device for p in plans] == ["cuda"]
+    assert plans[0].backend == "cohereasr" and plans[0].compute_type == "bfloat16"
+
+
+def test_cohereasr_model_unavailable_without_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"ctranslate2", "sherpa", "transformers"}),  # no cohereasr
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("cohere-transcribe-03-2026"), m)
+    assert plans == []     # gated off: no usable deployment
+
+
 def test_cohereasr_gated_on_cohere_asr_module(monkeypatch):
     import importlib.util as iu
     from sokuji_sidecar import accel

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -388,6 +388,19 @@ def test_installed_find_spec_raise_does_not_nuke_whole_set(monkeypatch):
     assert "transformers" in result      # … but other present backends survive
 
 
+def test_cohereasr_gated_on_cohere_asr_module(monkeypatch):
+    import importlib.util as iu
+    from sokuji_sidecar import accel
+    real = iu.find_spec
+
+    def fake_find_spec(name, *a, **k):
+        if name == "transformers.models.cohere_asr":
+            return None
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", fake_find_spec)
+    assert "cohereasr" not in accel._installed()
+
+
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
                     reason="set SOKUJI_RUN_GPU=1 (NVIDIA GPU + CUDA torch + transformers + Granite cached)")
 def test_real_gpu_granite_transcribes(tmp_path, monkeypatch):

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -393,11 +393,11 @@ def test_cohereasr_resolves_gpu_on_nvidia_with_runtime():
     m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
                       nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
                       apple_silicon=False, dml_adapters=(),
-                      installed=frozenset({"cohereasr", "transformers"}),
+                      installed=frozenset({"cohere_transformers", "transformers"}),
                       fingerprint="testfp")
     plans = accel.resolve_deployments(catalog.asr_model("cohere-transcribe-03-2026"), m)
     assert [p.device for p in plans] == ["cuda"]
-    assert plans[0].backend == "cohereasr" and plans[0].compute_type == "bfloat16"
+    assert plans[0].backend == "cohere_transformers" and plans[0].compute_type == "bfloat16"
 
 
 def test_cohereasr_model_unavailable_without_runtime():
@@ -421,7 +421,7 @@ def test_cohereasr_gated_on_cohere_asr_module(monkeypatch):
             return None
         return real(name, *a, **k)
     monkeypatch.setattr(accel.importlib.util, "find_spec", fake_find_spec)
-    assert "cohereasr" not in accel._installed()
+    assert "cohere_transformers" not in accel._installed()
 
 
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -242,3 +242,80 @@ def test_real_faster_whisper_transcribes():
     results += [m["text"] for m in eng.flush() if m["type"] == "result"]
     text = " ".join(results).lower()
     assert "gold" in text or "tribal" in text, f"unexpected transcript: {results!r}"
+
+
+class _UnloadBackend:
+    def __init__(self):
+        self.unloaded = False
+
+    def transcribe(self, samples, language):
+        from sokuji_sidecar.backends import AsrResult
+        return AsrResult("x")
+
+    def unload(self):
+        self.unloaded = True
+
+
+def test_engine_frees_old_model_on_reinit_and_close(monkeypatch):
+    # VRAM-leak regression: the singleton engine must unload the previous backend before
+    # loading the next (no pileup), and close() must free the current one.
+    from sokuji_sidecar import asr_engine as ae, accel
+    eng = ae.AsrEngine()
+    monkeypatch.setattr(eng, "_init_vad", lambda *a, **k: None)
+    fake_plan = accel.Plan("ctranslate2", "cpu", "cpu", "int8", "tiny", 1.0)
+    backends = []
+
+    def fake_load(plans):
+        b = _UnloadBackend()
+        backends.append(b)
+        return b, fake_plan, None
+
+    monkeypatch.setattr(accel, "resolve", lambda model_id, override="auto": [fake_plan])
+    monkeypatch.setattr(accel, "load_with_fallback", fake_load)
+    monkeypatch.setattr(accel, "measure_rtf", lambda *a, **k: None)
+
+    eng.init(model_id="whisper-tiny")
+    assert len(backends) == 1 and backends[0].unloaded is False
+    eng.init(model_id="whisper-tiny")                 # re-init frees the first
+    assert backends[0].unloaded is True
+    assert len(backends) == 2 and backends[1].unloaded is False
+    eng.close()                                       # close frees the current
+    assert backends[1].unloaded is True
+    assert eng._backend is None
+
+
+def test_conn_close_frees_asr_model():
+    # A session connection (asr_init set on_binary) closing must trigger engine.close()
+    # in _conn's finally, releasing the model from VRAM on stop.
+    closed = {"n": 0}
+
+    class Eng:
+        def init(self, *a, **k):
+            return 1
+
+        def feed(self, b):
+            return []
+
+        def close(self):
+            closed["n"] += 1
+
+    st = {"asr_engine": Eng(), "handlers": {}}
+    asr_engine.register(st)
+
+    class WS:
+        def __init__(self):
+            self._msgs = [json.dumps({"type": "asr_init", "id": 1, "model": "m"})]
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._msgs:
+                return self._msgs.pop(0)
+            raise StopAsyncIteration
+
+        async def send(self, d):
+            pass
+
+    asyncio.run(server._conn(st, WS()))
+    assert closed["n"] == 1

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -349,7 +349,7 @@ def test_qwen3asr_load_and_transcribe(monkeypatch):
 def test_cohereasr_is_gpu_only():
     b = backends.make_backend("cohere_transformers")
     with pytest.raises(backends.BackendLoadError):
-        b.load("CohereLabs/cohere-transcribe-03-2026", "cpu", "bfloat16")
+        b.load("AEmotionStudio/cohere-transcribe-03-2026-models", "cpu", "bfloat16")
 
 
 def _install_fake_cohere(monkeypatch, *, decoded="hello world"):
@@ -419,9 +419,9 @@ def _install_fake_cohere(monkeypatch, *, decoded="hello world"):
 def test_cohereasr_load_and_transcribe(monkeypatch):
     cap = _install_fake_cohere(monkeypatch)
     b = backends.make_backend("cohere_transformers")
-    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    b.load("AEmotionStudio/cohere-transcribe-03-2026-models", "cuda", "bfloat16")
     assert b.is_loaded
-    assert cap["repo"] == "CohereLabs/cohere-transcribe-03-2026"
+    assert cap["repo"] == "AEmotionStudio/cohere-transcribe-03-2026-models"
     assert cap["dtype"] == "BF16" and cap["model_device"] == "cuda"
     assert cap["proc_local_files_only"] is True
     assert cap["model_local_files_only"] is True
@@ -438,7 +438,7 @@ def test_cohereasr_load_and_transcribe(monkeypatch):
 def test_cohereasr_defaults_missing_language_to_english(monkeypatch):
     cap = _install_fake_cohere(monkeypatch)
     b = backends.make_backend("cohere_transformers")
-    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    b.load("AEmotionStudio/cohere-transcribe-03-2026-models", "cuda", "bfloat16")
     b.transcribe(np.zeros(16000, np.float32), "")        # empty → en
     assert cap["language"] == "en"
     b.transcribe(np.zeros(16000, np.float32), "auto")    # stale 'auto' value → en
@@ -446,13 +446,13 @@ def test_cohereasr_defaults_missing_language_to_english(monkeypatch):
 
 
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
-                    reason="set SOKUJI_RUN_GPU=1 (downloads CohereLabs/cohere-transcribe-03-2026 ~4GB; needs CUDA)")
+                    reason="set SOKUJI_RUN_GPU=1 (downloads AEmotionStudio/cohere-transcribe-03-2026-models ~4GB; needs CUDA)")
 def test_cohereasr_real_gpu_smoke():
     # Real flow: manager downloads first, backend loads from cache.
     from huggingface_hub import snapshot_download
-    snapshot_download("CohereLabs/cohere-transcribe-03-2026")
+    snapshot_download("AEmotionStudio/cohere-transcribe-03-2026-models")
     b = backends.make_backend("cohere_transformers")
-    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    b.load("AEmotionStudio/cohere-transcribe-03-2026-models", "cuda", "bfloat16")
     assert b.is_loaded
     clip = np.zeros(16000 * 3, np.float32)   # 3 s silence — exercises the full path
     t0 = time.perf_counter()

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -347,7 +347,7 @@ def test_qwen3asr_load_and_transcribe(monkeypatch):
 
 
 def test_cohereasr_is_gpu_only():
-    b = backends.make_backend("cohereasr")
+    b = backends.make_backend("cohere_transformers")
     with pytest.raises(backends.BackendLoadError):
         b.load("CohereLabs/cohere-transcribe-03-2026", "cpu", "bfloat16")
 
@@ -418,7 +418,7 @@ def _install_fake_cohere(monkeypatch, *, decoded="hello world"):
 
 def test_cohereasr_load_and_transcribe(monkeypatch):
     cap = _install_fake_cohere(monkeypatch)
-    b = backends.make_backend("cohereasr")
+    b = backends.make_backend("cohere_transformers")
     b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
     assert b.is_loaded
     assert cap["repo"] == "CohereLabs/cohere-transcribe-03-2026"
@@ -437,7 +437,7 @@ def test_cohereasr_load_and_transcribe(monkeypatch):
 
 def test_cohereasr_defaults_missing_language_to_english(monkeypatch):
     cap = _install_fake_cohere(monkeypatch)
-    b = backends.make_backend("cohereasr")
+    b = backends.make_backend("cohere_transformers")
     b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
     b.transcribe(np.zeros(16000, np.float32), "")        # empty → en
     assert cap["language"] == "en"
@@ -451,7 +451,7 @@ def test_cohereasr_real_gpu_smoke():
     # Real flow: manager downloads first, backend loads from cache.
     from huggingface_hub import snapshot_download
     snapshot_download("CohereLabs/cohere-transcribe-03-2026")
-    b = backends.make_backend("cohereasr")
+    b = backends.make_backend("cohere_transformers")
     b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
     assert b.is_loaded
     clip = np.zeros(16000 * 3, np.float32)   # 3 s silence — exercises the full path

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -344,3 +344,131 @@ def test_qwen3asr_load_and_transcribe(monkeypatch):
     assert cap["sr"] == 16000                       # TARGET_RATE
     assert cap["slice"] == (slice(None), slice(4, None))   # decode only new tokens after the 4-token prompt
     assert cap["gen_kw"]["do_sample"] is False
+
+
+def test_cohereasr_is_gpu_only():
+    b = backends.make_backend("cohereasr")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("CohereLabs/cohere-transcribe-03-2026", "cpu", "bfloat16")
+
+
+def _install_fake_cohere(monkeypatch, *, decoded="hello world"):
+    cap = {}
+
+    class FakeFeat:
+        def to(self, dtype):
+            cap["feat_dtype"] = dtype
+            return self
+
+    class FakeBatch(dict):
+        def to(self, device):
+            cap["inp_device"] = device
+            return self
+
+    class FakeProc:
+        # Cohere processor: positional audio + sampling_rate + language (no chat template)
+        def __call__(self, samples, sampling_rate, return_tensors, language):
+            cap["sr"] = sampling_rate
+            cap["language"] = language
+            b = FakeBatch()
+            b["input_features"] = FakeFeat()
+            return b
+        def batch_decode(self, seq, skip_special_tokens):
+            cap["decoded_seq"] = seq
+            return [decoded]
+
+    class FakeModel:
+        def to(self, device):
+            cap["model_device"] = device
+            return self
+        def eval(self):
+            return self
+        def generate(self, **kw):
+            cap["gen_kw"] = kw
+            return "OUT"
+
+    class FakeAutoProcessor:
+        @staticmethod
+        def from_pretrained(repo, local_files_only=False):
+            cap["proc_repo"] = repo
+            cap["proc_local_files_only"] = local_files_only
+            return FakeProc()
+
+    class FakeCohere:
+        @staticmethod
+        def from_pretrained(repo, dtype, local_files_only=False):
+            cap["repo"] = repo
+            cap["dtype"] = dtype
+            cap["model_local_files_only"] = local_files_only
+            return FakeModel()
+
+    tmod = types.ModuleType("transformers")
+    tmod.AutoProcessor = FakeAutoProcessor
+    tmod.CohereAsrForConditionalGeneration = FakeCohere
+    monkeypatch.setitem(sys.modules, "transformers", tmod)
+
+    torch_mod = types.ModuleType("torch")
+    torch_mod.bfloat16 = "BF16"
+    torch_mod.float16 = "F16"
+    torch_mod.inference_mode = contextlib.nullcontext
+    torch_mod.cuda = types.SimpleNamespace(empty_cache=lambda: None, is_available=lambda: True)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    return cap
+
+
+def test_cohereasr_load_and_transcribe(monkeypatch):
+    cap = _install_fake_cohere(monkeypatch)
+    b = backends.make_backend("cohereasr")
+    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    assert b.is_loaded
+    assert cap["repo"] == "CohereLabs/cohere-transcribe-03-2026"
+    assert cap["dtype"] == "BF16" and cap["model_device"] == "cuda"
+    assert cap["proc_local_files_only"] is True
+    assert cap["model_local_files_only"] is True
+    r = b.transcribe(np.zeros(16000, np.float32), "ja")
+    assert r.text == "hello world"            # decoded + stripped, no prefix logic
+    assert cap["feat_dtype"] == "BF16"          # input_features cast to model dtype
+    assert cap["sr"] == 16000                   # TARGET_RATE
+    assert cap["language"] == "ja"              # explicit language passed through
+    assert cap["gen_kw"]["do_sample"] is False
+    b.unload()
+    assert not b.is_loaded
+
+
+def test_cohereasr_defaults_missing_language_to_english(monkeypatch):
+    cap = _install_fake_cohere(monkeypatch)
+    b = backends.make_backend("cohereasr")
+    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    b.transcribe(np.zeros(16000, np.float32), "")        # empty → en
+    assert cap["language"] == "en"
+    b.transcribe(np.zeros(16000, np.float32), "auto")    # stale 'auto' value → en
+    assert cap["language"] == "en"
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads CohereLabs/cohere-transcribe-03-2026 ~4GB; needs CUDA)")
+def test_cohereasr_real_gpu_smoke():
+    # Real flow: manager downloads first, backend loads from cache.
+    from huggingface_hub import snapshot_download
+    snapshot_download("CohereLabs/cohere-transcribe-03-2026")
+    b = backends.make_backend("cohereasr")
+    b.load("CohereLabs/cohere-transcribe-03-2026", "cuda", "bfloat16")
+    assert b.is_loaded
+    clip = np.zeros(16000 * 3, np.float32)   # 3 s silence — exercises the full path
+    t0 = time.perf_counter()
+    r = b.transcribe(clip, "en")
+    rtf = (time.perf_counter() - t0) / 3.0
+    assert isinstance(r.text, str)           # may be empty for silence; must not raise
+    print(f"cohere-transcribe-03-2026 RTF={rtf:.4f}")
+    b.unload()
+    # coexistence regression: Granite + Qwen3 still load after Cohere unload + empty_cache
+    import torch
+    torch.cuda.empty_cache()
+    g = backends.make_backend("transformers")
+    g.load("ibm-granite/granite-speech-4.1-2b", "cuda", "bfloat16")
+    assert g.is_loaded
+    g.unload()
+    q = backends.make_backend("qwen3asr")
+    q.load("bezzam/Qwen3-ASR-1.7B", "cuda", "bfloat16")
+    assert q.is_loaded
+    q.unload()

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -6,7 +6,7 @@ def test_models_have_deployments_and_languages():
         assert m.deployments, f"{m.id} has no deployments"
         assert m.languages, f"{m.id} has no languages"
         for d in m.deployments:
-            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr", "cohereasr"}
+            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr", "cohere_transformers"}
 
 
 def test_system_has_a_cpu_floor():
@@ -56,13 +56,14 @@ def test_qwen3_asr_row():
 def test_cohere_asr_row():
     m = catalog.asr_model("cohere-transcribe-03-2026")
     assert m is not None
+    assert m.name == "Cohere Transcribe (Transformers)"
     assert m.languages == ("en", "de", "fr", "it", "es", "pt", "el",
                            "nl", "pl", "ar", "vi", "zh", "ja", "ko")
     assert m.recommended is True
     assert m.sort_order == 0          # sorted first
     d = m.deployments[0]
     assert (d.backend, d.tier, d.compute_type, d.artifact) == \
-        ("cohereasr", "gpu-cuda", "bfloat16", "CohereLabs/cohere-transcribe-03-2026")
+        ("cohere_transformers", "gpu-cuda", "bfloat16", "CohereLabs/cohere-transcribe-03-2026")
 
 
 def test_cohere_is_first_qwen3_shifted():

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -6,7 +6,7 @@ def test_models_have_deployments_and_languages():
         assert m.deployments, f"{m.id} has no deployments"
         assert m.languages, f"{m.id} has no languages"
         for d in m.deployments:
-            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr"}
+            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr", "cohereasr"}
 
 
 def test_system_has_a_cpu_floor():
@@ -47,7 +47,26 @@ def test_qwen3_asr_row():
     assert m.languages == ("zh", "en", "ja", "ko", "yue", "ar", "de", "es",
                            "fr", "it", "pt", "ru", "th", "vi", "hi", "id")
     assert m.recommended is True         # Phase 2: native runtime available → recommended
-    assert m.sort_order == 7
+    assert m.sort_order == 8
     d = m.deployments[0]
     assert (d.backend, d.tier, d.compute_type, d.artifact) == \
         ("qwen3asr", "gpu-cuda", "bfloat16", "bezzam/Qwen3-ASR-1.7B")
+
+
+def test_cohere_asr_row():
+    m = catalog.asr_model("cohere-transcribe-03-2026")
+    assert m is not None
+    assert m.languages == ("en", "de", "fr", "it", "es", "pt", "el",
+                           "nl", "pl", "ar", "vi", "zh", "ja", "ko")
+    assert m.recommended is True
+    assert m.sort_order == 0          # sorted first
+    d = m.deployments[0]
+    assert (d.backend, d.tier, d.compute_type, d.artifact) == \
+        ("cohereasr", "gpu-cuda", "bfloat16", "CohereLabs/cohere-transcribe-03-2026")
+
+
+def test_cohere_is_first_qwen3_shifted():
+    ids = [m.id for m in catalog.asr_models()]
+    assert ids[0] == "cohere-transcribe-03-2026"           # inserted first in the list
+    assert catalog.asr_model("qwen3-asr-1.7b").sort_order == 8   # shifted +1 from 7
+    assert catalog.asr_model("sense-voice").sort_order == 1      # shifted +1 from 0

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -56,7 +56,7 @@ def test_qwen3_asr_row():
 def test_cohere_asr_row():
     m = catalog.asr_model("cohere-transcribe-03-2026")
     assert m is not None
-    assert m.name == "Cohere Transcribe (Transformers)"
+    assert m.name == "Cohere Transcribe"
     assert m.languages == ("en", "de", "fr", "it", "es", "pt", "el",
                            "nl", "pl", "ar", "vi", "zh", "ja", "ko")
     assert m.recommended is True

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -63,7 +63,7 @@ def test_cohere_asr_row():
     assert m.sort_order == 0          # sorted first
     d = m.deployments[0]
     assert (d.backend, d.tier, d.compute_type, d.artifact) == \
-        ("cohere_transformers", "gpu-cuda", "bfloat16", "CohereLabs/cohere-transcribe-03-2026")
+        ("cohere_transformers", "gpu-cuda", "bfloat16", "AEmotionStudio/cohere-transcribe-03-2026-models")
 
 
 def test_cohere_is_first_qwen3_shifted():

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -154,3 +154,19 @@ def test_model_cancel_stops_download_at_file_boundary(monkeypatch):
     sent = [json.loads(s) for s in asyncio.run(scenario())]
     assert any(m['type'] == 'model_progress' for m in sent)
     assert sent[-1] == {'type': 'model_download_done', 'model': 'm', 'status': 'cancelled'}
+
+
+def test_model_status_rejects_interrupted_download(monkeypatch, tmp_path):
+    """A partial/interrupted download (a *.incomplete blob) must read as 'absent',
+    not 'ready' — snapshot_download(local_files_only) alone is fooled by partials."""
+    import huggingface_hub, huggingface_hub.constants
+    from sokuji_sidecar import native_models
+    repo = native_models.download_specs("cohere-transcribe-03-2026")["repos"][0]
+    blobs = tmp_path / f"models--{repo.replace('/', '--')}" / "blobs"
+    blobs.mkdir(parents=True)
+    monkeypatch.setattr(huggingface_hub.constants, "HF_HUB_CACHE", str(tmp_path))
+    monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: str(tmp_path))
+    (blobs / "abc123").write_text("a finalized blob")
+    assert native_models.model_status("cohere-transcribe-03-2026") == "ready"
+    (blobs / "def456.incomplete").write_bytes(b"half-fetched safetensors")
+    assert native_models.model_status("cohere-transcribe-03-2026") == "absent"

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -1,6 +1,7 @@
 import asyncio, json, os
 import pytest
 from sokuji_sidecar import native_models as nm
+from sokuji_sidecar import native_models
 from sokuji_sidecar import server
 
 
@@ -18,6 +19,13 @@ def test_download_specs_mapping():
     assert nm.download_specs('granite-speech-4.1-2b-plus')['repos'] == ['ibm-granite/granite-speech-4.1-2b-plus']
     # Qwen3-ASR must map to the bezzam/ HF repo, not the bare catalog id.
     assert nm.download_specs('qwen3-asr-1.7b')['repos'] == ['bezzam/Qwen3-ASR-1.7B']
+    # Cohere Transcribe must map to the CohereLabs/ HF repo.
+    assert nm.download_specs('cohere-transcribe-03-2026')['repos'] == ['CohereLabs/cohere-transcribe-03-2026']
+
+
+def test_download_specs_cohere():
+    assert native_models.download_specs("cohere-transcribe-03-2026") == \
+        {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
 
 
 def test_download_raises_when_no_files_resolved(monkeypatch):

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -157,8 +157,8 @@ def test_model_cancel_stops_download_at_file_boundary(monkeypatch):
 
 
 def test_model_status_rejects_interrupted_download(monkeypatch, tmp_path):
-    """A partial/interrupted download (a *.incomplete blob) must read as 'absent',
-    not 'ready' — snapshot_download(local_files_only) alone is fooled by partials."""
+    """Interrupted download (.incomplete with no finalized blob) → 'absent', but a
+    stale .incomplete alongside its finalized blob must still read 'ready'."""
     import huggingface_hub, huggingface_hub.constants
     from sokuji_sidecar import native_models
     repo = native_models.download_specs("cohere-transcribe-03-2026")["repos"][0]
@@ -168,5 +168,9 @@ def test_model_status_rejects_interrupted_download(monkeypatch, tmp_path):
     monkeypatch.setattr(huggingface_hub, "snapshot_download", lambda **k: str(tmp_path))
     (blobs / "abc123").write_text("a finalized blob")
     assert native_models.model_status("cohere-transcribe-03-2026") == "ready"
-    (blobs / "def456.incomplete").write_bytes(b"half-fetched safetensors")
+    # interrupted: '<sha>.<etag>.incomplete' with its finalized '<sha>' blob MISSING
+    (blobs / "def456.a1b2c3.incomplete").write_bytes(b"half-fetched safetensors")
     assert native_models.model_status("cohere-transcribe-03-2026") == "absent"
+    # stale leftover: the finalized blob has since landed → ignore the orphan .incomplete
+    (blobs / "def456").write_text("now finalized")
+    assert native_models.model_status("cohere-transcribe-03-2026") == "ready"

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -19,13 +19,13 @@ def test_download_specs_mapping():
     assert nm.download_specs('granite-speech-4.1-2b-plus')['repos'] == ['ibm-granite/granite-speech-4.1-2b-plus']
     # Qwen3-ASR must map to the bezzam/ HF repo, not the bare catalog id.
     assert nm.download_specs('qwen3-asr-1.7b')['repos'] == ['bezzam/Qwen3-ASR-1.7B']
-    # Cohere Transcribe must map to the CohereLabs/ HF repo.
-    assert nm.download_specs('cohere-transcribe-03-2026')['repos'] == ['CohereLabs/cohere-transcribe-03-2026']
+    # Cohere Transcribe maps to the non-gated AEmotionStudio mirror (byte-identical to CohereLabs).
+    assert nm.download_specs('cohere-transcribe-03-2026')['repos'] == ['AEmotionStudio/cohere-transcribe-03-2026-models']
 
 
 def test_download_specs_cohere():
     assert native_models.download_specs("cohere-transcribe-03-2026") == \
-        {"repos": ["CohereLabs/cohere-transcribe-03-2026"], "urls": []}
+        {"repos": ["AEmotionStudio/cohere-transcribe-03-2026-models"], "urls": []}
 
 
 def test_download_raises_when_no_files_resolved(monkeypatch):

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -155,8 +155,8 @@ const NativeModelCard: React.FC<{
               <button
                 className="model-card__btn model-card__btn--download"
                 onClick={(e) => { e.stopPropagation(); download(spec.downloadId as string); }}
-                disabled={disabled}
-                title={t('models.download', 'Download')}
+                disabled={disabled || hwGated}
+                title={hwGated ? t('models.requiresGpu', 'Requires a GPU') : t('models.download', 'Download')}
               >
                 <Download size={14} />
                 <span>{t('models.download', 'Download')}</span>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -92,20 +92,23 @@ const NativeModelCard: React.FC<{
                 {(spec.languages || []).map((l) => (<span key={l} className="model-card__lang-tag">{l}</span>))}
                 {spec.note && <span className="model-card__lang-tag">{spec.note}</span>}
               </div>
-              {activeTier && (() => {
-                const tl = tierLabel(activeTier.tier);
+              {(() => {
+                // One tier tag: for the model that just ran, show the RESOLVED device + measured
+                // rtf (ground truth — also catches a GPU→CPU fallback); otherwise the catalog's
+                // capability tier. Avoids two redundant "GPU CUDA" tags on the active card.
+                const showResolved = !!resolved && resolved.model === spec.selectId;
+                const tier = showResolved
+                  ? (resolved!.device === 'cpu' ? 'cpu' : `gpu-${resolved!.device}`)
+                  : activeTier?.tier;
+                if (!tier) return null;
+                const tl = tierLabel(tier);
+                const rtf = showResolved && resolved!.rtf !== undefined ? ` · ${formatRtf(resolved!.rtf)}` : '';
                 return (
                   <span className="model-card__lang-tag">
-                    {tl.accel && <Zap size={10} />}{tl.label}
+                    {tl.accel && <Zap size={10} />}{tl.label}{rtf}
                   </span>
                 );
               })()}
-              {resolved && resolved.model === spec.selectId && (
-                <span className="model-card__lang-tag">
-                  <Zap size={10} />{tierLabel(resolved.device === 'cpu' ? 'cpu' : `gpu-${resolved.device}`).label}
-                  {resolved.rtf !== undefined ? ` · ${formatRtf(resolved.rtf)}` : ''}
-                </span>
-              )}
               {hwGated && <span className="model-card__lang-tag">Requires GPU</span>}
               {spec.recommended && (
                 <span className="model-card__recommended-badge">

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -22,6 +22,7 @@ import {
   useNativeModelStatuses,
   useNativeModelProgress,
   useNativeModelSizes,
+  useNativeModelErrors,
   useNativeAsrResolved,
 } from '../../../stores/nativeModelStore';
 import { ModelGroup, RecommendedOthers, ModelStorageFooter } from './ModelManagementControls';
@@ -41,6 +42,7 @@ const NativeModelCard: React.FC<{
   const statuses = useNativeModelStatuses();
   const progress = useNativeModelProgress();
   const sizes = useNativeModelSizes();
+  const errors = useNativeModelErrors();
   const download = useNativeModelStore((s) => s.download);
   const cancelDownload = useNativeModelStore((s) => s.cancelDownload);
   const deleteModel = useNativeModelStore((s) => s.deleteModel);
@@ -54,6 +56,7 @@ const NativeModelCard: React.FC<{
 
   const status = noDownload ? 'ready' : (statuses[spec.downloadId as string] || 'absent');
   const ready = noDownload || status === 'ready';
+  const err = noDownload ? undefined : errors[spec.downloadId as string];
 
   const statusClass = noDownload ? 'model-card--none'
     : status === 'ready' ? 'model-card--downloaded'
@@ -64,6 +67,7 @@ const NativeModelCard: React.FC<{
     selected && 'model-card--selected',
     (incompatible || hwGated) && 'model-card--incompatible',
     disabled && 'model-card--disabled',
+    err && status !== 'downloading' && 'model-card--error',
   ].filter(Boolean).join(' ');
 
   const handleClick = () => { if (!disabled && !hwGated && ready) onSelect(); };
@@ -159,6 +163,9 @@ const NativeModelCard: React.FC<{
               </button>
             )}
           </div>
+          {err && status !== 'downloading' && (
+            <div className="model-card__error-message">{err}</div>
+          )}
         </div>
       </div>
     </div>

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -16,6 +16,7 @@ function electron(): ElectronInvoke {
 /** Manages native-model download/status against the sidecar (not session-bound). */
 export class NativeModelClient {
   private ws: WebSocket | null = null;
+  private connecting: Promise<void> | null = null;   // single-flight guard: concurrent connect() calls share one connection
   private nextId = 1;
   private pending = new Map<number, { resolve: (m: ServerMsg) => void; reject: (e: Error) => void }>();
   // In-flight downloads keyed by model — completion/progress is pushed (not
@@ -31,6 +32,16 @@ export class NativeModelClient {
 
   private async connect(): Promise<void> {
     if (this.ws && this.ws.readyState === WebSocket.OPEN) return;
+    // Single-flight: while a connection is being established (the sidecar can take
+    // seconds to boot on first use), concurrent callers must await the SAME attempt
+    // rather than each opening their own socket — otherwise the duplicates race and
+    // an orphaned socket's onclose() rejects everyone's in-flight requests.
+    if (this.connecting) return this.connecting;
+    this.connecting = this._connect().finally(() => { this.connecting = null; });
+    return this.connecting;
+  }
+
+  private async _connect(): Promise<void> {
     const r = await electron().invoke('native-host:start');
     if (!r?.ok) throw new Error(r?.error || 'failed to start native host');
     await new Promise<void>((resolve, reject) => {

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -43,20 +43,20 @@ describe('nativeCatalog', () => {
     expect(supportsLanguage({ languages: ['zh', 'en'] }, 'de')).toBe(false);
     expect(supportsLanguage({ languages: ['multi'] }, 'de')).toBe(true);
 
-    // for a sense-voice language, sense-voice is compatible + recommended-first
-    expect(compatibleNativeAsr('zh').map((m) => m.id)[0]).toBe('sense-voice');
-    // for an unsupported language, sense-voice drops out → whisper-base leads
+    // for a sense-voice language, cohere now leads (recommended, sortOrder 0)
+    expect(compatibleNativeAsr('zh').map((m) => m.id)[0]).toBe('cohere-transcribe-03-2026');
+    // for an unsupported language, sense-voice drops out → cohere leads (supports de)
     expect(compatibleNativeAsr('de').map((m) => m.id)).not.toContain('sense-voice');
-    expect(compatibleNativeAsr('de')[0].id).toBe('whisper-base');
+    expect(compatibleNativeAsr('de')[0].id).toBe('cohere-transcribe-03-2026');
 
     // auto-select keeps a still-compatible choice, else switches
     expect(nativeAsrForLanguage('zh', 'sense-voice')).toBe('sense-voice');
-    expect(nativeAsrForLanguage('de', 'sense-voice')).toBe('whisper-base');
+    expect(nativeAsrForLanguage('de', 'sense-voice')).toBe('cohere-transcribe-03-2026');
     expect(nativeAsrForLanguage('de', 'whisper-tiny')).toBe('whisper-tiny');
   });
 
   it('builds per-stage cards with the selectId/downloadId split', () => {
-    expect(nativeAsrCards('zh')[0]).toMatchObject({ selectId: 'sense-voice', downloadId: 'sense-voice', recommended: true });
+    expect(nativeAsrCards('zh')[0]).toMatchObject({ selectId: 'cohere-transcribe-03-2026', downloadId: 'cohere-transcribe-03-2026', recommended: true });
     expect(nativeAsrCards('de').map((c) => c.selectId)).not.toContain('sense-voice');
 
     const tr = nativeTranslationCards('zh', 'en');
@@ -79,8 +79,8 @@ describe('nativeCatalog', () => {
     expect(lv3!.recommended).toBeFalsy();
     // whisper-base stays the recommended multilingual fallback (CPU-real-time)
     expect(NATIVE_ASR.find((m) => m.id === 'whisper-base')!.recommended).toBe(true);
-    // a non-sense-voice language still leads with whisper-base, not large-v3
-    expect(compatibleNativeAsr('de')[0].id).toBe('whisper-base');
+    // a non-sense-voice language still leads with cohere (now recommended, sortOrder 0)
+    expect(compatibleNativeAsr('de')[0].id).toBe('cohere-transcribe-03-2026');
   });
 
   it('splits ASR into compatible / incompatible for a language', () => {
@@ -163,8 +163,8 @@ describe('nativeCatalog', () => {
     expect(compatibleNativeAsr('ja').map((m) => m.id)).not.toContain('granite-speech-4.1-2b-plus');
     // neither is recommended (sense-voice / whisper-base stay the recommended leaders)
     expect(NATIVE_ASR.find((m) => m.id === 'granite-speech-4.1-2b')!.recommended).toBeFalsy();
-    // a non-sense-voice language still leads with whisper-base, not granite
-    expect(compatibleNativeAsr('de')[0].id).toBe('whisper-base');
+    // a non-sense-voice language still leads with cohere (now recommended, sortOrder 0)
+    expect(compatibleNativeAsr('de')[0].id).toBe('cohere-transcribe-03-2026');
   });
 
   it('includes Qwen3-ASR 1.7B as a recommended GPU option with verbatim sidecar languages', () => {
@@ -172,10 +172,24 @@ describe('nativeCatalog', () => {
     expect(q).toBeTruthy();
     expect(q!.languages).toEqual(['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id']);
     expect(q!.recommended).toBe(true);
-    expect(q!.sortOrder).toBe(7);
-    // recommended, but its high sortOrder keeps the established leaders first
-    expect(nativeAsrCards('zh')[0].selectId).toBe('sense-voice');
-    expect(nativeAsrCards('de')[0].selectId).toBe('whisper-base');
+    expect(q!.sortOrder).toBe(8);
+    // recommended, but its high sortOrder keeps Cohere first
+    expect(nativeAsrCards('zh')[0].selectId).toBe('cohere-transcribe-03-2026');
+    expect(nativeAsrCards('de')[0].selectId).toBe('cohere-transcribe-03-2026');
+  });
+
+  it('includes Cohere Transcribe as the first (recommended) ASR with its 14 languages', () => {
+    const c = NATIVE_ASR.find((m) => m.id === 'cohere-transcribe-03-2026');
+    expect(c).toBeTruthy();
+    expect(c!.languages).toEqual(['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko']);
+    expect(c!.recommended).toBe(true);
+    expect(c!.sortOrder).toBe(0);
+    // Cohere leads for every language it supports...
+    expect(nativeAsrCards('zh')[0].selectId).toBe('cohere-transcribe-03-2026');
+    expect(nativeAsrCards('ja')[0].selectId).toBe('cohere-transcribe-03-2026');
+    expect(nativeAsrCards('de')[0].selectId).toBe('cohere-transcribe-03-2026');
+    // ...but not for Cantonese (yue), which Cohere does not support → sense-voice still leads
+    expect(nativeAsrCards('yue')[0].selectId).toBe('sense-voice');
   });
 
   it('maps hardware tiers to display labels', () => {

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -152,6 +152,23 @@ describe('nativeCatalog', () => {
         { asrModel: 'whisper-small', translationModel: '', ttsModel: '' });
       expect(r?.asrModel ?? 'sense-voice').toBe('sense-voice');
     });
+
+    const gatesCohere = (id: string | null) => id === 'cohere-transcribe-03-2026';
+
+    it('never auto-selects a downloaded but hardware-gated ASR (GPU-only on a CPU box)', () => {
+      // cohere (GPU-only, sorted first) + sense-voice both downloaded, but cohere is gated
+      // here → must pick sense-voice, never the unrunnable cohere.
+      const r = autoSelectNative('zh', 'en', cur({ asrModel: '' }),
+        downloaded('cohere-transcribe-03-2026', 'sense-voice', 'qwen'), null, gatesCohere);
+      expect(r?.asrModel).toBe('sense-voice');
+    });
+
+    it('reconciles away a remembered ASR that is now hardware-gated', () => {
+      // the current selection IS the GPU-only cohere but this machine can't run it → replace it
+      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'cohere-transcribe-03-2026' }),
+        downloaded('cohere-transcribe-03-2026', 'sense-voice', 'qwen'), null, gatesCohere);
+      expect(r?.asrModel).toBe('sense-voice');
+    });
   });
 
   it('exposes Granite speech-LLM ASR options with language-specific gating', () => {

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -181,6 +181,7 @@ describe('nativeCatalog', () => {
   it('includes Cohere Transcribe as the first (recommended) ASR with its 14 languages', () => {
     const c = NATIVE_ASR.find((m) => m.id === 'cohere-transcribe-03-2026');
     expect(c).toBeTruthy();
+    expect(c!.label).toBe('Cohere Transcribe (Transformers)');
     expect(c!.languages).toEqual(['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko']);
     expect(c!.recommended).toBe(true);
     expect(c!.sortOrder).toBe(0);

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -181,7 +181,7 @@ describe('nativeCatalog', () => {
   it('includes Cohere Transcribe as the first (recommended) ASR with its 14 languages', () => {
     const c = NATIVE_ASR.find((m) => m.id === 'cohere-transcribe-03-2026');
     expect(c).toBeTruthy();
-    expect(c!.label).toBe('Cohere Transcribe (Transformers)');
+    expect(c!.label).toBe('Cohere Transcribe');
     expect(c!.languages).toEqual(['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko']);
     expect(c!.recommended).toBe(true);
     expect(c!.sortOrder).toBe(0);

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -20,7 +20,7 @@ export function supportsLanguage(opt: { languages?: string[] }, lang: string): b
 }
 
 export const NATIVE_ASR: NativeModelOption[] = [
-  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe', languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'], recommended: true, sortOrder: 0 },
+  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe (Transformers)', languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'], recommended: true, sortOrder: 0 },
   { id: 'sense-voice', label: 'SenseVoice', languages: ['zh', 'en', 'ja', 'ko', 'yue'], recommended: true, sortOrder: 1 },
   { id: 'whisper-base', label: 'Whisper base', languages: ['multi'], recommended: true, sortOrder: 2 },
   { id: 'whisper-small', label: 'Whisper small', languages: ['multi'], sortOrder: 3 },

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -20,14 +20,15 @@ export function supportsLanguage(opt: { languages?: string[] }, lang: string): b
 }
 
 export const NATIVE_ASR: NativeModelOption[] = [
-  { id: 'sense-voice', label: 'SenseVoice', languages: ['zh', 'en', 'ja', 'ko', 'yue'], recommended: true, sortOrder: 0 },
-  { id: 'whisper-base', label: 'Whisper base', languages: ['multi'], recommended: true, sortOrder: 1 },
-  { id: 'whisper-small', label: 'Whisper small', languages: ['multi'], sortOrder: 2 },
-  { id: 'whisper-tiny', label: 'Whisper tiny', languages: ['multi'], sortOrder: 3 },
-  { id: 'whisper-large-v3', label: 'Whisper large-v3', languages: ['multi'], sortOrder: 4 },
-  { id: 'granite-speech-4.1-2b', label: 'Granite Speech 4.1 (2B)', languages: ['en', 'fr', 'de', 'es', 'pt', 'ja'], sortOrder: 5 },
-  { id: 'granite-speech-4.1-2b-plus', label: 'Granite Speech 4.1 (2B+)', languages: ['en', 'fr', 'de', 'es', 'pt'], sortOrder: 6 },
-  { id: 'qwen3-asr-1.7b', label: 'Qwen3-ASR 1.7B', languages: ['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id'], recommended: true, sortOrder: 7 },
+  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe', languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'], recommended: true, sortOrder: 0 },
+  { id: 'sense-voice', label: 'SenseVoice', languages: ['zh', 'en', 'ja', 'ko', 'yue'], recommended: true, sortOrder: 1 },
+  { id: 'whisper-base', label: 'Whisper base', languages: ['multi'], recommended: true, sortOrder: 2 },
+  { id: 'whisper-small', label: 'Whisper small', languages: ['multi'], sortOrder: 3 },
+  { id: 'whisper-tiny', label: 'Whisper tiny', languages: ['multi'], sortOrder: 4 },
+  { id: 'whisper-large-v3', label: 'Whisper large-v3', languages: ['multi'], sortOrder: 5 },
+  { id: 'granite-speech-4.1-2b', label: 'Granite Speech 4.1 (2B)', languages: ['en', 'fr', 'de', 'es', 'pt', 'ja'], sortOrder: 6 },
+  { id: 'granite-speech-4.1-2b-plus', label: 'Granite Speech 4.1 (2B+)', languages: ['en', 'fr', 'de', 'es', 'pt'], sortOrder: 7 },
+  { id: 'qwen3-asr-1.7b', label: 'Qwen3-ASR 1.7B', languages: ['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id'], recommended: true, sortOrder: 8 },
 ];
 
 export const NATIVE_TRANSLATION: NativeModelOption[] = [

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -267,6 +267,7 @@ export function autoSelectNative(
   current: NativeSelection,
   isDownloaded: (downloadId: string | null) => boolean,
   recalled?: Partial<NativeSelection> | null,
+  isHardwareGated: (downloadId: string | null) => boolean = () => false,
 ): Partial<NativeSelection> | null {
   let { asrModel, translationModel, ttsModel } = current;
   const input = { asrModel, translationModel, ttsModel };
@@ -280,11 +281,15 @@ export function autoSelectNative(
 
   const updates: Partial<NativeSelection> = {};
 
-  // 2+3. ASR — compatible with src (cards are pre-filtered) and downloaded
+  // 2+3. ASR — compatible with src (cards are pre-filtered), downloaded, AND runnable
+  // on this machine. A GPU-only model on a CPU-only box is hardware-gated; auto-selecting
+  // it passes readiness but then resolves to NoUsablePlan and fails at Start, so skip it.
   const asrCards = nativeAsrCards(src);
+  const asrUsable = (c: { downloadId: string | null }) =>
+    isDownloaded(c.downloadId) && !isHardwareGated(c.downloadId);
   const curAsr = asrCards.find((c) => c.selectId === asrModel);
-  if (!(curAsr && isDownloaded(curAsr.downloadId))) {
-    const best = asrCards.find((c) => isDownloaded(c.downloadId));
+  if (!(curAsr && asrUsable(curAsr))) {
+    const best = asrCards.find(asrUsable);
     const newId = best?.selectId ?? '';
     if (newId !== asrModel) updates.asrModel = newId;
   }

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -20,7 +20,7 @@ export function supportsLanguage(opt: { languages?: string[] }, lang: string): b
 }
 
 export const NATIVE_ASR: NativeModelOption[] = [
-  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe (Transformers)', languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'], recommended: true, sortOrder: 0 },
+  { id: 'cohere-transcribe-03-2026', label: 'Cohere Transcribe', languages: ['en', 'de', 'fr', 'it', 'es', 'pt', 'el', 'nl', 'pl', 'ar', 'vi', 'zh', 'ja', 'ko'], recommended: true, sortOrder: 0 },
   { id: 'sense-voice', label: 'SenseVoice', languages: ['zh', 'en', 'ja', 'ko', 'yue'], recommended: true, sortOrder: 1 },
   { id: 'whisper-base', label: 'Whisper base', languages: ['multi'], recommended: true, sortOrder: 2 },
   { id: 'whisper-small', label: 'Whisper small', languages: ['multi'], sortOrder: 3 },

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -18,6 +18,8 @@ class FakeWS {
         { id: 'sense-voice', name: 'SenseVoice', languages: ['zh'], recommended: true,
           tiers: [{ tier: 'cpu', backend: 'sherpa', available: true }] },
       ] }));
+    if (msg.type === 'model_delete') queueMicrotask(() =>
+      this.emit({ type: 'model_delete_result', id: msg.id, freed: 0 }));
   }
   close() {}
 }
@@ -58,6 +60,22 @@ describe('nativeModelStore.refreshCatalog', () => {
     const cat = useNativeModelStore.getState().catalog;
     expect(cat['sense-voice']).toMatchObject({ recommended: true });
     expect(cat['sense-voice'].tiers[0]).toMatchObject({ tier: 'cpu', available: true });
+  });
+});
+
+describe('nativeModelStore.deleteModel', () => {
+  it('hides the model optimistically — status flips to absent before the sidecar delete resolves', () => {
+    useNativeModelStore.setState({ statuses: { m: 'ready' } });
+    // Fire and DO NOT await: the optimistic flip must be visible synchronously,
+    // before the (slow) sidecar WS round-trip + disk rm completes.
+    void useNativeModelStore.getState().deleteModel('m');
+    expect(useNativeModelStore.getState().statuses['m']).toBe('absent');
+  });
+
+  it('still ends absent after the delete round-trip completes', async () => {
+    useNativeModelStore.setState({ statuses: { m: 'ready' } });
+    await useNativeModelStore.getState().deleteModel('m');
+    expect(useNativeModelStore.getState().statuses['m']).toBe('absent');
   });
 });
 

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -9,6 +9,7 @@ interface NativeModelStore {
   statuses: Record<string, NativeModelStatus>;
   progress: Record<string, { downloaded: number; total: number }>;
   sizes: Record<string, number>;
+  errors: Record<string, string>;
   /** Remembered selection per language pair, keyed `${src}→${tgt}` (mirrors modelStore.modelPreferences). */
   modelPreferences: Record<string, NativeSelection>;
   /** Per-machine model catalog from the sidecar (languages, recommended, tier availability). */
@@ -62,6 +63,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
   statuses: {},
   progress: {},
   sizes: {},
+  errors: {},
   catalog: {},
   modelPreferences: {},
   asrLoading: false,
@@ -100,15 +102,22 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
     set((s) => ({
       statuses: { ...s.statuses, [model]: 'downloading' },
       progress: { ...s.progress, [model]: { downloaded: 0, total: 0 } },
+      errors: { ...s.errors, [model]: '' },
     }));
     try {
       const status = await client.download(model, (p) =>
         set((s) => ({ progress: { ...s.progress, [model]: { downloaded: p.downloaded, total: p.total } } })));
       // 'cancelled' (or a partial fetch) leaves the model incomplete → absent.
-      set((s) => ({ statuses: { ...s.statuses, [model]: status === 'ready' ? 'ready' : 'absent' } }));
+      set((s) => ({
+        statuses: { ...s.statuses, [model]: status === 'ready' ? 'ready' : 'absent' },
+        errors: { ...s.errors, [model]: '' },
+      }));
       if (status === 'ready') await revalidateNativeProvider();
-    } catch {
-      set((s) => ({ statuses: { ...s.statuses, [model]: 'absent' } }));
+    } catch (err) {
+      set((s) => ({
+        statuses: { ...s.statuses, [model]: 'absent' },
+        errors: { ...s.errors, [model]: err instanceof Error ? err.message : String(err) },
+      }));
     }
   },
 
@@ -162,6 +171,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
 export const useNativeModelStatuses = () => useNativeModelStore((s) => s.statuses);
 export const useNativeModelProgress = () => useNativeModelStore((s) => s.progress);
 export const useNativeModelSizes = () => useNativeModelStore((s) => s.sizes);
+export const useNativeModelErrors = () => useNativeModelStore((s) => s.errors);
 export const useNativeCatalog = () => useNativeModelStore((s) => s.catalog);
 export const useNativeAsrLoading = () => useNativeModelStore((s) => s.asrLoading);
 export const useNativeAsrResolved = () => useNativeModelStore((s) => s.asrResolved);

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { NativeModelClient } from '../lib/local-inference/native/NativeModelClient';
 import type { NativeModelState, NativeModelInfo } from '../lib/local-inference/native/nativeProtocol';
-import { autoSelectNative, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
+import { autoSelectNative, hardwareGated, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
 
 export type NativeModelStatus = NativeModelState | 'downloading';
 
@@ -152,8 +152,12 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
 
   autoSelect: (src, tgt, current) => {
     const statuses = get().statuses;
+    const catalog = get().catalog;
     const isDownloaded = (id: string | null) => id === null || statuses[id] === 'ready';
-    const updates = autoSelectNative(src, tgt, current, isDownloaded, get().recallModels(src, tgt));
+    // A GPU-only model on a CPU-only machine is hardware-gated — never auto-select it
+    // (it would pass readiness but fail at Start with NoUsablePlan).
+    const isHardwareGated = (id: string | null) => id !== null && hardwareGated(catalog[id]);
+    const updates = autoSelectNative(src, tgt, current, isDownloaded, get().recallModels(src, tgt), isHardwareGated);
     const final: NativeSelection = {
       asrModel: updates?.asrModel ?? current.asrModel,
       translationModel: updates?.translationModel ?? current.translationModel,

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -120,12 +120,16 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
   },
 
   deleteModel: async (model) => {
+    // Optimistic: hide the model immediately. The sidecar delete is a WS round-trip
+    // + an rm of a multi-GB dir, so awaiting it first would freeze the card on
+    // "Downloaded" for a noticeable beat (mirrors download()'s optimistic 'downloading').
+    set((s) => ({ statuses: { ...s.statuses, [model]: 'absent' } }));
     try {
       await client.delete(model);
     } catch {
-      // sidecar refused/unavailable — fall through and reflect best-effort state
+      // sidecar refused/unavailable — keep the best-effort 'absent' (the model is
+      // hidden either way; readiness re-checks against the real cache on next refresh).
     }
-    set((s) => ({ statuses: { ...s.statuses, [model]: 'absent' } }));
     await revalidateNativeProvider();
   },
 


### PR DESCRIPTION
## Cohere Transcribe — native GPU ASR

Adds **Cohere Transcribe** as a native (Electron Python-sidecar) ASR backend — the GPU/full-precision counterpart to the existing in-browser (LOCAL_INFERENCE WebGPU) Cohere model.

- **Backend `cohere_transformers`** — `CohereAsrForConditionalGeneration` (HF transformers), GPU **bf16** via `.to(device)` (no accelerate), mirroring the shipped `Qwen3AsrBackend`. Coexists with Granite + Qwen3 on transformers 5.13. 14 languages, `recommended`, sorted first.
- **Non-gated source.** Sources `AEmotionStudio/cohere-transcribe-03-2026-models` — a non-gated re-upload of the gated `CohereLabs/…` weights, verified **byte-identical** (all **2152 tensors** SHA256-matched, config identical, loads with the native class — no `trust_remote_code`). Downloads with **no HF_TOKEN** → browser parity, no per-user auth.
- **`librosa`** added to the sidecar deps (the Cohere feature extractor requires it; the backend crashed without it).
- **Perf:** ~**100–154× realtime** (RTF ~0.006–0.010), ~80 ms/utterance, 4.17 GB VRAM on an RTX 4070 SUPER (CUDA-event timed on real clips).

## Download/delete UX fixes (native model management)

- **Optimistic delete** — the card hides immediately instead of after the multi-GB `rm` round-trip.
- **Surface download errors** on the card instead of a silent revert-to-absent.
- **Single-flight `connect()`** — fixes a cold-start race: while the sidecar boots, three mount calls + the download click each opened a duplicate WebSocket, and an orphan closing rejected the in-flight download (the "first-click flicker"). They now share one connection.

## Investigated + rejected: an onnxruntime-GPU "Plan B"

The non-gated `onnx-community` ONNX export runs its encoder on CUDA but its decoder's `GroupQueryAttention` op is rejected by the onnxruntime-CUDA kernel (it doesn't accept the `position_ids` the transformers.js-style export feeds it) → decoder is CPU-only (~7× hybrid vs the transformers path's ~100×). The non-gated *transformers* mirror made B unnecessary. Documented in the spec.

## Tests
- sidecar `pytest`: **104 passed** / 13 skipped (GPU-gated)
- renderer `vitest`: **131 passed**
- `npm run build`: clean

Design + plan: `docs/superpowers/specs/2026-06-24-native-asr-cohere-design.md`, `docs/superpowers/plans/2026-06-24-native-asr-cohere.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PP2rFdyAapsyYBZTG87yud


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Cohere Transcribe—a new native GPU-accelerated speech-to-text model available as the recommended option in the ASR selection
  * Per-model error messages now display in the native model management interface

* **Improvements**
  * Enhanced connection stability when establishing communication with the native sidecar backend
  * Improved user experience with optimistic model status updates during downloads and deletions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->