### PR TITLE
feat(native): Voxtral Mini 4B Realtime sidecar ASR — offline + streaming + pause-driven segmentation

### DIFF
--- a/docs/superpowers/plans/2026-06-25-voxtral-always-stream.md
+++ b/docs/superpowers/plans/2026-06-25-voxtral-always-stream.md
@@ -1,0 +1,532 @@
+# Voxtral Realtime Always-Stream (option d) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rework the Voxtral Realtime streaming engine to feed audio **continuously** (no VAD input-gating → no leading-word loss) and segment the **output** into per-sentence finals by the model's punctuation, with backpressure-driven degradation to Phase 2's per-utterance mode on hardware that can't keep up.
+
+**Architecture:** The engine gains a `_mode` (`"always_stream"` default | `"per_utterance"` fallback). Always-stream opens one long-lived `VoxtralRealtimeStream` up front, feeds every buffer, runs VAD only for state (speech-start cue, long-silence restart), drains tokens into a `_pending` buffer, and cuts `result`s on sentence-final punctuation (`split_sentences`). A growing input backlog flips `_mode` to per-utterance (the kept-as-is Phase 2 `_drive`). Reuses Phase 2's `VoxtralRealtimeStream`, transport, wire, and renderer unchanged.
+
+**Tech Stack:** Python sidecar (transformers 5.13 fork, torch cu128, threading + asyncio, silero VAD), pytest; no renderer changes.
+
+## Spike findings (verified live on the RTX 4070 — build on these)
+
+- **Feasibility:** continuous feed transcribes the first word correctly (no leading loss); one long-lived `generate` ran the whole clip with VRAM 8.86→9.05 GB (bounded); silence → empty (`''`) tokens, no hallucination; the model **batches** output (holds an utterance's tail ~3 s through a pause), so **sentence punctuation — not VAD timing — is the reliable cut signal**.
+- **Backpressure:** at 1× mic the input backlog sits flat at **~0.56 s** (model delay); the 4070 keeps up to **~2.5× over-feed**; past the ceiling the backlog grows **~2.4 s/wall-s, crossing 3 s in ~1 s**, then drains as fast once input slows. So healthy (0.56 s) vs overloaded (runaway) is cleanly separable at a **~3 s** lag threshold.
+- **`split_sentences` is verified** (see Task 1): `'x. Ask'`→`(['x.'],'Ask')`, `'3.5 ml '`→`([],...)` (decimal not split), `'country.'`→`([],...)` (held for the long-silence flush).
+
+## Global Constraints
+
+- **Continuous input, no VAD gating** in always-stream mode: every audio buffer is fed to the current stream.
+- **Finals cut on sentence-final punctuation** — `. ` / `! ` / `? ` (punctuation + whitespace; the trailing space avoids decimals like `3.5`), via `split_sentences`.
+- **VAD = state only** in always-stream: a speech-start `speech_start` cue (rising edge) + the long-silence trigger. It does NOT gate the input.
+- **Long silence (≥ 2.5 s)** → flush any pending un-punctuated text as a `result`, then restart the stream (`abort()` + `open_stream()`), bounding context/VRAM.
+- **Long-speech safety net:** if continuous speech runs > ~4 min with no long pause, restart at the next sentence boundary (pending empty).
+- **Backpressure:** track lag = `_fed_s − _delta_count*0.08`; healthy ~0.56 s; if **lag > 3.0 s**, degrade `_mode` to `"per_utterance"` for the rest of the session (flush pending, drop the always-stream, let the kept Phase 2 `_drive` run).
+- **Reuse unchanged:** `VoxtralRealtimeStream` (`feed`/`drain`/`end`/`abort`/`open_stream`), the transport (`run_stream` task, `feed_stream`, `_h_asr_init`, close-abort), the `partial`/`result` wire events, the renderer. **Phase 2's `_drive` is KEPT (renamed `_drive_utterance`) as the per-utterance fallback** — not deleted.
+- **`result` shape reused:** `{type:'result', text, startSample, durationMs, recognitionTimeMs}` — `startSample`/`durationMs`/`recognitionTimeMs` are approximate in always-stream mode.
+- **Hardware envelope:** sustained RTF < 1, VRAM ≥ ~9 GB (documented, not enforced beyond backpressure).
+- **Tests:** sidecar `cd sidecar && .venv/bin/python -m pytest`. GPU tests gated on `SOKUJI_RUN_GPU`. English-only comments. No renderer changes.
+
+---
+
+### Task 1: `split_sentences` helper
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/voxtral_stream.py` (add the module-level helper)
+- Test: `sidecar/tests/test_voxtral_stream.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `split_sentences(buffer: str) -> tuple[list[str], str]` — completed sentences (each ending `.!?`+whitespace, stripped) + the trailing remainder. Task 2 imports it into the engine.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_voxtral_stream.py`:
+
+```python
+def test_split_sentences():
+    from sokuji_sidecar.voxtral_stream import split_sentences
+    assert split_sentences("Ask what you do. Ask not ") == (["Ask what you do."], "Ask not ")
+    assert split_sentences("hello wor") == ([], "hello wor")
+    assert split_sentences("x. Ask") == (["x."], "Ask")          # delta straddling a boundary
+    assert split_sentences("3.5 ml ") == ([], "3.5 ml ")         # decimal NOT split (no space after .)
+    assert split_sentences("country.") == ([], "country.")       # no trailing space -> held for flush
+    assert split_sentences("a. b! c? d") == (["a.", "b!", "c?"], "d")
+    assert split_sentences("") == ([], "")
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_voxtral_stream.py -k split_sentences -v`
+Expected: FAIL — `ImportError: cannot import name 'split_sentences'`.
+
+- [ ] **Step 3: Implement the helper**
+
+In `sidecar/sokuji_sidecar/voxtral_stream.py`, add at module level (after the imports, before the class):
+
+```python
+import re
+
+_SENT_END = re.compile(r"(.*?[.!?])\s")
+
+
+def split_sentences(buffer):
+    """Cut `buffer` into completed sentences (each ending in . ! ? followed by whitespace)
+    and the trailing remainder. 'Ask what you do. Ask not ' -> (['Ask what you do.'],
+    'Ask not '). No sentence end -> ([], buffer). Decimals ('3.5') don't split (the
+    required trailing whitespace isn't there). A sentence with no trailing space yet is
+    held in the remainder until the next delta brings the space (or the long-silence flush
+    commits it)."""
+    out = []
+    while True:
+        m = _SENT_END.match(buffer)
+        if not m:
+            return out, buffer
+        out.append(m.group(1).strip())
+        buffer = buffer[m.end():]
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_voxtral_stream.py -k split_sentences -v`
+Expected: PASS. Then the full file: `cd sidecar && .venv/bin/python -m pytest tests/test_voxtral_stream.py -v` → PASS (no regression).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/voxtral_stream.py sidecar/tests/test_voxtral_stream.py
+git commit -m "feat(sidecar): split_sentences helper (punctuation-based output segmentation)"
+```
+
+---
+
+### Task 2: Always-stream engine path (default mode) + keep per-utterance as fallback
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/asr_engine.py` (rename `_drive`→`_drive_utterance`; add `_vad_state`, `_drive_always`, `_flush_and_restart`, `_result_event`; rework `init_streaming`, `run_stream`, `_drive_once`)
+- Test: `sidecar/tests/test_asr_engine.py` (migrate the Phase 2 streaming test to per-utterance mode; add the always-stream unit test)
+
+**Interfaces:**
+- Consumes: `split_sentences` (Task 1); `VoxtralRealtimeStream` via `self._backend.open_stream()` with `feed`/`drain`/`abort`; the existing `_init_vad`, `_vad`/`_window`/`_buf`, `_downsample_int16_to_f32_16k`, `TARGET_RATE`, `_resolve_streaming_backend`.
+- Produces: `AsrEngine._mode` (`"always_stream"`|`"per_utterance"`), `_drive_always(send, int16_bytes)`, `_drive_utterance(send, int16_bytes)` (the old `_drive`), `_vad_state(samples) -> (had_speech, rising)`, `_flush_and_restart(send)`, `_result_event(text) -> dict`. Task 3 adds backpressure inside `_drive_always`; Task 4 drives this on a GPU.
+
+- [ ] **Step 1: Write the failing tests (migrate the per-utterance test; add the always-stream test)**
+
+In `sidecar/tests/test_asr_engine.py`:
+
+(a) The existing `test_streaming_emits_speech_start_partials_result` exercises the per-utterance path. Make it set per-utterance mode explicitly. Change its engine setup so that after building `eng`, it sets `eng._mode = "per_utterance"` before driving. Concretely, in that test add `eng._mode = "per_utterance"` immediately after `eng.init_streaming(...)` (or after the engine is constructed in the test), and keep the rest. (If the test constructs the engine via a helper, set the attribute on the returned engine.)
+
+(b) Append the always-stream unit test:
+
+```python
+def test_always_stream_feeds_all_and_cuts_on_punctuation(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+
+    fed = {"n": 0}
+    pending = {"deltas": []}
+
+    class _FakeStream:
+        def feed(self, samples): fed["n"] += len(samples)
+        def drain(self):
+            out, pending["deltas"] = pending["deltas"], []
+            return out
+        def abort(self): pass
+        def end(self): return ""
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"
+    eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: _FakeStream()})()
+    eng._pending = ""; eng._utt_text = ""
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = 0; eng._stream_speech_samples = 0
+    # VAD stub: speech present, no rising edge, never long-silence
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+
+    sent = []
+    async def send(m): sent.append(m)
+    buf = (b"\x00\x00" * 1600)        # one 100ms buffer (1600 int16 samples)
+
+    # 1) a delta with no sentence end -> partial only, no result
+    pending["deltas"] = ["Ask not "]
+    asyncio.run(eng._drive_always(send, buf))
+    assert fed["n"] == 1600                          # the buffer was fed (not gated)
+    assert sent[-1] == {"type": "partial", "text": "Ask not"}
+    assert not any(m["type"] == "result" for m in sent)
+
+    # 2) a delta completing the sentence -> result + the remainder becomes the new partial
+    pending["deltas"] = ["what you do. Ask "]
+    asyncio.run(eng._drive_always(send, buf))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"] == "Ask not what you do."
+    assert sent[-1] == {"type": "partial", "text": "Ask"}
+
+
+def test_always_stream_long_silence_flushes_and_restarts(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, samples): pass
+        def drain(self): return []
+        def abort(self): pass
+        def end(self): return ""
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = ""; eng._utt_text = "trailing words"   # un-punctuated pending
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = int(2.5 * 16000)              # already at the long-silence threshold
+    eng._stream_speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False))   # silence
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"] == "trailing words"   # un-punctuated text flushed
+    assert opened["n"] == 1                                       # stream restarted
+    assert eng._utt_text == "" and eng._pending == ""            # reset
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k "always_stream or emits_speech_start" -v`
+Expected: FAIL — `_drive_always` / `_vad_state` not defined; the migrated per-utterance test fails until `_mode` is honored.
+
+- [ ] **Step 3: Implement the always-stream path**
+
+In `sidecar/sokuji_sidecar/asr_engine.py`:
+
+(a) Add the `split_sentences` import at the top (with the other module imports): `from .voxtral_stream import split_sentences` — but import it lazily inside `_drive_always` to avoid importing torch at module load. Use `from .voxtral_stream import split_sentences` inside the method.
+
+(b) **Rename** `_drive` → `_drive_utterance` (keep the body byte-for-byte; only the `def` name changes).
+
+(c) Rework `init_streaming` to open the stream up front + initialize always-stream state + default mode. Replace the body after `self._language = language or None` with:
+
+```python
+        self._audio_q = _queue.Queue()
+        self._mode = "always_stream"
+        self._stream = self._backend.open_stream()   # always-stream: one long-lived session
+        self._pending = ""           # un-segmented text accumulated from drain()
+        self._utt_text = ""          # current sentence (the partial)
+        self._partial_acc = []       # per-utterance fallback accumulator
+        self._utt_start_sample = 0
+        self._sample_cursor = 0
+        self._utt_samples = 0        # per-utterance fallback (20s cap)
+        self._silence_samples = 0    # consecutive silence (always-stream restart)
+        self._stream_speech_samples = 0   # speech since last restart (4min safety)
+        self._fed_s = 0.0            # audio seconds fed (backpressure, Task 3)
+        self._delta_count = 0        # tokens drained (backpressure, Task 3)
+        self._stop = False
+```
+
+(d) Make `run_stream` and `_drive_once` dispatch by mode. Replace `await self._drive(send, data)` in `run_stream` with:
+
+```python
+            if self._mode == "always_stream":
+                await self._drive_always(send, data)
+            else:
+                await self._drive_utterance(send, data)
+```
+and replace `run_stream`'s tail (`if self._stream is not None: await self._finalize(send)`) with:
+
+```python
+        if self._mode == "always_stream":
+            if self._utt_text:
+                await send(self._result_event(self._utt_text))
+        elif self._stream is not None:
+            await self._finalize(send)
+```
+and in `_drive_once`, replace `await self._drive(...)` with the same mode dispatch:
+
+```python
+    async def _drive_once(self, send):
+        """Test seam: drive exactly the buffers currently queued, once."""
+        while not self._audio_q.empty():
+            data = self._audio_q.get_nowait()
+            if self._mode == "always_stream":
+                await self._drive_always(send, data)
+            else:
+                await self._drive_utterance(send, data)
+```
+
+(e) Add the new methods (after `_drive_utterance`):
+
+```python
+    def _vad_state(self, samples):
+        """Run silero VAD over `samples` for STATE only (always-stream): return
+        (had_speech, rising_edge). Unlike _vad_events it does not gate input or emit
+        per-utterance start/speech/end."""
+        had_speech = False
+        rising = False
+        self._buf = np.concatenate([self._buf, samples])
+        while len(self._buf) >= self._window:
+            was = self._vad.is_speech_detected()
+            self._vad.accept_waveform(self._buf[:self._window])
+            self._buf = self._buf[self._window:]
+            now = self._vad.is_speech_detected()
+            if now:
+                had_speech = True
+            if not was and now:
+                rising = True
+        return had_speech, rising
+
+    def _result_event(self, text):
+        """A `result` envelope. startSample/durationMs are approximate in always-stream."""
+        return {"type": "result", "text": text.strip(),
+                "startSample": int(self._utt_start_sample),
+                "durationMs": int(self._sample_cursor / TARGET_RATE * 1000),
+                "recognitionTimeMs": 0}
+
+    async def _flush_and_restart(self, send):
+        """Flush any un-punctuated pending text as a final, then restart the stream
+        (abort + reopen) — bounds context/VRAM and recovers cleanly during silence."""
+        if self._utt_text:
+            await send(self._result_event(self._utt_text))
+        try:
+            self._stream.abort()
+        except Exception:
+            pass
+        self._stream = self._backend.open_stream()
+        self._pending = ""
+        self._utt_text = ""
+        self._silence_samples = 0
+        self._stream_speech_samples = 0
+
+    async def _drive_always(self, send, int16_bytes):
+        """Always-stream: feed every buffer (no gating); VAD only for the speech-start cue
+        + the long-silence restart; drain -> accumulate -> cut finals on sentence punctuation."""
+        from .voxtral_stream import split_sentences
+        samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
+        self._sample_cursor += len(samples)
+        self._fed_s += len(samples) / TARGET_RATE
+        self._stream.feed(samples)                       # continuous, never gated
+        try:
+            had_speech, rising = self._vad_state(samples)
+        except Exception:                                # VAD failure -> degrade gracefully
+            had_speech, rising = True, False             # assume speech; punctuation finals still work
+        if rising:
+            await send({"type": "speech_start"})
+        if had_speech:
+            self._silence_samples = 0
+            self._stream_speech_samples += len(samples)
+        else:
+            self._silence_samples += len(samples)
+        deltas = self._stream.drain()
+        self._delta_count += len(deltas)
+        if deltas:
+            self._pending += "".join(deltas)
+            sentences, remainder = split_sentences(self._pending)
+            for s in sentences:
+                await send(self._result_event(s))
+            self._pending = remainder
+            self._utt_text = remainder.strip()
+            await send({"type": "partial", "text": self._utt_text})
+        if getattr(self._stream, "aborted", False):      # generate died -> self-heal: flush + restart
+            await self._flush_and_restart(send)
+            return
+        if self._silence_samples >= int(2.5 * TARGET_RATE):
+            await self._flush_and_restart(send)
+        elif self._stream_speech_samples >= 4 * 60 * TARGET_RATE and not self._pending:
+            await self._flush_and_restart(send)
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k "always_stream or emits_speech_start" -v`
+Expected: PASS (the 2 always-stream tests + the migrated per-utterance test). Then the FULL `tests/test_asr_engine.py` → PASS (offline + transport tests unaffected; the GPU e2e test is updated in Task 4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/asr_engine.py sidecar/tests/test_asr_engine.py
+git commit -m "feat(sidecar): always-stream engine (continuous feed, punctuation finals, restart-on-silence); keep per-utterance as fallback"
+```
+
+---
+
+### Task 3: Backpressure → degrade to per-utterance
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/asr_engine.py` (`_drive_always`: lag check + degrade)
+- Test: `sidecar/tests/test_asr_engine.py`
+
+**Interfaces:**
+- Consumes: `_drive_always`, `_fed_s`, `_delta_count`, `_mode`, `_result_event` (Task 2).
+- Produces: when `lag = _fed_s − _delta_count*0.08 > 3.0`, `_mode` flips to `"per_utterance"`, the always-stream session is dropped, and pending text is flushed.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_asr_engine.py`:
+
+```python
+def test_backpressure_degrades_to_per_utterance(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+
+    class _SlowStream:      # never emits deltas -> processed audio stays 0 -> lag grows
+        def feed(self, samples): pass
+        def drain(self): return []
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _SlowStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: _SlowStream()})()
+    eng._pending = ""; eng._utt_text = "held text"
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = 0; eng._stream_speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+
+    sent = []
+    async def send(m): sent.append(m)
+    buf = b"\x00\x00" * 16000     # 1s of audio per call
+    # feed ~4s of audio with no deltas -> lag exceeds 3.0 -> degrade
+    for _ in range(4):
+        asyncio.run(eng._drive_always(send, buf))
+    assert eng._mode == "per_utterance"                     # degraded
+    assert eng._stream is None                              # always-stream session dropped
+    assert any(m["type"] == "result" and m["text"] == "held text" for m in sent)  # pending flushed
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k backpressure -v`
+Expected: FAIL — `_mode` stays `"always_stream"` (no lag check yet).
+
+- [ ] **Step 3: Add the lag check to `_drive_always`**
+
+In `_drive_always`, insert a backpressure check at the END of the method (after the silence/safety-restart block):
+
+```python
+        lag = self._fed_s - self._delta_count * 0.08          # ~0.56s healthy; >3s = can't keep up
+        if self._mode == "always_stream" and lag > 3.0:
+            if self._utt_text:
+                await send(self._result_event(self._utt_text))
+            try:
+                self._stream.abort()
+            except Exception:
+                pass
+            self._stream = None                               # per-utterance opens on next VAD start
+            self._mode = "per_utterance"
+            self._pending = ""
+            self._utt_text = ""
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k "backpressure or always_stream" -v`
+Expected: PASS (degrade test + the Task 2 always-stream tests still pass — their fakes emit deltas so lag stays low). Then full `tests/test_asr_engine.py` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/asr_engine.py sidecar/tests/test_asr_engine.py
+git commit -m "feat(sidecar): backpressure degrades always-stream to per-utterance when the GPU falls behind"
+```
+
+---
+
+### Task 4: GPU smoke (always-stream end-to-end)
+
+**Files:**
+- Test: `sidecar/tests/test_asr_engine.py` (update the gated `test_streaming_end_to_end_real_gpu` to assert always-stream behavior)
+
+**Interfaces:**
+- Consumes: the full always-stream path (Tasks 1-3) + a real GPU + the cached model + the `benchmark/test-speech-silence-speech.wav` clip.
+- Produces: a gated test proving no leading loss, sentence finals, a restart at the long silence, VRAM bounded.
+
+- [ ] **Step 1: Update the gated end-to-end test**
+
+Replace the body of `test_streaming_end_to_end_real_gpu` in `sidecar/tests/test_asr_engine.py` with the always-stream flow (paced concurrent feeder; the `speech-silence-speech` clip is 24 kHz, so `init_streaming(sample_rate=24000)` and the engine downsamples):
+
+```python
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (uses cached Voxtral-Mini-4B-Realtime; needs CUDA)")
+def test_streaming_end_to_end_real_gpu():
+    import wave, asyncio, glob
+    from huggingface_hub import snapshot_download
+    snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                      ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    wav = os.path.join(root, "benchmark", "test-speech-silence-speech.wav")
+    if not os.path.exists(wav):
+        wav = glob.glob(os.path.expanduser(
+            "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
+    w = wave.open(wav)
+    sr = w.getframerate()
+    pcm = w.readframes(w.getnframes())
+    eng = AsrEngine()
+    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en", sample_rate=sr, device="cuda")
+    opens = {"n": 0}
+    _orig = eng._backend.open_stream
+    eng._backend.open_stream = lambda: (opens.__setitem__("n", opens["n"] + 1) or _orig())
+    sent = []
+    async def send(m): sent.append(m)
+    step = int(0.1 * sr) * 2     # 100ms of int16 bytes
+    async def feeder():
+        for i in range(0, len(pcm), step):
+            eng.feed_stream(pcm[i:i + step])
+            await asyncio.sleep(0.1)
+        eng.feed_stream(None)
+    async def drive():
+        await asyncio.gather(feeder(), eng.run_stream(send))
+    asyncio.run(drive())
+    results = [m["text"] for m in sent if m["type"] == "result"]
+    full = " ".join(results).lower()
+    assert results, "no finals produced"
+    assert "ask" in full and "country" in full, f"unexpected: {results!r}"   # first word present, no leading loss
+    print(f"always-stream e2e: {len([m for m in sent if m['type']=='partial'])} partials, "
+          f"{len(results)} finals, restarts(open_stream calls)={opens['n']}")
+    eng.close()
+```
+
+- [ ] **Step 2: Verify it skips without the flag**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming_end_to_end -v` → `1 skipped`.
+
+- [ ] **Step 3: Run it on the 4070 (model cached)**
+
+Run: `cd sidecar && SOKUJI_RUN_GPU=1 .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming_end_to_end -v -s`
+Expected: PASS — prints partial/final counts + restart count; the finals contain "ask"/"country" (the first word is present — the leading-loss fix). The 2 s mid-clip silence should trigger ≥1 restart (`open_stream` called >1).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sidecar/tests/test_asr_engine.py
+git commit -m "test(sidecar): always-stream end-to-end GPU smoke (no leading loss, sentence finals, restart-on-silence)"
+```
+
+---
+
+### Task 5: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full sidecar pytest**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: PASS (GPU-gated tests skip without their flag).
+
+- [ ] **Step 2: Renderer vitest (unchanged contract — confirm no break)**
+
+Run: `npm run test -- src/lib/local-inference/native/ src/services/clients/LocalNativeClient.test.ts`
+Expected: PASS (the `partial`/`result` contract is unchanged, so these stay green).
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit only if Steps 1-3 surfaced fixes**
+
+If a fix was needed: `git add -A && git commit -m "test(native): green always-stream suites"`. Otherwise nothing to commit — skip.

--- a/docs/superpowers/plans/2026-06-25-voxtral-pause-segmentation.md
+++ b/docs/superpowers/plans/2026-06-25-voxtral-pause-segmentation.md
@@ -1,0 +1,417 @@
+# Voxtral Pause-Driven Segmentation (Plan A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cut ASR finals on silero's speech→silence endpoint (governed by the user's Min Silence Duration slider) via `end()`+reopen — flushing the complete held tail so the last word lands at the pause, and making the slider the live pause control.
+
+**Architecture:** Rework the just-landed `_drive_always`: drop the hardcoded `_silence_samples`/2.5 s counter and the `split_sentences` punctuation cut; cut on the silero endpoint (new `falling` edge from `_vad_state`) by calling `end()` (the only flush that commits the last token) and reopening a fresh stream. The asyncio audio queue is the during-`end()` buffer (serial, no leading loss). Keep a 20 s run-on cap + a min-utterance guard. The `_drive_utterance` fallback, backpressure degrade, transport, wire, and renderer are unchanged.
+
+**Tech Stack:** Python sidecar (transformers 5.13 fork, threading + asyncio, sherpa-onnx silero VAD), pytest; no renderer changes.
+
+## Spike findings (verified live — build on these)
+
+- **Soft-flush is insufficient:** feeding `_right_pad` silence mid-stream WITHOUT ending flushed most of a held tail but **kept holding the last word** until real new audio arrived. A non-terminating generate always holds the final token. **Only `end()` (terminates the generate) yields a complete final.**
+- **`end()` returns the complete transcript** including the held tail (proven; `VoxtralRealtimeStream.end()`).
+- **VAD chain is fully plumbed** to silero (`vadMinSilenceDuration` default 1.4 s) but `_drive_always` ignores silero's endpoint and uses a hardcoded 2.5 s counter — so the slider is masked. This plan makes the endpoint the trigger.
+
+## Global Constraints
+
+- **Cut on silero's endpoint**, not a constant: `_vad_state` reports a `falling` edge (`is_speech_detected()` True→False), governed by the user's `vadMinSilenceDuration`. Remove `_silence_samples`, the `2.5 * TARGET_RATE` cut, the 4-min safety, and the `split_sentences` punctuation cut from `_drive_always`.
+- **Pause-cut = `end()` + reopen.** `final = await loop.run_in_executor(None, self._stream.end)`; emit `final` as the `result` (the complete tail); `self._stream = self._backend.open_stream()`; reset per-stream state. The result text is **`end()`'s return**, not `_pending` (which lacks the tail).
+- **Min-utterance guard:** only cut when `self._pending.strip()` is non-empty.
+- **Run-on cap:** `self._speech_samples >= 20 * TARGET_RATE` (20 s of speech with no endpoint) forces an `end()`+reopen. A bound, not a knob.
+- **Per-stream backpressure counters:** `_end_and_reopen` and the aborted self-heal reset `_fed_s = 0.0` and `_delta_count = 0` (each utterance is a fresh stream; `end()`-flushed tokens aren't counted, so the lag must measure the current stream only).
+- **Unchanged:** `_drive_utterance` (per-utterance fallback) + `_vad_events`; the backpressure degrade (lag > 3 s → per-utterance); `run_stream`/`feed_stream`/`_drive_once` mode dispatch; the offline path; the `partial`/`result` wire shape; the renderer; the VAD plumbing. Default `vadMinSilenceDuration` stays 1.4 s.
+- **Tests:** `cd sidecar && .venv/bin/python -m pytest`. GPU tests gated on `SOKUJI_RUN_GPU`. English-only comments.
+
+---
+
+### Task 1: `_vad_state` reports the falling edge
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/asr_engine.py` (`_vad_state`, ~line 283)
+- Test: `sidecar/tests/test_asr_engine.py`
+
+**Interfaces:**
+- Produces: `_vad_state(samples) -> (had_speech: bool, rising: bool, falling: bool)` — `falling` is True if `is_speech_detected()` went True→False on any window in this buffer (silero's endpoint). Task 2 cuts on `falling`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_asr_engine.py`:
+
+```python
+def test_vad_state_reports_rising_and_falling_edges():
+    import numpy as np
+    from sokuji_sidecar.asr_engine import AsrEngine
+
+    class _FakeVad:
+        """is_speech_detected() returns the current state; accept_waveform() advances it
+        through `after` (the state AFTER each window)."""
+        def __init__(self, start, after):
+            self._cur = start
+            self._after = list(after)
+            self._k = 0
+        def is_speech_detected(self):
+            return self._cur
+        def accept_waveform(self, w):
+            self._cur = self._after[self._k]
+            self._k += 1
+
+    # falling: start speaking, one window flips to silence
+    eng = AsrEngine()
+    eng._vad = _FakeVad(start=True, after=[False])
+    eng._window = 100
+    eng._buf = np.zeros(0, np.float32)
+    had, rising, falling = eng._vad_state(np.zeros(100, np.float32))
+    assert (had, rising, falling) == (False, False, True)
+
+    # rising: start silent, one window flips to speech
+    eng2 = AsrEngine()
+    eng2._vad = _FakeVad(start=False, after=[True])
+    eng2._window = 100
+    eng2._buf = np.zeros(0, np.float32)
+    had2, rising2, falling2 = eng2._vad_state(np.zeros(100, np.float32))
+    assert (had2, rising2, falling2) == (True, True, False)
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k vad_state_reports -v`
+Expected: FAIL — `_vad_state` returns a 2-tuple, `ValueError: not enough values to unpack`.
+
+- [ ] **Step 3: Add the falling edge**
+
+In `sidecar/sokuji_sidecar/asr_engine.py`, replace `_vad_state` with:
+
+```python
+    def _vad_state(self, samples):
+        """Run silero VAD over `samples` for STATE only (always-stream): return
+        (had_speech, rising, falling). `falling` = silero's endpoint (is_speech_detected
+        True->False this buffer), governed by the user's min_silence_duration. Does not
+        gate input."""
+        had_speech = False
+        rising = False
+        falling = False
+        self._buf = np.concatenate([self._buf, samples])
+        while len(self._buf) >= self._window:
+            was = self._vad.is_speech_detected()
+            self._vad.accept_waveform(self._buf[:self._window])
+            self._buf = self._buf[self._window:]
+            now = self._vad.is_speech_detected()
+            if now:
+                had_speech = True
+            if not was and now:
+                rising = True
+            if was and not now:
+                falling = True
+        return had_speech, rising, falling
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k vad_state_reports -v`
+Expected: PASS. (The full suite is red until Task 2 — `_drive_always` still unpacks 2 values. That's expected; Task 2 fixes it.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/asr_engine.py sidecar/tests/test_asr_engine.py
+git commit -m "feat(sidecar): _vad_state reports silero falling edge (endpoint)"
+```
+
+---
+
+### Task 2: Rework `_drive_always` to cut on the endpoint via end()+reopen
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/asr_engine.py` (`init_streaming`, `run_stream` exit, remove `_flush_and_restart`, add `_end_and_reopen`, rewrite `_drive_always`)
+- Test: `sidecar/tests/test_asr_engine.py` (replace the punctuation/long-silence tests; update the aborted + backpressure tests)
+
+**Interfaces:**
+- Consumes: `_vad_state` 3-tuple (Task 1); `VoxtralRealtimeStream` `feed`/`drain`/`end`/`abort` via `open_stream()`; `_result_event`, `_downsample_int16_to_f32_16k`, `TARGET_RATE`, `_audio_q`.
+- Produces: `_end_and_reopen(send)`; reworked `_drive_always` (cuts on `falling`/20 s cap); `init_streaming` adds `_speech_samples`, drops `_silence_samples`/`_stream_speech_samples`/`_utt_text`.
+
+- [ ] **Step 1: Replace the punctuation/long-silence tests; add endpoint/cap/guard tests; update aborted + backpressure**
+
+In `sidecar/tests/test_asr_engine.py`: DELETE `test_always_stream_feeds_all_and_cuts_on_punctuation` and `test_always_stream_long_silence_flushes_and_restarts` (their mechanisms are gone). Add:
+
+```python
+def test_always_stream_cuts_on_endpoint_with_complete_tail(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []
+        def end(self): return "country can do for you. do for your country."   # COMPLETE (tail incl.)
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = "country can do for you."          # partial: the tail is MISSING here
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint this buffer
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and "do for your country." in results[-1]["text"]   # the held tail is in the final
+    assert opened["n"] == 1                                            # reopened
+    assert eng._pending == "" and eng._fed_s == 0.0 and eng._delta_count == 0
+
+
+def test_always_stream_endpoint_with_no_text_does_not_cut(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []
+        def end(self): return ""
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = ""                                  # nothing transcribed
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint, but no text
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    assert not [m for m in sent if m["type"] == "result"]   # min-utterance guard: no cut
+    assert opened["n"] == 0
+
+
+def test_always_stream_runon_cap_forces_cut(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []
+        def end(self): return "a very long run on utterance"
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = "a very long run on"
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._speech_samples = 20 * 16000                   # already at the run-on cap
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False, False))   # speaking, no endpoint
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    assert opened["n"] == 1                            # cap forced an end()+reopen
+    assert [m for m in sent if m["type"] == "result"]
+```
+
+Then UPDATE the two existing tests that referenced removed state:
+- In `test_always_stream_aborted_self_heals`: change `eng._utt_text = "partial words"` to `eng._pending = "partial words"`, change the VAD stub to `monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False, False))`, and add `eng._speech_samples = 0; eng._fed_s = 0.0; eng._delta_count = 0` to the setup. Keep the assertions (result `"partial words"` + `opened["n"] == 1`).
+- In `test_backpressure_degrades_to_per_utterance`: change the VAD stub to `monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False, False))` and add `eng._speech_samples = 0` to the setup. Keep the assertions.
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k "endpoint or runon or aborted or backpressure" -v`
+Expected: FAIL — `_drive_always` still cuts on punctuation / `_vad_state` 2-tuple unpack / `_end_and_reopen` undefined.
+
+- [ ] **Step 3: Rework the engine**
+
+In `sidecar/sokuji_sidecar/asr_engine.py`:
+
+(a) In `init_streaming`, replace the always-stream state block (the lines from `self._pending = ""` through `self._delta_count = 0`) with:
+
+```python
+        self._pending = ""           # text drained since the last cut (the partial)
+        self._partial_acc = []       # per-utterance fallback accumulator
+        self._utt_start_sample = 0
+        self._sample_cursor = 0
+        self._utt_samples = 0        # per-utterance fallback (its own cap)
+        self._speech_samples = 0     # speech in the current stream (20s run-on cap)
+        self._fed_s = 0.0            # audio seconds fed to the current stream (backpressure)
+        self._delta_count = 0        # tokens drained from the current stream (backpressure)
+```
+
+(b) Replace the `run_stream` tail (the `if self._mode == "always_stream": / if self._utt_text: ... elif self._stream is not None: await self._finalize(send)` block) with:
+
+```python
+        if self._mode == "always_stream":
+            if self._stream is not None and self._pending.strip():
+                try:
+                    final = await loop.run_in_executor(None, self._stream.end)
+                except Exception:
+                    final = ""
+                self._stream = None
+                if final.strip():
+                    await send(self._result_event(final))
+        elif self._stream is not None:
+            await self._finalize(send)
+```
+
+(c) DELETE `_flush_and_restart` entirely.
+
+(d) Add `_end_and_reopen` (next to `_result_event`):
+
+```python
+    async def _end_and_reopen(self, send):
+        """Pause-cut: end() the stream to flush the COMPLETE held tail, emit it as the
+        result, then open a fresh stream. Audio arriving during the ~1s end() backs up in
+        _audio_q and feeds the new stream after — no leading loss. Per-stream backpressure
+        counters reset (end()'s flushed tokens aren't counted via drain())."""
+        loop = asyncio.get_running_loop()
+        try:
+            final = await loop.run_in_executor(None, self._stream.end)
+        except Exception:                                # end() failed -> drop this final, still recover
+            final = ""
+        if final.strip():
+            await send(self._result_event(final))
+        self._stream = self._backend.open_stream()
+        self._pending = ""
+        self._speech_samples = 0
+        self._fed_s = 0.0
+        self._delta_count = 0
+```
+
+(e) Replace `_drive_always` with:
+
+```python
+    async def _drive_always(self, send, int16_bytes):
+        """Always-stream: feed every buffer (no gating); cut a final on silero's endpoint
+        (the falling edge, governed by the user's min_silence_duration) — or a 20s run-on
+        cap — via end()+reopen, which flushes the COMPLETE held tail. Continuous feed means
+        no leading loss."""
+        samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
+        self._sample_cursor += len(samples)
+        self._fed_s += len(samples) / TARGET_RATE
+        self._stream.feed(samples)                       # continuous, never gated
+        try:
+            had_speech, rising, falling = self._vad_state(samples)
+        except Exception:                                # VAD failure -> assume speech, no edges
+            had_speech, rising, falling = True, False, False
+        if rising:
+            await send({"type": "speech_start"})
+        if had_speech:
+            self._speech_samples += len(samples)
+        deltas = self._stream.drain()
+        self._delta_count += len(deltas)
+        if deltas:
+            self._pending += "".join(deltas)
+            await send({"type": "partial", "text": self._pending.strip()})
+        if getattr(self._stream, "aborted", False):      # generate died -> salvage + reopen
+            if self._pending.strip():
+                await send(self._result_event(self._pending))
+            try:
+                self._stream.abort()
+            except Exception:
+                pass
+            self._stream = self._backend.open_stream()
+            self._pending = ""; self._speech_samples = 0
+            self._fed_s = 0.0; self._delta_count = 0
+            return
+        if (falling or self._speech_samples >= 20 * TARGET_RATE) and self._pending.strip():
+            await self._end_and_reopen(send)
+            return
+        lag = self._fed_s - self._delta_count * 0.08          # ~0.56s healthy; >3s = can't keep up
+        if self._mode == "always_stream" and lag > 3.0:
+            if self._pending.strip():
+                await send(self._result_event(self._pending))
+            try:
+                self._stream.abort()
+            except Exception:
+                pass
+            self._stream = None
+            self._mode = "per_utterance"
+            self._pending = ""
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k "vad_state_reports or endpoint or runon or aborted or backpressure" -v`
+Expected: PASS. Then the FULL `tests/test_asr_engine.py` → PASS (offline + transport + per-utterance fallback unaffected; the GPU e2e test is updated in Task 3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/asr_engine.py sidecar/tests/test_asr_engine.py
+git commit -m "feat(sidecar): cut always-stream finals on the silero endpoint via end()+reopen (complete tail, user-tunable pause)"
+```
+
+---
+
+### Task 3: GPU smoke — tail-hold fix
+
+**Files:**
+- Test: `sidecar/tests/test_asr_engine.py` (update `test_streaming_end_to_end_real_gpu`)
+
+**Interfaces:**
+- Consumes: the full pause-segmentation path + a real GPU + the cached model + `benchmark/test-speech-silence-speech.wav`.
+- Produces: a gated test proving the tail-hold fix (the first sentence's last word is in the first final) + no leading loss.
+
+- [ ] **Step 1: Update the assertions in the gated test**
+
+In `test_streaming_end_to_end_real_gpu` (keep the existing setup: model download, the `speech-silence-speech` clip, `init_streaming(sample_rate=sr, device="cuda")`, the paced concurrent feeder with the `None` sentinel, the `open_stream` restart counter). Replace the assertion block (`results = ...` onward) with:
+
+```python
+    results = [m["text"] for m in sent if m["type"] == "result"]
+    full = " ".join(results).lower()
+    assert results, "no finals produced"
+    # tail-hold fix: the first sentence ends with "country" and it must be IN a final,
+    # not dropped/leaked onto the next utterance.
+    assert "ask" in full and "country" in full, f"unexpected: {results!r}"
+    # endpoint segmentation: the mid-clip pause should cut at least one final mid-clip,
+    # so >1 final (not one clump) and >1 stream opened (each utterance ended at its pause).
+    print(f"pause-seg e2e: {len([m for m in sent if m['type']=='partial'])} partials, "
+          f"{len(results)} finals, stream opens={opens['n']}, finals={results!r}")
+    assert len(results) >= 2, f"expected the pause to segment into >=2 finals, got {results!r}"
+    eng.close()
+```
+
+- [ ] **Step 2: Verify it skips without the flag**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming_end_to_end -v` → `1 skipped`.
+
+- [ ] **Step 3: Commit** (the controller runs the real GPU pass separately)
+
+```bash
+git add sidecar/tests/test_asr_engine.py
+git commit -m "test(sidecar): GPU smoke asserts pause segmentation + tail-hold fix"
+```
+
+---
+
+### Task 4: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full sidecar pytest**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: PASS (GPU-gated tests skip).
+
+- [ ] **Step 2: Renderer vitest (unchanged contract)**
+
+Run: `npm run test -- src/lib/local-inference/native/ src/services/clients/LocalNativeClient.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit only if Steps 1-3 surfaced fixes**
+
+If a fix was needed: `git add -A && git commit -m "test(native): green pause-segmentation suites"`. Otherwise nothing to commit.

--- a/docs/superpowers/plans/2026-06-25-voxtral-realtime-native-sidecar-asr.md
+++ b/docs/superpowers/plans/2026-06-25-voxtral-realtime-native-sidecar-asr.md
@@ -1,0 +1,751 @@
+# Voxtral Mini 4B Realtime — Native Sidecar ASR (Phase 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `mistralai/Voxtral-Mini-4B-Realtime-2602` as a GPU ASR model in the native Python sidecar, run **offline per VAD segment** through the existing `AsrBackend` seam (a drop-in peer of Qwen3-ASR / Cohere).
+
+**Architecture:** A new `VoxtralRealtimeBackend` (transformers-native, GPU bf16) registered under the existing `@register_backend` registry; the resolver self-gates it on `transformers.models.voxtral_realtime`; one declarative `catalog.py` row; a `native_models.download_specs` branch with a new `ignore` key (to skip the 8.86 GB Mistral-format duplicate); one renderer catalog row; the `mistral-common[audio]` dep added to `setup.sh`; and a `SOKUJI_RUN_GPU`-gated real smoke test.
+
+**Tech Stack:** Python (sidecar), HuggingFace transformers `5.13.0.dev0` (the PR-#43838 fork already pinned — `voxtral_realtime` ships in it, no bump), torch cu128, `mistral-common[audio]`, sherpa-onnx silero VAD; TypeScript/Vitest (renderer); pytest (sidecar).
+
+## Global Constraints
+
+(Copied verbatim from the spec — every task implicitly includes these.)
+
+- **Model id (catalog):** `voxtral-mini-4b-realtime`. **HF repo (artifact):** `mistralai/Voxtral-Mini-4B-Realtime-2602`. **Backend NAME:** `voxtral_realtime`. **Self-gate module:** `transformers.models.voxtral_realtime`.
+- **GPU-only, bf16.** No CPU deployment. `load()` on `device == "cpu"` raises `BackendLoadError`.
+- **Languages (13, exact order):** `en, fr, es, de, ru, zh, ja, it, pt, nl, ar, hi, ko`.
+- **`recommended = False` / `recommended` unset** (Phase 1); **`sort_order = 9`** (sidecar) and **`sortOrder = 9`** (renderer) — appended after Qwen3 (8); no existing rows shift.
+- **Offline load uses the snapshot-DIR pattern**, NOT the repo-id pattern: `mistral_common` ignores `local_files_only`/`HF_HUB_OFFLINE`, so resolve `d = snapshot_download(repo, local_files_only=True)` and load the processor + model from `d`.
+- **Download skips `consolidated.safetensors`** (8.86 GB Mistral-format duplicate; transformers uses `model.safetensors`) via a new optional `ignore` key on the `download_specs` dict, honored in `download()` and `model_size()`. The key defaults to `[]` and is inert for every existing model.
+- **Dependency:** `mistral-common[audio]>=1.9.0` is required (the processor's tokenizer is `MistralCommonBackend`); added to `sidecar/setup.sh`.
+- **Transcribe is audio-only:** no chat template, no language hint (multilingual auto-detect), no prompt slicing — `batch_decode(generate(**inputs), skip_special_tokens=True)[0]`. Generation length is the model's audio-derived auto-length (do NOT pass `max_new_tokens`).
+- **TARGET_RATE = 16000** (already a module constant in `backends.py`).
+- **Correctness gates:** `pytest` (sidecar) + `vitest` (renderer), NOT `tsc`. English-only comments.
+- **Run sidecar pytest from the `sidecar/` dir** with the venv: `sidecar/.venv/bin/python -m pytest`.
+
+---
+
+### Task 1: `VoxtralRealtimeBackend` (the backend adapter)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/backends.py` (append a new `@register_backend` class after `CohereTransformersBackend`, ~line 282)
+- Test: `sidecar/tests/test_backends.py` (append fakes + tests after the Cohere tests)
+
+**Interfaces:**
+- Consumes: `backends.register_backend`, `backends.make_backend`, `backends.AsrResult`, `backends.BackendLoadError`, `backends.TARGET_RATE` (all already defined).
+- Produces: a backend registered under `NAME = "voxtral_realtime"` honoring the `load(model_ref, device, compute_type)` / `transcribe(samples, language) -> AsrResult` / `unload()` / `is_loaded` contract. Later tasks (catalog, resolver, smoke) reference the string `"voxtral_realtime"`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_backends.py`:
+
+```python
+def test_voxtral_realtime_is_gpu_only():
+    b = backends.make_backend("voxtral_realtime")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cpu", "bfloat16")
+
+
+def _install_fake_voxtral(monkeypatch, *, decoded="  hello world  ", fail=False):
+    cap = {}
+
+    class FakeFeat:
+        def to(self, dtype):
+            cap["feat_dtype"] = dtype
+            return self
+
+    class FakeBatch(dict):
+        def to(self, device):
+            cap["inp_device"] = device
+            return self
+
+    class FakeProc:
+        # Voxtral realtime processor: positional audio + sampling_rate + return_tensors.
+        # No language (multilingual auto-detect), no chat template. If the backend ever
+        # passed language=, this signature would TypeError — guarding that contract.
+        def __call__(self, samples, sampling_rate, return_tensors):
+            cap["sr"] = sampling_rate
+            cap["n_samples"] = len(samples)
+            b = FakeBatch()
+            b["input_features"] = FakeFeat()
+            b["input_ids"] = "IDS"
+            return b
+
+        def batch_decode(self, seq, skip_special_tokens):
+            cap["decoded_seq"] = seq
+            cap["skip_special"] = skip_special_tokens
+            return [decoded]
+
+    class FakeModel:
+        def to(self, device):
+            cap["model_device"] = device
+            return self
+
+        def eval(self):
+            return self
+
+        def generate(self, **kw):
+            cap["gen_kw"] = kw
+            return "OUT"
+
+    class FakeAutoProcessor:
+        @staticmethod
+        def from_pretrained(path, local_files_only=False):
+            cap["proc_path"] = path
+            cap["proc_local_files_only"] = local_files_only
+            return FakeProc()
+
+    class FakeVoxtral:
+        @staticmethod
+        def from_pretrained(path, dtype, local_files_only=False):
+            if fail:
+                raise RuntimeError("voxtral_realtime missing")
+            cap["model_path"] = path
+            cap["dtype"] = dtype
+            cap["model_local_files_only"] = local_files_only
+            return FakeModel()
+
+    tmod = types.ModuleType("transformers")
+    tmod.AutoProcessor = FakeAutoProcessor
+    tmod.VoxtralRealtimeForConditionalGeneration = FakeVoxtral
+    monkeypatch.setitem(sys.modules, "transformers", tmod)
+
+    hub = types.ModuleType("huggingface_hub")
+
+    def fake_snapshot(repo, local_files_only=False):
+        cap["snap_repo"] = repo
+        cap["snap_local_files_only"] = local_files_only
+        return f"/fake/snapshot/{repo}"
+
+    hub.snapshot_download = fake_snapshot
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    torch_mod = types.ModuleType("torch")
+    torch_mod.bfloat16 = "BF16"
+    torch_mod.float16 = "F16"
+    torch_mod.inference_mode = contextlib.nullcontext
+    torch_mod.cuda = types.SimpleNamespace(empty_cache=lambda: None, is_available=lambda: True)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    return cap
+
+
+def test_voxtral_realtime_load_and_transcribe(monkeypatch):
+    cap = _install_fake_voxtral(monkeypatch)
+    b = backends.make_backend("voxtral_realtime")
+    assert not b.is_loaded
+    b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+    assert b.is_loaded
+    # Offline load resolves the snapshot DIR (local_files_only) and loads the processor
+    # + model FROM that dir — mistral_common ignores local_files_only on a repo id.
+    assert cap["snap_repo"] == "mistralai/Voxtral-Mini-4B-Realtime-2602"
+    assert cap["snap_local_files_only"] is True
+    assert cap["proc_path"] == "/fake/snapshot/mistralai/Voxtral-Mini-4B-Realtime-2602"
+    assert cap["model_path"] == "/fake/snapshot/mistralai/Voxtral-Mini-4B-Realtime-2602"
+    assert cap["dtype"] == "BF16"            # bfloat16 → torch.bfloat16
+    assert cap["model_device"] == "cuda"
+    assert cap["model_local_files_only"] is True
+    r = b.transcribe(np.zeros(16000, np.float32), "en")
+    assert r.text == "hello world"           # decoded + stripped, audio-only → no prefix/slice
+    assert cap["feat_dtype"] == "BF16"        # input_features cast to model dtype
+    assert cap["sr"] == 16000                 # TARGET_RATE
+    assert cap["skip_special"] is True
+    assert cap["gen_kw"]["do_sample"] is False
+    assert "max_new_tokens" not in cap["gen_kw"]   # audio-derived auto-length, no cap
+    b.unload()
+    assert not b.is_loaded
+
+
+def test_voxtral_realtime_load_failure_raises(monkeypatch):
+    _install_fake_voxtral(monkeypatch, fail=True)
+    b = backends.make_backend("voxtral_realtime")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k voxtral -v`
+Expected: FAIL — `BackendLoadError: unknown backend: voxtral_realtime` (the backend isn't registered yet). `test_voxtral_realtime_is_gpu_only` may pass-by-accident because `make_backend` raises `BackendLoadError` for the unknown name; that's fine, the other two must fail.
+
+- [ ] **Step 3: Implement the backend**
+
+Append to `sidecar/sokuji_sidecar/backends.py` (after the `CohereTransformersBackend` class):
+
+```python
+@register_backend
+class VoxtralRealtimeBackend:
+    """Voxtral Mini 4B Realtime via native transformers
+    (VoxtralRealtimeForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
+    loaded with .to(device) (no accelerate). Phase 1 runs the STREAMING model OFFLINE: one
+    whole VAD segment per generate() — audio-only input, transcript-only output (no chat
+    template, no prompt slice). Multilingual auto-detect, so the language arg is recorded,
+    not passed. The processor's tokenizer is mistral_common's, which ignores
+    local_files_only; so load() resolves the snapshot DIR and loads the processor from it."""
+    NAME = "voxtral_realtime"
+
+    def __init__(self):
+        self._model = None
+        self._proc = None
+        self._device = "cpu"
+        self._dtype = None
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._proc = None
+        if device == "cpu":
+            raise BackendLoadError("voxtral_realtime is GPU-only")
+        try:
+            import torch
+            from huggingface_hub import snapshot_download
+            from transformers import VoxtralRealtimeForConditionalGeneration, AutoProcessor
+            self._dtype = torch.bfloat16 if compute_type in ("bfloat16", "auto") else torch.float16
+            # mistral_common's tokenizer loader ignores local_files_only / HF_HUB_OFFLINE and
+            # tries to hit the hub; loading from the resolved snapshot DIR makes it read the
+            # cached tekken.json locally. SherpaBackend uses the same dir-resolve idiom.
+            d = snapshot_download(model_ref, local_files_only=True)
+            self._proc = AutoProcessor.from_pretrained(d)
+            self._model = VoxtralRealtimeForConditionalGeneration.from_pretrained(
+                d, dtype=self._dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing voxtral_realtime module, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language) -> AsrResult:
+        import torch
+        inp = self._proc(samples, sampling_rate=TARGET_RATE, return_tensors="pt").to(self._device)
+        if "input_features" in inp:  # features are float32, model is bf16
+            inp["input_features"] = inp["input_features"].to(self._dtype)
+        with torch.inference_mode():
+            out = self._model.generate(**inp, do_sample=False)  # audio-derived auto-length
+        text = self._proc.batch_decode(out, skip_special_tokens=True)[0]
+        return AsrResult(text.strip(), language)
+
+    def unload(self) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k voxtral -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/backends.py sidecar/tests/test_backends.py
+git commit -m "feat(sidecar): VoxtralRealtimeBackend (Voxtral Mini 4B Realtime, GPU bf16, offline)"
+```
+
+---
+
+### Task 2: Catalog row
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/catalog.py` (the `Deployment.backend` doc comment, line ~14; append an `AsrModel` row to `ASR_MODELS`, after the `qwen3-asr-1.7b` row ~line 67)
+- Test: `sidecar/tests/test_catalog.py` (extend the allowed-backend set, line 9; add a row test)
+
+**Interfaces:**
+- Consumes: the backend NAME string `"voxtral_realtime"` (Task 1), `catalog.AsrModel`, `catalog.Deployment`.
+- Produces: `catalog.asr_model("voxtral-mini-4b-realtime")` returning an `AsrModel` whose single `Deployment` is `("voxtral_realtime", "gpu-cuda", "bfloat16", "mistralai/Voxtral-Mini-4B-Realtime-2602")`, `recommended=False`, `sort_order=9`. Task 3 (resolver) and Task 4 (download) reference the id.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `sidecar/tests/test_catalog.py`, modify the allowed-backend set in `test_models_have_deployments_and_languages` (line 9) to include the new backend:
+
+```python
+            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr", "cohere_transformers", "voxtral_realtime"}
+```
+
+Then append a new test:
+
+```python
+def test_voxtral_realtime_row():
+    m = catalog.asr_model("voxtral-mini-4b-realtime")
+    assert m is not None
+    assert m.name == "Voxtral Mini 4B Realtime"
+    assert m.languages == ("en", "fr", "es", "de", "ru", "zh", "ja", "it", "pt", "nl", "ar", "hi", "ko")
+    assert m.recommended is False        # Phase 1: offline mode; promote when streaming lands
+    assert m.sort_order == 9             # appended after Qwen3 (8); no existing rows shift
+    d = m.deployments[0]
+    assert (d.backend, d.tier, d.compute_type, d.artifact) == \
+        ("voxtral_realtime", "gpu-cuda", "bfloat16", "mistralai/Voxtral-Mini-4B-Realtime-2602")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py -k voxtral -v`
+Expected: FAIL — `AttributeError: 'NoneType' object has no attribute 'name'` (`asr_model` returns `None`; the row doesn't exist yet).
+
+- [ ] **Step 3: Add the catalog row**
+
+In `sidecar/sokuji_sidecar/catalog.py`, update the `Deployment.backend` doc comment (line ~14) to list the new backend:
+
+```python
+    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohere_transformers" | "voxtral_realtime"
+```
+
+Then append this row to the `ASR_MODELS` list, immediately after the `qwen3-asr-1.7b` `AsrModel(...)` entry (keep it the last element):
+
+```python
+    AsrModel("voxtral-mini-4b-realtime", "Voxtral Mini 4B Realtime",
+             ("en", "fr", "es", "de", "ru", "zh", "ja", "it", "pt", "nl", "ar", "hi", "ko"),
+             (Deployment("voxtral_realtime", "gpu-cuda", "bfloat16",
+                         "mistralai/Voxtral-Mini-4B-Realtime-2602", 1.0),),
+             recommended=False, sort_order=9),
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py -v`
+Expected: PASS (all catalog tests, including the new `test_voxtral_realtime_row` and the updated allowed-backend set).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/catalog.py sidecar/tests/test_catalog.py
+git commit -m "feat(sidecar): voxtral-mini-4b-realtime catalog row (gpu-cuda bf16, 13 langs)"
+```
+
+---
+
+### Task 3: Resolver self-gate
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/accel.py` (`_installed()` `mods` dict, ~line 69)
+- Test: `sidecar/tests/test_accel.py` (append three tests after the Cohere gate tests, ~line 425)
+
+**Interfaces:**
+- Consumes: `catalog.asr_model("voxtral-mini-4b-realtime")` (Task 2), `accel._installed`, `accel.resolve_deployments`, `accel.Machine`, `accel.Gpu`.
+- Produces: `_installed()` includes `"voxtral_realtime"` iff `transformers.models.voxtral_realtime` imports; the resolver yields a single `gpu-cuda` plan on an NVIDIA box with the runtime installed, and `[]` otherwise (no CPU floor).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_voxtral_realtime_gated_on_voxtral_realtime_module(monkeypatch):
+    import importlib.util as iu
+    from sokuji_sidecar import accel
+    real = iu.find_spec
+
+    def absent(name, *a, **k):
+        if name == "transformers.models.voxtral_realtime":
+            return None
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", absent)
+    assert "voxtral_realtime" not in accel._installed()
+
+    def present(name, *a, **k):
+        if name == "transformers.models.voxtral_realtime":
+            return object()
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", present)
+    assert "voxtral_realtime" in accel._installed()
+
+
+def test_voxtral_resolves_gpu_on_nvidia_with_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"voxtral_realtime", "transformers"}),
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
+    assert [p.device for p in plans] == ["cuda"]
+    assert plans[0].backend == "voxtral_realtime" and plans[0].compute_type == "bfloat16"
+
+
+def test_voxtral_model_unavailable_without_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"ctranslate2", "sherpa", "transformers"}),  # no voxtral_realtime
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
+    assert plans == []     # GPU-only + runtime absent → no usable deployment
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_accel.py -k voxtral -v`
+Expected: FAIL — `test_voxtral_realtime_gated_on_voxtral_realtime_module`'s second assert fails (`_installed()` has no `voxtral_realtime` entry, so even with the module present it's not added), and `test_voxtral_resolves_gpu_on_nvidia_with_runtime` returns `[]` (the `installed` set names a backend the resolver never maps).
+
+- [ ] **Step 3: Add the self-gate entry**
+
+In `sidecar/sokuji_sidecar/accel.py`, inside `_installed()`'s `mods` dict (after the `cohere_transformers` entry, ~line 69), add:
+
+```python
+            # voxtral_realtime needs the native voxtral_realtime model (transformers >=5.2;
+            # present in our 5.13 fork). Same self-gate as qwen3asr/cohere.
+            "voxtral_realtime": "transformers.models.voxtral_realtime"}
+```
+
+(Move the closing `}` from the previous `cohere_transformers` line onto this new last entry — the dict literal ends here.)
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_accel.py -k voxtral -v`
+Expected: PASS (3 tests). Also run the full file to confirm no regression: `cd sidecar && .venv/bin/python -m pytest tests/test_accel.py -v` → PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/accel.py sidecar/tests/test_accel.py
+git commit -m "feat(sidecar): self-gate voxtral_realtime on transformers.models.voxtral_realtime"
+```
+
+---
+
+### Task 4: Download spec + `ignore` mechanism (skip `consolidated.safetensors`)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/native_models.py` (`download_specs` branch ~line 44; `model_size` loop ~line 60-64; `download` file-listing loop ~line 155-159)
+- Test: `sidecar/tests/test_native_models.py` (append tests)
+
+**Interfaces:**
+- Consumes: nothing new (the model id `"voxtral-mini-4b-realtime"` is a literal).
+- Produces: `download_specs("voxtral-mini-4b-realtime")` → `{"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [], "ignore": ["consolidated.safetensors"]}`; `download()` and `model_size()` honor the optional `ignore` key (default `[]`). `model_status()` needs no change (it checks for orphan `.incomplete` blobs, not the full expected file list, so a never-fetched `consolidated.safetensors` is simply absent and harmless).
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_native_models.py`:
+
+```python
+def test_download_specs_voxtral_skips_consolidated():
+    spec = nm.download_specs("voxtral-mini-4b-realtime")
+    assert spec["repos"] == ["mistralai/Voxtral-Mini-4B-Realtime-2602"]
+    assert spec["urls"] == []
+    assert spec["ignore"] == ["consolidated.safetensors"]
+
+
+def test_existing_specs_have_no_ignore_key():
+    # The ignore key is additive: every pre-existing model omits it (consumers use .get).
+    assert "ignore" not in nm.download_specs("cohere-transcribe-03-2026")
+    assert "ignore" not in nm.download_specs("qwen3-asr-1.7b")
+
+
+def test_download_honors_ignore_list(monkeypatch):
+    """The ignore list keeps consolidated.safetensors out of the fetched file set,
+    so transformers' model.safetensors is fetched but the 8.86GB duplicate is not."""
+    import huggingface_hub
+    fetched = []
+
+    class _Api:
+        def list_repo_files(self, repo):
+            return ["model.safetensors", "consolidated.safetensors", "config.json", "tekken.json"]
+
+    monkeypatch.setattr(nm, "download_specs", lambda m: {
+        "repos": ["r"], "urls": [], "ignore": ["consolidated.safetensors"]})
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download",
+                        lambda repo, fname: fetched.append(fname))
+
+    async def send(_m):
+        pass
+
+    status = asyncio.run(nm.download("voxtral-mini-4b-realtime", send))
+    assert status == "ready"
+    assert "consolidated.safetensors" not in fetched
+    assert "model.safetensors" in fetched and "tekken.json" in fetched
+
+
+def test_model_size_excludes_ignored_files(monkeypatch):
+    import huggingface_hub
+
+    class _Sib:
+        def __init__(self, name, size):
+            self.rfilename = name
+            self.size = size
+
+    class _Info:
+        siblings = [_Sib("model.safetensors", 8_000_000_000),
+                    _Sib("consolidated.safetensors", 8_000_000_000),
+                    _Sib("config.json", 1000)]
+
+    class _Api:
+        def repo_info(self, repo, files_metadata=False):
+            return _Info()
+
+    monkeypatch.setattr(nm, "download_specs", lambda m: {
+        "repos": ["r"], "urls": [], "ignore": ["consolidated.safetensors"]})
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    nm._SIZE_CACHE.clear()
+    assert nm.model_size("voxtral-mini-4b-realtime") == 8_000_001_000  # consolidated excluded
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_native_models.py -k "voxtral or ignore or ignored" -v`
+Expected: FAIL — `download_specs("voxtral-mini-4b-realtime")` hits the fallthrough returning `{"repos": ["voxtral-mini-4b-realtime"], "urls": []}` (no `ignore`, wrong repo); the download/size tests fail because the loops don't filter.
+
+- [ ] **Step 3: Add the branch + honor `ignore`**
+
+In `sidecar/sokuji_sidecar/native_models.py`:
+
+(a) In `download_specs`, before the final `return {"repos": [model_id], "urls": []}` fallthrough (~line 44), add:
+
+```python
+    if model_id == "voxtral-mini-4b-realtime":
+        # Repo ships model.safetensors (HF, needed) + consolidated.safetensors (Mistral
+        # format, 8.86GB, unused by transformers) — skip the duplicate.
+        return {"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [],
+                "ignore": ["consolidated.safetensors"]}
+```
+
+(b) In `model_size`, change the repo loop to skip ignored files:
+
+```python
+    api = HfApi()
+    ignore = set(specs.get("ignore", []))
+    for repo in specs["repos"]:
+        try:
+            info = api.repo_info(repo, files_metadata=True)
+            total += sum((s.size or 0) for s in (info.siblings or []) if s.rfilename not in ignore)
+        except Exception:
+            pass
+```
+
+(c) In `download`, change the file-listing loop to skip ignored files:
+
+```python
+    api = HfApi()
+    ignore = set(specs.get("ignore", []))
+    files = []
+    for repo in specs["repos"]:
+        try:
+            files.extend((repo, f) for f in api.list_repo_files(repo) if f not in ignore)
+        except Exception:
+            pass
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_native_models.py -v`
+Expected: PASS (all native_models tests, including the 4 new ones; the existing `test_download_specs_mapping`, `test_download_specs_cohere`, etc. still pass — `ignore` is additive).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/native_models.py sidecar/tests/test_native_models.py
+git commit -m "feat(sidecar): voxtral download_specs + ignore key (skip consolidated.safetensors)"
+```
+
+---
+
+### Task 5: `mistral-common[audio]` dependency in `setup.sh`
+
+**Files:**
+- Modify: `sidecar/setup.sh` (the stage-runtime pip install line, ~line 40, and its comment)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a fresh `setup.sh` run installs `mistral-common[audio]>=1.9.0`, so `VoxtralRealtimeProcessor` loads on a clean venv. (No unit test — `setup.sh` is shell; verification is the import check below + Task 7's GPU smoke.)
+
+- [ ] **Step 1: Edit setup.sh**
+
+In `sidecar/setup.sh`, find the stage-runtime install line:
+
+```bash
+"$PY" -m pip install -q "$TRANSFORMERS_REF" sherpa-onnx faster-whisper sacremoses librosa
+```
+
+Replace it with (adds `mistral-common[audio]` — the Voxtral Realtime processor's tokenizer backend):
+
+```bash
+"$PY" -m pip install -q "$TRANSFORMERS_REF" sherpa-onnx faster-whisper sacremoses librosa "mistral-common[audio]>=1.9.0"
+```
+
+And extend the comment just above that line (the `# transformers→tokenizers ...` block) with one line:
+
+```bash
+# mistral-common[audio]→VoxtralRealtimeProcessor tokenizer (MistralCommonBackend).
+```
+
+- [ ] **Step 2: Verify the dependency is importable in the venv**
+
+(The venv already has `mistral-common` from earlier work; this confirms the package name the edit installs is correct.)
+
+Run: `sidecar/.venv/bin/python -c "import mistral_common; from transformers import VoxtralRealtimeProcessor; print('ok', mistral_common.__version__)"`
+Expected: `ok 1.x.x` (no ImportError).
+
+- [ ] **Step 3: Verify setup.sh parses (syntax only — do NOT run the full installer)**
+
+Run: `bash -n sidecar/setup.sh && echo "syntax ok"`
+Expected: `syntax ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sidecar/setup.sh
+git commit -m "build(sidecar): install mistral-common[audio] for Voxtral Realtime processor"
+```
+
+---
+
+### Task 6: Renderer catalog row
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts` (`NATIVE_ASR` array, after the `qwen3-asr-1.7b` row, ~line 31)
+- Test: `src/lib/local-inference/native/nativeCatalog.test.ts` (add a test inside the `describe('nativeCatalog', ...)` block)
+
+**Interfaces:**
+- Consumes: the `NativeModelOption` type (`{ id, label, languages?, recommended?, sortOrder? }`), `NATIVE_ASR`, `compatibleNativeAsr` (all already exported).
+- Produces: a `NATIVE_ASR` entry `{ id: 'voxtral-mini-4b-realtime', sortOrder: 9 }` (no `recommended`), surfaced by `compatibleNativeAsr`/`nativeAsrCards` for its 13 languages.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/lib/local-inference/native/nativeCatalog.test.ts`, add inside the `describe('nativeCatalog', () => { ... })` block:
+
+```typescript
+  it('includes Voxtral Mini 4B Realtime (not recommended, sortOrder 9, 13 langs)', () => {
+    const v = NATIVE_ASR.find((m) => m.id === 'voxtral-mini-4b-realtime');
+    expect(v).toBeDefined();
+    expect(v!.label).toBe('Voxtral Mini 4B Realtime');
+    expect(v!.recommended).toBeFalsy();
+    expect(v!.sortOrder).toBe(9);
+    expect(v!.languages).toEqual(['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko']);
+    // listed for a supported language (ja), behind the recommended rows
+    expect(compatibleNativeAsr('ja').map((m) => m.id)).toContain('voxtral-mini-4b-realtime');
+    // dropped for a language it lacks (Thai 'th' — Qwen3 has it, Voxtral does not)
+    expect(compatibleNativeAsr('th').map((m) => m.id)).not.toContain('voxtral-mini-4b-realtime');
+    // does not displace cohere as the recommended leader for a shared language
+    expect(compatibleNativeAsr('zh')[0].id).toBe('cohere-transcribe-03-2026');
+  });
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/lib/local-inference/native/nativeCatalog.test.ts -t "Voxtral"`
+Expected: FAIL — `expect(v).toBeDefined()` fails (`NATIVE_ASR.find(...)` is `undefined`; the row doesn't exist).
+
+- [ ] **Step 3: Add the renderer row**
+
+In `src/lib/local-inference/native/nativeCatalog.ts`, append to the `NATIVE_ASR` array, immediately after the `qwen3-asr-1.7b` line (it becomes the last entry):
+
+```typescript
+  { id: 'voxtral-mini-4b-realtime', label: 'Voxtral Mini 4B Realtime', languages: ['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko'], sortOrder: 9 },
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS (the new test plus all existing `nativeCatalog` tests — the not-recommended/sortOrder-9 row doesn't disturb the recommended-first ordering the other tests assert).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(native): Voxtral Mini 4B Realtime renderer catalog row (sortOrder 9)"
+```
+
+---
+
+### Task 7: GPU smoke test (`SOKUJI_RUN_GPU`)
+
+**Files:**
+- Test: `sidecar/tests/test_backends.py` (append the gated real smoke after `test_voxtral_realtime_load_failure_raises`)
+
+**Interfaces:**
+- Consumes: `VoxtralRealtimeBackend` via `backends.make_backend("voxtral_realtime")` (Task 1); `mistral-common[audio]` (Task 5); the cached `CohereTransformersBackend` for the coexistence check.
+- Produces: a `SOKUJI_RUN_GPU`-gated test that downloads the model (HF-format only), loads it, transcribes a real English clip to a non-empty transcript, prints RTF, and verifies Cohere still loads after Voxtral `unload()` + `empty_cache()`.
+
+- [ ] **Step 1: Write the gated smoke test**
+
+Append to `sidecar/tests/test_backends.py`:
+
+```python
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads mistralai/Voxtral-Mini-4B-Realtime-2602 ~8.9GB; needs CUDA + mistral-common[audio])")
+def test_voxtral_realtime_real_gpu_smoke():
+    # Real flow: manager downloads first (HF-format only, skipping the consolidated dup),
+    # backend loads from cache via the snapshot-dir offline path.
+    import wave
+    from huggingface_hub import snapshot_download
+    snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                      ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    b = backends.make_backend("voxtral_realtime")
+    b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+    assert b.is_loaded
+    # real English speech (sense-voice test clip) → a non-empty transcript
+    d = snapshot_download("csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17")
+    w = wave.open(f"{d}/test_wavs/en.wav", "rb")
+    audio = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16).astype(np.float32) / 32768.0
+    t0 = time.perf_counter()
+    r = b.transcribe(audio, "en")
+    rtf = (time.perf_counter() - t0) / (len(audio) / 16000.0)
+    assert isinstance(r.text, str) and r.text.strip(), f"empty transcript on real speech: {r.text!r}"
+    print(f"voxtral-mini-4b-realtime RTF={rtf:.4f}")
+    b.unload()
+    # coexistence regression: Cohere still loads after Voxtral unload + empty_cache
+    import torch
+    torch.cuda.empty_cache()
+    c = backends.make_backend("cohere_transformers")
+    c.load("AEmotionStudio/cohere-transcribe-03-2026-models", "cuda", "bfloat16")
+    assert c.is_loaded
+    c.unload()
+```
+
+- [ ] **Step 2: Verify it is collected and SKIPS without the env flag**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k voxtral_realtime_real_gpu_smoke -v`
+Expected: `SKIPPED` (1 skipped) with the reason text — the gate works; no GPU download happens in normal runs.
+
+- [ ] **Step 3: (Optional, on a CUDA box) run the real smoke**
+
+Run: `cd sidecar && SOKUJI_RUN_GPU=1 .venv/bin/python -m pytest tests/test_backends.py -k voxtral_realtime_real_gpu_smoke -v -s`
+Expected: PASS, printing `voxtral-mini-4b-realtime RTF=~0.45` and a non-empty English transcript. (The model + Cohere are already cached on the dev 4070 from the brainstorming benchmark.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sidecar/tests/test_backends.py
+git commit -m "test(sidecar): GPU-gated Voxtral Realtime smoke (RTF + Cohere coexistence)"
+```
+
+---
+
+### Task 8: Full-suite verification
+
+**Files:** none (verification only).
+
+**Interfaces:**
+- Consumes: all prior tasks.
+- Produces: green sidecar pytest + renderer vitest, confirming no regression across the integration.
+
+- [ ] **Step 1: Run the full sidecar test suite**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: PASS (the GPU/model-gated tests `SKIPPED` without their env flags; everything else green).
+
+- [ ] **Step 2: Run the renderer native-catalog tests**
+
+Run: `npm run test -- src/lib/local-inference/native/`
+Expected: PASS (nativeCatalog + NativeModelClient + NativeAsrClient suites green).
+
+- [ ] **Step 3: Build the renderer (wiring sanity, not a correctness gate)**
+
+Run: `npm run build`
+Expected: build completes (the new catalog row is plain data; no type errors introduced).
+
+- [ ] **Step 4: Commit (only if Steps 1-3 surfaced fixes)**
+
+If any step required a fix, commit it:
+
+```bash
+git add -A
+git commit -m "test(native): green sidecar + renderer suites for Voxtral Realtime"
+```
+
+If all three passed with no changes, there is nothing to commit — skip.

--- a/docs/superpowers/plans/2026-06-25-voxtral-realtime-streaming.md
+++ b/docs/superpowers/plans/2026-06-25-voxtral-realtime-streaming.md
@@ -1,0 +1,974 @@
+# Voxtral Mini 4B Realtime — Continuous Streaming (Phase 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Deliver continuous, low-latency streaming ASR for Voxtral Mini 4B Realtime in the native sidecar — partials ~480 ms behind speech, a committed final at each VAD endpoint — without touching vLLM, translation, or TTS.
+
+**Architecture:** A per-utterance `VoxtralRealtimeStream` session wraps the experimental transformers streaming API (live-fed `input_features` generator + threaded `generate` + `TextIteratorStreamer`). The engine gains a streaming branch (an asyncio task: audio queue → silero VAD endpointing → feed session, drain deltas → emit `partial`/`result`); offline backends keep the unchanged synchronous path. The transport starts that task for `STREAMING` backends. The renderer mirrors the existing `LocalInferenceClient.partialUserItem` interim→final pattern.
+
+**Tech Stack:** Python sidecar (transformers `5.13.0.dev0`, torch cu128, threading + asyncio, silero VAD via sherpa-onnx); TypeScript/Vitest renderer; pytest.
+
+## Spike findings (verified on the RTX 4070 — these are facts, build on them)
+
+The §6 GPU spike was run live. `mistralai/Voxtral-Mini-4B-Realtime-2602` streams correctly:
+- Lazy generator pull confirmed: feeding realtime-paced 100 ms chunks, **83/102 partials arrived while still feeding**; first partial ≈ 0.6 s; VRAM peak **9.04 GB**; transcript correct ("…fifty pieces of gold.").
+- `VoxtralRealtimeProcessor` constants: `num_samples_first_audio_chunk=9000`, `num_samples_per_audio_chunk=1680`, `num_mel_frames_first_audio_chunk=56`, `audio_length_per_tok=8`, `raw_audio_length_per_tok=1280`; `feature_extractor.hop_length=160`, `win_length=400`, `sampling_rate=16000`.
+- `proc.num_right_pad_tokens` is a **method** `(transcription_delay_ms=None)->int` (the HF doc treats it as a value — that's the doc's bug); `proc.num_right_pad_tokens()` returns **17** at the default 480 ms delay.
+- `num_delay_tokens` comes from the first processor call (`first.num_delay_tokens`); `model.config.default_num_delay_tokens = 6`.
+- Subsequent-chunk window math: `start = mel_frame_idx*hop - win//2`, advancing `mel_frame_idx += audio_length_per_tok` (8) per chunk; chunk width `num_samples_per_audio_chunk` (1680).
+- Clean shutdown: **join the generate thread on end-of-utterance** (the spike's `exit 134`/"terminate called" was un-joined daemon threads at interpreter exit, not a streaming failure).
+
+## Global Constraints
+
+- **Streaming only for `voxtral_realtime`.** Engine branches on a backend class flag `STREAMING = True`. Every offline backend keeps the unchanged synchronous `feed()->list` path.
+- **Continuous streaming**, fixed `num_delay_tokens` = the processor default (6 ≈ 480 ms); no UI delay control.
+- **VAD = endpoint detector, not a recognition gate.** silero VAD (existing) marks speech-start (open session) and silence/endpoint (finalize + reset). Max-utterance cap = **20 s** forces finalize + reset to bound VRAM.
+- **Partials are display-only.** Only the VAD-endpointed **final** enters the existing translation→TTS pipeline; translation/TTS code is untouched.
+- **Offline `transcribe()` (Phase 1) stays** for the GPU smoke + fallback. No change to other backends or the WebGPU LOCAL_INFERENCE path.
+- **Audio**: renderer feeds Int16@24 kHz; engine downsamples to 16 kHz float32 via the existing `_downsample_int16_to_f32_16k`. `TARGET_RATE = 16000`.
+- **Offline load idiom** (Phase 1, reuse): resolve the snapshot dir with `snapshot_download(repo, local_files_only=True)`, load processor + model from the dir.
+- **Catalog**: promote `voxtral-mini-4b-realtime` to `recommended=True` (sidecar + renderer); ordering unchanged (`sort_order`/`sortOrder` 9).
+- **Wire event**: new id-less `partial {type:'partial', text}`; `result`/`speech_start` unchanged.
+- **Tests**: sidecar `cd sidecar && .venv/bin/python -m pytest`; renderer `npm run test`. English-only comments. GPU tests gated on `SOKUJI_RUN_GPU`.
+
+---
+
+### Task 1: `VoxtralRealtimeStream` session + backend `STREAMING` flag
+
+**Files:**
+- Create: `sidecar/sokuji_sidecar/voxtral_stream.py`
+- Modify: `sidecar/sokuji_sidecar/backends.py` (add `STREAMING = True` + `open_stream()` to `VoxtralRealtimeBackend`)
+- Test: `sidecar/tests/test_voxtral_stream.py`
+
+**Interfaces:**
+- Consumes: a loaded `model` + `proc` (the backend already loads these in Phase 1's `load()`), `BackendLoadError`.
+- Produces: `VoxtralRealtimeStream(model, proc, device, dtype)` with `feed(samples_f32_16k: np.ndarray) -> None`, `drain() -> list[str]` (text deltas available now, non-blocking), `end() -> str` (flush right-pad, join the generate thread, return the full transcript), `aborted` property; and `VoxtralRealtimeBackend.STREAMING = True`, `VoxtralRealtimeBackend.open_stream() -> VoxtralRealtimeStream`. The engine (Task 2) drives these.
+
+- [ ] **Step 1: Write the session unit test (pure helpers + lifecycle with a fake model)**
+
+Create `sidecar/tests/test_voxtral_stream.py`. The test fakes the model/processor so it runs on CPU/no-GPU: the fake `generate` consumes the `input_features` generator and pushes scripted tokens to the `streamer`, so the threading + buffering + right-pad flush are exercised deterministically.
+
+```python
+import threading
+import time
+import types
+
+import numpy as np
+import pytest
+
+
+class _FakeStreamer:
+    """Stand-in for TextIteratorStreamer: a thread-safe iterator of strings the
+    fake model 'generates'. end-of-iteration is signalled by put(None)."""
+    def __init__(self):
+        import queue
+        self._q = queue.Queue()
+    def put_text(self, s): self._q.put(s)
+    def end(self): self._q.put(None)
+    def __iter__(self): return self
+    def __next__(self):
+        v = self._q.get()
+        if v is None:
+            raise StopIteration
+        return v
+
+
+def _fake_proc():
+    fe = types.SimpleNamespace(hop_length=160, win_length=400, sampling_rate=16000)
+    proc = types.SimpleNamespace(
+        feature_extractor=fe,
+        num_samples_first_audio_chunk=9000,
+        num_samples_per_audio_chunk=1680,
+        num_mel_frames_first_audio_chunk=56,
+        audio_length_per_tok=8,
+        raw_audio_length_per_tok=1280,
+        num_right_pad_tokens=lambda transcription_delay_ms=None: 17,
+    )
+    # processor(samples, is_streaming=, is_first_audio_chunk=, return_tensors=) -> batch
+    def _call(samples, is_streaming, is_first_audio_chunk, return_tensors):
+        b = {"input_features": _Castable()}
+        if is_first_audio_chunk:
+            b["input_ids"] = "IDS"
+            b["num_delay_tokens"] = 6
+        return _FakeBatch(b)
+    proc.__call__ = _call
+    proc.tokenizer = object()
+    return proc
+
+
+class _Castable:
+    def to(self, device, dtype=None): return self
+
+class _FakeBatch(dict):
+    num_delay_tokens = 6
+    input_ids = "IDS"
+    input_features = _Castable()
+    def to(self, device, dtype=None): return self
+
+
+def _fake_model(streamer, generated="hello world"):
+    class M:
+        device = "cpu"
+        dtype = "BF16"
+        def generate(self, input_ids, input_features, num_delay_tokens, streamer):
+            # drain the live generator (proves lazy feeding works), then emit tokens
+            for _ in input_features:
+                pass
+            for tok in generated.split():
+                streamer.put_text(tok + " ")
+            streamer.end()
+    return M()
+
+
+def test_stream_feed_drain_end(monkeypatch):
+    from sokuji_sidecar import voxtral_stream
+    proc = _fake_proc()
+    streamer = _FakeStreamer()
+    monkeypatch.setattr(voxtral_stream, "TextIteratorStreamer", lambda *a, **k: streamer)
+    model = _fake_model(streamer)
+    s = voxtral_stream.VoxtralRealtimeStream(model, proc, "cpu", "BF16")
+    # feed enough to start (>= first chunk), then more
+    s.feed(np.zeros(9000, np.float32))
+    s.feed(np.zeros(4000, np.float32))
+    final = s.end()                       # flushes right-pad, joins the generate thread
+    assert final.strip() == "hello world"
+    assert s.aborted is False
+```
+
+(The realtime correctness — lazy live pull, latency, VRAM — is covered by the GPU test in Step 6; this test pins the buffering/threading/flush contract on CPU.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_voxtral_stream.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'sokuji_sidecar.voxtral_stream'`.
+
+- [ ] **Step 3: Implement the streaming session**
+
+Create `sidecar/sokuji_sidecar/voxtral_stream.py` (the verified spike logic, wrapped as a session with a clean thread-joining `end()`):
+
+```python
+"""One streaming utterance for Voxtral Mini 4B Realtime. Wraps the experimental
+transformers streaming API: a live-fed input_features generator + threaded generate
++ TextIteratorStreamer. feed() appends 16kHz float32 audio (thread-safe); drain()
+returns text deltas available now; end() appends the model's right-pad to flush the
+tail, joins the generate thread, and returns the full transcript. One session per
+utterance — the padding cache + KV live in the generate call and are freed when the
+thread joins. Constants verified live (see the plan's Spike findings)."""
+import queue
+import threading
+
+import numpy as np
+from transformers import TextIteratorStreamer
+
+
+class VoxtralRealtimeStream:
+    def __init__(self, model, proc, device, dtype):
+        self._model = model
+        self._proc = proc
+        self._device = device
+        self._dtype = dtype
+        fe = proc.feature_extractor
+        self._FIRST = proc.num_samples_first_audio_chunk
+        self._CHUNK = proc.num_samples_per_audio_chunk
+        self._HOP = fe.hop_length
+        self._WIN = fe.win_length
+        self._ADV = proc.audio_length_per_tok
+        self._right_pad = proc.num_right_pad_tokens() * proc.raw_audio_length_per_tok
+        self._buf = np.zeros(0, np.float32)
+        self._lock = threading.Lock()
+        self._ended = threading.Event()      # end-of-utterance: right-pad appended
+        self._deltas = queue.Queue()         # str tokens; None = generation finished
+        self._collected = []                 # accumulated final text
+        self._gen_thread = None
+        self._reader_thread = None
+        self._started = False
+        self.aborted = False
+
+    def _buflen(self):
+        with self._lock:
+            return len(self._buf)
+
+    def _wait_for(self, n):
+        """Block until the buffer has >= n samples, or end-of-utterance with no more."""
+        while True:
+            with self._lock:
+                if len(self._buf) >= n:
+                    return True
+            if self._ended.is_set():
+                with self._lock:
+                    return len(self._buf) >= n
+            self._ended.wait(0.005)
+
+    def _input_features_generator(self, first_features):
+        yield first_features
+        mel_frame_idx = self._proc.num_mel_frames_first_audio_chunk
+        start = mel_frame_idx * self._HOP - self._WIN // 2
+        while True:
+            end = start + self._CHUNK
+            if not self._wait_for(end):
+                break
+            with self._lock:
+                seg = self._buf[start:end].copy()
+            inp = self._proc(seg, is_streaming=True, is_first_audio_chunk=False,
+                             return_tensors="pt").to(self._device, dtype=self._dtype)
+            yield inp.input_features
+            mel_frame_idx += self._ADV
+            start = mel_frame_idx * self._HOP - self._WIN // 2
+
+    def _start(self):
+        with self._lock:
+            first_audio = self._buf[:self._FIRST].copy()
+        first = self._proc(first_audio, is_streaming=True, is_first_audio_chunk=True,
+                           return_tensors="pt").to(self._device, dtype=self._dtype)
+        streamer = TextIteratorStreamer(self._proc.tokenizer, skip_special_tokens=True,
+                                        clean_up_tokenization_spaces=True)
+
+        def _run():
+            try:
+                self._model.generate(
+                    input_ids=first.input_ids,
+                    input_features=self._input_features_generator(first.input_features),
+                    num_delay_tokens=first.num_delay_tokens, streamer=streamer)
+            except Exception:
+                self.aborted = True
+
+        def _read():
+            try:
+                for tok in streamer:
+                    self._collected.append(tok)
+                    self._deltas.put(tok)
+            finally:
+                self._deltas.put(None)
+
+        self._started = True
+        self._gen_thread = threading.Thread(target=_run, daemon=True)
+        self._gen_thread.start()
+        self._reader_thread = threading.Thread(target=_read, daemon=True)
+        self._reader_thread.start()
+
+    def feed(self, samples_f32_16k):
+        with self._lock:
+            self._buf = np.concatenate([self._buf, samples_f32_16k])
+        if not self._started and self._buflen() >= self._FIRST:
+            self._start()
+
+    def drain(self):
+        """Non-blocking: return text deltas available right now."""
+        out = []
+        while True:
+            try:
+                v = self._deltas.get_nowait()
+            except queue.Empty:
+                break
+            if v is not None:
+                out.append(v)
+        return out
+
+    def end(self):
+        """End-of-utterance: append right-pad to flush the tail, drain to completion,
+        join the threads, return the full transcript."""
+        with self._lock:
+            self._buf = np.concatenate([self._buf, np.zeros(self._right_pad, np.float32)])
+        self._ended.set()
+        if not self._started:        # utterance shorter than the first chunk → start now
+            with self._lock:
+                if len(self._buf) >= self._FIRST or len(self._buf) > 0:
+                    pass
+            self._start()
+        # drain until the reader signals completion (None sentinel)
+        while True:
+            v = self._deltas.get()
+            if v is None:
+                break
+        if self._gen_thread:
+            self._gen_thread.join(timeout=30)
+        if self._reader_thread:
+            self._reader_thread.join(timeout=5)
+        return "".join(self._collected)
+```
+
+Then in `sidecar/sokuji_sidecar/backends.py`, add to `VoxtralRealtimeBackend`:
+
+```python
+    STREAMING = True
+
+    def open_stream(self):
+        if self._model is None:
+            raise BackendLoadError("voxtral_realtime not loaded")
+        from .voxtral_stream import VoxtralRealtimeStream
+        return VoxtralRealtimeStream(self._model, self._proc, self._device, self._dtype)
+```
+
+(Other backends have no `STREAMING` attribute; the engine treats its absence as False.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_voxtral_stream.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Write the GPU spike/smoke test (reproduces the validated live spike)**
+
+Append to `sidecar/tests/test_voxtral_stream.py`:
+
+```python
+import os
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (uses cached Voxtral-Mini-4B-Realtime; needs CUDA)")
+def test_voxtral_stream_real_gpu_live():
+    import glob
+    import wave
+    import torch
+    from huggingface_hub import snapshot_download
+    from sokuji_sidecar import backends
+    d = snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                          ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    b = backends.make_backend("voxtral_realtime")
+    b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+    wav = glob.glob(os.path.expanduser(
+        "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
+    w = wave.open(wav)
+    audio = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16).astype(np.float32) / 32768.0
+    s = b.open_stream()
+    partials = []
+    for i in range(0, len(audio), 1600):          # 100ms chunks
+        s.feed(audio[i:i + 1600])
+        partials += s.drain()
+    final = s.end()
+    assert final.strip(), f"empty final: {final!r}"
+    assert "tribal" in final.lower() or "gold" in final.lower(), f"unexpected: {final!r}"
+    assert len(partials) > 0, "no partials streamed"
+    print(f"voxtral stream: {len(partials)} partials, final={final.strip()!r}")
+    b.unload()
+```
+
+- [ ] **Step 6: Verify the GPU test skips (and optionally run it on the box)**
+
+Run (no flag): `cd sidecar && .venv/bin/python -m pytest tests/test_voxtral_stream.py -k real_gpu_live -v` → `1 skipped`.
+Optionally on the 4070: `SOKUJI_RUN_GPU=1 .venv/bin/python -m pytest tests/test_voxtral_stream.py -k real_gpu_live -v -s` → PASS, prints partials count + final (model is cached).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/voxtral_stream.py sidecar/sokuji_sidecar/backends.py sidecar/tests/test_voxtral_stream.py
+git commit -m "feat(sidecar): VoxtralRealtimeStream session (live streaming) + backend STREAMING flag"
+```
+
+---
+
+### Task 2: Engine streaming path (VAD endpointing + emit partial/result)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/asr_engine.py` (add a streaming branch; offline path unchanged)
+- Test: `sidecar/tests/test_asr_engine.py` (append streaming tests with a fake stream session)
+
+**Interfaces:**
+- Consumes: `VoxtralRealtimeBackend.STREAMING` + `open_stream()` (Task 1); the existing `_downsample_int16_to_f32_16k`, the silero VAD setup (`_init_vad`), `accel.resolve`/`load_with_fallback`.
+- Produces: `AsrEngine.is_streaming -> bool` (True when the resolved backend has `STREAMING`); an async `run_stream(send)` coroutine the transport drives (Task 3), and `feed_stream(int16_bytes)` that enqueues audio. Emits dicts: `{"type":"speech_start"}`, `{"type":"partial","text":...}`, `{"type":"result","text":...,"startSample":...,"durationMs":...,"recognitionTimeMs":...}`.
+
+- [ ] **Step 1: Write the engine streaming test (fake stream session, no GPU, deterministic)**
+
+Append to `sidecar/tests/test_asr_engine.py`:
+
+```python
+import asyncio
+import numpy as np
+from sokuji_sidecar.asr_engine import AsrEngine
+
+
+class _FakeStream:
+    """Scripted stream session: drain() returns queued deltas, end() returns the join."""
+    def __init__(self):
+        self.fed = 0
+        self._pending = ["he", "llo "]
+        self.ended = False
+    def feed(self, samples):
+        self.fed += len(samples)
+    def drain(self):
+        out, self._pending = self._pending, []
+        return out
+    def end(self):
+        self.ended = True
+        return "hello world"
+
+
+def _streaming_engine(monkeypatch, fake_stream, vad_segments):
+    """Build an AsrEngine whose resolved backend is streaming and whose VAD is faked
+    to yield a scripted speech_start then endpoint."""
+    eng = AsrEngine()
+    backend = type("B", (), {"STREAMING": True, "open_stream": lambda self: fake_stream,
+                             "unload": lambda self: None})()
+    # bypass real resolve/VAD: inject the backend + a fake VAD endpoint generator
+    monkeypatch.setattr(eng, "_resolve_streaming_backend", lambda model, device: backend)
+    monkeypatch.setattr(eng, "_vad_events", lambda samples: vad_segments)  # ['start'|'speech'|'end']
+    return eng
+
+
+def test_streaming_emits_speech_start_partials_result(monkeypatch):
+    fs = _FakeStream()
+    eng = _streaming_engine(monkeypatch, fs, vad_segments=["start", "speech", "end"])
+    sent = []
+    async def send(msg): sent.append(msg)
+    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en", device="cuda")
+    # feed one buffer that the fake VAD turns into start→speech→end
+    eng.feed_stream(np.zeros(16000, np.int16).tobytes())
+    asyncio.run(eng._drive_once(send))   # one iteration of the streaming loop
+    types_seen = [m["type"] for m in sent]
+    assert types_seen[0] == "speech_start"
+    assert "partial" in types_seen
+    assert types_seen[-1] == "result"
+    assert sent[-1]["text"] == "hello world"
+    assert fs.ended is True
+```
+
+(Exact private method names — `_drive_once`, `_vad_events`, `_resolve_streaming_backend`, `init_streaming` — are introduced by Step 3; keep them identical there.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming -v`
+Expected: FAIL — `AttributeError` (`init_streaming`/`feed_stream`/`_drive_once` not defined).
+
+- [ ] **Step 3: Implement the streaming branch**
+
+In `sidecar/sokuji_sidecar/asr_engine.py`, add (leaving the existing offline `init`/`feed`/`flush` untouched):
+
+```python
+    def is_streaming(self):
+        return bool(getattr(self._backend, "STREAMING", False))
+
+    def init_streaming(self, model_id=None, language="", sample_rate=SRC_RATE,
+                       vad_threshold=None, vad_min_silence=None, vad_min_speech=None, device="auto"):
+        """Like init(), but for a STREAMING backend: resolve+load, set up VAD for
+        endpointing, and prepare the audio queue + per-utterance stream state."""
+        import queue as _queue
+        self.close()
+        self._init_vad(sample_rate, vad_threshold, vad_min_silence, vad_min_speech)
+        self._backend = self._resolve_streaming_backend(model_id, device)
+        self._language = language or None
+        self._audio_q = _queue.Queue()
+        self._stream = None
+        self._utt_start_sample = 0
+        self._sample_cursor = 0
+        self._partial_acc = []
+        self._utt_samples = 0
+        self._stop = False
+
+    def feed_stream(self, int16_bytes):
+        """Non-blocking: hand raw audio to the streaming loop (called from on_binary)."""
+        self._audio_q.put_nowait(int16_bytes)
+
+    async def run_stream(self, send):
+        """The asyncio streaming loop (Approach A). Owns VAD endpointing, the stream
+        session lifecycle, and pushes speech_start/partial/result via `send`."""
+        loop = __import__("asyncio").get_event_loop()
+        while not self._stop:
+            try:
+                data = await loop.run_in_executor(None, self._audio_q.get, True, 0.1)
+            except Exception:
+                continue
+            if data is None:
+                break
+            await self._drive(send, data)
+        if self._stream is not None:
+            await self._finalize(send)
+
+    async def _drive(self, send, int16_bytes):
+        """Process one audio buffer: VAD → manage session → emit events. Factored so
+        tests can call _drive_once with scripted VAD."""
+        samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
+        for ev in self._vad_events(samples):
+            if ev == "start":
+                self._utt_start_sample = self._sample_cursor
+                self._stream = self._backend.open_stream()
+                await send({"type": "speech_start"})
+            elif ev == "speech" and self._stream is not None:
+                self._stream.feed(samples)
+                deltas = self._stream.drain()
+                if deltas:
+                    self._partial_acc += deltas
+                    await send({"type": "partial", "text": "".join(self._partial_acc)})
+            elif ev == "end" and self._stream is not None:
+                await self._finalize(send)
+        self._sample_cursor += len(samples)
+
+    async def _finalize(self, send):
+        import time as _time
+        t0 = _time.time()
+        loop = __import__("asyncio").get_event_loop()
+        final = await loop.run_in_executor(None, self._stream.end)
+        dur_ms = int((self._sample_cursor - self._utt_start_sample) / TARGET_RATE * 1000)
+        if final.strip():
+            await send({"type": "result", "text": final.strip(),
+                        "startSample": int(self._utt_start_sample),
+                        "durationMs": dur_ms,
+                        "recognitionTimeMs": int((_time.time() - t0) * 1000)})
+        self._stream = None
+        self._partial_acc = []
+
+    async def _drive_once(self, send):
+        """Test seam: drive exactly the buffers currently queued, once."""
+        while not self._audio_q.empty():
+            await self._drive(send, self._audio_q.get_nowait())
+```
+
+Add the two helpers the loop relies on (real implementations; the test monkeypatches them):
+
+```python
+    def _resolve_streaming_backend(self, model_id, device):
+        from . import accel
+        plans = accel.resolve(model_id or "voxtral-mini-4b-realtime", override=device or "auto")
+        backend, _plan, _notice = accel.load_with_fallback(plans)
+        return backend
+
+    def _vad_events(self, samples):
+        """Feed `samples` to silero VAD; yield 'start' on rising edge, 'speech' while
+        active, 'end' on endpoint (silence) or the 20s max-utterance cap (bounds VRAM)."""
+        events = []
+        cap = 20 * TARGET_RATE
+        self._buf = np.concatenate([self._buf, samples])
+        while len(self._buf) >= self._window:
+            was = self._vad.is_speech_detected()
+            self._vad.accept_waveform(self._buf[:self._window])
+            self._buf = self._buf[self._window:]
+            now = self._vad.is_speech_detected()
+            if not was and now:
+                self._utt_samples = 0
+                events.append("start")
+            if now:
+                self._utt_samples += self._window
+                events.append("speech")
+                if self._utt_samples >= cap:          # force endpoint to bound VRAM
+                    events.append("end")
+                    self._utt_samples = 0
+            if was and not now:
+                events.append("end")
+        return events
+```
+
+(`_vad_events` reuses the engine's existing `_vad`, `_window`, `_buf` from `_init_vad`; `_utt_samples`
+(init 0 in `init_streaming`) tracks speech since the last start and forces an `"end"` at the 20 s cap.
+After a cap-forced end the engine finalizes the session; the next silence→speech opens a fresh one —
+a 20 s+ continuous utterance is split, which is the intended VRAM bound.)
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming -v`
+Expected: PASS. Then full file: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -v` → PASS (offline tests unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/asr_engine.py sidecar/tests/test_asr_engine.py
+git commit -m "feat(sidecar): streaming engine path (VAD endpointing, emit partial/result)"
+```
+
+---
+
+### Task 3: Transport wiring (`asr_init` starts the streaming task)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/asr_engine.py` (the `_h_asr_init` handler) and/or `server.py`
+- Test: `sidecar/tests/test_server_conn.py` (or `test_asr_engine.py`) — fake conn
+
+**Interfaces:**
+- Consumes: `eng.is_streaming()`, `eng.init_streaming(...)`, `eng.feed_stream(...)`, `eng.run_stream(send)` (Task 2); the existing `_h_asr_init`, `conn.ctx["on_binary"]`, `conn.send`.
+- Produces: for a streaming backend, `asr_init` sets `on_binary = eng.feed_stream` and starts `asyncio.create_task(eng.run_stream(conn.send))`; offline backends keep `on_binary = eng.feed` (sync). The `ready` reply shape is unchanged.
+
+- [ ] **Step 1: Write the transport test**
+
+Append to `sidecar/tests/test_asr_engine.py` (handler-level, with a fake engine + fake conn):
+
+```python
+import json
+from sokuji_sidecar import asr_engine as ae
+from sokuji_sidecar import server
+
+
+def test_asr_init_starts_streaming_task_for_streaming_backend(monkeypatch):
+    started = {"task": False, "on_binary": None}
+
+    class FakeEng:
+        def init_streaming(self, **kw): started["init"] = kw
+        def init(self, *a, **k): started["offline"] = True
+        def is_streaming(self): return True
+        def feed_stream(self, b): pass
+        async def run_stream(self, send): started["task"] = True
+        resolved = {"backend": "voxtral_realtime", "device": "cuda", "computeType": "bfloat16"}
+
+    eng = FakeEng()
+
+    async def scenario():
+        state = {"asr_engine": eng, "handlers": {}}
+        ae.register(state)
+        conn = server.Conn(type("WS", (), {"send": lambda self, d: None})())
+        reply, _ = await server.handle_message(
+            state, json.dumps({"type": "asr_init", "id": 1, "model": "voxtral-mini-4b-realtime",
+                               "language": "en", "device": "cuda"}), None, conn)
+        await asyncio.sleep(0)            # let the created task run
+        return reply, conn
+
+    reply, conn = asyncio.run(scenario())
+    assert reply["type"] == "ready"
+    assert conn.ctx["on_binary"] == eng.feed_stream    # streaming uses the enqueue feeder
+    assert started["task"] is True                     # run_stream task was started
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k starts_streaming_task -v`
+Expected: FAIL — current `_h_asr_init` always wires `on_binary = eng.feed` and never starts a task.
+
+- [ ] **Step 3: Branch `_h_asr_init` on streaming**
+
+In `sidecar/sokuji_sidecar/asr_engine.py`, replace the body of `_h_asr_init` so it branches:
+
+```python
+async def _h_asr_init(state, msg, _b, conn=None):
+    import asyncio
+    eng = state["asr_engine"]
+    model = msg.get("model")
+    # Decide streaming vs offline up front by resolving the backend once.
+    eng_is_streaming = False
+    if hasattr(eng, "init_streaming"):
+        eng.init_streaming(model, msg.get("language", ""), msg.get("sampleRate", SRC_RATE),
+                           msg.get("vadThreshold"), msg.get("vadMinSilenceDuration"),
+                           msg.get("vadMinSpeechDuration"), msg.get("device", "auto"))
+        eng_is_streaming = eng.is_streaming()
+    if eng_is_streaming:
+        if conn is not None:
+            conn.ctx["on_binary"] = eng.feed_stream
+            conn.ctx["stream_task"] = asyncio.create_task(eng.run_stream(conn.send))
+        ms = 0
+    else:
+        ms = eng.init(model, msg.get("language", ""), msg.get("sampleRate", SRC_RATE),
+                      msg.get("vadThreshold"), msg.get("vadMinSilenceDuration"),
+                      msg.get("vadMinSpeechDuration"), msg.get("device", "auto"))
+        if conn is not None:
+            conn.ctx["on_binary"] = eng.feed
+    reply = {"type": "ready", "id": msg.get("id"), "loadTimeMs": ms}
+    resolved = getattr(eng, "resolved", None)
+    if resolved:
+        reply.update(resolved)
+    return reply, None
+```
+
+(Note: `init_streaming` resolves+loads the backend so `is_streaming()` is accurate; for an offline backend the load happens twice — acceptable, or guard with a dry resolve. Keep `init_streaming` cheap when the resolved backend is not streaming: have it return early without loading the model if `not getattr(backend, "STREAMING", False)`, leaving the offline `init()` to load. Implement that early-return so offline models aren't loaded twice.)
+
+Also extend `server.py` `_conn` cleanup to cancel the task on close (just before `eng.close()`):
+
+```python
+        task = conn.ctx.get("stream_task")
+        if task is not None:
+            task.cancel()
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k "starts_streaming_task or streaming" -v`
+Expected: PASS. Then `cd sidecar && .venv/bin/python -m pytest tests/test_server_conn.py tests/test_server_envelope.py -v` → PASS (offline transport unaffected).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/asr_engine.py sidecar/sokuji_sidecar/server.py sidecar/tests/test_asr_engine.py
+git commit -m "feat(sidecar): asr_init starts the streaming task for STREAMING backends"
+```
+
+---
+
+### Task 4: Wire `partial` event + `NativeAsrClient.onPartialResult`
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeProtocol.ts`, `src/lib/local-inference/native/NativeAsrClient.ts`
+- Test: `src/lib/local-inference/native/NativeAsrClient.test.ts`
+
+**Interfaces:**
+- Consumes: the id-less `partial {type:'partial', text}` event (Task 2/3).
+- Produces: `AsrPartialMsg` in `ServerMsg`; `NativeAsrClient.onPartialResult: ((text: string) => void) | null` invoked on `partial`. Task 5 consumes `onPartialResult`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/lib/local-inference/native/NativeAsrClient.test.ts`, add a test that a `partial` message routes to `onPartialResult` and `result` still routes to `onResult`:
+
+```typescript
+it('dispatches partial → onPartialResult and id-less result → onResult', () => {
+  const c = new NativeAsrClient();
+  const partials: string[] = [];
+  const finals: string[] = [];
+  c.onPartialResult = (t) => partials.push(t);
+  c.onResult = (r) => finals.push(r.text);
+  // reach the private onMessage via the same path the WS uses
+  (c as any).onMessage(JSON.stringify({ type: 'partial', text: 'he llo' }));
+  (c as any).onMessage(JSON.stringify({ type: 'result', text: 'hello world', durationMs: 1000, recognitionTimeMs: 50 }));
+  expect(partials).toEqual(['he llo']);
+  expect(finals).toEqual(['hello world']);
+});
+```
+
+(If the existing test file constructs the client differently, follow its existing setup; the assertion is the contract.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/lib/local-inference/native/NativeAsrClient.test.ts -t "onPartialResult"`
+Expected: FAIL — `onPartialResult` is undefined / `partial` falls through to no handler.
+
+- [ ] **Step 3: Implement**
+
+In `src/lib/local-inference/native/nativeProtocol.ts`, add the message type and union it:
+
+```typescript
+export interface AsrPartialMsg { type: 'partial'; text: string; }
+```
+and add `| AsrPartialMsg` to the `ServerMsg` union.
+
+In `src/lib/local-inference/native/NativeAsrClient.ts`, add the callback field next to `onResult`:
+
+```typescript
+  onPartialResult: ((text: string) => void) | null = null;
+```
+and in `onMessage`, before the `result` branch:
+
+```typescript
+    if (msg.type === 'partial') { this.onPartialResult?.(msg.text); return; }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/lib/local-inference/native/NativeAsrClient.test.ts`
+Expected: PASS (new test + existing NativeAsrClient tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeProtocol.ts src/lib/local-inference/native/NativeAsrClient.ts src/lib/local-inference/native/NativeAsrClient.test.ts
+git commit -m "feat(native): partial wire event + NativeAsrClient.onPartialResult"
+```
+
+---
+
+### Task 5: `LocalNativeClient` interim→final (`partialUserItem`)
+
+**Files:**
+- Modify: `src/services/clients/LocalNativeClient.ts`
+- Test: `src/services/clients/LocalNativeClient.test.ts`
+
+**Interfaces:**
+- Consumes: `NativeAsrClient.onPartialResult` (Task 4); the existing `onAsrResult`, `emit`, `runJob`, `translate`.
+- Produces: a `partialUserItem` that updates on partials (no pipeline job) and finalizes on the result (then runs the existing translation job once). Mirrors `LocalInferenceClient`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `src/services/clients/LocalNativeClient.test.ts`, add (using the existing test's fake `asr`/`translate` deps):
+
+```typescript
+it('renders partials as one in-progress item and runs the job only on the final', async () => {
+  const translate = { init: async () => {}, translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
+  const asr: any = { init: async () => ({ device: 'cuda' }), feedAudio() {}, flush() {}, dispose() {}, onResult: null, onPartialResult: null, onError: null };
+  const client = new LocalNativeClient({ asr, translate });
+  const items: any[] = [];
+  client.setEventHandlers({ onConversationUpdated: ({ item }) => items.push({ id: item.id, status: item.status, text: item.formatted?.transcript }), onOpen() {}, onRealtimeEvent() {} } as any);
+  await client.connect(LOCAL_NATIVE_CONFIG);  // reuse the exact config object the existing LocalNativeClient.test.ts connect() test already builds — copy that fixture/factory into this test rather than inventing a new one
+  asr.onPartialResult('he');            // partial 1
+  asr.onPartialResult('hello');         // partial 2 (same item updates)
+  expect(translate.translate).not.toHaveBeenCalled();
+  asr.onResult({ text: 'hello world' }); // final
+  await new Promise((r) => setTimeout(r, 0));
+  expect(translate.translate).toHaveBeenCalledTimes(1);
+  const userItems = items.filter((i) => i.id.startsWith('user'));
+  expect(new Set(userItems.map((i) => i.id)).size).toBe(1);  // one user item across partials+final
+});
+```
+
+(Match the existing `LocalNativeClient.test.ts` config/mocks; the assertions are the contract: partials don't translate, finals do, one user item.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npm run test -- src/services/clients/LocalNativeClient.test.ts -t "in-progress item"`
+Expected: FAIL — no `onPartialResult` wiring; partials are ignored or each becomes a new completed item.
+
+- [ ] **Step 3: Implement (mirror `LocalInferenceClient.partialUserItem`)**
+
+In `src/services/clients/LocalNativeClient.ts`:
+- Add a field: `private partialUserItem: ConversationItem | null = null;`
+- In `connect()`, wire the callback: `this.asr.onPartialResult = (text: string) => this.onAsrPartial(text);`
+- Add the handler:
+
+```typescript
+  private onAsrPartial(text: string): void {
+    if (!text) return;
+    if (!this.partialUserItem) {
+      this.partialUserItem = {
+        id: this.nextId('user'), role: 'user', type: 'message', status: 'in_progress',
+        createdAt: Date.now(), formatted: { transcript: text },
+      };
+      this.items.push(this.partialUserItem);
+      this.emit(this.partialUserItem);
+    } else {
+      this.partialUserItem.formatted!.transcript = text;
+      this.emit(this.partialUserItem, { transcript: text });
+    }
+  }
+```
+- Change `onAsrResult` to finalize the partial item instead of always creating a new one:
+
+```typescript
+  private onAsrResult(r: { text: string }): void {
+    if (!r.text?.trim()) return;
+    this.emitEvent('local.native.asr.result', 'server', { text: r.text });
+    let userItem = this.partialUserItem;
+    if (userItem) {
+      userItem.status = 'completed';
+      userItem.formatted!.transcript = r.text;
+      this.partialUserItem = null;
+    } else {
+      userItem = {
+        id: this.nextId('user'), role: 'user', type: 'message', status: 'completed',
+        createdAt: Date.now(), formatted: { transcript: r.text },
+      };
+      this.items.push(userItem);
+    }
+    this.emit(userItem);
+    this.queue = this.queue.then(() => this.runJob(r.text)).catch((e) => {
+      this.emitEvent('local.native.error', 'client', { error: String(e) });
+      this.handlers.onError?.(String(e));
+    });
+  }
+```
+- In `disconnect()` and `reset()`, add `this.partialUserItem = null;`
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npm run test -- src/services/clients/LocalNativeClient.test.ts`
+Expected: PASS (new test + existing LocalNativeClient tests — the offline `result`-only path still works via the `else` branch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/clients/LocalNativeClient.ts src/services/clients/LocalNativeClient.test.ts
+git commit -m "feat(native): LocalNativeClient renders streaming partials (interim→final)"
+```
+
+---
+
+### Task 6: Promote the catalog row to `recommended`
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/catalog.py`, `src/lib/local-inference/native/nativeCatalog.ts`
+- Test: `sidecar/tests/test_catalog.py`, `src/lib/local-inference/native/nativeCatalog.test.ts`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `voxtral-mini-4b-realtime` with `recommended=True` (sidecar) / `recommended: true` (renderer); `sort_order`/`sortOrder` 9 unchanged.
+
+- [ ] **Step 1: Update the tests (RED)**
+
+In `sidecar/tests/test_catalog.py`, change the `test_voxtral_realtime_row` assertion `assert m.recommended is False` → `assert m.recommended is True`.
+In `src/lib/local-inference/native/nativeCatalog.test.ts`, change the Voxtral test's `expect(v!.recommended).toBeFalsy();` → `expect(v!.recommended).toBe(true);`.
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py -k voxtral -v` → FAIL; `npm run test -- src/lib/local-inference/native/nativeCatalog.test.ts -t "Voxtral"` → FAIL.
+
+- [ ] **Step 3: Flip the flag in both catalogs**
+
+In `sidecar/sokuji_sidecar/catalog.py`, the `voxtral-mini-4b-realtime` `AsrModel`: `recommended=False` → `recommended=True`.
+In `src/lib/local-inference/native/nativeCatalog.ts`, the Voxtral row: add `recommended: true` (place before `sortOrder: 9`).
+
+- [ ] **Step 4: Run to verify they pass**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py -v` → PASS; `npm run test -- src/lib/local-inference/native/nativeCatalog.test.ts` → PASS (the recommended-first ordering tests still hold — Voxtral now joins the recommended set but `sortOrder 9` keeps it after the existing recommended rows).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/catalog.py src/lib/local-inference/native/nativeCatalog.ts sidecar/tests/test_catalog.py src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(native): promote Voxtral Mini 4B Realtime to recommended (streaming landed)"
+```
+
+---
+
+### Task 7: End-to-end streaming GPU smoke (through the engine + transport)
+
+**Files:**
+- Test: `sidecar/tests/test_asr_engine.py` (a `SOKUJI_RUN_GPU`-gated end-to-end test driving `run_stream` with a fake conn)
+
+**Interfaces:**
+- Consumes: the full streaming path (Tasks 1-3) + a real GPU + the cached model.
+- Produces: a gated test that feeds a real clip through `init_streaming` + `feed_stream` + `run_stream`, asserting `speech_start` → partials → a non-empty `result`.
+
+- [ ] **Step 1: Write the gated end-to-end test**
+
+Append to `sidecar/tests/test_asr_engine.py`:
+
+```python
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (uses cached Voxtral-Mini-4B-Realtime; needs CUDA)")
+def test_streaming_end_to_end_real_gpu():
+    import glob, wave, asyncio
+    from huggingface_hub import snapshot_download
+    snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                      ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    eng = AsrEngine()
+    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en",
+                       sample_rate=16000, device="cuda")
+    wav = glob.glob(os.path.expanduser(
+        "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
+    w = wave.open(wav)
+    pcm = w.readframes(w.getnframes())
+    sent = []
+    async def send(m): sent.append(m)
+    async def drive():
+        for i in range(0, len(pcm), 3200):       # ~100ms @16k int16
+            eng.feed_stream(pcm[i:i + 3200])
+        eng.feed_stream(None)                     # end-of-stream sentinel
+        await eng.run_stream(send)
+    asyncio.run(drive())
+    types_seen = [m["type"] for m in sent]
+    assert "speech_start" in types_seen and "partial" in types_seen
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"].strip()
+    print(f"streaming e2e: {types_seen.count('partial')} partials, final={results[-1]['text']!r}")
+    eng.close()
+```
+
+- [ ] **Step 2: Verify it skips without the flag**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming_end_to_end -v` → `1 skipped`.
+
+- [ ] **Step 3: Run it on the 4070 (model cached)**
+
+Run: `cd sidecar && SOKUJI_RUN_GPU=1 .venv/bin/python -m pytest tests/test_asr_engine.py -k streaming_end_to_end -v -s`
+Expected: PASS — prints partial count + final transcript. If the VAD endpoint never fires on a clip with no trailing silence, the 20 s cap (or end-of-stream sentinel) forces the final; confirm the final is non-empty.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sidecar/tests/test_asr_engine.py
+git commit -m "test(sidecar): end-to-end streaming GPU smoke (speech_start → partials → result)"
+```
+
+---
+
+### Task 8: Full-suite verification
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Full sidecar pytest**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: PASS (GPU-gated tests skipped without their flag).
+
+- [ ] **Step 2: Renderer vitest (native + clients)**
+
+Run: `npm run test -- src/lib/local-inference/native/ src/services/clients/LocalNativeClient.test.ts`
+Expected: PASS.
+
+- [ ] **Step 3: Build**
+
+Run: `npm run build`
+Expected: exit 0.
+
+- [ ] **Step 4: Commit only if Steps 1-3 surfaced fixes**
+
+If a fix was needed: `git add -A && git commit -m "test(native): green streaming suites"`. Otherwise nothing to commit — skip.

--- a/docs/superpowers/specs/2026-06-25-voxtral-always-stream-design.md
+++ b/docs/superpowers/specs/2026-06-25-voxtral-always-stream-design.md
@@ -1,0 +1,193 @@
+# Native ASR: Voxtral Realtime — Always-Stream (option d) — Design
+
+**Status:** PLANNED. Supersedes the VAD-input-gated streaming of Phase 2 for the `voxtral_realtime` backend.
+**Branch:** `feat/native-asr-voxtral-always-stream` (to be cut from `feat/native-asr-voxtral-streaming`).
+**Date:** 2026-06-25.
+**Builds on:** Phase 2 streaming (`docs/superpowers/specs/2026-06-25-voxtral-realtime-streaming-design.md`).
+
+## 1. Goal
+
+Eliminate the **leading-word loss** in Phase 2 (the first ~0.25 s of each utterance is dropped because the
+stream is only opened on the VAD speech-start *rising edge*, which lags the true onset). Switch to the
+architecture the Realtime model was built for: **feed all audio continuously to one long-lived streaming
+session** (no input gating), and use silero VAD + the model's own punctuation to segment the **output**
+into per-sentence finals. This also removes Phase 2's per-utterance reset.
+
+**Out of scope:** vLLM; any translation/TTS change (finals still feed the unchanged pipeline); the offline
+path; the renderer wire/render contract (reused as-is). ASR streaming only.
+
+## 2. Context: what Phase 2 gives us, and what changes
+
+- **Phase 2** opens a fresh `VoxtralRealtimeStream` per utterance on the VAD `"start"` event and feeds only
+  from that point (`asr_engine.py` `_drive`/`_vad_events`/`_finalize`). The rising edge lags the onset by
+  `min_speech_duration` (~0.25 s) + silero detection latency → the first word(s) are never fed → dropped.
+- **Reused unchanged:** the `VoxtralRealtimeStream` session (`voxtral_stream.py`) — it already supports
+  continuous `feed()` / `drain()` / `end()`; the `STREAMING` flag + `open_stream()`; the transport
+  `run_stream` asyncio task + `feed_stream` enqueue + the close-abort cleanup; the `partial`/`result` wire
+  events; the renderer (`NativeAsrClient.onPartialResult`, `LocalNativeClient.partialUserItem`).
+- **Changed:** the engine's streaming branch logic (`_drive`/`_vad_events`/`_finalize`) is reworked into the
+  always-stream loop (§5). Phase 2's input-gated open/feed/finalize is superseded.
+
+## 3. Spike findings (verified live on the RTX 4070 — the design is built on these)
+
+A GPU spike fed a `speech-silence-speech` clip (9.69 s) continuously to ONE long-lived stream (never reset),
+realtime-paced, logging each token's arrival time + VRAM:
+
+- **Continuous input solves the leading loss.** The very first word transcribed correctly; the full final
+  was the complete, correct transcript with no clipped beginning.
+- **Stable + VRAM bounded.** One `generate` ran the whole clip with **VRAM 8.86→9.05 GB** (0.19 GB drift) —
+  the model's sliding-window attention (text 4096 / encoder 750) holds it flat. No crash.
+- **Silence emits empties, not hallucinations.** During the ~2 s mid-clip silence the model emitted empty
+  (`''`) deltas and **no spurious text**, then resumed correctly on the second utterance.
+- **Output timing does NOT cleanly align with utterance boundaries (the key finding).** The model *batches*:
+  the last words of utterance 1 ("…your country.") were **held and flushed ~3.3 s after their audio**
+  (through the silence), then utterance 2's "Ask" arrived **0.09 s later**. So there is no reliable *gap* in
+  the output at a boundary, and "VAD endpoint + fixed delay" would chop the held tail.
+- **The model's punctuation is clean and well-placed:** "…can do for you**. **Ask what you can do for your
+  country**. **Ask not…". Sentence-final punctuation is the reliable segmentation signal — and yields
+  translation-ideal sentence chunks.
+
+A second **rate-limit (backpressure) spike** simulated slower GPUs by feeding faster than real time
+(feed-rate R× ≈ a GPU with effective RTF ≈ 0.45·R at a 1× mic):
+
+- At true 1× mic rate the input backlog sits **flat at the model's intrinsic ~0.56 s**. The 4070 keeps up
+  even at **2.5× over-feed** (backlog ≤ 0.7 s) — under continuous streaming it batches more efficiently than
+  the 0.45 RTF estimate, so its real ceiling is ~2.5×.
+- **Past the ceiling (5× over-feed ≈ a GPU ~2.25× too slow) the backlog grows ~2.4 s per wall-second and
+  crosses 3 s within ~1 s of sustained overload** — then **drains just as fast (~2.4 s/s) the moment the
+  input slows** (RTF < 1). So a healthy session (~0.56 s, flat) is cleanly separable from an overloaded one
+  (runaway), and a marginal machine recovers as soon as it gets pause-slack — exactly what degrading to
+  per-utterance provides. This grounds the §7 backpressure threshold.
+
+## 4. Decisions
+
+1. **Continuous input, no VAD gating.** All audio is fed to the current stream. VAD no longer decides what
+   the model hears — it only tracks speech/silence *state*.
+2. **Finals are cut on sentence-final punctuation** (`. ` / `! ` / `? ` — punctuation followed by whitespace,
+   which avoids decimals like `3.5`), not on VAD timing (misaligned by the model's hold/delay, §3).
+3. **VAD long-silence (≥ 2.5 s) does two things:** (a) flush any pending un-punctuated text as a final
+   (covers trailing-off utterances), and (b) restart the stream (`end()` + reopen) — a clean restart during
+   silence loses no audio and caps per-stream context regardless of session length.
+4. **Reuse `VoxtralRealtimeStream` as the per-stream-segment session;** the engine owns the continuous loop +
+   segmentation. Fixed `num_delay_tokens` (480 ms) as Phase 2.
+5. **Long-speech safety net:** if speech runs > ~4 min with no long pause, force a restart at the next
+   sentence cut (avoids the >5.5-min sliding-window edge, unverified).
+6. **Backpressure + graceful degradation (§7):** always-stream requires sustained RTF < 1; on hardware that
+   can't keep up, the engine detects a growing input backlog and degrades to Phase 2's per-utterance mode for
+   the rest of the session, rather than letting latency climb unboundedly.
+
+## 5. Architecture
+
+### 5.1 The always-stream loop (`asr_engine.py`, reworking the streaming branch)
+
+`init_streaming` opens one `VoxtralRealtimeStream` up front (or on the first audio) and initializes
+`_utt_text = ""`, `_sentence_re`, the VAD, a silence-duration counter, and a stream-age counter. The
+`run_stream` asyncio task, per audio buffer pulled from the queue:
+
+1. **Feed unconditionally:** downsample → `self._stream.feed(samples)` (no VAD gate).
+2. **VAD state:** run silero VAD on the same samples; track `silence_ms` (reset on speech) and emit
+   `speech_start` on a silence→speech rising edge (UI cue only).
+3. **Drain + accumulate:** `for d in self._stream.drain(): self._pending += d`; then segment `self._pending`
+   (§5.2), emitting `result`s for completed sentences and keeping the trailing remainder in `_utt_text`;
+   emit `partial {text: _utt_text}` if it changed.
+4. **Long silence (≥ 2500 ms) or stream-age > ~4 min:** flush `_utt_text` as a `result` if non-empty, then
+   `self._stream.end()` (or `abort()`), `self._stream = self._backend.open_stream()`, reset counters. Keep
+   feeding the new stream.
+
+### 5.2 Sentence segmentation (the one tricky unit — its own helper)
+
+A pure function `split_sentences(buffer: str) -> (list[str], str)` so it's unit-testable in isolation:
+
+```python
+import re
+_SENT_END = re.compile(r"(.*?[.!?])\s")   # smallest chunk ending in . ! ? then whitespace
+
+def split_sentences(buffer):
+    """Cut `buffer` into completed sentences (each ending in .!? + whitespace) and the
+    trailing remainder. 'Ask what you do. Ask not ' -> (['Ask what you do.'], 'Ask not ').
+    A buffer with no sentence end -> ([], buffer). Decimals ('3.5') don't split (no space)."""
+    out = []
+    while True:
+        m = _SENT_END.match(buffer)
+        if not m:
+            return out, buffer
+        out.append(m.group(1).strip())
+        buffer = buffer[m.end():]
+```
+
+The loop appends each completed sentence to `result`s, and `_utt_text = remainder.strip()` (the current
+incomplete sentence shown as the partial). This correctly handles a single delta straddling a boundary
+(`"country. Ask"` → final `"…country."`, partial `"Ask"`).
+
+### 5.3 What's reused / unchanged
+
+`VoxtralRealtimeStream` (feed/drain/end/abort), the `STREAMING` flag, `feed_stream`/`run_stream` wiring,
+`_h_asr_init`'s streaming branch start, the close-abort cleanup, the `partial`/`result` wire events, and the
+renderer. The `result` event keeps its shape (`text`, `startSample`, `durationMs`, `recognitionTimeMs` —
+the latter best-effort/approximate in always-stream mode).
+
+## 6. Error handling
+
+- **Generate error mid-session:** the stream's `aborted` flag flips; the loop flushes `_utt_text` as a final
+  and restarts the stream (self-heal) rather than dying.
+- **Connection close:** the Phase 2 close-abort path (`AsrEngine.close()` ends the open stream + sentinel) is
+  reused verbatim — no mid-utterance thread/VRAM leak.
+- **VAD failure:** degrade gracefully — punctuation finals still work; only restart + un-punctuated-flush are
+  lost (the long-speech safety net still caps context).
+- **No-punctuation drift:** if the model never emits sentence-final punctuation (rare), the VAD-long-silence
+  flush + the long-speech safety net guarantee finals still land.
+
+## 7. Hardware envelope & backpressure
+
+Always-stream is more throughput-hungry than Phase 2's per-utterance mode: it feeds and decodes
+**continuously, including during silence** (the model emits ~12.5 tok/s of empty tokens through a pause, §3),
+so it has **none of the "catch up during the user's pauses" slack** the per-utterance path enjoys. Sustained
+GPU throughput is therefore the binding constraint.
+
+**Requirements:**
+- **VRAM ≥ ~9 GB** — the bf16 4B model + bounded sliding-window cache (independent of always-stream; <9 GB
+  GPUs can't run the model at all without quantization).
+- **Sustained RTF < 1** — the GPU must transcribe audio faster than it arrives. A live mic produces audio at
+  exactly 1× real time, so the input queue stays empty iff RTF < 1. The dev 4070 is RTF ≈ 0.45 (~2.2× margin,
+  measured). A GPU/CPU with RTF ≥ 1 cannot keep up: the backlog grows without bound and latency climbs.
+
+**Backpressure + graceful degradation:** the engine monitors the input backlog — the `_audio_q` depth, or the
+fed-audio-time minus processed-audio-time lag. On adequate hardware this sits near the model's ~0.5 s
+intrinsic delay. If the backlog **grows monotonically past ~3 s** (a sustained sign that RTF ≥ 1 on this
+machine), the engine **degrades to Phase 2's per-utterance mode** for the rest of the session — per-utterance
+reclaims pause-slack and bounds latency, trading the leading-word fix back for keeping up. This makes
+always-stream the **default on capable GPUs and a self-downgrading choice on marginal ones**, not a
+4070-only design. (The ~3 s threshold + the backlog-growth rate are confirmed by the rate-limit spike, §3.)
+
+## 8. Testing
+
+- **Unit — `split_sentences`** (`test_voxtral_stream.py` or a new `test_segmentation.py`): `"a. b. "` →
+  `(["a.", "b."], "")`; `"hello wor"` → `([], "hello wor")`; `"x. Ask"` → `(["x."], "Ask")`; `"3.5 ml "` →
+  `([], "3.5 ml ")` (decimal not split).
+- **Unit — engine always-stream** (`test_asr_engine.py`, fake stream + VAD stub, no GPU): every buffer is fed
+  (assert the fake stream's fed-sample count == all input, i.e. NOT gated); deltas accumulate into `partial`;
+  a delta with `". "` cuts a `result` + carries the remainder; a VAD long-silence flushes a pending final +
+  opens a new stream (assert `open_stream` called twice).
+- **GPU smoke (`SOKUJI_RUN_GPU`)** — the `speech-silence-speech` clip, paced + concurrent (per Phase 2): the
+  **first word is present** (no leading loss), ≥1 sentence-level `result` per half, a stream restart occurs
+  at the long silence, and VRAM stays ~9 GB. This is the spike, frozen.
+- Gates: `pytest` (sidecar) + `vitest` (renderer, unchanged); `npm run build`.
+
+## 9. Out of scope (YAGNI)
+
+- No vLLM; no translation/TTS change; no offline-path or renderer-contract change.
+- No abbreviation-aware sentence splitting (`Mr.`/`Dr.`) — spoken-ASR transcripts rarely hit it; the
+  whitespace rule already excludes decimals. Revisit only if it misfires in practice.
+- No per-token timestamps / word-level timing (the `result` `durationMs`/`startSample` are approximate).
+- No configurable silence/restart thresholds in the UI (fixed: 2.5 s restart, ~4 min safety net).
+
+## 10. Files touched
+
+- `sidecar/sokuji_sidecar/asr_engine.py` — rework the streaming branch into the always-stream loop
+  (continuous feed, VAD state, drain+segment, restart-on-long-silence); `split_sentences` helper (here or in
+  `voxtral_stream.py`). The offline path stays unchanged.
+- `sidecar/sokuji_sidecar/voxtral_stream.py` — only if `abort()` needs a non-blocking variant for restart
+  (it already exists from Phase 2's final fix).
+- `sidecar/tests/test_asr_engine.py`, `sidecar/tests/test_voxtral_stream.py` (or `test_segmentation.py`) —
+  the `split_sentences` unit tests, the always-stream engine unit test, and the updated GPU smoke.
+- No renderer changes (the `partial`/`result` contract is unchanged).

--- a/docs/superpowers/specs/2026-06-25-voxtral-pause-segmentation-design.md
+++ b/docs/superpowers/specs/2026-06-25-voxtral-pause-segmentation-design.md
@@ -1,0 +1,139 @@
+# Native ASR: Voxtral Realtime — Pause-Driven Segmentation (Plan A) — Design
+
+**Status:** PLANNED. Reworks the always-stream segmentation that just landed
+(`2026-06-25-voxtral-always-stream-design.md`).
+**Branch:** `feat/native-asr-voxtral-always-stream`.
+**Date:** 2026-06-25.
+
+## 1. Goal
+
+Make the always-stream Voxtral ASR commit finals (→ translation) **promptly, completely, and under the
+user's control**, fixing three coupled problems found in real use:
+
+1. **Slow/clumpy translation.** Finals only fire on a hardcoded `_silence_samples >= 2.5s` counter, so
+   translation arrives ~3.9 s after you stop (silero's 1.4 s endpoint + the 2.5 s counter on top).
+2. **Tail-hold.** The last word of an utterance is never in the partial — it appears only when the *next*
+   utterance starts. (The model holds the final token until the generate terminates or new audio arrives.)
+3. **The "Min Silence Duration" slider is masked.** It reaches silero, but the hardcoded 2.5 s counter
+   dominates segmentation, so the slider (labeled *"split speech segments faster"*) barely changes timing.
+
+**Out of scope:** vLLM, TTS, the translation model; the offline path; the transport/wire/renderer contract
+(reused unchanged); changing the global VAD defaults (the 1.4 s default stays — we only make it *effective*).
+
+## 2. Context: the VAD chain + what always-stream does today
+
+The VAD settings are fully plumbed: UI sliders (`LocalSettingsControls.tsx`) → store
+(`vadMinSilenceDuration` default **1.4 s**, `settingsStore.ts:373`) → `LocalNativeClient` →
+`NativeAsrClient` (`asr_init` msg) → backend `_h_asr_init` → `_init_vad` → `silero_vad.min_silence_duration`.
+
+But `_drive_always` (the just-landed always-stream loop) ignores silero's endpoint for segmentation: it runs
+its own `_vad_state` (rising edge + per-buffer speech) and cuts on `_silence_samples >= int(2.5*TARGET_RATE)`
+(`asr_engine.py:356`), plus a `split_sentences` punctuation cut that never fires (the model emits commas but
+no sentence-final period). So segmentation is governed by the 2.5 s constant, not the user's slider.
+
+## 3. Spike findings (verified live on the RTX 4070)
+
+- **Soft-flush is insufficient (the decisive finding).** Feeding the model's `_right_pad` (17×1280 = 21760
+  samples ≈ 1.36 s of silence) mid-stream *without* ending flushed most of a held tail (`"do for your"`) but
+  **kept holding the very last word (`"country."`)**; that word only emerged when the next utterance's audio
+  arrived. A *non-terminating* generate always holds the final token until it terminates or sees real new
+  audio. **So only `end()` (which terminates the generate) yields a complete final.**
+- **`end()` flushes the complete tail** — it appends `_right_pad`, drains to the generate's completion, and
+  returns the full transcript including the held last word. (Proven; `VoxtralRealtimeStream.end()`.)
+- **The held tail is not recoverable any other way** — two spikes confirmed silence padding alone (even ~2 s)
+  does not commit the last token.
+
+## 4. Decisions
+
+1. **Segment on silero's endpoint, not a constant.** The pause-cut fires on silero's speech→silence
+   transition (`is_speech_detected()` True→False), which is governed by the user's `vadMinSilenceDuration`.
+   The slider becomes the real, live pause threshold (0.05–2.0 s). Remove the `_silence_samples` counter, the
+   2.5 s constant, and the 4-min safety.
+2. **Pause-cut = `end()` + reopen.** On the endpoint, `end()` the current stream (flushes the **complete**
+   tail → the last word lands at the pause, not at the next utterance) and emit `end()`'s full transcript as
+   the `result`. Then `open_stream()` a fresh session and keep feeding. Continuous feed is preserved, so no
+   leading loss (the reopen happens during the pause; the next utterance is captured from its first word).
+3. **The audio queue is the during-end buffer.** `end()` runs in the asyncio executor (~0.6–1 s, doesn't
+   block the loop logic, but the loop awaits it); incoming audio accumulates in `_audio_q` meanwhile and is
+   fed to the new stream once it opens. Nothing is dropped; if the user resumes mid-`end()` (rare — they just
+   paused ≥1.4 s) that speech is delayed ~1 s, never lost. Serial: one utterance fully finalizes before the
+   next begins, so the renderer never sees interleaved items.
+4. **Drop punctuation cutting from the hot path.** `split_sentences` never fires for this model and a
+   mid-stream punctuation cut would have the same tail-hold problem. The endpoint is the sole cut.
+   `split_sentences` stays as a tested utility (unused) — optional later cleanup.
+5. **Keep one safety net:** a `_max_speech_samples` cap (~20 s of unbroken speech with no endpoint) forces an
+   `end()`+reopen so run-on speech can't starve translation or grow VRAM. A bound, not a tuning knob.
+6. **Min-utterance guard:** only `end()`+reopen on an endpoint if the stream produced text (`_pending`
+   non-empty) — avoids empty finals + wasted reopens on a speech blip that transcribed to nothing.
+7. **Default stays 1.4 s** (global; untouched so other models' endpointing is unaffected). The user tunes the
+   Voxtral pause live via the now-functional slider.
+
+## 5. Architecture
+
+### 5.1 `_vad_state` returns the falling edge (`asr_engine.py`)
+
+Today `_vad_state(samples) -> (had_speech, rising)`. Extend it to `-> (had_speech, rising, falling)`, where
+`falling` is True on any window where `is_speech_detected()` goes True→False this buffer (silero's endpoint,
+governed by `min_silence_duration`). Mirrors the rising-edge logic already in the method.
+
+### 5.2 Reworked `_drive_always` loop
+
+Per audio buffer:
+1. Downsample; `self._stream.feed(samples)` (continuous, never gated); `self._fed_s += …` (backpressure,
+   unchanged); `self._speech_samples += len(samples)` while `had_speech`.
+2. `had_speech, rising, falling = self._vad_state(samples)` (VAD-failure try/except unchanged → treat as
+   speech). Emit `speech_start` on `rising` (UI cue).
+3. Drain → `self._pending += "".join(deltas)`; emit `partial {text: self._pending.strip()}`.
+4. `aborted` self-heal (unchanged): `getattr(stream,"aborted",False)` → end+reopen + return.
+5. **Pause-cut:** if `(falling or self._speech_samples >= 20*TARGET_RATE)` **and** `self._pending.strip()`:
+   - `final = await loop.run_in_executor(None, self._stream.end)` (complete tail; queue backs up meanwhile).
+   - `if final.strip(): await send(self._result_event(final))`.
+   - `self._stream = self._backend.open_stream()`; reset `self._pending=""`, `self._speech_samples=0`.
+
+`run_stream`, `_drive_once`, `init_streaming` mode dispatch, the per-utterance fallback (`_drive_utterance`),
+and the backpressure degrade (lag > 3 s, Task 3) are unchanged. `init_streaming` drops `_silence_samples` /
+`_stream_speech_samples`; adds `_speech_samples` and keeps `_pending`.
+
+### 5.3 The result is `end()`'s transcript, not `_pending`
+
+`_pending` (the streamed partial) is missing the held tail; `end()` returns the authoritative complete text.
+The `result` carries `end()`'s return. The renderer's `LocalNativeClient.onAsrResult` replaces the in-progress
+item's text with it, so the held tail (e.g. `"… do for your country."`) appears at the pause.
+
+## 6. Error handling
+
+- **`end()` raises / times out:** wrap the executor call; on failure log, still `open_stream()` + reset so
+  the session self-heals (drop that utterance's final rather than wedging).
+- **Connection close mid-end:** `AsrEngine.close()` (reused) aborts the open stream + sentinel; an in-flight
+  executor `end()` completes or is abandoned with the threads joined.
+- **VAD failure:** `_vad_state` try/except → treat as speech (no false endpoint); the 20 s cap still bounds.
+- **Backpressure:** unchanged — lag > 3 s degrades to per-utterance (which reclaims pause-slack).
+
+## 7. Testing
+
+- **Unit (`test_asr_engine.py`, fake stream + VAD stub, no GPU):**
+  - `_vad_state` returns `falling=True` on a True→False transition.
+  - Endpoint with `_pending` non-empty → `end()` called once, `open_stream()` called once, the `result` text
+    equals the fake `end()`'s return (the complete tail, not `_pending`).
+  - Endpoint with empty `_pending` → no cut, no reopen (min-utterance guard).
+  - 20 s of continuous speech with no endpoint → forced end+reopen.
+  - During the awaited `end()`, queued buffers feed the NEW stream after reopen (assert no buffer dropped).
+  - Backpressure degrade test (Task 3) still green.
+- **GPU smoke (`SOKUJI_RUN_GPU`)** — the `speech-silence-speech` clip: assert the **last word of utterance 1
+  appears in utterance 1's final** (not on utterance 2) — i.e. the final contains the complete first sentence
+  — proving the tail-hold fix; finals are cut at the silero endpoint; first word present (no leading loss).
+- Gates: `pytest` (sidecar) + `vitest` (renderer, unchanged); `npm run build`.
+
+## 8. Out of scope (YAGNI)
+
+- No overlap/2-stream concurrency (the serial queue-buffer is enough); no changes to global VAD defaults; no
+  UI changes (the existing slider is reused); no punctuation/clause cutting; no per-token timestamps.
+
+## 9. Files touched
+
+- `sidecar/sokuji_sidecar/asr_engine.py` — `_vad_state` (+falling edge); `_drive_always` (endpoint→end+reopen,
+  remove `_silence_samples`/2.5 s/4-min/punctuation-cut, add `_speech_samples` 20 s cap + min-utterance
+  guard); `init_streaming` state init. Offline path + `_drive_utterance` + backpressure unchanged.
+- `sidecar/tests/test_asr_engine.py` — update the always-stream unit tests (endpoint-based) + the GPU smoke
+  (tail-hold assertion). The long-silence/punctuation tests from the prior design are replaced.
+- No renderer changes (the `partial`/`result` contract + the VAD plumbing are already correct).

--- a/docs/superpowers/specs/2026-06-25-voxtral-realtime-native-sidecar-asr-design.md
+++ b/docs/superpowers/specs/2026-06-25-voxtral-realtime-native-sidecar-asr-design.md
@@ -1,0 +1,332 @@
+# Native ASR: Voxtral Mini 4B Realtime (GPU sidecar) — Design
+
+**Status:** PLANNED. Phase 1 (offline-segment adapter) is the implementable scope of this spec.
+Phase 2 (true streaming engine) is sketched in §9 and gets its own spec → plan later.
+**Branch:** `feat/native-asr-voxtral-realtime` (to be cut from `native-sidecar`).
+**Date:** 2026-06-25.
+
+## 0. Empirical validation (measured 2026-06-25 on RTX 4070 SUPER, 12 GB) — supersedes the "unverified" hedges below
+
+A real load + transcription was run on the actual hardware (sidecar venv, transformers
+`5.13.0.dev0`, torch `2.11.0+cu128`), and a vLLM runtime comparison was done in an isolated venv.
+
+- **Transformers-native FITS 12 GB and works.** Weights 8.86 GB; **peak 10.3 GB** (nvidia-smi) during
+  offline per-segment generate — ~1.9 GB headroom. Load 6.1 s. **RTF ≈ 0.45–0.50 (~2× realtime)** —
+  a 5 s clip transcribes in ~2.5 s. Transcripts correct on en/ja/ko/zh (Cantonese `yue` garbled — not
+  one of the 13 languages, expected). **§4.4's 12 GB target is confirmed**; the "≥16 GB" is the default
+  ~3 h-context figure, irrelevant to bounded per-segment use.
+- **`mistral-common[audio]` is a CONFIRMED required dependency** (1.11.3 installed). The processor's
+  tokenizer *is* `MistralCommonBackend`.
+- **Offline loading needs the snapshot-DIR pattern, not the repo-id pattern.** `mistral_common`'s
+  tokenizer loader ignores transformers' `local_files_only=True` and `HF_HUB_OFFLINE=1` (both raise).
+  The working offline path: `d = snapshot_download(repo, local_files_only=True)` →
+  `AutoProcessor.from_pretrained(d)` + model from `d`. This differs from Cohere/Qwen3 (which pass the
+  repo id) and is the SherpaBackend dir-resolve pattern. See §5.1.
+- **Download must skip `consolidated.safetensors`.** The repo is 17.73 GB = `model.safetensors`
+  (8.86 GB, HF format, needed) + `consolidated.safetensors` (8.86 GB, Mistral format, NOT needed by
+  transformers). `download_specs`/`download` must ignore the consolidated file or every user wastes
+  8.86 GB. See §5.2.
+- **vLLM rejected for this use (measured).** Same single-stream speed (RTF 0.47 ≈ transformers 0.45),
+  but: needs an isolated venv (pins transformers 5.12.1, conflicting with the sidecar's 5.13 fork);
+  FlashInfer's ninja JIT kernel build fails on this CUDA toolchain out-of-box; only loads on 12 GB
+  when crippled to `max-model-len 512` (0.82 GiB KV, 1.37× concurrency — no batching headroom); and
+  it's a separate server process. Its real advantages (batched throughput, production `/v1/realtime`
+  WS) need ≥16 GB and don't fit sokuji's local single-user model. **Runtime decision = transformers
+  native (§4.1), now on evidence.**
+
+## 1. Goal
+
+Add **Voxtral Mini 4B Realtime** (`mistralai/Voxtral-Mini-4B-Realtime-2602`) as a GPU ASR model
+in the LOCAL_NATIVE Python sidecar, bf16 on CUDA, through the existing `AsrBackend` seam — the
+same path that already ships Granite Speech, Qwen3-ASR, and Cohere Transcribe.
+
+Voxtral Realtime is a *streaming* speech-LLM whose payoff is sub-500 ms live transcription
+(configurable 80 ms–2.4 s delay; recommended 480 ms). That payoff only materializes with a
+streaming recognizer, which the current sidecar engine does not have. So this work is **phased**:
+
+- **Phase 1 (this spec):** run the model **offline, per VAD segment** — a drop-in backend exactly
+  like Qwen3/Cohere. This validates catalog/download/gating/load/coexistence on real hardware and
+  ships a working (if not-yet-realtime) Voxtral ASR. It deliberately does **not** use the model's
+  streaming API.
+- **Phase 2 (future, §9):** a streaming engine seam that feeds continuous audio and emits
+  incremental transcripts at the configured delay — the actual reason to pick the realtime variant.
+
+Pure ASR only: Voxtral's built-in speech-*translation* (audio → text in another language) is noted
+as a future possibility (§9) but out of scope — sokuji keeps ASR and translation as separate stages.
+
+## 2. Context: what we already have
+
+- **The `AsrBackend` adapter pattern** (`load`/`transcribe`/`unload`/`is_loaded`), a
+  `@register_backend` registry (`make_backend`), the `accel.py` resolver with its `_installed()`
+  self-gate + tier ranking + CPU-floor fallback, the `catalog.py` model registry,
+  `native_models.download_specs`/status/download, and the renderer `nativeCatalog.ts` +
+  `NativeModelManagementSection`. Adding a GPU speech-LLM ASR is, by now, a well-worn path:
+  Granite (`TransformersBackend`), Qwen3-ASR (`Qwen3AsrBackend`), Cohere (`cohere_transformers`).
+- **The engine seam is offline-per-segment** (`AsrEngine`, `sidecar/sokuji_sidecar/asr_engine.py`):
+  silero VAD cuts speech into segments; each whole segment goes through
+  `backend.transcribe(samples_f32_16k, language)` and returns full text via a `result` event.
+  Phase 1 plugs straight into this — **no engine, wire-protocol, or renderer-rendering changes.**
+
+## 3. Verified facts (de-risking complete)
+
+Confirmed by live execution in the actual sidecar venv (`sidecar/.venv`, transformers
+`5.13.0.dev0` — the PR #43838 fork already pinned for Qwen3-ASR; torch `2.11.0+cu128`):
+
+- `transformers.models.voxtral_realtime` → `importlib.util.find_spec(...)` is **present**, and the
+  top-level `transformers` namespace exposes `VoxtralRealtimeForConditionalGeneration`,
+  `VoxtralRealtimeProcessor`, `VoxtralRealtimeFeatureExtractor`, `VoxtralRealtimeConfig`. **No venv
+  change, no transformers bump, no new pin.** (The model card requires `transformers >= 5.2.0`;
+  our fork branched from main well after that, so a future swap to a released `>=5.13` keeps it.)
+- The model's `config.json` reports `model_type: "voxtral_realtime"`,
+  `architectures: ["VoxtralRealtimeForConditionalGeneration"]`, and carries
+  `default_num_delay_tokens` + `audio_length_per_tok` (the streaming knobs — Phase 2 territory).
+- **The realtime processor is NOT API-compatible with the offline one.** `VoxtralProcessor`
+  (offline `voxtral`) has `apply_transcription_request` / `apply_chat_template`; the realtime
+  `VoxtralRealtimeProcessor` exposes only `__call__` — no transcription-request or chat-template
+  helper. So Phase 1 cannot reuse the offline-Voxtral idiom; it uses the documented realtime
+  offline path (audio-only `processor(...)` → `generate()` → `batch_decode`).
+- Granite / Qwen3 / Cohere all still import on the same transformers → Voxtral Realtime
+  **coexists** with the other speech-LLMs in one venv (the §6 spike re-checks this after `unload()`).
+
+Model facts (HuggingFace model card, `mistralai/Voxtral-Mini-4B-Realtime-2602`):
+
+| Property | Value |
+|---|---|
+| Checkpoint | `mistralai/Voxtral-Mini-4B-Realtime-2602` |
+| Weights | safetensors, bf16, ~8.8 GB |
+| Architecture | ≈3.4 B LM + ≈970 M audio encoder; **causal** audio encoder + sliding-window attention for "infinite" streaming |
+| Languages (13) | en, fr, es, de, ru, zh, ja, it, pt, nl, ar, hi, ko |
+| License | Apache 2.0 |
+| Audio | 16 kHz; `processor.feature_extractor.sampling_rate` is the canonical rate |
+| Streaming knobs | delay 80 ms–2.4 s (rec. 480 ms); 1 text token = 80 ms; `default_num_delay_tokens` (Phase 2) |
+| VRAM | "≥16 GB" — but that is at the **default ~3 h context** (`max-model-len 131072`). Weights are ~8.8 GB; a bounded context (our per-segment / streaming-window use) is expected to fit the 4070's 12 GB. **Unverified until the §6 spike.** |
+| Recommended runtime | vLLM (production streaming) **or** HF transformers native (`VoxtralRealtimeForConditionalGeneration`) |
+
+Documented HF-transformers **offline** path (model card), the basis for Phase 1's `transcribe`:
+
+```python
+from transformers import VoxtralRealtimeForConditionalGeneration, AutoProcessor
+processor = AutoProcessor.from_pretrained(repo_id)
+model = VoxtralRealtimeForConditionalGeneration.from_pretrained(repo_id, device_map="auto")
+inputs = processor(audio_array_16k, return_tensors="pt").to(model.device, dtype=model.dtype)
+outputs = model.generate(**inputs)
+print(processor.batch_decode(outputs, skip_special_tokens=True)[0])
+```
+
+Note: the card's example obtains `audio_array` via `mistral_common`'s `Audio.from_file` purely to
+load+resample a file. We already hold float32@16k samples from the VAD, so we feed them straight to
+`processor(...)`. Whether `mistral_common` is nonetheless a load-time dependency of the processor is
+an open item the §6 spike settles (the Cohere precedent: `librosa` was a hidden hard dep that only a
+real load surfaced).
+
+## 4. Decisions
+
+1. **Runtime = HF transformers native** (not vLLM) — **measured** (§0). It fits the existing
+   `backends.py` pattern with zero new process/dependency-runtime and matches every other backend. The
+   vLLM comparison showed identical single-stream speed but worse fit on every axis that matters here
+   (venv conflict, toolchain JIT failure, KV-starved on 12 GB, separate server). vLLM (Mistral's
+   production Realtime WebSocket API) is deferred to a possible Phase 2 only if transformers' native
+   streaming proves inadequate AND a ≥16 GB deployment is in scope. No ONNX/sherpa export exists.
+2. **Phased; Phase 1 is offline-per-segment.** The model runs through the unchanged VAD-segment
+   seam. The streaming engine is Phase 2 (§9).
+3. **`recommended = False` in Phase 1.** Offline mode is not this model's strength, and it's GPU-only
+   + large; promote to `recommended` when Phase 2 (streaming) lands. It appends after the existing
+   ASR rows: sidecar `sort_order = 9`, renderer `sortOrder = 9` (after Qwen3 at 8). No existing rows
+   shift.
+4. **VRAM target = 12 GB, measured.** The §6 spike loads on the 4070 with a bounded context and
+   records the real footprint. If it fits 12 GB: advertise the model under the existing has-GPU gate
+   (no new VRAM gating), and the GPU smoke runs locally. If it does **not** fit even bounded: fall
+   back to a follow-up that adds VRAM-size gating (the resolver/catalog can't see VRAM today —
+   `_nvidia_gpus()` reports `vram_mb = 0`; `hardwareGated()` only knows GPU present/absent). That
+   gating mechanism is explicitly **not** built in Phase 1.
+5. **Language = auto.** The model is multilingual and the offline example passes no language. Phase 1
+   does not pass a language hint (auto-detect); the catalog lists the 13 supported languages so the
+   compatible/incompatible split works. The §6 spike confirms whether the processor even accepts a
+   hint; if a hint materially helps, wiring it is a small follow-up (no `requiresExplicitLanguage`,
+   unlike Cohere).
+
+## 5. Architecture (Phase 1)
+
+### 5.1 `VoxtralRealtimeBackend` (`sidecar/sokuji_sidecar/backends.py`)
+
+A new `@register_backend` class, `NAME = "voxtral_realtime"`, GPU-only, mirroring
+`CohereTransformersBackend` (audio-only input, no chat template, no prompt slicing).
+
+```python
+@register_backend
+class VoxtralRealtimeBackend:
+    """Voxtral Mini 4B Realtime via native transformers
+    (VoxtralRealtimeForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
+    loaded with .to(device) (no accelerate). Phase 1 runs the streaming model OFFLINE,
+    one whole VAD segment per generate() — audio-only input, transcript-only output (no
+    chat template). Multilingual auto-detect: the language arg is recorded, not passed."""
+    NAME = "voxtral_realtime"
+
+    def load(self, model_ref, device, compute_type):
+        self._model = None; self._proc = None
+        if device == "cpu":
+            raise BackendLoadError("voxtral_realtime is GPU-only")
+        try:
+            import torch
+            from huggingface_hub import snapshot_download
+            from transformers import VoxtralRealtimeForConditionalGeneration, AutoProcessor
+            self._dtype = torch.bfloat16 if compute_type in ("bfloat16", "auto") else torch.float16
+            # mistral_common's tokenizer loader ignores local_files_only / HF_HUB_OFFLINE and
+            # tries to hit the hub; passing the resolved snapshot DIRECTORY makes it load the
+            # cached tekken.json locally (verified §0). This is the SherpaBackend dir-resolve
+            # idiom, NOT Cohere/Qwen3's repo-id idiom.
+            d = snapshot_download(model_ref, local_files_only=True)
+            self._proc = AutoProcessor.from_pretrained(d)
+            self._model = VoxtralRealtimeForConditionalGeneration.from_pretrained(
+                d, dtype=self._dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:   # missing voxtral_realtime module, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language):
+        import torch
+        inp = self._proc(samples, sampling_rate=TARGET_RATE, return_tensors="pt").to(self._device)
+        if "input_features" in inp:                 # the Qwen3/Cohere lesson: cast features to model dtype
+            inp["input_features"] = inp["input_features"].to(self._dtype)
+        with torch.inference_mode():
+            out = self._model.generate(**inp, max_new_tokens=256, do_sample=False)
+        text = self._proc.batch_decode(out, skip_special_tokens=True)[0]
+        return AsrResult(text.strip(), language)    # prefix-strip helper added only if the spike shows one
+```
+
+Open items the §6 spike confirms (not assumed): the exact processor signature
+(`AutoProcessor`/`VoxtralRealtimeProcessor`; the input key — `input_features` vs other), whether
+`generate()` output needs input-prompt slicing (the card decodes `outputs` directly, suggesting
+audio-only → transcript-only), the accepted `language` form (if any), the `mistral_common`
+dependency, and the **real VRAM footprint** at our bounded context.
+
+Bounding the context: per-segment offline keeps generation short (`max_new_tokens=256`; segments are
+seconds). If the realtime model pre-allocates a cache for its default ~3 h `max-model-len`, the spike
+will show it; the fix is to construct it with a small cache/`max_position_embeddings`-bounded config.
+This is the §4.4 measurement that decides 12 GB-target vs 16 GB-gating.
+
+### 5.2 Registry wiring (three one-line touches, identical to Cohere/Qwen3)
+
+- **`catalog.py`** — new row, appended (no existing rows shift):
+  ```python
+  AsrModel("voxtral-mini-4b-realtime", "Voxtral Mini 4B Realtime",
+           ("en","fr","es","de","ru","zh","ja","it","pt","nl","ar","hi","ko"),
+           (Deployment("voxtral_realtime", "gpu-cuda", "bfloat16",
+                       "mistralai/Voxtral-Mini-4B-Realtime-2602", 1.0),),
+           recommended=False, sort_order=9)
+  ```
+- **`accel.py` `_installed()`** — add `"voxtral_realtime": "transformers.models.voxtral_realtime"`
+  to the `mods` dict. Present on the 5.13 fork → lights up; the `_has_mod` self-gate still protects
+  builds where the module is absent.
+- **`native_models.py` `download_specs`** — before the fallthrough:
+  ```python
+  if model_id == "voxtral-mini-4b-realtime":
+      return {"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [],
+              "ignore": ["consolidated.safetensors"]}  # Mistral-format dup; transformers uses model.safetensors
+  ```
+  This adds a **new optional `ignore` key** to the spec dict. `download()`, `model_status()`, and
+  `model_size()` currently enumerate *all* repo files (`list_repo_files`/`siblings`) — each must filter
+  out names in `ignore` so we don't fetch (or size-check, or status-check) the 8.86 GB
+  `consolidated.safetensors`. Without it: download is 17.73 GB instead of 8.87 GB, and `model_status`
+  would report "absent" for a perfectly usable model because the consolidated blob is missing. The
+  `ignore` key defaults to `[]` for every existing model, so this is additive and inert elsewhere.
+
+### 5.3 Renderer (`src/lib/local-inference/native/nativeCatalog.ts`)
+
+One row in `NATIVE_ASR`, appended after Qwen3 (`sortOrder 8`):
+```ts
+{ id: 'voxtral-mini-4b-realtime', label: 'Voxtral Mini 4B Realtime',
+  languages: ['en','fr','es','de','ru','zh','ja','it','pt','nl','ar','hi','ko'], sortOrder: 9 },
+```
+No new `NativeModelOption` fields, no `LanguageSection` change (Voxtral auto-detects, so unlike
+Cohere it doesn't set `requiresExplicitLanguage`). `asrToCard` renders it; the existing has-GPU
+hardware-gating (`hardwareGated()` + `autoSelectNative`'s `isHardwareGated`) already excludes it on
+no-GPU boxes and won't auto-select a model that fails readiness.
+
+### 5.4 Dependency
+
+**`mistral-common[audio]>=1.9.0` is a CONFIRMED required dependency** (§0; `VoxtralRealtimeProcessor`'s
+tokenizer is `MistralCommonBackend`). Add it to `sidecar/setup.sh` next to `librosa`/`sacremoses` (the
+heavy stage runtimes live there, not in the light `requirements.txt`). Verified: installing it does not
+perturb the pinned transformers fork (Granite/Qwen3/Cohere still import). The `[audio]` extra pulls
+`soundfile`/`soxr`.
+
+## 6. Validation spike (de-risker)
+
+**Mostly executed already (§0):** load + transcribe on the 4070 succeeded, VRAM/RTF measured,
+`mistral_common` dep confirmed, the offline snapshot-dir load path proven, the dual-format download
+identified, and the output format confirmed (audio-only → transcript, `batch_decode(outputs)` directly,
+no prompt slice). **Remaining open items:** confirm whether the processor accepts a `language=` hint
+(currently treated as auto), and the coexistence regression after `unload()`. The reproducible smoke
+(to land as the GPU-gated test) mirrors the real flow — download first, then load from cache:
+
+1. `snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602")`, then
+   `AutoProcessor.from_pretrained(ref, local_files_only=True)` and
+   `VoxtralRealtimeForConditionalGeneration.from_pretrained(ref, dtype=torch.bfloat16,
+   local_files_only=True).to("cuda").eval()` — surfaces any hidden dep (e.g. `mistral_common`).
+2. `proc(samples_f32_16k, sampling_rate=16000, return_tensors="pt")` →
+   `model.generate(**inputs, max_new_tokens=256)` → `proc.batch_decode(out, skip_special_tokens=True)`.
+
+Assert / observe: a plausible transcript on a real clip; the **output format** (any prefix to strip?
+does the output echo the prompt → need slicing?); whether a **`language=` hint** is accepted and our
+codes (`en`, `ja`, …) are valid; **RTF and the real VRAM footprint on the 4070** (the §4.4 gate — does
+it fit 12 GB at a bounded context?); and the coexistence regression — **Granite / Qwen3 / Cohere still
+load** after Voxtral `unload()` + `torch.cuda.empty_cache()`.
+
+The spike's measured facts feed back into §5.1 (final `transcribe` shape) and §4.4 (12 GB vs 16 GB).
+
+## 7. Testing
+
+- **Mocked unit tests** (`sidecar/tests/test_backends.py`): a fake processor + model (mirroring the
+  Qwen3/Cohere fakes) asserting the bf16 dtype cast, the GPU-only guard raises `BackendLoadError` on
+  `cpu`, and the decode path; plus the `SOKUJI_RUN_GPU`-gated real smoke from §6.
+- **Catalog** (`test_catalog.py`): the new row — `recommended is False`, `sort_order == 9`, the 13
+  languages, backend `voxtral_realtime`. Add `"voxtral_realtime"` to the allowed-backend set.
+- **Resolver** (`test_accel.py`): `voxtral_realtime` gated on `transformers.models.voxtral_realtime`;
+  present + NVIDIA machine → resolves the gpu-cuda plan; CPU-only box → `NoUsablePlan` (no CPU floor).
+- **Download** (`test_native_models.py`): `download_specs("voxtral-mini-4b-realtime")` → the single
+  `mistralai/Voxtral-Mini-4B-Realtime-2602` repo, no urls.
+- **Renderer** (`nativeCatalog.test.ts`): the Voxtral row present (not recommended, `sortOrder 9`, 13
+  languages), appears in `compatibleNativeAsr` for a supported language and behind incompatible for an
+  unsupported one, and does not disturb the existing recommended-first ordering.
+- Gates: `pytest` (sidecar) + `vitest` (renderer) are the correctness gates (not `tsc`);
+  `npm run build` for the renderer wiring.
+
+## 8. Out of scope (Phase 1 / YAGNI)
+
+- **No streaming** — Phase 1 runs the model offline per segment; the realtime API is Phase 2 (§9).
+- **No CPU / ONNX / GGUF path** — GPU bf16 only; CPU ASR is covered by Whisper (`ctranslate2`) and
+  SenseVoice (`sherpa`). No CPU floor for this row (a sub-capable box yields `AllPlansFailed` at
+  Start, consistent with the other GPU-only rows).
+- **No VRAM-size gating mechanism** — built only if §6 proves the model can't fit 12 GB (§4.4).
+- **No word timestamps / diarization / speaker labels.**
+- **No changes to Granite / Qwen3 / Cohere**; `requirements.txt` unchanged (any new dep goes in
+  `setup.sh`, §5.4).
+
+## 9. Phase 2 (future — separate spec)
+
+The realtime payoff. A streaming recognizer seam, roughly:
+
+- A streaming backend contract (`feed(frames) → partial/final tokens`) alongside today's offline
+  `transcribe(segment)`, driven by the model's causal encoder + `default_num_delay_tokens` (~480 ms).
+- Engine changes: stream audio into the model continuously (the transport already pushes Int16 frames
+  via `on_binary`), emit incremental transcripts rather than per-VAD-segment finals — VAD may shift to
+  endpointing/segmentation hints rather than gating recognition.
+- Wire protocol: partial-result events (`partial` vs `result`) and the renderer rendering them.
+- Promote the catalog row to `recommended` once streaming lands.
+- Possibly evaluate vLLM's Realtime WebSocket API if transformers streaming is inadequate.
+- **Separately**, Voxtral's built-in speech-translation (fuse ASR+translate into one stage) and
+  `mistralai/Voxtral-4B-TTS-2603` for the TTS stage are independent future investigations.
+
+## 10. Files touched (Phase 1)
+
+- `sidecar/sokuji_sidecar/backends.py` — `VoxtralRealtimeBackend`.
+- `sidecar/sokuji_sidecar/catalog.py` — the `voxtral-mini-4b-realtime` row.
+- `sidecar/sokuji_sidecar/accel.py` — `_installed()` gate entry.
+- `sidecar/sokuji_sidecar/native_models.py` — `download_specs` branch **+ the new `ignore` key**
+  honored in `download()`, `model_status()`, `model_size()` (skip `consolidated.safetensors`).
+- `sidecar/setup.sh` — add `mistral-common[audio]>=1.9.0` (confirmed §0/§5.4).
+- `sidecar/tests/test_backends.py`, `test_catalog.py`, `test_accel.py`, `test_native_models.py` —
+  tests + the GPU smoke.
+- `src/lib/local-inference/native/nativeCatalog.ts` — the row.
+- `src/lib/local-inference/native/nativeCatalog.test.ts` — the row test.

--- a/docs/superpowers/specs/2026-06-25-voxtral-realtime-streaming-design.md
+++ b/docs/superpowers/specs/2026-06-25-voxtral-realtime-streaming-design.md
@@ -1,0 +1,222 @@
+# Native ASR: Voxtral Mini 4B Realtime — Continuous Streaming (Phase 2) — Design
+
+**Status:** PLANNED. Builds on Phase 1 (offline-segment backend, landed on `feat/native-asr-voxtral-realtime`).
+**Branch:** `feat/native-asr-voxtral-streaming` (to be cut from `feat/native-asr-voxtral-realtime`).
+**Date:** 2026-06-25.
+**Phase 1 spec:** `docs/superpowers/specs/2026-06-25-voxtral-realtime-native-sidecar-asr-design.md`.
+
+## 1. Goal
+
+Deliver the realtime payoff that motivated choosing the Realtime variant: **continuous, low-latency
+streaming ASR** in the native sidecar. As the user speaks, emit incremental (`partial`) transcripts
+~480 ms behind the audio, then a committed `result` at each utterance boundary — using the model's
+experimental transformers streaming API (`is_streaming` chunks + `TextIteratorStreamer` +
+`num_delay_tokens` + per-stream padding cache).
+
+**Explicitly out of scope:** vLLM; any change to the translation or TTS stages (only the final
+utterance enters that pipeline, exactly as today); a user-facing delay slider; per-word timestamps;
+the WebGPU LOCAL_INFERENCE path. This is LOCAL_NATIVE ASR only.
+
+## 2. Context: what we already have
+
+- **Phase 1** shipped `VoxtralRealtimeBackend` (`backends.py`), GPU bf16, run **offline per VAD
+  segment** through the synchronous engine seam. The offline `transcribe()` stays — it backs the GPU
+  smoke and is a fallback. Phase 2 adds a *streaming* path alongside it; it does not replace it.
+- **The engine seam is synchronous.** `AsrEngine.feed(int16_bytes)` returns a *list* of events that
+  the transport sends (`server.py` `_conn`: `for out in feeder(data): await conn.send(out)`). A
+  threaded `TextIteratorStreamer` emits tokens from a background thread over hundreds of ms, so the
+  sync `feed()→list` contract cannot carry streaming output.
+- **The renderer already renders interim transcripts — on the WebGPU path.** `AsrEngine.ts`
+  (LOCAL_INFERENCE) has `onPartialResult` + a `partial` event; `cohere-transcribe-webgpu` /
+  `voxtral-3b-webgpu` workers emit token-by-token `partial`s via `TextStreamer`; and
+  `LocalInferenceClient.ts` renders an in-progress **`partialUserItem`** that updates then finalizes.
+  **The native path does not:** `NativeAsrClient` exposes only `onResult`/`onSpeechStart`, and
+  `LocalNativeClient.onAsrResult` creates a *completed* user item per final. Phase 2 brings the native
+  path to parity by mirroring the existing `partialUserItem` pattern — it does not invent new UI.
+- **The existing WebGPU "streaming" is per-segment, not continuous** (VAD waits for the utterance to
+  end, then streams the *decode*). Phase 2 is genuinely continuous (partials *while* speaking), which
+  is the reason the Realtime model was chosen and what the WebGPU path cannot do.
+
+## 3. Verified facts (from live exploration)
+
+Confirmed in the sidecar venv (transformers `5.13.0.dev0`) + by reading the model doc and the codebase:
+
+- `transformers` ships a **documented (experimental) streaming example** for
+  `VoxtralRealtimeForConditionalGeneration` (model doc `voxtral_realtime`, "Streaming Transcription",
+  flagged *"experimental and the API is subject to change"*). Its shape:
+  ```python
+  first = processor(audio[:processor.num_samples_first_audio_chunk],
+                    is_streaming=True, is_first_audio_chunk=True, return_tensors="pt")
+  def input_features_generator():
+      yield first.input_features
+      # then, per chunk: processor(audio[start:end], is_streaming=True,
+      #                            is_first_audio_chunk=False).input_features
+      ...
+  streamer = TextIteratorStreamer(processor.tokenizer, skip_special_tokens=True)
+  Thread(target=model.generate, kwargs={
+      "input_ids": first.input_ids, "input_features": input_features_generator(),
+      "num_delay_tokens": first.num_delay_tokens, "streamer": streamer}).start()
+  for text_chunk in streamer: ...   # partials arrive here
+  ```
+  `generate` consumes a **generator** for `input_features` — the basis for feeding *live* audio (the
+  generator blocks for the next chunk instead of reading a complete buffer). The `VoxtralRealtimeProcessor`
+  `__call__` already takes `is_streaming` / `is_first_audio_chunk` (Phase 1 §0 confirmed the processor
+  surface). `config.default_num_delay_tokens = 6` (= 6 × 80 ms = 480 ms).
+- **Wire/transport** (`server.py`): after `asr_init`, `conn.ctx["on_binary"] = eng.feed`; binary
+  frames route to the feeder; connection close calls `eng.close()` (frees VRAM) only for the
+  ASR-owning connection.
+- **Renderer surface**: `NativeAsrClient.feedAudio(Int16)` → `ws.send(buffer)`; `onMessage` dispatches
+  id-less `result`/`speech_start`. `LocalInferenceClient.partialUserItem` is the interim→final pattern
+  to mirror in `LocalNativeClient`.
+
+## 4. Decisions
+
+1. **Continuous streaming** (not per-segment token-streaming). Partials appear ~480 ms behind speech,
+   while talking — the realtime payoff.
+2. **Transport = Approach A: engine owns an asyncio task + audio queue.** At `asr_init`, if the resolved
+   backend is streaming-capable, `on_binary` becomes a non-blocking enqueue and a long-lived asyncio
+   task (holding `conn.send`) owns the streaming loop and pushes events. The experimental streaming API
+   is isolated inside the backend; VAD + transport stay in the engine where the offline path lives.
+   (Rejected: B — backend-owned threads bridged to the engine, more coupling; C — synchronous
+   chunk-stepping, fights the autoregressive `generate`.)
+3. **VAD = endpoint detector, not a recognition gate.** silero VAD marks speech-start (open a stream)
+   and speech-end/silence (finalize + reset). The streaming model runs continuously *within* an
+   utterance. A max-utterance cap (~20 s) forces periodic finalize + reset to bound VRAM even if no
+   endpoint fires.
+4. **Partials are display-only.** Only the VAD-endpointed **final** enters the existing
+   translation→TTS pipeline — so translation/TTS are untouched (scope constraint honored structurally).
+5. **Fixed delay** `num_delay_tokens = 6` (480 ms, the recommended sweet spot). Not exposed in the UI.
+6. **Per-utterance stream session** owns the padding cache + KV and frees them on `end()` — this is
+   what bounds VRAM across a long conversation.
+7. **Promote the catalog row to `recommended=True`** (both catalogs) — Phase 1 set `False` pending
+   exactly this.
+
+## 5. Architecture
+
+### 5.1 Streaming backend (`sidecar/sokuji_sidecar/backends.py` + a stream helper)
+
+`VoxtralRealtimeBackend` gains a class flag `STREAMING = True` and `open_stream() -> VoxtralRealtimeStream`.
+The `VoxtralRealtimeStream` session (a focused new unit — likely its own module
+`voxtral_stream.py` to keep `backends.py` small) encapsulates the experimental API:
+
+- A thread-safe **audio queue** (16 kHz float32 pushed by the engine).
+- An **`input_features_generator`** adapted from the doc example to read *live*: it blocks until the
+  next chunk's `num_samples_per_audio_chunk` samples are available, yields that chunk's features
+  (`is_first_audio_chunk` only on the first), and stops when an end-of-utterance sentinel is enqueued
+  (applying the model's right-padding so the tail tokens flush).
+- A `TextIteratorStreamer` and the `generate(...)` call on a worker `Thread`, wired with the first
+  chunk's `input_ids` + `num_delay_tokens`.
+
+Interface: `feed(samples_f32_16k)` (enqueue), `text_deltas()` (iterate `TextIteratorStreamer` → token
+strings; drained by the engine), `end() -> str` (enqueue sentinel, join the thread, return the final
+full text, free the cache). One session per utterance.
+
+Open items the §6 spike must close (the API is experimental): the exact processor chunk attributes
+(`num_samples_first_audio_chunk`, `num_samples_per_audio_chunk`, `num_mel_frames_first_audio_chunk`,
+`audio_length_per_tok`, `num_right_pad_tokens`, `raw_audio_length_per_tok`); that `generate` pulls the
+`input_features` generator **lazily** (so live feeding works, not eager drain); how end-of-utterance
+flushes the final tokens (right-padding); and the dtype cast on each chunk's `input_features`.
+
+### 5.2 Streaming engine path (`sidecar/sokuji_sidecar/asr_engine.py`)
+
+The engine branches on `backend.STREAMING`. Offline backends keep the **unchanged** synchronous
+`feed()→list` path. For a streaming backend, an asyncio task (started by the transport, §5.3) runs:
+
+1. Pull audio bytes from the queue → `_downsample_int16_to_f32_16k` (existing) → 16 kHz float32.
+2. Run silero VAD (existing 512-sample windows) for endpointing.
+3. On speech-start: emit `speech_start`; `open_stream()`.
+4. During speech: `stream.feed(samples)`; concurrently drain `stream.text_deltas()` and emit
+   `partial {text}` with the accumulated text (~480 ms latency).
+5. On VAD silence (endpoint) or the max-utterance cap: `final = stream.end()`; emit `result` (final,
+   reusing the existing `result` shape — `text`, `startSample`, `durationMs`, `recognitionTimeMs`);
+   reset for the next utterance.
+
+Bridging the blocking `TextIteratorStreamer` reads into asyncio uses `asyncio.to_thread` (or the
+streamer's `timeout`) — pinned by the spike. `close()` cancels the task, ends any open session, frees
+VRAM (extends the Phase 1 `close()`).
+
+### 5.3 Transport (`sidecar/sokuji_sidecar/server.py`)
+
+At `asr_init`, the handler checks whether the resolved backend is `STREAMING`. If so: set
+`on_binary` to a non-blocking enqueue into the engine's audio queue (returns no events), and
+`asyncio.create_task(...)` the engine's streaming loop, passing `conn.send`. The loop pushes
+`speech_start`/`partial`/`result`/`error` itself. Non-streaming backends keep the current
+`on_binary = eng.feed` sync path verbatim. Connection close cancels the task before `eng.close()`.
+Add nothing to the synchronous dispatch; the streaming task is the only new control flow.
+
+### 5.4 Wire protocol + renderer
+
+- **`nativeProtocol.ts`**: add `AsrPartialMsg { type: 'partial'; text: string }` to `ServerMsg`.
+- **`NativeAsrClient`**: add `onPartialResult: ((text: string) => void) | null`; in `onMessage`,
+  dispatch id-less `partial` → `onPartialResult(msg.text)` (alongside the existing id-less `result`).
+- **`LocalNativeClient`**: mirror `LocalInferenceClient`'s `partialUserItem`:
+  - `this.asr.onPartialResult = (text) => this.onAsrPartial(text)` in `connect()`.
+  - `onAsrPartial(text)`: if no `partialUserItem`, create an `in_progress` user item
+    (`formatted.transcript = text`) and emit; else update its transcript and emit with a delta. **No**
+    pipeline job.
+  - `onAsrResult(final)`: if a `partialUserItem` exists, finalize it (`status='completed'`,
+    `transcript=final`), clear it, emit; else create a completed item (back-compat with offline
+    backends). Then run the existing translation job — unchanged.
+  - `disconnect()`/`reset()` clear `partialUserItem`.
+
+### 5.5 Catalog
+
+Set `recommended=True` for `voxtral-mini-4b-realtime` in `catalog.py` and `nativeCatalog.ts` (and
+update the Phase 1 row tests `recommended is False` → `True`). Ordering unchanged (`sort_order`/
+`sortOrder` 9).
+
+## 6. Validation spike (de-risker — run FIRST, the API is experimental)
+
+A `SOKUJI_RUN_GPU`-gated spike that proves the live-streaming adaptation before any engine/transport
+wiring:
+
+1. Drive `VoxtralRealtimeStream` against a real clip fed in small chunks (simulating live audio): assert
+   `text_deltas()` yields growing partials *before* `end()`, and `end()` returns a correct full
+   transcript matching the Phase 1 offline result on the same clip.
+2. Confirm `generate` consumes the `input_features` generator **lazily** (feed a chunk, observe a
+   partial, feed more — not an eager up-front drain), and that the processor chunk attributes (§5.1)
+   exist with the expected meaning.
+3. Measure **first-partial latency** (target ≈ 480 ms behind the fed audio) and **VRAM across several
+   utterances** (open/end repeatedly → no growth; peak ≈ Phase 1 ~10 GB).
+
+The spike's findings pin §5.1/§5.2 (final code shape, the to_thread bridge, the end-of-utterance flush).
+
+## 7. Testing
+
+- **Unit (sidecar, no GPU):** a fake stream session (a scripted `TextIteratorStreamer` stand-in) drives
+  the engine streaming path → assert ordered `speech_start` → N×`partial` (monotonically growing text)
+  → `result`; a VAD endpoint finalizes; the next utterance opens a fresh session (reset/cache-free
+  called). Transport: a fake `conn` asserts the streaming task pushes `partial`/`result` async and that
+  a non-streaming backend still uses the sync `feed()→list` path. A `partial` message-shape test.
+- **Renderer (vitest):** `NativeAsrClient` dispatches `partial`→`onPartialResult` and id-less
+  `result`→`onResult`. `LocalNativeClient`: partials create/update ONE `in_progress` item and run NO
+  job; the `result` finalizes that same item and runs the translation job exactly once (mirror the
+  `LocalInferenceClient` partial tests). `catalog`/`nativeCatalog` tests updated to `recommended` true.
+- **GPU smoke (`SOKUJI_RUN_GPU`):** stream a real multi-utterance clip end-to-end → partials precede
+  each final, finals non-empty, first-partial latency ≈ 480 ms, VRAM bounded across utterances.
+- Gates: `pytest` (sidecar) + `vitest` (renderer); `npm run build` for renderer wiring.
+
+## 8. Out of scope (Phase 2 / YAGNI)
+
+- **No vLLM** (Phase 1 §0 rejected it; same here).
+- **No translation/TTS change** — only finals enter that pipeline, unchanged. Partials are display-only.
+- **No delay slider / configurability** — fixed `num_delay_tokens=6` (480 ms).
+- **No per-word timestamps, no diarization.**
+- **No change to the offline `transcribe()`** (kept for the GPU smoke + as a fallback) or to any other
+  backend / the WebGPU LOCAL_INFERENCE path.
+
+## 9. Files touched (Phase 2)
+
+- `sidecar/sokuji_sidecar/backends.py` — `STREAMING` flag + `open_stream()` on `VoxtralRealtimeBackend`.
+- `sidecar/sokuji_sidecar/voxtral_stream.py` (new) — `VoxtralRealtimeStream` session.
+- `sidecar/sokuji_sidecar/asr_engine.py` — streaming branch (asyncio loop, VAD endpointing, emit
+  `partial`/`result`); offline path unchanged.
+- `sidecar/sokuji_sidecar/server.py` — `asr_init` wires the streaming task for streaming backends.
+- `sidecar/sokuji_sidecar/catalog.py` — `voxtral-mini-4b-realtime` `recommended=True`.
+- `sidecar/tests/test_voxtral_stream.py` (new), `test_asr_engine.py`, `test_server_*.py`,
+  `test_catalog.py` — unit tests + the GPU spike/smoke.
+- `src/lib/local-inference/native/nativeProtocol.ts` — `AsrPartialMsg`.
+- `src/lib/local-inference/native/NativeAsrClient.ts` — `onPartialResult` + `partial` dispatch.
+- `src/services/clients/LocalNativeClient.ts` — `partialUserItem` interim→final.
+- `src/lib/local-inference/native/nativeCatalog.ts` — `recommended: true`.
+- renderer tests: `NativeAsrClient.test.ts`, `LocalNativeClient.test.ts`, `nativeCatalog.test.ts`.

--- a/sidecar/setup.sh
+++ b/sidecar/setup.sh
@@ -35,12 +35,13 @@ case "$(uname -s)" in
 esac
 # transformers→tokenizers + Granite/Qwen3 speech-LLMs; faster-whisper→ASR whisper backend;
 # sacremoses→Marian (opus-mt) tokenizer.
+# mistral-common[audio]→VoxtralRealtimeProcessor tokenizer (MistralCommonBackend).
 # transformers is pinned to an IMMUTABLE commit SHA on the PR #43838 fork (native Qwen3-ASR
 # support, not yet in any PyPI release). A SHA is content-addressed, so the fork's branch
 # cannot shift the installed code under us (unlike a mutable branch archive). Swap to a
 # released 'transformers>=5.13' from PyPI once huggingface/transformers PR #43838 merges.
 TRANSFORMERS_REF="git+https://github.com/mbtariq82/transformers@a2ec912647e42dee56eb89e64b0ec539ad9e7b65"
-"$PY" -m pip install -q "$TRANSFORMERS_REF" sherpa-onnx faster-whisper sacremoses librosa
+"$PY" -m pip install -q "$TRANSFORMERS_REF" sherpa-onnx faster-whisper sacremoses librosa "mistral-common[audio]>=1.9.0"
 
 if [ "${1:-}" = "--no-models" ]; then
   echo "[setup] deps installed; skipping models (--no-models). Done."

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -66,7 +66,10 @@ def _installed() -> frozenset:
             "qwen3asr": "transformers.models.qwen3_asr",
             # cohere_transformers needs the native cohere_asr model (mainline since
             # transformers 5.4); present in our 5.13 venv. Same self-gate as qwen3asr.
-            "cohere_transformers": "transformers.models.cohere_asr"}
+            "cohere_transformers": "transformers.models.cohere_asr",
+            # voxtral_realtime needs the native voxtral_realtime model (transformers >=5.2;
+            # present in our 5.13 fork). Same self-gate as qwen3asr/cohere.
+            "voxtral_realtime": "transformers.models.voxtral_realtime"}
     return frozenset(b for b, mod in mods.items() if _has_mod(mod))
 
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -67,10 +67,14 @@ def _installed() -> frozenset:
             # cohere_transformers needs the native cohere_asr model (mainline since
             # transformers 5.4); present in our 5.13 venv. Same self-gate as qwen3asr.
             "cohere_transformers": "transformers.models.cohere_asr",
-            # voxtral_realtime needs the native voxtral_realtime model (transformers >=5.2;
-            # present in our 5.13 fork). Same self-gate as qwen3asr/cohere.
-            "voxtral_realtime": "transformers.models.voxtral_realtime"}
-    return frozenset(b for b, mod in mods.items() if _has_mod(mod))
+            # voxtral_realtime needs BOTH the native voxtral_realtime model (transformers >=5.2;
+            # present in our 5.13 fork) AND mistral_common (its processor/tokenizer) — gate on
+            # both so a half-installed env doesn't advertise it in the catalog then fail at load().
+            "voxtral_realtime": ("transformers.models.voxtral_realtime", "mistral_common")}
+
+    def _ready(spec):
+        return all(_has_mod(m) for m in ((spec,) if isinstance(spec, str) else spec))
+    return frozenset(b for b, spec in mods.items() if _ready(spec))
 
 
 def _safe(fn, default):

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -354,6 +354,18 @@ class AsrEngine:
             await self._flush_and_restart(send)
         elif self._stream_speech_samples >= 4 * 60 * TARGET_RATE and not self._pending:
             await self._flush_and_restart(send)
+        lag = self._fed_s - self._delta_count * 0.08          # ~0.56s healthy; >3s = can't keep up
+        if self._mode == "always_stream" and lag > 3.0:
+            if self._utt_text:
+                await send(self._result_event(self._utt_text))
+            try:
+                self._stream.abort()
+            except Exception:
+                pass
+            self._stream = None                               # per-utterance opens on next VAD start
+            self._mode = "per_utterance"
+            self._pending = ""
+            self._utt_text = ""
 
     def resolves_to_streaming(self, model_id, device):
         """Cheap pre-check (no model load): does this model resolve to a STREAMING backend?

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -234,7 +234,9 @@ class AsrEngine:
         samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
         events = self._vad_events(samples)
         if "start" in events:
-            # Close any leftover stream (e.g. from always-stream init or prior utterance).
+            # Defensive: in practice _stream is already None here (an "end" precedes every
+            # "start", and degrade nulls it) — abort + reopen guards against a stale stream
+            # from any source.
             if self._stream is not None:
                 try:
                     self._stream.abort()
@@ -345,6 +347,7 @@ class AsrEngine:
             for s in sentences:
                 await send(self._result_event(s))
             self._pending = remainder
+            # _utt_text is _pending stripped for the partial display + flush; _pending keeps the raw text for split_sentences.
             self._utt_text = remainder.strip()
             await send({"type": "partial", "text": self._utt_text})
         if getattr(self._stream, "aborted", False):      # generate died -> self-heal: flush + restart

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -282,10 +282,12 @@ class AsrEngine:
 
     def _vad_state(self, samples):
         """Run silero VAD over `samples` for STATE only (always-stream): return
-        (had_speech, rising_edge). Unlike _vad_events it does not gate input or emit
-        per-utterance start/speech/end."""
+        (had_speech, rising, falling). `falling` = silero's endpoint (is_speech_detected
+        True->False this buffer), governed by the user's min_silence_duration. Does not
+        gate input."""
         had_speech = False
         rising = False
+        falling = False
         self._buf = np.concatenate([self._buf, samples])
         while len(self._buf) >= self._window:
             was = self._vad.is_speech_detected()
@@ -296,7 +298,9 @@ class AsrEngine:
                 had_speech = True
             if not was and now:
                 rising = True
-        return had_speech, rising
+            if was and not now:
+                falling = True
+        return had_speech, rising, falling
 
     def _result_event(self, text):
         """A `result` envelope. startSample/durationMs are approximate in always-stream."""

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -173,8 +173,11 @@ class AsrEngine:
         self._stop = False
 
     def feed_stream(self, int16_bytes):
-        """Non-blocking: hand raw audio to the streaming loop (called from on_binary)."""
+        """Non-blocking: hand raw audio to the streaming loop (called from on_binary).
+        Returns [] — streaming events are pushed asynchronously by run_stream, so there
+        is nothing to send synchronously from the _conn feeder loop."""
         self._audio_q.put_nowait(int16_bytes)
+        return []
 
     async def run_stream(self, send):
         """The asyncio streaming loop (Approach A). Owns VAD endpointing, the stream

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -229,6 +229,26 @@ class AsrEngine:
         while not self._audio_q.empty():
             await self._drive(send, self._audio_q.get_nowait())
 
+    def resolves_to_streaming(self, model_id, device):
+        """Cheap pre-check (no model load): does this model resolve to a STREAMING backend?
+
+        Instantiates a bare backend object (no load()) and reads its STREAMING class flag.
+        Only the top-ranked plan is checked. Returns False on any resolution error so the
+        caller can safely fall back to the offline path."""
+        from . import accel, backends
+        try:
+            plans = accel.resolve(model_id or "sense-voice", override=device or "auto")
+        except Exception:
+            return False
+        if not plans:
+            return False
+        try:
+            # make_backend() instantiates the class — no model load, no I/O.
+            obj = backends.make_backend(plans[0].backend)
+            return bool(getattr(obj, "STREAMING", False))
+        except Exception:
+            return False
+
     def _resolve_streaming_backend(self, model_id, device):
         from . import accel
         plans = accel.resolve(model_id or "voxtral-mini-4b-realtime", override=device or "auto")
@@ -261,12 +281,36 @@ class AsrEngine:
 
 
 async def _h_asr_init(state, msg, _b, conn=None):
+    import asyncio
     eng = state["asr_engine"]
-    ms = eng.init(msg.get("model"), msg.get("language", ""), msg.get("sampleRate", SRC_RATE),
-                  msg.get("vadThreshold"), msg.get("vadMinSilenceDuration"),
-                  msg.get("vadMinSpeechDuration"), msg.get("device", "auto"))
-    if conn is not None:
-        conn.ctx["on_binary"] = eng.feed   # route subsequent binary frames to the recognizer
+    model = msg.get("model")
+    device = msg.get("device", "auto")
+    language = msg.get("language", "")
+    sample_rate = msg.get("sampleRate", SRC_RATE)
+    vad_threshold = msg.get("vadThreshold")
+    vad_min_silence = msg.get("vadMinSilenceDuration")
+    vad_min_speech = msg.get("vadMinSpeechDuration")
+
+    # Cheap pre-check: resolve the backend NAME without loading the model, then read
+    # its STREAMING flag. This ensures each branch loads the model exactly once.
+    is_streaming = (hasattr(eng, "resolves_to_streaming")
+                    and eng.resolves_to_streaming(model, device))
+
+    if is_streaming:
+        # Streaming path: init_streaming resolves+loads the backend once.
+        eng.init_streaming(model, language, sample_rate,
+                           vad_threshold, vad_min_silence, vad_min_speech, device)
+        if conn is not None:
+            conn.ctx["on_binary"] = eng.feed_stream
+            conn.ctx["stream_task"] = asyncio.create_task(eng.run_stream(conn.send))
+        ms = 0
+    else:
+        # Offline path (unchanged Phase 1 behaviour): init() loads the model once.
+        ms = eng.init(model, language, sample_rate,
+                      vad_threshold, vad_min_silence, vad_min_speech, device)
+        if conn is not None:
+            conn.ctx["on_binary"] = eng.feed
+
     reply = {"type": "ready", "id": msg.get("id"), "loadTimeMs": ms}
     resolved = getattr(eng, "resolved", None)
     if resolved:

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -186,16 +186,14 @@ class AsrEngine:
         self._audio_q = _queue.Queue()
         self._mode = "always_stream"
         self._stream = self._backend.open_stream()   # always-stream: one long-lived session
-        self._pending = ""           # un-segmented text accumulated from drain()
-        self._utt_text = ""          # current sentence (the partial)
+        self._pending = ""           # text drained since the last cut (the partial)
         self._partial_acc = []       # per-utterance fallback accumulator
         self._utt_start_sample = 0
         self._sample_cursor = 0
-        self._utt_samples = 0        # per-utterance fallback (20s cap)
-        self._silence_samples = 0    # consecutive silence (always-stream restart)
-        self._stream_speech_samples = 0   # speech since last restart (4min safety)
-        self._fed_s = 0.0            # audio seconds fed (backpressure, Task 3)
-        self._delta_count = 0        # tokens drained (backpressure, Task 3)
+        self._utt_samples = 0        # per-utterance fallback (its own cap)
+        self._speech_samples = 0     # speech in the current stream (20s run-on cap)
+        self._fed_s = 0.0            # audio seconds fed to the current stream (backpressure)
+        self._delta_count = 0        # tokens drained from the current stream (backpressure)
         self._stop = False
 
     def feed_stream(self, int16_bytes):
@@ -221,8 +219,14 @@ class AsrEngine:
             else:
                 await self._drive_utterance(send, data)
         if self._mode == "always_stream":
-            if self._utt_text:
-                await send(self._result_event(self._utt_text))
+            if self._stream is not None and self._pending.strip():
+                try:
+                    final = await loop.run_in_executor(None, self._stream.end)
+                except Exception:
+                    final = ""
+                self._stream = None
+                if final.strip():
+                    await send(self._result_event(final))
         elif self._stream is not None:
             await self._finalize(send)
 
@@ -309,70 +313,71 @@ class AsrEngine:
                 "durationMs": int(self._sample_cursor / TARGET_RATE * 1000),
                 "recognitionTimeMs": 0}
 
-    async def _flush_and_restart(self, send):
-        """Flush any un-punctuated pending text as a final, then restart the stream
-        (abort + reopen) — bounds context/VRAM and recovers cleanly during silence."""
-        if self._utt_text:
-            await send(self._result_event(self._utt_text))
+    async def _end_and_reopen(self, send):
+        """Pause-cut: end() the stream to flush the COMPLETE held tail, emit it as the
+        result, then open a fresh stream. Audio arriving during the ~1s end() backs up in
+        _audio_q and feeds the new stream after — no leading loss. Per-stream backpressure
+        counters reset (end()'s flushed tokens aren't counted via drain())."""
+        loop = asyncio.get_running_loop()
         try:
-            self._stream.abort()
-        except Exception:
-            pass
+            final = await loop.run_in_executor(None, self._stream.end)
+        except Exception:                                # end() failed -> drop this final, still recover
+            final = ""
+        if final.strip():
+            await send(self._result_event(final))
         self._stream = self._backend.open_stream()
         self._pending = ""
-        self._utt_text = ""
-        self._silence_samples = 0
-        self._stream_speech_samples = 0
+        self._speech_samples = 0
+        self._fed_s = 0.0
+        self._delta_count = 0
 
     async def _drive_always(self, send, int16_bytes):
-        """Always-stream: feed every buffer (no gating); VAD only for the speech-start cue
-        + the long-silence restart; drain -> accumulate -> cut finals on sentence punctuation."""
-        from .voxtral_stream import split_sentences
+        """Always-stream: feed every buffer (no gating); cut a final on silero's endpoint
+        (the falling edge, governed by the user's min_silence_duration) — or a 20s run-on
+        cap — via end()+reopen, which flushes the COMPLETE held tail. Continuous feed means
+        no leading loss."""
         samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
         self._sample_cursor += len(samples)
         self._fed_s += len(samples) / TARGET_RATE
         self._stream.feed(samples)                       # continuous, never gated
         try:
-            had_speech, rising = self._vad_state(samples)
-        except Exception:                                # VAD failure -> degrade gracefully
-            had_speech, rising = True, False             # assume speech; punctuation finals still work
+            had_speech, rising, falling = self._vad_state(samples)
+        except Exception:                                # VAD failure -> assume speech, no edges
+            had_speech, rising, falling = True, False, False
         if rising:
             await send({"type": "speech_start"})
         if had_speech:
-            self._silence_samples = 0
-            self._stream_speech_samples += len(samples)
-        else:
-            self._silence_samples += len(samples)
+            self._speech_samples += len(samples)
         deltas = self._stream.drain()
         self._delta_count += len(deltas)
         if deltas:
             self._pending += "".join(deltas)
-            sentences, remainder = split_sentences(self._pending)
-            for s in sentences:
-                await send(self._result_event(s))
-            self._pending = remainder
-            # _utt_text is _pending stripped for the partial display + flush; _pending keeps the raw text for split_sentences.
-            self._utt_text = remainder.strip()
-            await send({"type": "partial", "text": self._utt_text})
-        if getattr(self._stream, "aborted", False):      # generate died -> self-heal: flush + restart
-            await self._flush_and_restart(send)
-            return
-        if self._silence_samples >= int(2.5 * TARGET_RATE):
-            await self._flush_and_restart(send)
-        elif self._stream_speech_samples >= 4 * 60 * TARGET_RATE and not self._pending:
-            await self._flush_and_restart(send)
-        lag = self._fed_s - self._delta_count * 0.08          # ~0.56s healthy; >3s = can't keep up
-        if self._mode == "always_stream" and lag > 3.0:
-            if self._utt_text:
-                await send(self._result_event(self._utt_text))
+            await send({"type": "partial", "text": self._pending.strip()})
+        if getattr(self._stream, "aborted", False):      # generate died -> salvage + reopen
+            if self._pending.strip():
+                await send(self._result_event(self._pending))
             try:
                 self._stream.abort()
             except Exception:
                 pass
-            self._stream = None                               # per-utterance opens on next VAD start
+            self._stream = self._backend.open_stream()
+            self._pending = ""; self._speech_samples = 0
+            self._fed_s = 0.0; self._delta_count = 0
+            return
+        if (falling or self._speech_samples >= 20 * TARGET_RATE) and self._pending.strip():
+            await self._end_and_reopen(send)
+            return
+        lag = self._fed_s - self._delta_count * 0.08          # ~0.56s healthy; >3s = can't keep up
+        if self._mode == "always_stream" and lag > 3.0:
+            if self._pending.strip():
+                await send(self._result_event(self._pending))
+            try:
+                self._stream.abort()
+            except Exception:
+                pass
+            self._stream = None
             self._mode = "per_utterance"
             self._pending = ""
-            self._utt_text = ""
 
     def resolves_to_streaming(self, model_id, device):
         """Cheap pre-check (no model load): does this model resolve to a STREAMING backend?

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -219,7 +219,9 @@ class AsrEngine:
             else:
                 await self._drive_utterance(send, data)
         if self._mode == "always_stream":
-            if self._stream is not None and self._pending.strip():
+            # Flush the last stream if it saw speech (its tail text may still be held by the
+            # model with _pending empty) — gating on speech, not _pending, mirrors the pause-cut.
+            if self._stream is not None and self._speech_samples > 0:
                 try:
                     final = await loop.run_in_executor(None, self._stream.end)
                 except Exception:
@@ -364,7 +366,11 @@ class AsrEngine:
             self._pending = ""; self._speech_samples = 0
             self._fed_s = 0.0; self._delta_count = 0
             return
-        if (falling or self._speech_samples >= 20 * TARGET_RATE) and self._pending.strip():
+        # Cut on the silero endpoint (or the run-on cap) whenever this stream has SEEN SPEECH —
+        # NOT when _pending has text. The model can hold a short utterance's text until end(),
+        # so gating on _pending would drop/merge short or slow-first-token utterances. end()
+        # flushes the held text and _end_and_reopen's `if final.strip()` skips truly-empty finals.
+        if (falling or self._speech_samples >= 20 * TARGET_RATE) and self._speech_samples > 0:
             await self._end_and_reopen(send)
             return
         lag = self._fed_s - self._delta_count * 0.08          # ~0.56s healthy; >3s = can't keep up

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -150,6 +150,115 @@ class AsrEngine:
         self._vad.flush()
         return self._drain()
 
+    # ── Streaming branch (STREAMING backends only; offline path above is unchanged) ──
+
+    def is_streaming(self):
+        return bool(getattr(self._backend, "STREAMING", False))
+
+    def init_streaming(self, model_id=None, language="", sample_rate=SRC_RATE,
+                       vad_threshold=None, vad_min_silence=None, vad_min_speech=None, device="auto"):
+        """Like init(), but for a STREAMING backend: resolve+load, set up VAD for
+        endpointing, and prepare the audio queue + per-utterance stream state."""
+        import queue as _queue
+        self.close()
+        self._init_vad(sample_rate, vad_threshold, vad_min_silence, vad_min_speech)
+        self._backend = self._resolve_streaming_backend(model_id, device)
+        self._language = language or None
+        self._audio_q = _queue.Queue()
+        self._stream = None
+        self._utt_start_sample = 0
+        self._sample_cursor = 0
+        self._partial_acc = []
+        self._utt_samples = 0
+        self._stop = False
+
+    def feed_stream(self, int16_bytes):
+        """Non-blocking: hand raw audio to the streaming loop (called from on_binary)."""
+        self._audio_q.put_nowait(int16_bytes)
+
+    async def run_stream(self, send):
+        """The asyncio streaming loop (Approach A). Owns VAD endpointing, the stream
+        session lifecycle, and pushes speech_start/partial/result via `send`."""
+        loop = __import__("asyncio").get_event_loop()
+        while not self._stop:
+            try:
+                data = await loop.run_in_executor(None, self._audio_q.get, True, 0.1)
+            except Exception:
+                continue
+            if data is None:
+                break
+            await self._drive(send, data)
+        if self._stream is not None:
+            await self._finalize(send)
+
+    async def _drive(self, send, int16_bytes):
+        """Process one audio buffer: VAD → manage session → emit events. Factored so
+        tests can call _drive_once with scripted VAD."""
+        samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
+        for ev in self._vad_events(samples):
+            if ev == "start":
+                self._utt_start_sample = self._sample_cursor
+                self._stream = self._backend.open_stream()
+                await send({"type": "speech_start"})
+            elif ev == "speech" and self._stream is not None:
+                self._stream.feed(samples)
+                deltas = self._stream.drain()
+                if deltas:
+                    self._partial_acc += deltas
+                    await send({"type": "partial", "text": "".join(self._partial_acc)})
+            elif ev == "end" and self._stream is not None:
+                await self._finalize(send)
+        self._sample_cursor += len(samples)
+
+    async def _finalize(self, send):
+        import time as _time
+        t0 = _time.time()
+        loop = __import__("asyncio").get_event_loop()
+        final = await loop.run_in_executor(None, self._stream.end)
+        dur_ms = int((self._sample_cursor - self._utt_start_sample) / TARGET_RATE * 1000)
+        if final.strip():
+            await send({"type": "result", "text": final.strip(),
+                        "startSample": int(self._utt_start_sample),
+                        "durationMs": dur_ms,
+                        "recognitionTimeMs": int((_time.time() - t0) * 1000)})
+        self._stream = None
+        self._partial_acc = []
+
+    async def _drive_once(self, send):
+        """Test seam: drive exactly the buffers currently queued, once."""
+        while not self._audio_q.empty():
+            await self._drive(send, self._audio_q.get_nowait())
+
+    def _resolve_streaming_backend(self, model_id, device):
+        from . import accel
+        plans = accel.resolve(model_id or "voxtral-mini-4b-realtime", override=device or "auto")
+        backend, _plan, _notice = accel.load_with_fallback(plans)
+        return backend
+
+    def _vad_events(self, samples):
+        """Feed `samples` to silero VAD; yield 'start' on rising edge, 'speech' while
+        active, 'end' on endpoint (silence) or the 20s max-utterance cap (bounds VRAM)."""
+        events = []
+        cap = 20 * TARGET_RATE
+        self._buf = np.concatenate([self._buf, samples])
+        while len(self._buf) >= self._window:
+            was = self._vad.is_speech_detected()
+            self._vad.accept_waveform(self._buf[:self._window])
+            self._buf = self._buf[self._window:]
+            now = self._vad.is_speech_detected()
+            if not was and now:
+                self._utt_samples = 0
+                events.append("start")
+            if now:
+                self._utt_samples += self._window
+                events.append("speech")
+                if self._utt_samples >= cap:          # force endpoint to bound VRAM
+                    events.append("end")
+                    self._utt_samples = 0
+            if was and not now:
+                events.append("end")
+        return events
+
 
 async def _h_asr_init(state, msg, _b, conn=None):
     eng = state["asr_engine"]

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -196,21 +196,23 @@ class AsrEngine:
 
     async def _drive(self, send, int16_bytes):
         """Process one audio buffer: VAD → manage session → emit events. Factored so
-        tests can call _drive_once with scripted VAD."""
+        tests can call _drive_once with scripted VAD. Feeds the buffer to the stream
+        ONCE per call — a single buffer spans several VAD windows, so feeding per-event
+        would duplicate the audio and scramble the streaming model's features."""
         samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
-        for ev in self._vad_events(samples):
-            if ev == "start":
-                self._utt_start_sample = self._sample_cursor
-                self._stream = self._backend.open_stream()
-                await send({"type": "speech_start"})
-            elif ev == "speech" and self._stream is not None:
-                self._stream.feed(samples)
-                deltas = self._stream.drain()
-                if deltas:
-                    self._partial_acc += deltas
-                    await send({"type": "partial", "text": "".join(self._partial_acc)})
-            elif ev == "end" and self._stream is not None:
-                await self._finalize(send)
+        events = self._vad_events(samples)
+        if "start" in events and self._stream is None:
+            self._utt_start_sample = self._sample_cursor
+            self._stream = self._backend.open_stream()
+            await send({"type": "speech_start"})
+        if self._stream is not None and "speech" in events:
+            self._stream.feed(samples)
+            deltas = self._stream.drain()
+            if deltas:
+                self._partial_acc += deltas
+                await send({"type": "partial", "text": "".join(self._partial_acc)})
+        if "end" in events and self._stream is not None:
+            await self._finalize(send)
         self._sample_cursor += len(samples)
 
     async def _finalize(self, send):

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -177,18 +177,25 @@ class AsrEngine:
     def init_streaming(self, model_id=None, language="", sample_rate=SRC_RATE,
                        vad_threshold=None, vad_min_silence=None, vad_min_speech=None, device="auto"):
         """Like init(), but for a STREAMING backend: resolve+load, set up VAD for
-        endpointing, and prepare the audio queue + per-utterance stream state."""
+        endpointing, and prepare the audio queue + always-stream state (default mode)."""
         import queue as _queue
         self.close()
         self._init_vad(sample_rate, vad_threshold, vad_min_silence, vad_min_speech)
         self._backend = self._resolve_streaming_backend(model_id, device)
         self._language = language or None
         self._audio_q = _queue.Queue()
-        self._stream = None
+        self._mode = "always_stream"
+        self._stream = self._backend.open_stream()   # always-stream: one long-lived session
+        self._pending = ""           # un-segmented text accumulated from drain()
+        self._utt_text = ""          # current sentence (the partial)
+        self._partial_acc = []       # per-utterance fallback accumulator
         self._utt_start_sample = 0
         self._sample_cursor = 0
-        self._partial_acc = []
-        self._utt_samples = 0
+        self._utt_samples = 0        # per-utterance fallback (20s cap)
+        self._silence_samples = 0    # consecutive silence (always-stream restart)
+        self._stream_speech_samples = 0   # speech since last restart (4min safety)
+        self._fed_s = 0.0            # audio seconds fed (backpressure, Task 3)
+        self._delta_count = 0        # tokens drained (backpressure, Task 3)
         self._stop = False
 
     def feed_stream(self, int16_bytes):
@@ -209,18 +216,32 @@ class AsrEngine:
                 continue
             if data is None:
                 break
-            await self._drive(send, data)
-        if self._stream is not None:
+            if self._mode == "always_stream":
+                await self._drive_always(send, data)
+            else:
+                await self._drive_utterance(send, data)
+        if self._mode == "always_stream":
+            if self._utt_text:
+                await send(self._result_event(self._utt_text))
+        elif self._stream is not None:
             await self._finalize(send)
 
-    async def _drive(self, send, int16_bytes):
+    async def _drive_utterance(self, send, int16_bytes):
         """Process one audio buffer: VAD → manage session → emit events. Factored so
         tests can call _drive_once with scripted VAD. Feeds the buffer to the stream
         ONCE per call — a single buffer spans several VAD windows, so feeding per-event
         would duplicate the audio and scramble the streaming model's features."""
         samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
         events = self._vad_events(samples)
-        if "start" in events and self._stream is None:
+        if "start" in events:
+            # Close any leftover stream (e.g. from always-stream init or prior utterance).
+            if self._stream is not None:
+                try:
+                    self._stream.abort()
+                except Exception:
+                    pass
+                self._stream = None
+                self._partial_acc = []
             self._utt_start_sample = self._sample_cursor
             self._stream = self._backend.open_stream()
             await send({"type": "speech_start"})
@@ -251,7 +272,88 @@ class AsrEngine:
     async def _drive_once(self, send):
         """Test seam: drive exactly the buffers currently queued, once."""
         while not self._audio_q.empty():
-            await self._drive(send, self._audio_q.get_nowait())
+            data = self._audio_q.get_nowait()
+            if self._mode == "always_stream":
+                await self._drive_always(send, data)
+            else:
+                await self._drive_utterance(send, data)
+
+    def _vad_state(self, samples):
+        """Run silero VAD over `samples` for STATE only (always-stream): return
+        (had_speech, rising_edge). Unlike _vad_events it does not gate input or emit
+        per-utterance start/speech/end."""
+        had_speech = False
+        rising = False
+        self._buf = np.concatenate([self._buf, samples])
+        while len(self._buf) >= self._window:
+            was = self._vad.is_speech_detected()
+            self._vad.accept_waveform(self._buf[:self._window])
+            self._buf = self._buf[self._window:]
+            now = self._vad.is_speech_detected()
+            if now:
+                had_speech = True
+            if not was and now:
+                rising = True
+        return had_speech, rising
+
+    def _result_event(self, text):
+        """A `result` envelope. startSample/durationMs are approximate in always-stream."""
+        return {"type": "result", "text": text.strip(),
+                "startSample": int(self._utt_start_sample),
+                "durationMs": int(self._sample_cursor / TARGET_RATE * 1000),
+                "recognitionTimeMs": 0}
+
+    async def _flush_and_restart(self, send):
+        """Flush any un-punctuated pending text as a final, then restart the stream
+        (abort + reopen) — bounds context/VRAM and recovers cleanly during silence."""
+        if self._utt_text:
+            await send(self._result_event(self._utt_text))
+        try:
+            self._stream.abort()
+        except Exception:
+            pass
+        self._stream = self._backend.open_stream()
+        self._pending = ""
+        self._utt_text = ""
+        self._silence_samples = 0
+        self._stream_speech_samples = 0
+
+    async def _drive_always(self, send, int16_bytes):
+        """Always-stream: feed every buffer (no gating); VAD only for the speech-start cue
+        + the long-silence restart; drain -> accumulate -> cut finals on sentence punctuation."""
+        from .voxtral_stream import split_sentences
+        samples = _downsample_int16_to_f32_16k(int16_bytes, self._src_rate)
+        self._sample_cursor += len(samples)
+        self._fed_s += len(samples) / TARGET_RATE
+        self._stream.feed(samples)                       # continuous, never gated
+        try:
+            had_speech, rising = self._vad_state(samples)
+        except Exception:                                # VAD failure -> degrade gracefully
+            had_speech, rising = True, False             # assume speech; punctuation finals still work
+        if rising:
+            await send({"type": "speech_start"})
+        if had_speech:
+            self._silence_samples = 0
+            self._stream_speech_samples += len(samples)
+        else:
+            self._silence_samples += len(samples)
+        deltas = self._stream.drain()
+        self._delta_count += len(deltas)
+        if deltas:
+            self._pending += "".join(deltas)
+            sentences, remainder = split_sentences(self._pending)
+            for s in sentences:
+                await send(self._result_event(s))
+            self._pending = remainder
+            self._utt_text = remainder.strip()
+            await send({"type": "partial", "text": self._utt_text})
+        if getattr(self._stream, "aborted", False):      # generate died -> self-heal: flush + restart
+            await self._flush_and_restart(send)
+            return
+        if self._silence_samples >= int(2.5 * TARGET_RATE):
+            await self._flush_and_restart(send)
+        elif self._stream_speech_samples >= 4 * 60 * TARGET_RATE and not self._pending:
+            await self._flush_and_restart(send)
 
     def resolves_to_streaming(self, model_id, device):
         """Cheap pre-check (no model load): does this model resolve to a STREAMING backend?

--- a/sidecar/sokuji_sidecar/asr_engine.py
+++ b/sidecar/sokuji_sidecar/asr_engine.py
@@ -1,4 +1,7 @@
-import os, time
+import asyncio
+import os
+import queue
+import time
 import numpy as np
 
 TARGET_RATE = 16000
@@ -109,7 +112,23 @@ class AsrEngine:
 
     def close(self):
         """Free the loaded ASR model and its GPU memory. Idempotent — called at the start
-        of each init() and when a session connection closes, so VRAM never accumulates."""
+        of each init() and when a session connection closes, so VRAM never accumulates.
+        Also ends any open streaming session (its generate thread holds an independent
+        model reference that unload() alone cannot reclaim)."""
+        self._stop = True
+        stream = getattr(self, "_stream", None)
+        if stream is not None:
+            try:
+                stream.abort()
+            except Exception:
+                pass
+            self._stream = None
+        q = getattr(self, "_audio_q", None)   # unblock run_stream's queue.get promptly
+        if q is not None:
+            try:
+                q.put_nowait(None)
+            except Exception:
+                pass
         backend = self._backend
         self._backend = None
         if backend is not None:
@@ -182,11 +201,11 @@ class AsrEngine:
     async def run_stream(self, send):
         """The asyncio streaming loop (Approach A). Owns VAD endpointing, the stream
         session lifecycle, and pushes speech_start/partial/result via `send`."""
-        loop = __import__("asyncio").get_event_loop()
+        loop = asyncio.get_running_loop()
         while not self._stop:
             try:
                 data = await loop.run_in_executor(None, self._audio_q.get, True, 0.1)
-            except Exception:
+            except queue.Empty:
                 continue
             if data is None:
                 break
@@ -218,7 +237,7 @@ class AsrEngine:
     async def _finalize(self, send):
         import time as _time
         t0 = _time.time()
-        loop = __import__("asyncio").get_event_loop()
+        loop = asyncio.get_running_loop()
         final = await loop.run_in_executor(None, self._stream.end)
         dur_ms = int((self._sample_cursor - self._utt_start_sample) / TARGET_RATE * 1000)
         if final.strip():

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -291,6 +291,7 @@ class VoxtralRealtimeBackend:
     not passed. The processor's tokenizer is mistral_common's, which ignores
     local_files_only; so load() resolves the snapshot DIR and loads the processor from it."""
     NAME = "voxtral_realtime"
+    STREAMING = True
 
     def __init__(self):
         self._model = None
@@ -337,6 +338,12 @@ class VoxtralRealtimeBackend:
             torch.cuda.empty_cache()
         except Exception:
             pass
+
+    def open_stream(self):
+        if self._model is None:
+            raise BackendLoadError("voxtral_realtime not loaded")
+        from .voxtral_stream import VoxtralRealtimeStream
+        return VoxtralRealtimeStream(self._model, self._proc, self._device, self._dtype)
 
     @property
     def is_loaded(self) -> bool:

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -280,6 +280,7 @@ class CohereTransformersBackend:
     def is_loaded(self) -> bool:
         return self._model is not None
 
+
 @register_backend
 class VoxtralRealtimeBackend:
     """Voxtral Mini 4B Realtime via native transformers

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -279,3 +279,64 @@ class CohereTransformersBackend:
     @property
     def is_loaded(self) -> bool:
         return self._model is not None
+
+@register_backend
+class VoxtralRealtimeBackend:
+    """Voxtral Mini 4B Realtime via native transformers
+    (VoxtralRealtimeForConditionalGeneration). model_ref is the HF repo; GPU-tier (bf16),
+    loaded with .to(device) (no accelerate). Phase 1 runs the STREAMING model OFFLINE: one
+    whole VAD segment per generate() — audio-only input, transcript-only output (no chat
+    template, no prompt slice). Multilingual auto-detect, so the language arg is recorded,
+    not passed. The processor's tokenizer is mistral_common's, which ignores
+    local_files_only; so load() resolves the snapshot DIR and loads the processor from it."""
+    NAME = "voxtral_realtime"
+
+    def __init__(self):
+        self._model = None
+        self._proc = None
+        self._device = "cpu"
+        self._dtype = None
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._proc = None
+        if device == "cpu":
+            raise BackendLoadError("voxtral_realtime is GPU-only")
+        try:
+            import torch
+            from huggingface_hub import snapshot_download
+            from transformers import VoxtralRealtimeForConditionalGeneration, AutoProcessor
+            self._dtype = torch.bfloat16 if compute_type in ("bfloat16", "auto") else torch.float16
+            # mistral_common's tokenizer loader ignores local_files_only / HF_HUB_OFFLINE and
+            # tries to hit the hub; loading from the resolved snapshot DIR makes it read the
+            # cached tekken.json locally. SherpaBackend uses the same dir-resolve idiom.
+            d = snapshot_download(model_ref, local_files_only=True)
+            self._proc = AutoProcessor.from_pretrained(d)
+            self._model = VoxtralRealtimeForConditionalGeneration.from_pretrained(
+                d, dtype=self._dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing voxtral_realtime module, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language) -> AsrResult:
+        import torch
+        inp = self._proc(samples, sampling_rate=TARGET_RATE, return_tensors="pt").to(self._device)
+        if "input_features" in inp:  # features are float32, model is bf16
+            inp["input_features"] = inp["input_features"].to(self._dtype)
+        with torch.inference_mode():
+            out = self._model.generate(**inp, do_sample=False)  # audio-derived auto-length
+        text = self._proc.batch_decode(out, skip_special_tokens=True)[0]
+        return AsrResult(text.strip(), language)
+
+    def unload(self) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -69,7 +69,7 @@ ASR_MODELS: list[AsrModel] = [
              ("en", "fr", "es", "de", "ru", "zh", "ja", "it", "pt", "nl", "ar", "hi", "ko"),
              (Deployment("voxtral_realtime", "gpu-cuda", "bfloat16",
                          "mistralai/Voxtral-Mini-4B-Realtime-2602", 1.0),),
-             recommended=False, sort_order=9),
+             recommended=True, sort_order=9),
 ]
 
 

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -11,7 +11,7 @@ SENSE_VOICE_REPO = os.environ.get(
 
 @dataclass(frozen=True)
 class Deployment:
-    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohere_transformers"
+    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohere_transformers" | "voxtral_realtime"
     tier: str           # "cpu" (Phase 0); "gpu-cuda"/... later
     compute_type: str   # "int8" | ...
     artifact: str       # backend.load() model_ref: whisper size, or sherpa repo id
@@ -65,6 +65,11 @@ ASR_MODELS: list[AsrModel] = [
               "fr", "it", "pt", "ru", "th", "vi", "hi", "id"),
              (Deployment("qwen3asr", "gpu-cuda", "bfloat16", "bezzam/Qwen3-ASR-1.7B", 1.0),),
              recommended=True, sort_order=8),
+    AsrModel("voxtral-mini-4b-realtime", "Voxtral Mini 4B Realtime",
+             ("en", "fr", "es", "de", "ru", "zh", "ja", "it", "pt", "nl", "ar", "hi", "ko"),
+             (Deployment("voxtral_realtime", "gpu-cuda", "bfloat16",
+                         "mistralai/Voxtral-Mini-4B-Realtime-2602", 1.0),),
+             recommended=False, sort_order=9),
 ]
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -42,6 +42,11 @@ def download_specs(model_id):
         return {"repos": ["bezzam/Qwen3-ASR-1.7B"], "urls": []}
     if model_id == "cohere-transcribe-03-2026":
         return {"repos": ["AEmotionStudio/cohere-transcribe-03-2026-models"], "urls": []}
+    if model_id == "voxtral-mini-4b-realtime":
+        # Repo ships model.safetensors (HF, needed) + consolidated.safetensors (Mistral
+        # format, 8.86GB, unused by transformers) — skip the duplicate.
+        return {"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [],
+                "ignore": ["consolidated.safetensors"]}
     return {"repos": [model_id], "urls": []}
 
 
@@ -57,10 +62,11 @@ def model_size(model_id):
     specs = download_specs(model_id)
     total = 0
     api = HfApi()
+    ignore = set(specs.get("ignore", []))
     for repo in specs["repos"]:
         try:
             info = api.repo_info(repo, files_metadata=True)
-            total += sum((s.size or 0) for s in (info.siblings or []))
+            total += sum((s.size or 0) for s in (info.siblings or []) if s.rfilename not in ignore)
         except Exception:
             pass
     total += len(specs["urls"]) * _SILERO_VAD_BYTES
@@ -151,10 +157,11 @@ async def download(model_id, send, should_cancel=None):
     cancelled = (lambda: bool(should_cancel and should_cancel()))
     specs = download_specs(model_id)
     api = HfApi()
+    ignore = set(specs.get("ignore", []))
     files = []
     for repo in specs["repos"]:
         try:
-            files.extend((repo, f) for f in api.list_repo_files(repo))
+            files.extend((repo, f) for f in api.list_repo_files(repo) if f not in ignore)
         except Exception:
             pass
     # Never report a no-op download as success: if a model declares repos but none

--- a/sidecar/sokuji_sidecar/server.py
+++ b/sidecar/sokuji_sidecar/server.py
@@ -62,6 +62,9 @@ async def _conn(state, ws):
         # connection that started ASR streaming (on_binary set) owns the engine; the
         # model-management connection has no on_binary, so it leaves the model alone.
         if conn.ctx.get("on_binary") is not None:
+            task = conn.ctx.get("stream_task")
+            if task is not None:
+                task.cancel()
             eng = state.get("asr_engine")
             if eng is not None:
                 try:

--- a/sidecar/sokuji_sidecar/voxtral_stream.py
+++ b/sidecar/sokuji_sidecar/voxtral_stream.py
@@ -115,6 +115,21 @@ class VoxtralRealtimeStream:
                 out.append(v)
         return out
 
+    def abort(self):
+        """Stop the stream WITHOUT producing a final transcript (e.g. the session
+        closed mid-utterance). Set _ended so the input-features generator stops at its
+        next wait, let generate finish, join the threads briefly, and drop the heavy
+        refs so the model can be reclaimed. Idempotent."""
+        self._ended.set()
+        if self._gen_thread is not None:
+            self._gen_thread.join(timeout=5)
+            self._gen_thread = None
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=2)
+            self._reader_thread = None
+        self._model = None
+        self._proc = None
+
     def end(self):
         """End-of-utterance: append right-pad to flush the tail, drain to completion,
         join the threads, return the full transcript."""
@@ -122,9 +137,6 @@ class VoxtralRealtimeStream:
             self._buf = np.concatenate([self._buf, np.zeros(self._right_pad, np.float32)])
         self._ended.set()
         if not self._started:        # utterance shorter than the first chunk → start now
-            with self._lock:
-                if len(self._buf) >= self._FIRST or len(self._buf) > 0:
-                    pass
             self._start()
         # drain until the reader signals completion (None sentinel)
         while True:

--- a/sidecar/sokuji_sidecar/voxtral_stream.py
+++ b/sidecar/sokuji_sidecar/voxtral_stream.py
@@ -1,0 +1,138 @@
+"""One streaming utterance for Voxtral Mini 4B Realtime. Wraps the experimental
+transformers streaming API: a live-fed input_features generator + threaded generate
++ TextIteratorStreamer. feed() appends 16kHz float32 audio (thread-safe); drain()
+returns text deltas available now; end() appends the model's right-pad to flush the
+tail, joins the generate thread, and returns the full transcript. One session per
+utterance — the padding cache + KV live in the generate call and are freed when the
+thread joins. Constants verified live (see the plan's Spike findings)."""
+import queue
+import threading
+
+import numpy as np
+from transformers import TextIteratorStreamer
+
+
+class VoxtralRealtimeStream:
+    def __init__(self, model, proc, device, dtype):
+        self._model = model
+        self._proc = proc
+        self._device = device
+        self._dtype = dtype
+        fe = proc.feature_extractor
+        self._FIRST = proc.num_samples_first_audio_chunk
+        self._CHUNK = proc.num_samples_per_audio_chunk
+        self._HOP = fe.hop_length
+        self._WIN = fe.win_length
+        self._ADV = proc.audio_length_per_tok
+        self._right_pad = proc.num_right_pad_tokens() * proc.raw_audio_length_per_tok
+        self._buf = np.zeros(0, np.float32)
+        self._lock = threading.Lock()
+        self._ended = threading.Event()      # end-of-utterance: right-pad appended
+        self._deltas = queue.Queue()         # str tokens; None = generation finished
+        self._collected = []                 # accumulated final text
+        self._gen_thread = None
+        self._reader_thread = None
+        self._started = False
+        self.aborted = False
+
+    def _buflen(self):
+        with self._lock:
+            return len(self._buf)
+
+    def _wait_for(self, n):
+        """Block until the buffer has >= n samples, or end-of-utterance with no more."""
+        while True:
+            with self._lock:
+                if len(self._buf) >= n:
+                    return True
+            if self._ended.is_set():
+                with self._lock:
+                    return len(self._buf) >= n
+            self._ended.wait(0.005)
+
+    def _input_features_generator(self, first_features):
+        yield first_features
+        mel_frame_idx = self._proc.num_mel_frames_first_audio_chunk
+        start = mel_frame_idx * self._HOP - self._WIN // 2
+        while True:
+            end = start + self._CHUNK
+            if not self._wait_for(end):
+                break
+            with self._lock:
+                seg = self._buf[start:end].copy()
+            inp = self._proc(seg, is_streaming=True, is_first_audio_chunk=False,
+                             return_tensors="pt").to(self._device, dtype=self._dtype)
+            yield inp.input_features
+            mel_frame_idx += self._ADV
+            start = mel_frame_idx * self._HOP - self._WIN // 2
+
+    def _start(self):
+        with self._lock:
+            first_audio = self._buf[:self._FIRST].copy()
+        first = self._proc(first_audio, is_streaming=True, is_first_audio_chunk=True,
+                           return_tensors="pt").to(self._device, dtype=self._dtype)
+        streamer = TextIteratorStreamer(self._proc.tokenizer, skip_special_tokens=True,
+                                        clean_up_tokenization_spaces=True)
+
+        def _run():
+            try:
+                self._model.generate(
+                    input_ids=first.input_ids,
+                    input_features=self._input_features_generator(first.input_features),
+                    num_delay_tokens=first.num_delay_tokens, streamer=streamer)
+            except Exception:
+                self.aborted = True
+
+        def _read():
+            try:
+                for tok in streamer:
+                    self._collected.append(tok)
+                    self._deltas.put(tok)
+            finally:
+                self._deltas.put(None)
+
+        self._started = True
+        self._gen_thread = threading.Thread(target=_run, daemon=True)
+        self._gen_thread.start()
+        self._reader_thread = threading.Thread(target=_read, daemon=True)
+        self._reader_thread.start()
+
+    def feed(self, samples_f32_16k):
+        with self._lock:
+            self._buf = np.concatenate([self._buf, samples_f32_16k])
+        if not self._started and self._buflen() >= self._FIRST:
+            self._start()
+
+    def drain(self):
+        """Non-blocking: return text deltas available right now."""
+        out = []
+        while True:
+            try:
+                v = self._deltas.get_nowait()
+            except queue.Empty:
+                break
+            if v is not None:
+                out.append(v)
+        return out
+
+    def end(self):
+        """End-of-utterance: append right-pad to flush the tail, drain to completion,
+        join the threads, return the full transcript."""
+        with self._lock:
+            self._buf = np.concatenate([self._buf, np.zeros(self._right_pad, np.float32)])
+        self._ended.set()
+        if not self._started:        # utterance shorter than the first chunk → start now
+            with self._lock:
+                if len(self._buf) >= self._FIRST or len(self._buf) > 0:
+                    pass
+            self._start()
+        # drain until the reader signals completion (None sentinel)
+        while True:
+            v = self._deltas.get()
+            if v is None:
+                break
+        if self._gen_thread:
+            self._gen_thread.join(timeout=30)
+        if self._reader_thread:
+            self._reader_thread.join(timeout=5)
+        return "".join(self._collected)

--- a/sidecar/sokuji_sidecar/voxtral_stream.py
+++ b/sidecar/sokuji_sidecar/voxtral_stream.py
@@ -131,8 +131,10 @@ class VoxtralRealtimeStream:
                 v = self._deltas.get_nowait()
             except queue.Empty:
                 break
-            if v is not None:
-                out.append(v)
+            if v is None:
+                self._deltas.put(v)   # preserve the completion sentinel so end() can observe it
+                break
+            out.append(v)
         return out
 
     def abort(self):

--- a/sidecar/sokuji_sidecar/voxtral_stream.py
+++ b/sidecar/sokuji_sidecar/voxtral_stream.py
@@ -102,6 +102,12 @@ class VoxtralRealtimeStream:
                     num_delay_tokens=first.num_delay_tokens, streamer=streamer)
             except Exception:
                 self.aborted = True
+                try:
+                    streamer.end()   # generate raised before its own streamer.end(); unblock
+                                     # _read()'s iterator so it emits the None sentinel and
+                                     # end() can't deadlock waiting for it.
+                except Exception:
+                    pass
 
         def _read():
             try:

--- a/sidecar/sokuji_sidecar/voxtral_stream.py
+++ b/sidecar/sokuji_sidecar/voxtral_stream.py
@@ -6,10 +6,30 @@ tail, joins the generate thread, and returns the full transcript. One session pe
 utterance — the padding cache + KV live in the generate call and are freed when the
 thread joins. Constants verified live (see the plan's Spike findings)."""
 import queue
+import re
 import threading
 
 import numpy as np
 from transformers import TextIteratorStreamer
+
+
+_SENT_END = re.compile(r"(.*?[.!?])\s")
+
+
+def split_sentences(buffer):
+    """Cut `buffer` into completed sentences (each ending in . ! ? followed by whitespace)
+    and the trailing remainder. 'Ask what you do. Ask not ' -> (['Ask what you do.'],
+    'Ask not '). No sentence end -> ([], buffer). Decimals ('3.5') don't split (the
+    required trailing whitespace isn't there). A sentence with no trailing space yet is
+    held in the remainder until the next delta brings the space (or the long-silence flush
+    commits it)."""
+    out = []
+    while True:
+        m = _SENT_END.match(buffer)
+        if not m:
+            return out, buffer
+        out.append(m.group(1).strip())
+        buffer = buffer[m.end():]
 
 
 class VoxtralRealtimeStream:

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -445,3 +445,46 @@ def test_real_gpu_granite_transcribes(tmp_path, monkeypatch):
         assert rtf is not None and rtf < 1.0, f"speech-LLM should be faster than realtime on GPU, rtf={rtf}"
     finally:
         backend.unload()
+
+
+def test_voxtral_realtime_gated_on_voxtral_realtime_module(monkeypatch):
+    import importlib.util as iu
+    from sokuji_sidecar import accel
+    real = iu.find_spec
+
+    def absent(name, *a, **k):
+        if name == "transformers.models.voxtral_realtime":
+            return None
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", absent)
+    assert "voxtral_realtime" not in accel._installed()
+
+    def present(name, *a, **k):
+        if name == "transformers.models.voxtral_realtime":
+            return object()
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", present)
+    assert "voxtral_realtime" in accel._installed()
+
+
+def test_voxtral_resolves_gpu_on_nvidia_with_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"voxtral_realtime", "transformers"}),
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
+    assert [p.device for p in plans] == ["cuda"]
+    assert plans[0].backend == "voxtral_realtime" and plans[0].compute_type == "bfloat16"
+
+
+def test_voxtral_model_unavailable_without_runtime():
+    from sokuji_sidecar import accel, catalog
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"ctranslate2", "sherpa", "transformers"}),  # no voxtral_realtime
+                      fingerprint="testfp")
+    plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
+    assert plans == []     # GPU-only + runtime absent → no usable deployment

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -314,6 +314,16 @@ def test_installed_includes_transformers():
     assert "transformers" in accel._installed()
 
 
+def test_voxtral_readiness_requires_mistral_common(monkeypatch):
+    # VoxtralRealtimeBackend.load() needs both the transformers voxtral_realtime model AND
+    # mistral_common (processor/tokenizer). A half-installed env (model present, mistral_common
+    # missing) must NOT advertise voxtral_realtime, else the catalog shows it but load() fails.
+    monkeypatch.setattr(accel, "_has_mod", lambda m: m != "mistral_common")  # all present except mistral_common
+    assert "voxtral_realtime" not in accel._installed()
+    monkeypatch.setattr(accel, "_has_mod", lambda m: True)                   # both present
+    assert "voxtral_realtime" in accel._installed()
+
+
 def test_granite_resolves_gpu_only_on_nvidia_with_transformers():
     m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),), installed=frozenset({"transformers"}))
     plans = accel.resolve("granite-speech-4.1-2b", machine=m)

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -414,7 +414,7 @@ def test_always_stream_cuts_on_endpoint_with_complete_tail(monkeypatch):
     eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
     eng._pending = "country can do for you."          # partial: the tail is MISSING here
     eng._sample_cursor = 0; eng._utt_start_sample = 0
-    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 8000   # real utterance (speech seen)
     monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint this buffer
 
     sent = []
@@ -444,13 +444,45 @@ def test_always_stream_endpoint_with_no_text_does_not_cut(monkeypatch):
     eng._pending = ""                                  # nothing transcribed
     eng._sample_cursor = 0; eng._utt_start_sample = 0
     eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
-    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint, but no text
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint, no speech
 
     sent = []
     async def send(m): sent.append(m)
     asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
-    assert not [m for m in sent if m["type"] == "result"]   # min-utterance guard: no cut
+    assert not [m for m in sent if m["type"] == "result"]   # no speech this stream: no cut
     assert opened["n"] == 0
+
+
+def test_always_stream_endpoint_flushes_held_text_with_empty_pending(monkeypatch):
+    # A short utterance whose text the model still HOLDS (so _pending is empty at the falling
+    # edge) must still cut + end()-flush. Gating on speech, not on _pending text — otherwise
+    # short commands / slow-first-token utterances get dropped or merged into the next one.
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []                       # nothing emitted yet (text held by the model)
+        def end(self): return "ok"                       # end() flushes the held short utterance
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = ""                                    # held text not yet drained
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._speech_samples = 8000                           # ~0.5s of speech happened in prior buffers
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint this buffer
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"] == "ok"       # end() flushed the held utterance
+    assert opened["n"] == 1                              # reopened
 
 
 def test_always_stream_runon_cap_forces_cut(monkeypatch):
@@ -666,7 +698,7 @@ def test_always_stream_endpoint_end_failure_still_reopens(monkeypatch):
     eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
     eng._pending = "some words"
     eng._sample_cursor = 0; eng._utt_start_sample = 0
-    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 8000   # real utterance (speech seen)
     monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint this buffer
 
     sent = []

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -486,11 +486,13 @@ def test_streaming_end_to_end_real_gpu():
     pcm = w.readframes(w.getnframes())
     sent = []
     async def send(m): sent.append(m)
-    async def drive():
+    async def feeder():
         for i in range(0, len(pcm), 3200):       # ~100ms @16k int16
             eng.feed_stream(pcm[i:i + 3200])
+            await asyncio.sleep(0.1)              # realtime pacing so partials emerge
         eng.feed_stream(None)                     # end-of-stream sentinel
-        await eng.run_stream(send)
+    async def drive():
+        await asyncio.gather(feeder(), eng.run_stream(send))
     asyncio.run(drive())
     types_seen = [m["type"] for m in sent]
     assert "speech_start" in types_seen and "partial" in types_seen

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -569,32 +569,40 @@ def test_asr_init_offline_path_unchanged():
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
                     reason="set SOKUJI_RUN_GPU=1 (uses cached Voxtral-Mini-4B-Realtime; needs CUDA)")
 def test_streaming_end_to_end_real_gpu():
-    import glob, wave, asyncio
+    import wave, asyncio, glob
     from huggingface_hub import snapshot_download
     snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
                       ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
-    eng = AsrEngine()
-    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en",
-                       sample_rate=16000, device="cuda")
-    wav = glob.glob(os.path.expanduser(
-        "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
+    root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    wav = os.path.join(root, "benchmark", "test-speech-silence-speech.wav")
+    if not os.path.exists(wav):
+        wav = glob.glob(os.path.expanduser(
+            "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
     w = wave.open(wav)
+    sr = w.getframerate()
     pcm = w.readframes(w.getnframes())
+    eng = AsrEngine()
+    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en", sample_rate=sr, device="cuda")
+    opens = {"n": 0}
+    _orig = eng._backend.open_stream
+    eng._backend.open_stream = lambda: (opens.__setitem__("n", opens["n"] + 1) or _orig())
     sent = []
     async def send(m): sent.append(m)
+    step = int(0.1 * sr) * 2     # 100ms of int16 bytes
     async def feeder():
-        for i in range(0, len(pcm), 3200):       # ~100ms @16k int16
-            eng.feed_stream(pcm[i:i + 3200])
-            await asyncio.sleep(0.1)              # realtime pacing so partials emerge
-        eng.feed_stream(None)                     # end-of-stream sentinel
+        for i in range(0, len(pcm), step):
+            eng.feed_stream(pcm[i:i + step])
+            await asyncio.sleep(0.1)
+        eng.feed_stream(None)
     async def drive():
         await asyncio.gather(feeder(), eng.run_stream(send))
     asyncio.run(drive())
-    types_seen = [m["type"] for m in sent]
-    assert "speech_start" in types_seen and "partial" in types_seen
-    results = [m for m in sent if m["type"] == "result"]
-    assert results and results[-1]["text"].strip()
-    print(f"streaming e2e: {types_seen.count('partial')} partials, final={results[-1]['text']!r}")
+    results = [m["text"] for m in sent if m["type"] == "result"]
+    full = " ".join(results).lower()
+    assert results, "no finals produced"
+    assert "ask" in full and "country" in full, f"unexpected: {results!r}"   # first word present, no leading loss
+    print(f"always-stream e2e: {len([m for m in sent if m['type']=='partial'])} partials, "
+          f"{len(results)} finals, restarts(open_stream calls)={opens['n']}")
     eng.close()
 
 

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -664,3 +664,37 @@ def test_backpressure_degrades_to_per_utterance(monkeypatch):
     assert eng._mode == "per_utterance"                     # degraded
     assert eng._stream is None                              # always-stream session dropped
     assert any(m["type"] == "result" and m["text"] == "held text" for m in sent)  # pending flushed
+
+
+def test_vad_state_reports_rising_and_falling_edges():
+    import numpy as np
+    from sokuji_sidecar.asr_engine import AsrEngine
+
+    class _FakeVad:
+        """is_speech_detected() returns the current state; accept_waveform() advances it
+        through `after` (the state AFTER each window)."""
+        def __init__(self, start, after):
+            self._cur = start
+            self._after = list(after)
+            self._k = 0
+        def is_speech_detected(self):
+            return self._cur
+        def accept_waveform(self, w):
+            self._cur = self._after[self._k]
+            self._k += 1
+
+    # falling: start speaking, one window flips to silence
+    eng = AsrEngine()
+    eng._vad = _FakeVad(start=True, after=[False])
+    eng._window = 100
+    eng._buf = np.zeros(0, np.float32)
+    had, rising, falling = eng._vad_state(np.zeros(100, np.float32))
+    assert (had, rising, falling) == (False, False, True)
+
+    # rising: start silent, one window flips to speech
+    eng2 = AsrEngine()
+    eng2._vad = _FakeVad(start=False, after=[True])
+    eng2._window = 100
+    eng2._buf = np.zeros(0, np.float32)
+    had2, rising2, falling2 = eng2._vad_state(np.zeros(100, np.float32))
+    assert (had2, rising2, falling2) == (True, True, False)

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -607,9 +607,14 @@ def test_streaming_end_to_end_real_gpu():
     results = [m["text"] for m in sent if m["type"] == "result"]
     full = " ".join(results).lower()
     assert results, "no finals produced"
-    assert "ask" in full and "country" in full, f"unexpected: {results!r}"   # first word present, no leading loss
-    print(f"always-stream e2e: {len([m for m in sent if m['type']=='partial'])} partials, "
-          f"{len(results)} finals, restarts(open_stream calls)={opens['n']}")
+    # tail-hold fix: the first sentence ends with "country" and it must be IN a final,
+    # not dropped/leaked onto the next utterance.
+    assert "ask" in full and "country" in full, f"unexpected: {results!r}"
+    # endpoint segmentation: the mid-clip pause should cut at least one final mid-clip,
+    # so >1 final (not one clump) and >1 stream opened (each utterance ended at its pause).
+    print(f"pause-seg e2e: {len([m for m in sent if m['type']=='partial'])} partials, "
+          f"{len(results)} finals, stream opens={opens['n']}, finals={results!r}")
+    assert len(results) >= 2, f"expected the pause to segment into >=2 finals, got {results!r}"
     eng.close()
 
 

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -385,6 +385,7 @@ def test_streaming_emits_speech_start_partials_result(monkeypatch):
     sent = []
     async def send(msg): sent.append(msg)
     eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en", device="cuda")
+    eng._mode = "per_utterance"   # exercise the per-utterance fallback path explicitly
     # feed one buffer that the fake VAD turns into start→speech→end
     eng.feed_stream(np.zeros(16000, np.int16).tobytes())
     asyncio.run(eng._drive_once(send))   # one iteration of the streaming loop
@@ -394,6 +395,83 @@ def test_streaming_emits_speech_start_partials_result(monkeypatch):
     assert types_seen[-1] == "result"
     assert sent[-1]["text"] == "hello world"
     assert fs.ended is True
+
+
+def test_always_stream_feeds_all_and_cuts_on_punctuation(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+
+    fed = {"n": 0}
+    pending = {"deltas": []}
+
+    class _FakeStream:
+        def feed(self, samples): fed["n"] += len(samples)
+        def drain(self):
+            out, pending["deltas"] = pending["deltas"], []
+            return out
+        def abort(self): pass
+        def end(self): return ""
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"
+    eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: _FakeStream()})()
+    eng._pending = ""; eng._utt_text = ""
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = 0; eng._stream_speech_samples = 0
+    # VAD stub: speech present, no rising edge, never long-silence
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+
+    sent = []
+    async def send(m): sent.append(m)
+    buf = (b"\x00\x00" * 1600)        # one 100ms buffer (1600 int16 samples)
+
+    # 1) a delta with no sentence end -> partial only, no result
+    pending["deltas"] = ["Ask not "]
+    asyncio.run(eng._drive_always(send, buf))
+    assert fed["n"] == 1600                          # the buffer was fed (not gated)
+    assert sent[-1] == {"type": "partial", "text": "Ask not"}
+    assert not any(m["type"] == "result" for m in sent)
+
+    # 2) a delta completing the sentence -> result + the remainder becomes the new partial
+    pending["deltas"] = ["what you do. Ask "]
+    asyncio.run(eng._drive_always(send, buf))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"] == "Ask not what you do."
+    assert sent[-1] == {"type": "partial", "text": "Ask"}
+
+
+def test_always_stream_long_silence_flushes_and_restarts(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, samples): pass
+        def drain(self): return []
+        def abort(self): pass
+        def end(self): return ""
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = ""; eng._utt_text = "trailing words"   # un-punctuated pending
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = int(2.5 * 16000)              # already at the long-silence threshold
+    eng._stream_speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False))   # silence
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"] == "trailing words"   # un-punctuated text flushed
+    assert opened["n"] == 1                                       # stream restarted
+    assert eng._utt_text == "" and eng._pending == ""            # reset
 
 
 def test_asr_init_starts_streaming_task_for_streaming_backend():

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -367,3 +367,95 @@ def test_streaming_emits_speech_start_partials_result(monkeypatch):
     assert types_seen[-1] == "result"
     assert sent[-1]["text"] == "hello world"
     assert fs.ended is True
+
+
+def test_asr_init_starts_streaming_task_for_streaming_backend():
+    started = {"task": False, "init_streaming": None}
+
+    class FakeEng:
+        resolved = {"backend": "voxtral_realtime", "device": "cuda", "computeType": "bfloat16"}
+
+        def resolves_to_streaming(self, model_id, device):
+            return True
+
+        def init_streaming(self, model_id=None, language="", sample_rate=None,
+                           vad_threshold=None, vad_min_silence=None, vad_min_speech=None, device="auto"):
+            started["init_streaming"] = {"model": model_id, "device": device}
+
+        def init(self, *a, **k):
+            started["offline"] = True
+            return 0
+
+        def is_streaming(self):
+            return True
+
+        def feed_stream(self, b):
+            pass
+
+        async def run_stream(self, send):
+            started["task"] = True
+
+    eng = FakeEng()
+
+    async def scenario():
+        state = {"asr_engine": eng, "handlers": {}}
+        from sokuji_sidecar import asr_engine as ae
+        ae.register(state)
+        conn = server.Conn(type("WS", (), {"send": lambda self, d: None})())
+        reply, _ = await server.handle_message(
+            state, json.dumps({"type": "asr_init", "id": 1, "model": "voxtral-mini-4b-realtime",
+                               "language": "en", "device": "cuda"}), None, conn)
+        await asyncio.sleep(0)            # let the created task run once
+        return reply, conn
+
+    reply, conn = asyncio.run(scenario())
+    assert reply["type"] == "ready"
+    assert reply["id"] == 1
+    # streaming backend wires feed_stream, not feed
+    assert conn.ctx["on_binary"] == eng.feed_stream
+    # run_stream task was started and ran
+    assert started["task"] is True
+    # offline init was NOT called (no double-load)
+    assert "offline" not in started
+    # init_streaming was called with the right params
+    assert started["init_streaming"]["model"] == "voxtral-mini-4b-realtime"
+    assert started["init_streaming"]["device"] == "cuda"
+
+
+def test_asr_init_offline_path_unchanged():
+    """An engine without resolves_to_streaming (or returning False) must use the
+    old sync path: on_binary = eng.feed, eng.init() called once."""
+    loaded = {"init_calls": 0}
+
+    class OfflineEng:
+        def resolves_to_streaming(self, model_id, device):
+            return False
+
+        def init(self, model_id=None, language="", sample_rate=None,
+                 vad_threshold=None, vad_min_silence=None, vad_min_speech=None, device="auto"):
+            loaded["init_calls"] += 1
+            return 42
+
+        def feed(self, b):
+            return []
+
+    eng = OfflineEng()
+
+    async def scenario():
+        state = {"asr_engine": eng, "handlers": {}}
+        from sokuji_sidecar import asr_engine as ae
+        ae.register(state)
+        conn = server.Conn(type("WS", (), {"send": lambda self, d: None})())
+        reply, _ = await server.handle_message(
+            state, json.dumps({"type": "asr_init", "id": 2, "model": "sense-voice",
+                               "language": "ja", "device": "auto"}), None, conn)
+        return reply, conn
+
+    reply, conn = asyncio.run(scenario())
+    assert reply == {"type": "ready", "id": 2, "loadTimeMs": 42}
+    # offline: on_binary = eng.feed
+    assert conn.ctx["on_binary"] == eng.feed
+    # init called exactly once (no double-load)
+    assert loaded["init_calls"] == 1
+    # no stream_task created
+    assert conn.ctx.get("stream_task") is None

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -468,3 +468,33 @@ def test_asr_init_offline_path_unchanged():
     assert loaded["init_calls"] == 1
     # no stream_task created
     assert conn.ctx.get("stream_task") is None
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (uses cached Voxtral-Mini-4B-Realtime; needs CUDA)")
+def test_streaming_end_to_end_real_gpu():
+    import glob, wave, asyncio
+    from huggingface_hub import snapshot_download
+    snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                      ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    eng = AsrEngine()
+    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en",
+                       sample_rate=16000, device="cuda")
+    wav = glob.glob(os.path.expanduser(
+        "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
+    w = wave.open(wav)
+    pcm = w.readframes(w.getnframes())
+    sent = []
+    async def send(m): sent.append(m)
+    async def drive():
+        for i in range(0, len(pcm), 3200):       # ~100ms @16k int16
+            eng.feed_stream(pcm[i:i + 3200])
+        eng.feed_stream(None)                     # end-of-stream sentinel
+        await eng.run_stream(send)
+    asyncio.run(drive())
+    types_seen = [m["type"] for m in sent]
+    assert "speech_start" in types_seen and "partial" in types_seen
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"].strip()
+    print(f"streaming e2e: {types_seen.count('partial')} partials, final={results[-1]['text']!r}")
+    eng.close()

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -319,3 +319,51 @@ def test_conn_close_frees_asr_model():
 
     asyncio.run(server._conn(st, WS()))
     assert closed["n"] == 1
+
+
+from sokuji_sidecar.asr_engine import AsrEngine
+
+
+class _FakeStream:
+    """Scripted stream session: drain() returns queued deltas, end() returns the join."""
+    def __init__(self):
+        self.fed = 0
+        self._pending = ["he", "llo "]
+        self.ended = False
+    def feed(self, samples):
+        self.fed += len(samples)
+    def drain(self):
+        out, self._pending = self._pending, []
+        return out
+    def end(self):
+        self.ended = True
+        return "hello world"
+
+
+def _streaming_engine(monkeypatch, fake_stream, vad_segments):
+    """Build an AsrEngine whose resolved backend is streaming and whose VAD is faked
+    to yield a scripted speech_start then endpoint."""
+    eng = AsrEngine()
+    backend = type("B", (), {"STREAMING": True, "open_stream": lambda self: fake_stream,
+                             "unload": lambda self: None})()
+    # bypass real resolve/VAD: inject the backend + a fake VAD endpoint generator
+    monkeypatch.setattr(eng, "_resolve_streaming_backend", lambda model, device: backend)
+    monkeypatch.setattr(eng, "_vad_events", lambda samples: vad_segments)  # ['start'|'speech'|'end']
+    return eng
+
+
+def test_streaming_emits_speech_start_partials_result(monkeypatch):
+    fs = _FakeStream()
+    eng = _streaming_engine(monkeypatch, fs, vad_segments=["start", "speech", "end"])
+    sent = []
+    async def send(msg): sent.append(msg)
+    eng.init_streaming(model_id="voxtral-mini-4b-realtime", language="en", device="cuda")
+    # feed one buffer that the fake VAD turns into start→speech→end
+    eng.feed_stream(np.zeros(16000, np.int16).tobytes())
+    asyncio.run(eng._drive_once(send))   # one iteration of the streaming loop
+    types_seen = [m["type"] for m in sent]
+    assert types_seen[0] == "speech_start"
+    assert "partial" in types_seen
+    assert types_seen[-1] == "result"
+    assert sent[-1]["text"] == "hello world"
+    assert fs.ended is True

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -397,81 +397,88 @@ def test_streaming_emits_speech_start_partials_result(monkeypatch):
     assert fs.ended is True
 
 
-def test_always_stream_feeds_all_and_cuts_on_punctuation(monkeypatch):
-    import asyncio
-    from sokuji_sidecar.asr_engine import AsrEngine
-
-    fed = {"n": 0}
-    pending = {"deltas": []}
-
-    class _FakeStream:
-        def feed(self, samples): fed["n"] += len(samples)
-        def drain(self):
-            out, pending["deltas"] = pending["deltas"], []
-            return out
-        def abort(self): pass
-        def end(self): return ""
-
-    eng = AsrEngine()
-    eng._mode = "always_stream"
-    eng._src_rate = 16000
-    eng._stream = _FakeStream()
-    eng._backend = type("B", (), {"open_stream": lambda self: _FakeStream()})()
-    eng._pending = ""; eng._utt_text = ""
-    eng._sample_cursor = 0; eng._utt_start_sample = 0
-    eng._fed_s = 0.0; eng._delta_count = 0
-    eng._silence_samples = 0; eng._stream_speech_samples = 0
-    # VAD stub: speech present, no rising edge, never long-silence
-    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
-
-    sent = []
-    async def send(m): sent.append(m)
-    buf = (b"\x00\x00" * 1600)        # one 100ms buffer (1600 int16 samples)
-
-    # 1) a delta with no sentence end -> partial only, no result
-    pending["deltas"] = ["Ask not "]
-    asyncio.run(eng._drive_always(send, buf))
-    assert fed["n"] == 1600                          # the buffer was fed (not gated)
-    assert sent[-1] == {"type": "partial", "text": "Ask not"}
-    assert not any(m["type"] == "result" for m in sent)
-
-    # 2) a delta completing the sentence -> result + the remainder becomes the new partial
-    pending["deltas"] = ["what you do. Ask "]
-    asyncio.run(eng._drive_always(send, buf))
-    results = [m for m in sent if m["type"] == "result"]
-    assert results and results[-1]["text"] == "Ask not what you do."
-    assert sent[-1] == {"type": "partial", "text": "Ask"}
-
-
-def test_always_stream_long_silence_flushes_and_restarts(monkeypatch):
+def test_always_stream_cuts_on_endpoint_with_complete_tail(monkeypatch):
     import asyncio
     from sokuji_sidecar.asr_engine import AsrEngine
     opened = {"n": 0}
 
     class _FakeStream:
-        def feed(self, samples): pass
+        def feed(self, s): pass
         def drain(self): return []
+        def end(self): return "country can do for you. do for your country."   # COMPLETE (tail incl.)
         def abort(self): pass
-        def end(self): return ""
 
     eng = AsrEngine()
     eng._mode = "always_stream"; eng._src_rate = 16000
     eng._stream = _FakeStream()
     eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
-    eng._pending = ""; eng._utt_text = "trailing words"   # un-punctuated pending
+    eng._pending = "country can do for you."          # partial: the tail is MISSING here
     eng._sample_cursor = 0; eng._utt_start_sample = 0
-    eng._fed_s = 0.0; eng._delta_count = 0
-    eng._silence_samples = int(2.5 * 16000)              # already at the long-silence threshold
-    eng._stream_speech_samples = 0
-    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False))   # silence
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint this buffer
 
     sent = []
     async def send(m): sent.append(m)
     asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
     results = [m for m in sent if m["type"] == "result"]
-    assert results and results[-1]["text"] == "trailing words"   # un-punctuated text flushed
-    assert opened["n"] == 1                                       # stream restarted
-    assert eng._utt_text == "" and eng._pending == ""            # reset
+    assert results and "do for your country." in results[-1]["text"]   # the held tail is in the final
+    assert opened["n"] == 1                                            # reopened
+    assert eng._pending == "" and eng._fed_s == 0.0 and eng._delta_count == 0
+
+
+def test_always_stream_endpoint_with_no_text_does_not_cut(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []
+        def end(self): return ""
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = ""                                  # nothing transcribed
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint, but no text
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    assert not [m for m in sent if m["type"] == "result"]   # min-utterance guard: no cut
+    assert opened["n"] == 0
+
+
+def test_always_stream_runon_cap_forces_cut(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []
+        def end(self): return "a very long run on utterance"
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = "a very long run on"
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._speech_samples = 20 * 16000                   # already at the run-on cap
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False, False))   # speaking, no endpoint
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    assert opened["n"] == 1                            # cap forced an end()+reopen
+    assert [m for m in sent if m["type"] == "result"]
 
 
 def test_asr_init_starts_streaming_task_for_streaming_backend():
@@ -622,11 +629,11 @@ def test_always_stream_aborted_self_heals(monkeypatch):
     eng._mode = "always_stream"; eng._src_rate = 16000
     eng._stream = _AbortedStream()
     eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _AbortedStream())})()
-    eng._pending = ""; eng._utt_text = "partial words"
+    eng._pending = "partial words"
     eng._sample_cursor = 0; eng._utt_start_sample = 0
     eng._fed_s = 0.0; eng._delta_count = 0
-    eng._silence_samples = 0; eng._stream_speech_samples = 0
-    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+    eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False, False))
 
     sent = []
     async def send(m): sent.append(m)
@@ -649,11 +656,11 @@ def test_backpressure_degrades_to_per_utterance(monkeypatch):
     eng._mode = "always_stream"; eng._src_rate = 16000
     eng._stream = _SlowStream()
     eng._backend = type("B", (), {"open_stream": lambda self: _SlowStream()})()
-    eng._pending = ""; eng._utt_text = "held text"
+    eng._pending = "held text"
     eng._sample_cursor = 0; eng._utt_start_sample = 0
     eng._fed_s = 0.0; eng._delta_count = 0
-    eng._silence_samples = 0; eng._stream_speech_samples = 0
-    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+    eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False, False))
 
     sent = []
     async def send(m): sent.append(m)

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -352,6 +352,15 @@ def _streaming_engine(monkeypatch, fake_stream, vad_segments):
     return eng
 
 
+def test_feed_stream_returns_iterable_for_conn_loop():
+    import queue
+    eng = AsrEngine()
+    eng._audio_q = queue.Queue()
+    out = eng.feed_stream(b"\x00\x00\x01\x00")
+    assert list(out) == []                 # _conn's `for out in feeder(data)` is safe
+    assert eng._audio_q.qsize() == 1       # audio was enqueued for the streaming task
+
+
 def test_streaming_emits_speech_start_partials_result(monkeypatch):
     fs = _FakeStream()
     eng = _streaming_engine(monkeypatch, fs, vad_segments=["start", "speech", "end"])

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -646,6 +646,35 @@ def test_always_stream_aborted_self_heals(monkeypatch):
     results = [m for m in sent if m["type"] == "result"]
     assert results and results[-1]["text"] == "partial words"   # pending flushed on self-heal
     assert opened["n"] == 1                                      # stream restarted
+    assert eng._pending == "" and eng._fed_s == 0.0 and eng._delta_count == 0 and eng._speech_samples == 0
+
+
+def test_always_stream_endpoint_end_failure_still_reopens(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _FakeStream:
+        def feed(self, s): pass
+        def drain(self): return []
+        def end(self): raise RuntimeError("generate crashed during flush")
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _FakeStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _FakeStream())})()
+    eng._pending = "some words"
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0; eng._speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (False, False, True))   # endpoint this buffer
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    assert opened["n"] == 1                                   # reopened despite end() raising
+    assert not [m for m in sent if m["type"] == "result"]     # no final emitted on failure
+    assert eng._pending == ""                                 # state reset (self-heal)
 
 
 def test_backpressure_degrades_to_per_utterance(monkeypatch):

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -596,3 +596,33 @@ def test_streaming_end_to_end_real_gpu():
     assert results and results[-1]["text"].strip()
     print(f"streaming e2e: {types_seen.count('partial')} partials, final={results[-1]['text']!r}")
     eng.close()
+
+
+def test_backpressure_degrades_to_per_utterance(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+
+    class _SlowStream:      # never emits deltas -> processed audio stays 0 -> lag grows
+        def feed(self, samples): pass
+        def drain(self): return []
+        def abort(self): pass
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _SlowStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: _SlowStream()})()
+    eng._pending = ""; eng._utt_text = "held text"
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = 0; eng._stream_speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+
+    sent = []
+    async def send(m): sent.append(m)
+    buf = b"\x00\x00" * 16000     # 1s of audio per call
+    # feed ~4s of audio with no deltas -> lag exceeds 3.0 -> degrade
+    for _ in range(4):
+        asyncio.run(eng._drive_always(send, buf))
+    assert eng._mode == "per_utterance"                     # degraded
+    assert eng._stream is None                              # always-stream session dropped
+    assert any(m["type"] == "result" and m["text"] == "held text" for m in sent)  # pending flushed

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -606,6 +606,36 @@ def test_streaming_end_to_end_real_gpu():
     eng.close()
 
 
+def test_always_stream_aborted_self_heals(monkeypatch):
+    import asyncio
+    from sokuji_sidecar.asr_engine import AsrEngine
+    opened = {"n": 0}
+
+    class _AbortedStream:
+        aborted = True                     # generate died
+        def feed(self, samples): pass
+        def drain(self): return []
+        def abort(self): pass
+        def end(self): return ""
+
+    eng = AsrEngine()
+    eng._mode = "always_stream"; eng._src_rate = 16000
+    eng._stream = _AbortedStream()
+    eng._backend = type("B", (), {"open_stream": lambda self: (opened.__setitem__("n", opened["n"] + 1) or _AbortedStream())})()
+    eng._pending = ""; eng._utt_text = "partial words"
+    eng._sample_cursor = 0; eng._utt_start_sample = 0
+    eng._fed_s = 0.0; eng._delta_count = 0
+    eng._silence_samples = 0; eng._stream_speech_samples = 0
+    monkeypatch.setattr(eng, "_vad_state", lambda s: (True, False))
+
+    sent = []
+    async def send(m): sent.append(m)
+    asyncio.run(eng._drive_always(send, b"\x00\x00" * 1600))
+    results = [m for m in sent if m["type"] == "result"]
+    assert results and results[-1]["text"] == "partial words"   # pending flushed on self-heal
+    assert opened["n"] == 1                                      # stream restarted
+
+
 def test_backpressure_degrades_to_per_utterance(monkeypatch):
     import asyncio
     from sokuji_sidecar.asr_engine import AsrEngine

--- a/sidecar/tests/test_asr_engine.py
+++ b/sidecar/tests/test_asr_engine.py
@@ -321,6 +321,24 @@ def test_conn_close_frees_asr_model():
     assert closed["n"] == 1
 
 
+def test_close_aborts_open_streaming_session():
+    """A mid-utterance close() must end the open stream (not leak its threads)."""
+    from sokuji_sidecar.asr_engine import AsrEngine
+    import queue as _q
+    eng = AsrEngine()
+    aborted = {"called": False}
+    class _S:
+        def abort(self): aborted["called"] = True
+        def end(self): return ""
+    eng._stream = _S()
+    eng._audio_q = _q.Queue()
+    eng._backend = type("B", (), {"unload": lambda self: None})()
+    eng.close()
+    assert aborted["called"] is True          # the open stream was ended
+    assert eng._stream is None
+    assert eng._audio_q.get_nowait() is None   # run_stream gets the stop sentinel
+
+
 from sokuji_sidecar.asr_engine import AsrEngine
 
 

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -472,3 +472,125 @@ def test_cohereasr_real_gpu_smoke():
     q.load("bezzam/Qwen3-ASR-1.7B", "cuda", "bfloat16")
     assert q.is_loaded
     q.unload()
+
+
+def test_voxtral_realtime_is_gpu_only():
+    b = backends.make_backend("voxtral_realtime")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cpu", "bfloat16")
+
+
+def _install_fake_voxtral(monkeypatch, *, decoded="  hello world  ", fail=False):
+    cap = {}
+
+    class FakeFeat:
+        def to(self, dtype):
+            cap["feat_dtype"] = dtype
+            return self
+
+    class FakeBatch(dict):
+        def to(self, device):
+            cap["inp_device"] = device
+            return self
+
+    class FakeProc:
+        # Voxtral realtime processor: positional audio + sampling_rate + return_tensors.
+        # No language (multilingual auto-detect), no chat template. If the backend ever
+        # passed language=, this signature would TypeError — guarding that contract.
+        def __call__(self, samples, sampling_rate, return_tensors):
+            cap["sr"] = sampling_rate
+            cap["n_samples"] = len(samples)
+            b = FakeBatch()
+            b["input_features"] = FakeFeat()
+            b["input_ids"] = "IDS"
+            return b
+
+        def batch_decode(self, seq, skip_special_tokens):
+            cap["decoded_seq"] = seq
+            cap["skip_special"] = skip_special_tokens
+            return [decoded]
+
+    class FakeModel:
+        def to(self, device):
+            cap["model_device"] = device
+            return self
+
+        def eval(self):
+            return self
+
+        def generate(self, **kw):
+            cap["gen_kw"] = kw
+            return "OUT"
+
+    class FakeAutoProcessor:
+        @staticmethod
+        def from_pretrained(path, local_files_only=False):
+            cap["proc_path"] = path
+            cap["proc_local_files_only"] = local_files_only
+            return FakeProc()
+
+    class FakeVoxtral:
+        @staticmethod
+        def from_pretrained(path, dtype, local_files_only=False):
+            if fail:
+                raise RuntimeError("voxtral_realtime missing")
+            cap["model_path"] = path
+            cap["dtype"] = dtype
+            cap["model_local_files_only"] = local_files_only
+            return FakeModel()
+
+    tmod = types.ModuleType("transformers")
+    tmod.AutoProcessor = FakeAutoProcessor
+    tmod.VoxtralRealtimeForConditionalGeneration = FakeVoxtral
+    monkeypatch.setitem(sys.modules, "transformers", tmod)
+
+    hub = types.ModuleType("huggingface_hub")
+
+    def fake_snapshot(repo, local_files_only=False):
+        cap["snap_repo"] = repo
+        cap["snap_local_files_only"] = local_files_only
+        return f"/fake/snapshot/{repo}"
+
+    hub.snapshot_download = fake_snapshot
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    torch_mod = types.ModuleType("torch")
+    torch_mod.bfloat16 = "BF16"
+    torch_mod.float16 = "F16"
+    torch_mod.inference_mode = contextlib.nullcontext
+    torch_mod.cuda = types.SimpleNamespace(empty_cache=lambda: None, is_available=lambda: True)
+    monkeypatch.setitem(sys.modules, "torch", torch_mod)
+    return cap
+
+
+def test_voxtral_realtime_load_and_transcribe(monkeypatch):
+    cap = _install_fake_voxtral(monkeypatch)
+    b = backends.make_backend("voxtral_realtime")
+    assert not b.is_loaded
+    b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+    assert b.is_loaded
+    # Offline load resolves the snapshot DIR (local_files_only) and loads the processor
+    # + model FROM that dir — mistral_common ignores local_files_only on a repo id.
+    assert cap["snap_repo"] == "mistralai/Voxtral-Mini-4B-Realtime-2602"
+    assert cap["snap_local_files_only"] is True
+    assert cap["proc_path"] == "/fake/snapshot/mistralai/Voxtral-Mini-4B-Realtime-2602"
+    assert cap["model_path"] == "/fake/snapshot/mistralai/Voxtral-Mini-4B-Realtime-2602"
+    assert cap["dtype"] == "BF16"            # bfloat16 → torch.bfloat16
+    assert cap["model_device"] == "cuda"
+    assert cap["model_local_files_only"] is True
+    r = b.transcribe(np.zeros(16000, np.float32), "en")
+    assert r.text == "hello world"           # decoded + stripped, audio-only → no prefix/slice
+    assert cap["feat_dtype"] == "BF16"        # input_features cast to model dtype
+    assert cap["sr"] == 16000                 # TARGET_RATE
+    assert cap["skip_special"] is True
+    assert cap["gen_kw"]["do_sample"] is False
+    assert "max_new_tokens" not in cap["gen_kw"]   # audio-derived auto-length, no cap
+    b.unload()
+    assert not b.is_loaded
+
+
+def test_voxtral_realtime_load_failure_raises(monkeypatch):
+    _install_fake_voxtral(monkeypatch, fail=True)
+    b = backends.make_backend("voxtral_realtime")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -594,3 +594,34 @@ def test_voxtral_realtime_load_failure_raises(monkeypatch):
     b = backends.make_backend("voxtral_realtime")
     with pytest.raises(backends.BackendLoadError):
         b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads mistralai/Voxtral-Mini-4B-Realtime-2602 ~8.9GB; needs CUDA + mistral-common[audio])")
+def test_voxtral_realtime_real_gpu_smoke():
+    # Real flow: manager downloads first (HF-format only, skipping the consolidated dup),
+    # backend loads from cache via the snapshot-dir offline path.
+    import wave
+    from huggingface_hub import snapshot_download
+    snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                      ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    b = backends.make_backend("voxtral_realtime")
+    b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+    assert b.is_loaded
+    # real English speech (sense-voice test clip) → a non-empty transcript
+    d = snapshot_download("csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17")
+    w = wave.open(f"{d}/test_wavs/en.wav", "rb")
+    audio = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16).astype(np.float32) / 32768.0
+    t0 = time.perf_counter()
+    r = b.transcribe(audio, "en")
+    rtf = (time.perf_counter() - t0) / (len(audio) / 16000.0)
+    assert isinstance(r.text, str) and r.text.strip(), f"empty transcript on real speech: {r.text!r}"
+    print(f"voxtral-mini-4b-realtime RTF={rtf:.4f}")
+    b.unload()
+    # coexistence regression: Cohere still loads after Voxtral unload + empty_cache
+    import torch
+    torch.cuda.empty_cache()
+    c = backends.make_backend("cohere_transformers")
+    c.load("AEmotionStudio/cohere-transcribe-03-2026-models", "cuda", "bfloat16")
+    assert c.is_loaded
+    c.unload()

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -578,6 +578,7 @@ def test_voxtral_realtime_load_and_transcribe(monkeypatch):
     assert cap["dtype"] == "BF16"            # bfloat16 → torch.bfloat16
     assert cap["model_device"] == "cuda"
     assert cap["model_local_files_only"] is True
+    assert cap["proc_local_files_only"] is False  # processor loaded WITHOUT local_files_only (mistral_common ignores it)
     r = b.transcribe(np.zeros(16000, np.float32), "en")
     assert r.text == "hello world"           # decoded + stripped, audio-only → no prefix/slice
     assert cap["feat_dtype"] == "BF16"        # input_features cast to model dtype

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -78,7 +78,7 @@ def test_voxtral_realtime_row():
     assert m is not None
     assert m.name == "Voxtral Mini 4B Realtime"
     assert m.languages == ("en", "fr", "es", "de", "ru", "zh", "ja", "it", "pt", "nl", "ar", "hi", "ko")
-    assert m.recommended is False        # Phase 1: offline mode; promote when streaming lands
+    assert m.recommended is True         # Phase 2: streaming landed → promote to recommended
     assert m.sort_order == 9             # appended after Qwen3 (8); no existing rows shift
     d = m.deployments[0]
     assert (d.backend, d.tier, d.compute_type, d.artifact) == \

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -6,7 +6,7 @@ def test_models_have_deployments_and_languages():
         assert m.deployments, f"{m.id} has no deployments"
         assert m.languages, f"{m.id} has no languages"
         for d in m.deployments:
-            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr", "cohere_transformers"}
+            assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr", "cohere_transformers", "voxtral_realtime"}
 
 
 def test_system_has_a_cpu_floor():
@@ -71,3 +71,15 @@ def test_cohere_is_first_qwen3_shifted():
     assert ids[0] == "cohere-transcribe-03-2026"           # inserted first in the list
     assert catalog.asr_model("qwen3-asr-1.7b").sort_order == 8   # shifted +1 from 7
     assert catalog.asr_model("sense-voice").sort_order == 1      # shifted +1 from 0
+
+
+def test_voxtral_realtime_row():
+    m = catalog.asr_model("voxtral-mini-4b-realtime")
+    assert m is not None
+    assert m.name == "Voxtral Mini 4B Realtime"
+    assert m.languages == ("en", "fr", "es", "de", "ru", "zh", "ja", "it", "pt", "nl", "ar", "hi", "ko")
+    assert m.recommended is False        # Phase 1: offline mode; promote when streaming lands
+    assert m.sort_order == 9             # appended after Qwen3 (8); no existing rows shift
+    d = m.deployments[0]
+    assert (d.backend, d.tier, d.compute_type, d.artifact) == \
+        ("voxtral_realtime", "gpu-cuda", "bfloat16", "mistralai/Voxtral-Mini-4B-Realtime-2602")

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -174,3 +174,65 @@ def test_model_status_rejects_interrupted_download(monkeypatch, tmp_path):
     # stale leftover: the finalized blob has since landed → ignore the orphan .incomplete
     (blobs / "def456").write_text("now finalized")
     assert native_models.model_status("cohere-transcribe-03-2026") == "ready"
+
+
+def test_download_specs_voxtral_skips_consolidated():
+    spec = nm.download_specs("voxtral-mini-4b-realtime")
+    assert spec["repos"] == ["mistralai/Voxtral-Mini-4B-Realtime-2602"]
+    assert spec["urls"] == []
+    assert spec["ignore"] == ["consolidated.safetensors"]
+
+
+def test_existing_specs_have_no_ignore_key():
+    # The ignore key is additive: every pre-existing model omits it (consumers use .get).
+    assert "ignore" not in nm.download_specs("cohere-transcribe-03-2026")
+    assert "ignore" not in nm.download_specs("qwen3-asr-1.7b")
+
+
+def test_download_honors_ignore_list(monkeypatch):
+    """The ignore list keeps consolidated.safetensors out of the fetched file set,
+    so transformers' model.safetensors is fetched but the 8.86GB duplicate is not."""
+    import huggingface_hub
+    fetched = []
+
+    class _Api:
+        def list_repo_files(self, repo):
+            return ["model.safetensors", "consolidated.safetensors", "config.json", "tekken.json"]
+
+    monkeypatch.setattr(nm, "download_specs", lambda m: {
+        "repos": ["r"], "urls": [], "ignore": ["consolidated.safetensors"]})
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download",
+                        lambda repo, fname: fetched.append(fname))
+
+    async def send(_m):
+        pass
+
+    status = asyncio.run(nm.download("voxtral-mini-4b-realtime", send))
+    assert status == "ready"
+    assert "consolidated.safetensors" not in fetched
+    assert "model.safetensors" in fetched and "tekken.json" in fetched
+
+
+def test_model_size_excludes_ignored_files(monkeypatch):
+    import huggingface_hub
+
+    class _Sib:
+        def __init__(self, name, size):
+            self.rfilename = name
+            self.size = size
+
+    class _Info:
+        siblings = [_Sib("model.safetensors", 8_000_000_000),
+                    _Sib("consolidated.safetensors", 8_000_000_000),
+                    _Sib("config.json", 1000)]
+
+    class _Api:
+        def repo_info(self, repo, files_metadata=False):
+            return _Info()
+
+    monkeypatch.setattr(nm, "download_specs", lambda m: {
+        "repos": ["r"], "urls": [], "ignore": ["consolidated.safetensors"]})
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    nm._SIZE_CACHE.clear()
+    assert nm.model_size("voxtral-mini-4b-realtime") == 8_000_001_000  # consolidated excluded

--- a/sidecar/tests/test_voxtral_stream.py
+++ b/sidecar/tests/test_voxtral_stream.py
@@ -1,0 +1,121 @@
+import threading
+import time
+import types
+
+import numpy as np
+import pytest
+
+
+class _FakeStreamer:
+    """Stand-in for TextIteratorStreamer: a thread-safe iterator of strings the
+    fake model 'generates'. end-of-iteration is signalled by put(None)."""
+    def __init__(self):
+        import queue
+        self._q = queue.Queue()
+    def put_text(self, s): self._q.put(s)
+    def end(self): self._q.put(None)
+    def __iter__(self): return self
+    def __next__(self):
+        v = self._q.get()
+        if v is None:
+            raise StopIteration
+        return v
+
+
+def _fake_proc():
+    fe = types.SimpleNamespace(hop_length=160, win_length=400, sampling_rate=16000)
+
+    # processor(samples, is_streaming=, is_first_audio_chunk=, return_tensors=) -> batch
+    def _call(samples, is_streaming, is_first_audio_chunk, return_tensors):
+        b = {"input_features": _Castable()}
+        if is_first_audio_chunk:
+            b["input_ids"] = "IDS"
+            b["num_delay_tokens"] = 6
+        return _FakeBatch(b)
+
+    # SimpleNamespace doesn't support dunder methods on instances; use a class
+    class _Proc:
+        feature_extractor = fe
+        num_samples_first_audio_chunk = 9000
+        num_samples_per_audio_chunk = 1680
+        num_mel_frames_first_audio_chunk = 56
+        audio_length_per_tok = 8
+        raw_audio_length_per_tok = 1280
+        tokenizer = object()
+        @staticmethod
+        def num_right_pad_tokens(transcription_delay_ms=None): return 17
+        def __call__(self, samples, is_streaming, is_first_audio_chunk, return_tensors):
+            return _call(samples, is_streaming, is_first_audio_chunk, return_tensors)
+
+    return _Proc()
+
+
+class _Castable:
+    def to(self, device, dtype=None): return self
+
+class _FakeBatch(dict):
+    num_delay_tokens = 6
+    input_ids = "IDS"
+    input_features = _Castable()
+    def to(self, device, dtype=None): return self
+
+
+def _fake_model(streamer, generated="hello world"):
+    class M:
+        device = "cpu"
+        dtype = "BF16"
+        def generate(self, input_ids, input_features, num_delay_tokens, streamer):
+            # drain the live generator (proves lazy feeding works), then emit tokens
+            for _ in input_features:
+                pass
+            for tok in generated.split():
+                streamer.put_text(tok + " ")
+            streamer.end()
+    return M()
+
+
+def test_stream_feed_drain_end(monkeypatch):
+    from sokuji_sidecar import voxtral_stream
+    proc = _fake_proc()
+    streamer = _FakeStreamer()
+    monkeypatch.setattr(voxtral_stream, "TextIteratorStreamer", lambda *a, **k: streamer)
+    model = _fake_model(streamer)
+    s = voxtral_stream.VoxtralRealtimeStream(model, proc, "cpu", "BF16")
+    # feed enough to start (>= first chunk), then more
+    s.feed(np.zeros(9000, np.float32))
+    s.feed(np.zeros(4000, np.float32))
+    final = s.end()                       # flushes right-pad, joins the generate thread
+    assert final.strip() == "hello world"
+    assert s.aborted is False
+
+
+import os
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (uses cached Voxtral-Mini-4B-Realtime; needs CUDA)")
+def test_voxtral_stream_real_gpu_live():
+    import glob
+    import wave
+    import torch
+    from huggingface_hub import snapshot_download
+    from sokuji_sidecar import backends
+    d = snapshot_download("mistralai/Voxtral-Mini-4B-Realtime-2602",
+                          ignore_patterns=["consolidated.safetensors", "*.gitattributes"])
+    b = backends.make_backend("voxtral_realtime")
+    b.load("mistralai/Voxtral-Mini-4B-Realtime-2602", "cuda", "bfloat16")
+    wav = glob.glob(os.path.expanduser(
+        "~/.cache/huggingface/hub/models--csukuangfj--sherpa-onnx-sense-voice*/snapshots/*/test_wavs/en.wav"))[0]
+    w = wave.open(wav)
+    audio = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16).astype(np.float32) / 32768.0
+    s = b.open_stream()
+    partials = []
+    for i in range(0, len(audio), 1600):          # 100ms chunks
+        s.feed(audio[i:i + 1600])
+        partials += s.drain()
+    final = s.end()
+    assert final.strip(), f"empty final: {final!r}"
+    assert "tribal" in final.lower() or "gold" in final.lower(), f"unexpected: {final!r}"
+    assert len(partials) > 0, "no partials streamed"
+    print(f"voxtral stream: {len(partials)} partials, final={final.strip()!r}")
+    b.unload()

--- a/sidecar/tests/test_voxtral_stream.py
+++ b/sidecar/tests/test_voxtral_stream.py
@@ -130,6 +130,27 @@ def test_split_sentences():
     assert split_sentences("") == ([], "")
 
 
+def test_generate_exception_unblocks_reader_and_end(monkeypatch):
+    # If model.generate() raises, _read() must still terminate (via streamer.end() in the
+    # except) so it emits the None sentinel and end() returns instead of deadlocking.
+    from sokuji_sidecar import voxtral_stream
+    proc = _fake_proc()
+    streamer = _FakeStreamer()
+    monkeypatch.setattr(voxtral_stream, "TextIteratorStreamer", lambda *a, **k: streamer)
+
+    class _BoomModel:
+        device = "cpu"
+        dtype = "BF16"
+        def generate(self, **kwargs):
+            raise RuntimeError("generate crashed")
+
+    s = voxtral_stream.VoxtralRealtimeStream(_BoomModel(), proc, "cpu", "BF16")
+    s.feed(np.zeros(9000, np.float32))     # >= first chunk -> starts the gen + reader threads
+    final = s.end()                        # must return, not hang
+    assert s.aborted is True
+    assert final == ""                     # nothing generated
+
+
 def test_drain_preserves_completion_sentinel():
     # drain() must NOT consume the None completion sentinel — end() blocks on get() until it
     # sees None, so if drain() removed it (e.g. generate finished/crashed before end()), end()

--- a/sidecar/tests/test_voxtral_stream.py
+++ b/sidecar/tests/test_voxtral_stream.py
@@ -117,3 +117,14 @@ def test_voxtral_stream_real_gpu_live():
     assert len(partials) > 0, "no partials streamed"
     print(f"voxtral stream: {len(partials)} partials, final={final.strip()!r}")
     b.unload()
+
+
+def test_split_sentences():
+    from sokuji_sidecar.voxtral_stream import split_sentences
+    assert split_sentences("Ask what you do. Ask not ") == (["Ask what you do."], "Ask not ")
+    assert split_sentences("hello wor") == ([], "hello wor")
+    assert split_sentences("x. Ask") == (["x."], "Ask")          # delta straddling a boundary
+    assert split_sentences("3.5 ml ") == ([], "3.5 ml ")         # decimal NOT split (no space after .)
+    assert split_sentences("country.") == ([], "country.")       # no trailing space -> held for flush
+    assert split_sentences("a. b! c? d") == (["a.", "b!", "c?"], "d")
+    assert split_sentences("") == ([], "")

--- a/sidecar/tests/test_voxtral_stream.py
+++ b/sidecar/tests/test_voxtral_stream.py
@@ -128,3 +128,18 @@ def test_split_sentences():
     assert split_sentences("country.") == ([], "country.")       # no trailing space -> held for flush
     assert split_sentences("a. b! c? d") == (["a.", "b!", "c?"], "d")
     assert split_sentences("") == ([], "")
+
+
+def test_drain_preserves_completion_sentinel():
+    # drain() must NOT consume the None completion sentinel — end() blocks on get() until it
+    # sees None, so if drain() removed it (e.g. generate finished/crashed before end()), end()
+    # would hang forever. drain() should requeue the sentinel and stop.
+    import queue
+    from sokuji_sidecar import voxtral_stream
+    s = voxtral_stream.VoxtralRealtimeStream(object(), _fake_proc(), "cpu", "BF16")
+    s._deltas.put("a ")
+    s._deltas.put("b ")
+    s._deltas.put(None)                          # generation finished
+    assert s.drain() == ["a ", "b "]             # real deltas returned
+    assert s.drain() == []                       # nothing left but the preserved sentinel
+    assert s._deltas.get_nowait() is None        # sentinel still there for end()

--- a/sidecar/tests/test_voxtral_stream.py
+++ b/sidecar/tests/test_voxtral_stream.py
@@ -1,3 +1,4 @@
+import os
 import threading
 import time
 import types
@@ -87,9 +88,6 @@ def test_stream_feed_drain_end(monkeypatch):
     final = s.end()                       # flushes right-pad, joins the generate thread
     assert final.strip() == "hello world"
     assert s.aborted is False
-
-
-import os
 
 
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),

--- a/src/lib/local-inference/native/NativeAsrClient.test.ts
+++ b/src/lib/local-inference/native/NativeAsrClient.test.ts
@@ -118,4 +118,17 @@ describe('NativeAsrClient', () => {
     expect(starts).toBe(1);
     expect(results).toEqual(['hi']);
   });
+
+  it('dispatches partial → onPartialResult and id-less result → onResult', () => {
+    const c = new NativeAsrClient();
+    const partials: string[] = [];
+    const finals: string[] = [];
+    c.onPartialResult = (t) => partials.push(t);
+    c.onResult = (r) => finals.push(r.text);
+    // reach the private onMessage via the same path the WS uses
+    (c as any).onMessage(JSON.stringify({ type: 'partial', text: 'he llo' }));
+    (c as any).onMessage(JSON.stringify({ type: 'result', text: 'hello world', durationMs: 1000, recognitionTimeMs: 50 }));
+    expect(partials).toEqual(['he llo']);
+    expect(finals).toEqual(['hello world']);
+  });
 });

--- a/src/lib/local-inference/native/NativeAsrClient.ts
+++ b/src/lib/local-inference/native/NativeAsrClient.ts
@@ -11,6 +11,7 @@ function electron(): ElectronInvoke {
 
 export class NativeAsrClient {
   onResult: ((r: NativeAsrResult) => void) | null = null;
+  onPartialResult: ((text: string) => void) | null = null;
   onSpeechStart: (() => void) | null = null;
   onStatus: ((m: string) => void) | null = null;
   onError: ((e: string) => void) | null = null;
@@ -40,6 +41,7 @@ export class NativeAsrClient {
   private onMessage(data: any) {
     const msg = JSON.parse(data) as any;
     if (msg.type === 'speech_start') { this.onSpeechStart?.(); return; }
+    if (msg.type === 'partial') { this.onPartialResult?.(msg.text); return; }
     // ASR results are pushed without an id; TTS results (Phase 1) carry an id.
     if (msg.type === 'result' && msg.id === undefined) {
       this.onResult?.({ text: msg.text, startSample: msg.startSample, durationMs: msg.durationMs, recognitionTimeMs: msg.recognitionTimeMs });

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -210,11 +210,11 @@ describe('nativeCatalog', () => {
     expect(nativeAsrCards('yue')[0].selectId).toBe('sense-voice');
   });
 
-  it('includes Voxtral Mini 4B Realtime (not recommended, sortOrder 9, 13 langs)', () => {
+  it('includes Voxtral Mini 4B Realtime (recommended, sortOrder 9, 13 langs)', () => {
     const v = NATIVE_ASR.find((m) => m.id === 'voxtral-mini-4b-realtime');
     expect(v).toBeDefined();
     expect(v!.label).toBe('Voxtral Mini 4B Realtime');
-    expect(v!.recommended).toBeFalsy();
+    expect(v!.recommended).toBe(true);
     expect(v!.sortOrder).toBe(9);
     expect(v!.languages).toEqual(['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko']);
     // listed for a supported language (ja), behind the recommended rows

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -210,6 +210,21 @@ describe('nativeCatalog', () => {
     expect(nativeAsrCards('yue')[0].selectId).toBe('sense-voice');
   });
 
+  it('includes Voxtral Mini 4B Realtime (not recommended, sortOrder 9, 13 langs)', () => {
+    const v = NATIVE_ASR.find((m) => m.id === 'voxtral-mini-4b-realtime');
+    expect(v).toBeDefined();
+    expect(v!.label).toBe('Voxtral Mini 4B Realtime');
+    expect(v!.recommended).toBeFalsy();
+    expect(v!.sortOrder).toBe(9);
+    expect(v!.languages).toEqual(['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko']);
+    // listed for a supported language (ja), behind the recommended rows
+    expect(compatibleNativeAsr('ja').map((m) => m.id)).toContain('voxtral-mini-4b-realtime');
+    // dropped for a language it lacks (Thai 'th' — Qwen3 has it, Voxtral does not)
+    expect(compatibleNativeAsr('th').map((m) => m.id)).not.toContain('voxtral-mini-4b-realtime');
+    // does not displace cohere as the recommended leader for a shared language
+    expect(compatibleNativeAsr('zh')[0].id).toBe('cohere-transcribe-03-2026');
+  });
+
   it('maps hardware tiers to display labels', () => {
     expect(tierLabel('cpu')).toEqual({ label: 'CPU', accel: false });
     expect(tierLabel('gpu-cuda')).toEqual({ label: 'GPU · CUDA', accel: true });

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -29,6 +29,7 @@ export const NATIVE_ASR: NativeModelOption[] = [
   { id: 'granite-speech-4.1-2b', label: 'Granite Speech 4.1 (2B)', languages: ['en', 'fr', 'de', 'es', 'pt', 'ja'], sortOrder: 6 },
   { id: 'granite-speech-4.1-2b-plus', label: 'Granite Speech 4.1 (2B+)', languages: ['en', 'fr', 'de', 'es', 'pt'], sortOrder: 7 },
   { id: 'qwen3-asr-1.7b', label: 'Qwen3-ASR 1.7B', languages: ['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id'], recommended: true, sortOrder: 8 },
+  { id: 'voxtral-mini-4b-realtime', label: 'Voxtral Mini 4B Realtime', languages: ['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko'], sortOrder: 9 },
 ];
 
 export const NATIVE_TRANSLATION: NativeModelOption[] = [

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -29,7 +29,7 @@ export const NATIVE_ASR: NativeModelOption[] = [
   { id: 'granite-speech-4.1-2b', label: 'Granite Speech 4.1 (2B)', languages: ['en', 'fr', 'de', 'es', 'pt', 'ja'], sortOrder: 6 },
   { id: 'granite-speech-4.1-2b-plus', label: 'Granite Speech 4.1 (2B+)', languages: ['en', 'fr', 'de', 'es', 'pt'], sortOrder: 7 },
   { id: 'qwen3-asr-1.7b', label: 'Qwen3-ASR 1.7B', languages: ['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id'], recommended: true, sortOrder: 8 },
-  { id: 'voxtral-mini-4b-realtime', label: 'Voxtral Mini 4B Realtime', languages: ['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko'], sortOrder: 9 },
+  { id: 'voxtral-mini-4b-realtime', label: 'Voxtral Mini 4B Realtime', languages: ['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko'], recommended: true, sortOrder: 9 },
 ];
 
 export const NATIVE_TRANSLATION: NativeModelOption[] = [

--- a/src/lib/local-inference/native/nativeProtocol.ts
+++ b/src/lib/local-inference/native/nativeProtocol.ts
@@ -21,6 +21,7 @@ export interface ResultMsg { type: 'result'; id: number; sampleRate: number; gen
 export interface ErrorMsg { type: 'error'; id?: number; model?: string; message: string; }
 export interface TranslationMsg { type: 'translation'; id: number; sourceText: string; translatedText: string; inferenceTimeMs: number; }
 export interface SpeechStartMsg { type: 'speech_start'; }
+export interface AsrPartialMsg { type: 'partial'; text: string; }
 export interface AsrResultMsg { type: 'result'; text: string; startSample?: number; durationMs: number; recognitionTimeMs: number; }
 export type NativeModelState = 'ready' | 'absent';
 export interface ModelStatusResultMsg { type: 'model_status_result'; id: number; statuses: Record<string, NativeModelState>; }
@@ -29,4 +30,4 @@ export interface ModelDeleteResultMsg { type: 'model_delete_result'; id: number;
 export interface ModelProgressMsg { type: 'model_progress'; model: string; downloaded: number; total: number; }
 export type ModelDownloadStatus = 'ready' | 'cancelled';
 export interface ModelDownloadDoneMsg { type: 'model_download_done'; model: string; status: ModelDownloadStatus; }
-export type ServerMsg = ReadyMsg | OkMsg | ResultMsg | TranslationMsg | SpeechStartMsg | AsrResultMsg | ModelStatusResultMsg | ModelSizesResultMsg | ModelDeleteResultMsg | ModelProgressMsg | ModelDownloadDoneMsg | ErrorMsg | HardwareInfoResultMsg | ModelsCatalogResultMsg;
+export type ServerMsg = ReadyMsg | OkMsg | ResultMsg | TranslationMsg | SpeechStartMsg | AsrPartialMsg | AsrResultMsg | ModelStatusResultMsg | ModelSizesResultMsg | ModelDeleteResultMsg | ModelProgressMsg | ModelDownloadDoneMsg | ErrorMsg | HardwareInfoResultMsg | ModelsCatalogResultMsg;

--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -2,9 +2,14 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { LocalNativeClient } from './LocalNativeClient';
 import { useNativeModelStore } from '../../stores/nativeModelStore';
 
+const LOCAL_NATIVE_CONFIG: any = {
+  provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
+  asrModelId: 'sense-voice', translationModelId: 'opus-mt-es-en',
+};
+
 function mocks() {
   const asr: any = {
-    onResult: null, onSpeechStart: null, onStatus: null, onError: null,
+    onResult: null, onSpeechStart: null, onStatus: null, onError: null, onPartialResult: null,
     init: vi.fn().mockResolvedValue({ loadTimeMs: 1 }), feedAudio: vi.fn(), flush: vi.fn(), dispose: vi.fn(),
   };
   const translate: any = {
@@ -90,6 +95,23 @@ describe('LocalNativeClient', () => {
     const buf = new Int16Array(10);
     c.appendInputAudio(buf);
     expect(m.asr.feedAudio).toHaveBeenCalledWith(buf, 24000);
+  });
+
+  it('renders partials as one in-progress item and runs the job only on the final', async () => {
+    const translate = { init: async () => {}, translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
+    const asr: any = { init: async () => ({ device: 'cuda' }), feedAudio() {}, flush() {}, dispose() {}, onResult: null, onPartialResult: null, onError: null };
+    const client = new LocalNativeClient({ asr, translate });
+    const items: any[] = [];
+    client.setEventHandlers({ onConversationUpdated: ({ item }) => items.push({ id: item.id, status: item.status, text: item.formatted?.transcript }), onOpen() {}, onRealtimeEvent() {} } as any);
+    await client.connect(LOCAL_NATIVE_CONFIG);
+    asr.onPartialResult('he');            // partial 1
+    asr.onPartialResult('hello');         // partial 2 (same item updates)
+    expect(translate.translate).not.toHaveBeenCalled();
+    asr.onResult({ text: 'hello world' }); // final
+    await new Promise((r) => setTimeout(r, 0));
+    expect(translate.translate).toHaveBeenCalledTimes(1);
+    const userItems = items.filter((i) => i.id.startsWith('user'));
+    expect(new Set(userItems.map((i) => i.id)).size).toBe(1);  // one user item across partials+final
   });
 });
 

--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -113,6 +113,21 @@ describe('LocalNativeClient', () => {
     const userItems = items.filter((i) => i.id.startsWith('user'));
     expect(new Set(userItems.map((i) => i.id)).size).toBe(1);  // one user item across partials+final
   });
+
+  it('drops the stale partial after clearConversationItems so the next final still lands', async () => {
+    const translate = { init: async () => {}, translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
+    const asr: any = { init: async () => ({ device: 'cuda' }), feedAudio() {}, flush() {}, dispose() {}, onResult: null, onPartialResult: null, onError: null };
+    const client = new LocalNativeClient({ asr, translate });
+    client.setEventHandlers({ onConversationUpdated() {}, onOpen() {}, onRealtimeEvent() {} } as any);
+    await client.connect(LOCAL_NATIVE_CONFIG);
+    asr.onPartialResult('hel');                 // a partial user item is in progress
+    client.clearConversationItems();            // user clears the conversation mid-utterance
+    asr.onResult({ text: 'hello' });            // the final then arrives
+    await new Promise((r) => setTimeout(r, 0));
+    const userItems = client.getConversationItems().filter((i: any) => i.id.startsWith('user'));
+    expect(userItems.length).toBe(1);                                   // the final landed as a fresh item
+    expect(userItems[0].formatted?.transcript).toBe('hello');           // not lost on the detached item
+  });
 });
 
 // ── Task 3: loading flag + resolved plan ──────────────────────────────────────

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -32,6 +32,7 @@ export class LocalNativeClient implements IClient {
   private ttsEnabled = false;
   private ttsSpeed = 1.0;
   private queue: Promise<void> = Promise.resolve();
+  private partialUserItem: ConversationItem | null = null;
 
   constructor(deps: Deps = {}) {
     this.asr = deps.asr ?? new NativeAsrClient();
@@ -43,6 +44,7 @@ export class LocalNativeClient implements IClient {
     if (!isLocalNativeSessionConfig(config)) throw new Error('LocalNativeClient requires a local_native config');
     this.cfg = config;
     this.asr.onResult = (r: any) => this.onAsrResult(r);
+    this.asr.onPartialResult = (text: string) => this.onAsrPartial(text);
     this.asr.onError = (e: string) => this.handlers.onError?.(e);
     this.translate.onError = (e: string) => this.handlers.onError?.(e);
     this.emitEvent('local.native.init.start', 'client', {
@@ -87,14 +89,36 @@ export class LocalNativeClient implements IClient {
     this.handlers.onRealtimeEvent?.({ source, event: { type, data } } as any);
   }
 
+  private onAsrPartial(text: string): void {
+    if (!text) return;
+    if (!this.partialUserItem) {
+      this.partialUserItem = {
+        id: this.nextId('user'), role: 'user', type: 'message', status: 'in_progress',
+        createdAt: Date.now(), formatted: { transcript: text },
+      };
+      this.items.push(this.partialUserItem);
+      this.emit(this.partialUserItem);
+    } else {
+      this.partialUserItem.formatted!.transcript = text;
+      this.emit(this.partialUserItem, { transcript: text });
+    }
+  }
+
   private onAsrResult(r: { text: string }): void {
     if (!r.text?.trim()) return;
     this.emitEvent('local.native.asr.result', 'server', { text: r.text });
-    const userItem: ConversationItem = {
-      id: this.nextId('user'), role: 'user', type: 'message', status: 'completed',
-      createdAt: Date.now(), formatted: { transcript: r.text },
-    };
-    this.items.push(userItem);
+    let userItem = this.partialUserItem;
+    if (userItem) {
+      userItem.status = 'completed';
+      userItem.formatted!.transcript = r.text;
+      this.partialUserItem = null;
+    } else {
+      userItem = {
+        id: this.nextId('user'), role: 'user', type: 'message', status: 'completed',
+        createdAt: Date.now(), formatted: { transcript: r.text },
+      };
+      this.items.push(userItem);
+    }
     this.emit(userItem);
     // serialize pipeline jobs so text/audio stay ordered
     this.queue = this.queue.then(() => this.runJob(r.text)).catch((e) => {
@@ -130,13 +154,14 @@ export class LocalNativeClient implements IClient {
   cancelResponse(): void {}
   async disconnect(): Promise<void> {
     this.connected = false;
+    this.partialUserItem = null;
     this.emitEvent('local.native.session.closed', 'client', { reason: 'user_disconnect' });
     this.asr.dispose?.(); this.translate.dispose?.(); this.tts.dispose?.();
     this.handlers.onClose?.({});
   }
   isConnected(): boolean { return this.connected; }
   updateSession(_config: Partial<SessionConfig>): void {}
-  reset(): void { this.items = []; }
+  reset(): void { this.items = []; this.partialUserItem = null; }
   getConversationItems(): ConversationItem[] { return [...this.items]; }  // fresh ref so setItems() re-renders
   clearConversationItems(): void { this.items = []; }
   setEventHandlers(handlers: ClientEventHandlers): void { this.handlers = handlers; }

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -163,7 +163,7 @@ export class LocalNativeClient implements IClient {
   updateSession(_config: Partial<SessionConfig>): void {}
   reset(): void { this.items = []; this.partialUserItem = null; }
   getConversationItems(): ConversationItem[] { return [...this.items]; }  // fresh ref so setItems() re-renders
-  clearConversationItems(): void { this.items = []; }
+  clearConversationItems(): void { this.items = []; this.partialUserItem = null; }  // drop the in-progress partial too, else the next final mutates a detached item
   setEventHandlers(handlers: ClientEventHandlers): void { this.handlers = handlers; }
   getProvider(): ProviderType { return Provider.LOCAL_NATIVE; }
 }


### PR DESCRIPTION
## Summary
Native (Electron Python-sidecar) ASR using **Voxtral Mini 4B Realtime**
(`mistralai/Voxtral-Mini-4B-Realtime-2602`), GPU bf16, validated on an RTX 4070.
Four stacked iterations, each spec'd → planned → TDD-implemented → GPU-validated:

1. **Offline backend (Phase 1)** — `VoxtralRealtimeBackend` + catalog row, transformers-native
   (vLLM rejected: needs ≥16 GB VRAM), self-gated on the transformers fork.
2. **Continuous streaming (Phase 2)** — `VoxtralRealtimeStream` (threaded generate +
   TextIteratorStreamer), streaming engine path, `partial` wire event + renderer interim→final.
3. **Always-stream (option d)** — feed audio continuously (no VAD input-gating → no leading-word
   loss); backpressure degrades to per-utterance on slow hardware.
4. **Pause-driven segmentation (Plan A)** — cut finals on silero's endpoint (the user's Min Silence
   Duration slider) via `end()`+reopen, which flushes the model's held tail. Fixes slow/clumpy
   translation, the dropped last word (tail-hold), and the previously-masked slider.

## Validation
- GPU smokes (gated `SOKUJI_RUN_GPU`): no leading loss, complete sentence finals, pause
  segmentation, tail-hold fixed.
- Sidecar pytest 132 passed / 16 skipped; renderer 55 passed; build OK.

## Notes
- Design specs + implementation plans under `docs/superpowers/`.
- vLLM / TTS / translation internals are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Voxtral realtime ASR option with streaming transcripts, including live partial updates and final results.
  * Added Voxtral model availability in the native model picker and backend selection flow.
  * Improved native ASR handling so interim speech updates appear as one in-progress message before finalizing.

* **Bug Fixes**
  * Reduced missing-tail issues by improving how final transcripts are completed.
  * Prevented duplicate downloads of unnecessary model files and improved model size calculations.
  * Added stronger cleanup on disconnect so streaming sessions reset cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->