### PR TITLE
feat(native): Qwen text translation — device selection, version ladder, GPU badges + tokens/sec

### DIFF
--- a/docs/superpowers/plans/2026-06-26-native-qwen-translate-device.md
+++ b/docs/superpowers/plans/2026-06-26-native-qwen-translate-device.md
@@ -1,0 +1,1182 @@
+# Native Qwen Translation: version ladder + device selection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Give the LOCAL_NATIVE sidecar translation engine ASR-parity AUTO/CPU/GPU device selection and a selectable Qwen version ladder (2.5-0.5B, 3-0.6B, 3.5-0.8B, 3.5-2B), reusing the existing `accel.py` resolver.
+
+**Architecture:** Add a translation catalog mirroring the ASR `AsrModel`/`Deployment` data model; add a `resolve_translate()` sibling to the stage-agnostic resolver; add two transformers backends split by architecture (CausalLM for 2.5/3, the Qwen3.5 VLM class for 3.5, used text-only); wire a `device` parameter through the engine, the WS contract, the renderer client, settings, catalog, and UI.
+
+**Tech Stack:** Python sidecar (`sidecar/sokuji_sidecar/*.py`, pytest), HuggingFace transformers (PyTorch), React/TypeScript renderer (Zustand stores, vitest), WebSocket JSON contract.
+
+## Global Constraints
+
+Copied verbatim from the spec; every task implicitly includes these:
+
+- **Single transformers backend strategy** — GPU and CPU both via transformers (`.to(device)` + dtype). No CTranslate2/GGUF/quantized CPU path in this increment. CPU = float32, GPU = bfloat16.
+- **Every translation model carries two deployments**: `gpu-cuda` (bfloat16) + `cpu` (float32). AUTO degrades to CPU; explicit CPU always has a plan.
+- **Self-gate Qwen3.5** — the `qwen35_translate` backend is reported available only when `transformers.models.qwen3_5` is importable. If absent, the two Qwen3.5 rows disappear (no broken card, no hard failure).
+- **Opus-MT untouched** — the `OpusMtTranslator` branch (onnxruntime, no device) stays as-is. The legacy `""`/`"qwen"` download id → `Qwen/Qwen2.5-0.5B-Instruct` (overridable via `SOKUJI_TRANSLATE_MODEL`) is preserved.
+- **Text-only** — Qwen3.5 is a VLM class but fed text only (no image tokens).
+- **Exact native id → repo map:** `qwen2.5-0.5b`→`Qwen/Qwen2.5-0.5B-Instruct`, `qwen3-0.6b`→`Qwen/Qwen3-0.6B`, `qwen3.5-0.8b`→`Qwen/Qwen3.5-0.8B`, `qwen3.5-2b`→`Qwen/Qwen3.5-2B`.
+- **Device wire values:** `'auto' | 'cpu' | 'cuda'` (default `'auto'`).
+
+---
+
+## File Structure
+
+**Sidecar (Python):**
+- `sidecar/sokuji_sidecar/catalog.py` — add `TranslateModel`, `TRANSLATE_MODELS`, `translate_models()`, `translate_model()`.
+- `sidecar/sokuji_sidecar/accel.py` — extract `_resolve_model()`, add `resolve_translate()`, extend `_installed()` map, add `kind` to `_h_models_catalog`.
+- `sidecar/sokuji_sidecar/translate_backends.py` — **new**: `QwenTranslateBackend`, `Qwen35TranslateBackend`, `_default_prompt`, `_strip_think`.
+- `sidecar/sokuji_sidecar/translate_engine.py` — `init(device=...)`, `close()`, resolver wiring, `resolved` echo, handler reads `device`.
+- `sidecar/sokuji_sidecar/native_models.py` — `download_specs` rows for the four ids.
+- Tests: `sidecar/tests/test_catalog.py`, `test_accel.py`, `test_translate_backends.py` (new), `test_translate_engine.py`, `test_native_models.py`.
+
+**Renderer (TypeScript):**
+- `src/stores/settingsStore.ts` — `translationDevice` field + default + session-config line.
+- `src/services/interfaces/IClient.ts` — `translationDevice?` on `LocalNativeSessionConfig`.
+- `src/lib/local-inference/native/NativeTranslateClient.ts` — `init(..., device?)` sends `device`, returns resolved.
+- `src/services/clients/LocalNativeClient.ts` — pass `config.translationDevice`; record resolved.
+- `src/stores/nativeModelStore.ts` — `translationResolved` state + setter.
+- `src/lib/local-inference/native/nativeCatalog.ts` — four Qwen translation rows.
+- `src/components/Settings/sections/NativeModelManagementSection.tsx` — translation device segmented control.
+- Tests: colocated `*.test.ts(x)`.
+
+---
+
+## Task 1: Translation catalog
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/catalog.py`
+- Test: `sidecar/tests/test_catalog.py`
+
+**Interfaces:**
+- Consumes: existing `Deployment` dataclass.
+- Produces: `TranslateModel(id, name, languages, deployments, recommended=False, sort_order=99)`; `translate_models() -> list[TranslateModel]`; `translate_model(model_id) -> TranslateModel | None`. Backend NAMEs used in rows: `"qwen_translate"`, `"qwen35_translate"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_catalog.py`:
+
+```python
+def test_translate_models_have_deployments_and_cpu_floor():
+    for m in catalog.translate_models():
+        assert m.deployments, f"{m.id} has no deployments"
+        assert m.languages, f"{m.id} has no languages"
+        assert any(d.tier == "cpu" for d in m.deployments), f"{m.id} lacks a cpu floor"
+        for d in m.deployments:
+            assert d.backend in {"qwen_translate", "qwen35_translate"}
+
+
+def test_translate_model_ids_unique_and_lookup():
+    ids = [m.id for m in catalog.translate_models()]
+    assert len(ids) == len(set(ids))
+    assert catalog.translate_model("does-not-exist") is None
+
+
+def test_translate_rows_map_to_qwen_repos():
+    expected = {
+        "qwen2.5-0.5b": ("qwen_translate", "Qwen/Qwen2.5-0.5B-Instruct"),
+        "qwen3-0.6b": ("qwen_translate", "Qwen/Qwen3-0.6B"),
+        "qwen3.5-0.8b": ("qwen35_translate", "Qwen/Qwen3.5-0.8B"),
+        "qwen3.5-2b": ("qwen35_translate", "Qwen/Qwen3.5-2B"),
+    }
+    for mid, (backend, repo) in expected.items():
+        m = catalog.translate_model(mid)
+        assert m is not None, f"missing {mid}"
+        tiers = [(d.backend, d.tier, d.compute_type, d.artifact) for d in m.deployments]
+        assert (backend, "gpu-cuda", "bfloat16", repo) in tiers
+        assert (backend, "cpu", "float32", repo) in tiers
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sidecar && python -m pytest tests/test_catalog.py::test_translate_rows_map_to_qwen_repos -v`
+Expected: FAIL with `AttributeError: module 'sokuji_sidecar.catalog' has no attribute 'translate_models'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `sidecar/sokuji_sidecar/catalog.py`, after the `AsrModel` definition and `asr_model()` (end of file region), add:
+
+```python
+@dataclass(frozen=True)
+class TranslateModel:
+    id: str
+    name: str
+    languages: tuple[str, ...]   # ("multi",) means any language
+    deployments: tuple[Deployment, ...]
+    recommended: bool = False
+    sort_order: int = 99
+
+
+def _qwen_translate_row(mid, name, repo, backend, sort_order, recommended=False):
+    return TranslateModel(mid, name, ("multi",), (
+        Deployment(backend, "gpu-cuda", "bfloat16", repo, 1.0),
+        Deployment(backend, "cpu", "float32", repo, 1.0),
+    ), recommended=recommended, sort_order=sort_order)
+
+
+TRANSLATE_MODELS: list[TranslateModel] = [
+    _qwen_translate_row("qwen2.5-0.5b", "Qwen 2.5 0.5B",
+                        "Qwen/Qwen2.5-0.5B-Instruct", "qwen_translate", 1, recommended=True),
+    _qwen_translate_row("qwen3-0.6b", "Qwen 3 0.6B",
+                        "Qwen/Qwen3-0.6B", "qwen_translate", 2, recommended=True),
+    _qwen_translate_row("qwen3.5-0.8b", "Qwen 3.5 0.8B",
+                        "Qwen/Qwen3.5-0.8B", "qwen35_translate", 3),
+    _qwen_translate_row("qwen3.5-2b", "Qwen 3.5 2B",
+                        "Qwen/Qwen3.5-2B", "qwen35_translate", 4),
+]
+
+
+def translate_models() -> list[TranslateModel]:
+    return TRANSLATE_MODELS
+
+
+def translate_model(model_id: str) -> TranslateModel | None:
+    return next((m for m in TRANSLATE_MODELS if m.id == model_id), None)
+```
+
+Also extend the `Deployment.backend` comment to mention the two new names (optional, keeps the doc accurate).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sidecar && python -m pytest tests/test_catalog.py -v`
+Expected: PASS (all, including the three new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/catalog.py sidecar/tests/test_catalog.py
+git commit -m "feat(sidecar): translation catalog with Qwen 2.5/3/3.5 version ladder"
+```
+
+---
+
+## Task 2: Resolver generalization + `resolve_translate` + gating
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/accel.py` (`resolve()` body → `_resolve_model()`, add `resolve_translate()`, extend `_installed()` map)
+- Test: `sidecar/tests/test_accel.py`
+
+**Interfaces:**
+- Consumes: `catalog.translate_model()` (Task 1); existing `resolve_deployments`, `load_with_fallback`, `probe`, `Machine`, `bench_load`, `_bench_key`, `TIER_DEVICE`, `NoUsablePlan`.
+- Produces: `resolve_translate(model_id, override="auto", machine=None) -> list[Plan]` (raises `ValueError` on unknown id, `NoUsablePlan` if no plan). `_installed()` now includes `"qwen_translate"` and `"qwen35_translate"`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_resolve_translate_prefers_gpu():
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                 installed=frozenset({"qwen_translate"}))
+    plans = accel.resolve_translate("qwen2.5-0.5b", "auto", m)
+    assert [p.device for p in plans] == ["cuda", "cpu"]
+    assert plans[0].artifact == "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+def test_resolve_translate_cpu_only_machine():
+    m = _machine(installed=frozenset({"qwen_translate"}))
+    plans = accel.resolve_translate("qwen3-0.6b", "auto", m)
+    assert [p.device for p in plans] == ["cpu"]
+
+
+def test_resolve_translate_override_cpu_pins_front():
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                 installed=frozenset({"qwen_translate"}))
+    plans = accel.resolve_translate("qwen3-0.6b", "cpu", m)
+    assert [p.device for p in plans] == ["cpu", "cuda"]
+
+
+def test_resolve_translate_qwen35_self_gates_off():
+    # transformers lacks qwen3_5 → qwen35_translate not installed → no plan.
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                 installed=frozenset({"qwen_translate"}))
+    with pytest.raises(accel.NoUsablePlan):
+        accel.resolve_translate("qwen3.5-0.8b", "auto", m)
+
+
+def test_resolve_translate_unknown_id_raises():
+    with pytest.raises(ValueError):
+        accel.resolve_translate("nope", "auto", _machine())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sidecar && python -m pytest tests/test_accel.py::test_resolve_translate_prefers_gpu -v`
+Expected: FAIL with `AttributeError: module 'sokuji_sidecar.accel' has no attribute 'resolve_translate'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `sidecar/sokuji_sidecar/accel.py`, replace the body of `resolve()` (currently lines ~165-182) with a shared helper + two entry points:
+
+```python
+def _resolve_model(model, model_id: str, override: str, machine: Machine) -> list[Plan]:
+    cache = bench_load()
+    bench = {}
+    for d in model.deployments:
+        device = TIER_DEVICE[d.tier]
+        key = _bench_key(machine.fingerprint, model_id, d.backend, device, d.compute_type)
+        if key in cache:
+            bench[(d.backend, device, d.compute_type)] = cache[key]
+    plans = resolve_deployments(model, machine, override, bench=bench or None)
+    if not plans:
+        raise NoUsablePlan(model_id)
+    return plans
+
+
+def resolve(model_id: str, override: str = "auto", machine: Machine | None = None) -> list[Plan]:
+    from . import catalog
+    model = catalog.asr_model(model_id)
+    if model is None:
+        raise ValueError(f"unknown asr model: {model_id}")
+    return _resolve_model(model, model_id, override, machine or probe())
+
+
+def resolve_translate(model_id: str, override: str = "auto", machine: Machine | None = None) -> list[Plan]:
+    from . import catalog
+    model = catalog.translate_model(model_id)
+    if model is None:
+        raise ValueError(f"unknown translate model: {model_id}")
+    return _resolve_model(model, model_id, override, machine or probe())
+```
+
+In `_installed()`'s `mods` dict (currently ~lines 61-73), add two entries:
+
+```python
+        # translation: 2.5/3 are CausalLM (always present with transformers); 3.5 is the
+        # qwen3_5 VLM class (self-gates off until transformers ships it), used text-only.
+        "qwen_translate": "transformers",
+        "qwen35_translate": "transformers.models.qwen3_5",
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sidecar && python -m pytest tests/test_accel.py -v`
+Expected: PASS (all existing + 5 new). The existing ASR `resolve` tests still pass (behavior unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/accel.py sidecar/tests/test_accel.py
+git commit -m "feat(sidecar): resolve_translate + qwen translate backend gating"
+```
+
+---
+
+## Task 3: Translation backends
+
+**Files:**
+- Create: `sidecar/sokuji_sidecar/translate_backends.py`
+- Test: `sidecar/tests/test_translate_backends.py`
+
+**Interfaces:**
+- Consumes: `backends.register_backend`, `backends.BackendLoadError`.
+- Produces: `QwenTranslateBackend` (NAME `"qwen_translate"`) and `Qwen35TranslateBackend` (NAME `"qwen35_translate"`), both with `load(model_ref, device, compute_type)`, `translate(text, system_prompt, src, tgt, wrap) -> str`, `unload()`, `is_loaded`. Module-level `_default_prompt(src, tgt) -> str` and `_strip_think(text) -> str`. Registered into the shared `backends._BACKENDS` on import.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `sidecar/tests/test_translate_backends.py`:
+
+```python
+from unittest.mock import MagicMock
+import pytest
+from sokuji_sidecar import translate_backends as tb
+from sokuji_sidecar import backends
+
+
+class FakeInputs(dict):
+    def to(self, device):
+        return self
+
+
+def _fake_tok(captured):
+    tok = MagicMock()
+
+    def apply_chat_template(messages, **kw):
+        captured.clear()
+        captured.extend(messages)
+        return "PROMPT"
+    tok.apply_chat_template.side_effect = apply_chat_template
+    tok.side_effect = lambda prompt, **kw: FakeInputs(input_ids=MagicMock(shape=[1, 5]))
+    tok.decode.return_value = "translated"
+    return tok
+
+
+def _fake_model():
+    model = MagicMock()
+    gen_out = MagicMock()
+    gen_out.__getitem__ = MagicMock(return_value=MagicMock())  # out[0]
+    model.generate.return_value = [gen_out]
+    return model
+
+
+def test_backends_are_registered():
+    assert backends._BACKENDS.get("qwen_translate") is tb.QwenTranslateBackend
+    assert backends._BACKENDS.get("qwen35_translate") is tb.Qwen35TranslateBackend
+
+
+def test_default_prompt_mentions_langs():
+    p = tb._default_prompt("Japanese", "English")
+    assert "Japanese" in p and "English" in p and "only" in p.lower()
+
+
+def test_strip_think_removes_block():
+    assert tb._strip_think("<think>reasoning</think>  hello") == "hello"
+    assert tb._strip_think("plain") == "plain"
+
+
+def test_qwen3_appends_no_think_and_wraps():
+    captured = []
+    b = tb.QwenTranslateBackend()
+    b._tok = _fake_tok(captured)
+    b._model = _fake_model()
+    b._device = "cpu"
+    b._ref = "Qwen/Qwen3-0.6B"
+    b.translate("hi", "", "Japanese", "English", wrap=True)
+    sys_msg = next(m for m in captured if m["role"] == "system")
+    user_msg = next(m for m in captured if m["role"] == "user")
+    assert sys_msg["content"].endswith("/no_think")
+    assert user_msg["content"] == "<transcript>hi</transcript>"
+
+
+def test_qwen25_no_no_think_and_bare():
+    captured = []
+    b = tb.QwenTranslateBackend()
+    b._tok = _fake_tok(captured)
+    b._model = _fake_model()
+    b._device = "cpu"
+    b._ref = "Qwen/Qwen2.5-0.5B-Instruct"
+    b.translate("hi", "", "Japanese", "English", wrap=False)
+    sys_msg = next(m for m in captured if m["role"] == "system")
+    user_msg = next(m for m in captured if m["role"] == "user")
+    assert "/no_think" not in sys_msg["content"]
+    assert user_msg["content"] == "hi"
+
+
+def test_qwen35_load_raises_when_class_missing(monkeypatch):
+    # Simulate a transformers without Qwen3_5ForConditionalGeneration.
+    import sys
+    fake_transformers = MagicMock()
+    del fake_transformers.Qwen3_5ForConditionalGeneration  # attribute access raises AttributeError
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    b = tb.Qwen35TranslateBackend()
+    with pytest.raises(backends.BackendLoadError):
+        b.load("Qwen/Qwen3.5-0.8B", "cuda", "bfloat16")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sidecar && python -m pytest tests/test_translate_backends.py::test_backends_are_registered -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'sokuji_sidecar.translate_backends'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `sidecar/sokuji_sidecar/translate_backends.py`:
+
+```python
+"""Translation backend adapters (transformers, text-only). Mirror the ASR
+backends' load()/unload() contract but expose translate() instead of
+transcribe(). Registered into the shared backends registry on import.
+
+  qwen_translate    — Qwen 2.5 / 3, AutoModelForCausalLM (/no_think for Qwen3).
+  qwen35_translate  — Qwen 3.5, Qwen3_5ForConditionalGeneration (VLM class), text-only.
+
+Both support CPU (float32) and GPU (bfloat16) via .to(device)."""
+from .backends import register_backend, BackendLoadError
+
+
+def _default_prompt(src: str, tgt: str) -> str:
+    s = src or "the source language"
+    t = tgt or "the target language"
+    return (f"You are a translator. Translate the text from {s} to {t}. "
+            "Output only the translation, no explanations, no refusal.")
+
+
+def _strip_think(text: str) -> str:
+    """Defensive: drop any <think>…</think> reasoning block a model emits."""
+    if "</think>" in text:
+        return text.split("</think>", 1)[1].strip()
+    return text.strip()
+
+
+@register_backend
+class QwenTranslateBackend:
+    NAME = "qwen_translate"
+
+    def __init__(self):
+        self._model = None
+        self._tok = None
+        self._device = "cpu"
+        self._ref = ""
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+            self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
+            self._model = AutoModelForCausalLM.from_pretrained(
+                model_ref, torch_dtype=dtype, local_files_only=True).to(device).eval()
+            self._device = device
+            self._ref = model_ref
+        except Exception as e:  # missing torch/transformers, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> str:
+        import torch
+        sys_p = system_prompt or _default_prompt(src, tgt)
+        if "qwen3" in self._ref.lower():        # Qwen3 thinking-mode off; Qwen2.5 ignores it
+            sys_p = f"{sys_p} /no_think"
+        user = f"<transcript>{text}</transcript>" if wrap else text
+        messages = [{"role": "system", "content": sys_p},
+                    {"role": "user", "content": user}]
+        prompt = self._tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        inputs = self._tok(prompt, return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
+        gen = out[0][inputs["input_ids"].shape[1]:]
+        return _strip_think(self._tok.decode(gen, skip_special_tokens=True))
+
+    def unload(self) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+
+@register_backend
+class Qwen35TranslateBackend:
+    NAME = "qwen35_translate"
+
+    def __init__(self):
+        self._model = None
+        self._proc = None
+        self._device = "cpu"
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            from transformers import Qwen3_5ForConditionalGeneration, AutoProcessor
+            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+            self._proc = AutoProcessor.from_pretrained(model_ref, local_files_only=True)
+            self._model = Qwen3_5ForConditionalGeneration.from_pretrained(
+                model_ref, dtype=dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing qwen3_5 class, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> str:
+        import torch
+        sys_p = system_prompt or _default_prompt(src, tgt)   # Qwen3.5 is non-thinking by default
+        user = f"<transcript>{text}</transcript>" if wrap else text
+        messages = [{"role": "system", "content": [{"type": "text", "text": sys_p}]},
+                    {"role": "user", "content": [{"type": "text", "text": user}]}]
+        prompt = self._proc.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        inputs = self._proc(text=prompt, return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
+        gen = out[0][inputs["input_ids"].shape[1]:]
+        return _strip_think(self._proc.batch_decode([gen], skip_special_tokens=True)[0])
+
+    def unload(self) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sidecar && python -m pytest tests/test_translate_backends.py -v`
+Expected: PASS (all 7).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/translate_backends.py sidecar/tests/test_translate_backends.py
+git commit -m "feat(sidecar): qwen_translate + qwen35_translate transformers backends"
+```
+
+---
+
+## Task 4: Engine wiring (device, close, resolved, handler)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/translate_engine.py`
+- Test: `sidecar/tests/test_translate_engine.py`
+
+**Interfaces:**
+- Consumes: `accel.resolve_translate`, `accel.load_with_fallback` (Task 2); `translate_backends` (Task 3, imported for registration); backend `.translate(text, system_prompt, src, tgt, wrap)` + `.unload()`.
+- Produces: `TranslateEngine.init(model_id=None, source_lang="", target_lang="", device="auto") -> int`; `TranslateEngine.close()`; `self.resolved` dict; `translate_init` reply merges `resolved`. `translate()` now delegates to the loaded backend (or Opus).
+
+- [ ] **Step 1: Write the failing test**
+
+The existing `FakeTranslate.init` in `test_translate_engine.py` has signature `(model_id=None, source_lang="", target_lang="")`. Update it to accept `device` and add tests for the new behavior. Replace the `FakeTranslate` class and add tests:
+
+```python
+class FakeTranslate:
+    def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
+        self.langs = (source_lang, target_lang)
+        self.device = device
+        self.resolved = {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
+        return 21
+
+    def translate(self, text, system_prompt="", wrap_transcript=False):
+        return f"<{text}>", 8
+
+
+def test_translate_init_echoes_device_and_resolved():
+    st = make_state()
+    reply, _ = asyncio.run(server.handle_message(
+        st, json.dumps({"type": "translate_init", "id": 1, "sourceLang": "ja",
+                        "targetLang": "en", "device": "cuda"})))
+    assert reply["type"] == "ready" and reply["id"] == 1 and reply["loadTimeMs"] == 21
+    assert reply["backend"] == "qwen_translate"
+    assert reply["device"] == "cuda"
+    assert reply["computeType"] == "bfloat16"
+    assert st["translate_engine"].device == "cuda"
+```
+
+Add a real-engine test (mocking the resolver + backend) for `close()`/resolver wiring:
+
+```python
+def test_init_uses_resolver_and_sets_resolved(monkeypatch):
+    from sokuji_sidecar import accel
+    fake_backend = MagicMock()
+    fake_plan = MagicMock(backend="qwen_translate", device="cuda", compute_type="bfloat16")
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "load_with_fallback", lambda plans: (fake_backend, fake_plan, None))
+
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id="qwen2.5-0.5b", source_lang="ja", target_lang="en", device="cuda")
+    assert eng.resolved == {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
+    assert eng._backend is fake_backend
+
+    fake_backend.translate.return_value = "hola->hi"
+    out, ms = eng.translate("hola", wrap_transcript=True)
+    fake_backend.translate.assert_called_once_with("hola", "", "ja", "en", True)
+    assert out == "hola->hi" and ms >= 0
+
+
+def test_close_unloads_prior_backend_before_reinit(monkeypatch):
+    from sokuji_sidecar import accel
+    first, second = MagicMock(), MagicMock()
+    plan = MagicMock(backend="qwen_translate", device="cpu", compute_type="float32")
+    backends_iter = iter([(first, plan, None), (second, plan, None)])
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "load_with_fallback", lambda plans: next(backends_iter))
+
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id="qwen2.5-0.5b", source_lang="ja", target_lang="en")
+    eng.init(model_id="qwen3-0.6b", source_lang="ja", target_lang="en")
+    first.unload.assert_called_once()   # prior backend freed before loading the next
+    assert eng._backend is second
+```
+
+Note: the existing `test_wrap_transcript_wraps_user_content` exercised the old inline Qwen path in `translate()`. That path moves into the backend (Task 3 covers it). Update that test to set `eng._backend` to a fake and assert delegation, OR delete it (the backend test now covers wrap). Replace its body with:
+
+```python
+def test_translate_delegates_to_backend_when_loaded():
+    eng = translate_engine.TranslateEngine()
+    eng._opus = None
+    eng._backend = MagicMock()
+    eng._backend.translate.return_value = "translated"
+    eng._src, eng._tgt = "Japanese", "English"
+    out, _ = eng.translate("hello", wrap_transcript=True)
+    eng._backend.translate.assert_called_once_with("hello", "", "Japanese", "English", True)
+    assert out == "translated"
+```
+
+(Keep `test_wrap_transcript_not_applied_to_opus`, `test_opus_to_qwen_switch_clears_opus`, the skipif real-model tests — but `test_opus_to_qwen_switch_clears_opus` must monkeypatch the resolver since the Qwen branch no longer loads transformers directly. Update its Step-2 section: after switching to Qwen, patch `accel.resolve_translate`/`accel.load_with_fallback` so it doesn't hit real models, and assert `eng._opus is None`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sidecar && python -m pytest tests/test_translate_engine.py::test_init_uses_resolver_and_sets_resolved -v`
+Expected: FAIL (current `init()` has no `device` param / no `resolved` / no `_backend`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Rewrite `sidecar/sokuji_sidecar/translate_engine.py`'s `TranslateEngine` and `_h_translate_init`:
+
+```python
+import time
+from . import translate_backends  # noqa: F401 — registers qwen_translate/qwen35_translate
+
+
+class TranslateEngine:
+    def __init__(self):
+        self._tok = None
+        self._model = None
+        self._opus = None
+        self._backend = None
+        self._src = ""
+        self._tgt = ""
+        self.resolved = None
+
+    def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
+        t0 = time.time()
+        self.close()                       # VRAM hygiene: free any prior model first
+        self._src, self._tgt = source_lang, target_lang
+        if model_id and "opus-mt" in model_id:
+            from .opus_mt import OpusMtTranslator
+            onnx_repo = model_id if "/" in model_id else f"Xenova/{model_id}"
+            self._opus = OpusMtTranslator(onnx_repo)
+            self.resolved = {"backend": "opus_mt", "device": "cpu", "computeType": "int8"}
+            return int((time.time() - t0) * 1000)
+        self._opus = None
+        from . import accel
+        plans = accel.resolve_translate(model_id or "qwen2.5-0.5b", override=device or "auto")
+        self._backend, plan, _notice = accel.load_with_fallback(plans)
+        self.resolved = {"backend": plan.backend, "device": plan.device,
+                         "computeType": plan.compute_type}
+        return int((time.time() - t0) * 1000)
+
+    def translate(self, text, system_prompt="", wrap_transcript=False):
+        t0 = time.time()
+        if not text.strip():
+            return "", 0
+        if self._opus is not None:
+            return self._opus.translate(text), int((time.time() - t0) * 1000)
+        out = self._backend.translate(text, system_prompt, self._src, self._tgt, wrap_transcript)
+        return out, int((time.time() - t0) * 1000)
+
+    def close(self):
+        if self._backend is not None:
+            try:
+                self._backend.unload()
+            except Exception:
+                pass
+            self._backend = None
+        self._opus = None
+        self._tok = None
+        self._model = None
+
+
+async def _h_translate_init(state, msg, _b, conn=None):
+    ms = state["translate_engine"].init(
+        msg.get("model"), msg.get("sourceLang", ""), msg.get("targetLang", ""),
+        msg.get("device", "auto"))
+    reply = {"type": "ready", "id": msg.get("id"), "loadTimeMs": ms}
+    resolved = getattr(state["translate_engine"], "resolved", None)
+    if resolved:
+        reply.update(resolved)
+    return reply, None
+```
+
+Keep `_h_translate` and `register()` unchanged.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sidecar && python -m pytest tests/test_translate_engine.py -v`
+Expected: PASS (updated + new tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/translate_engine.py sidecar/tests/test_translate_engine.py
+git commit -m "feat(sidecar): translate engine device selection + VRAM-safe re-init"
+```
+
+---
+
+## Task 5: Download mapping + catalog feed `kind`
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/native_models.py` (`download_specs`)
+- Modify: `sidecar/sokuji_sidecar/accel.py` (`_h_models_catalog`)
+- Test: `sidecar/tests/test_native_models.py`, `sidecar/tests/test_accel.py`
+
+**Interfaces:**
+- Consumes: `catalog.translate_models()` (Task 1).
+- Produces: `download_specs(mid)` rows for the four ids; `models_catalog` message accepts `kind: "asr" | "translate"` (default `"asr"`).
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_native_models.py`:
+
+```python
+def test_download_specs_qwen_translate_repos():
+    from sokuji_sidecar import native_models as nm
+    assert nm.download_specs("qwen2.5-0.5b")["repos"] == ["Qwen/Qwen2.5-0.5B-Instruct"]
+    assert nm.download_specs("qwen3-0.6b")["repos"] == ["Qwen/Qwen3-0.6B"]
+    assert nm.download_specs("qwen3.5-0.8b")["repos"] == ["Qwen/Qwen3.5-0.8B"]
+    assert nm.download_specs("qwen3.5-2b")["repos"] == ["Qwen/Qwen3.5-2B"]
+```
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_models_catalog_kind_translate_returns_qwen_rows(monkeypatch):
+    monkeypatch.setattr(accel, "probe", lambda force=False: _machine(
+        nvidia=(accel.Gpu("nvidia", "x", 0),), installed=frozenset({"qwen_translate"})))
+    reply, _ = asyncio.run(accel._h_models_catalog(
+        {}, {"type": "models_catalog", "id": 1, "kind": "translate"}, None))
+    ids = [m["id"] for m in reply["models"]]
+    assert "qwen2.5-0.5b" in ids and "qwen3-0.6b" in ids
+    row = next(m for m in reply["models"] if m["id"] == "qwen2.5-0.5b")
+    tiers = {t["tier"]: t["available"] for t in row["tiers"]}
+    assert tiers["gpu-cuda"] is True and tiers["cpu"] is True
+
+
+def test_models_catalog_kind_defaults_to_asr(monkeypatch):
+    monkeypatch.setattr(accel, "probe", lambda force=False: _machine())
+    reply, _ = asyncio.run(accel._h_models_catalog(
+        {}, {"type": "models_catalog", "id": 2}, None))
+    ids = [m["id"] for m in reply["models"]]
+    assert "sense-voice" in ids       # ASR catalog, unchanged default
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sidecar && python -m pytest tests/test_native_models.py::test_download_specs_qwen_translate_repos tests/test_accel.py::test_models_catalog_kind_translate_returns_qwen_rows -v`
+Expected: FAIL (download rows missing; `_h_models_catalog` ignores `kind`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `sidecar/sokuji_sidecar/native_models.py`, inside `download_specs(model_id)`, before the final fallthrough/return, add:
+
+```python
+    if model_id == "qwen2.5-0.5b":
+        return {"repos": ["Qwen/Qwen2.5-0.5B-Instruct"], "urls": []}
+    if model_id == "qwen3-0.6b":
+        return {"repos": ["Qwen/Qwen3-0.6B"], "urls": []}
+    if model_id == "qwen3.5-0.8b":
+        return {"repos": ["Qwen/Qwen3.5-0.8B"], "urls": []}
+    if model_id == "qwen3.5-2b":
+        return {"repos": ["Qwen/Qwen3.5-2B"], "urls": []}
+```
+
+(The existing `""`/`"qwen"` → `Qwen/Qwen2.5-0.5B-Instruct` line stays first; the new ids are distinct.)
+
+In `sidecar/sokuji_sidecar/accel.py`, change `_h_models_catalog` to honor `kind`:
+
+```python
+async def _h_models_catalog(state, msg, _b, conn=None):
+    from . import catalog
+    m = probe()
+    kind = msg.get("kind", "asr")
+    source = catalog.translate_models() if kind == "translate" else catalog.asr_models()
+    wanted = msg.get("models")
+    if wanted and not isinstance(wanted, list):
+        wanted = [wanted]
+    models = source
+    if wanted:
+        models = [x for x in models if x.id in wanted]
+    out = []
+    for mdl in models:
+        tiers = [{"tier": d.tier, "backend": d.backend,
+                  "available": d.backend in m.installed and _tier_available(d.tier, m)}
+                 for d in mdl.deployments]
+        out.append({"id": mdl.id, "name": mdl.name, "languages": list(mdl.languages),
+                    "recommended": mdl.recommended, "tiers": tiers})
+    return {"type": "models_catalog_result", "id": msg.get("id"), "models": out}, None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd sidecar && python -m pytest tests/test_native_models.py tests/test_accel.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Run the full sidecar suite**
+
+Run: `cd sidecar && python -m pytest -q`
+Expected: PASS (no regressions across catalog/accel/backends/engine/native_models).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/native_models.py sidecar/sokuji_sidecar/accel.py sidecar/tests/test_native_models.py sidecar/tests/test_accel.py
+git commit -m "feat(sidecar): qwen translate download specs + models_catalog kind"
+```
+
+---
+
+## Task 6: Renderer settings — `translationDevice`
+
+**Files:**
+- Modify: `src/stores/settingsStore.ts` (interface field, default, session-config line)
+- Modify: `src/services/interfaces/IClient.ts` (`translationDevice?`)
+- Test: `src/stores/settingsStore.test.ts` (or the existing settings test file)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `settings.translationDevice: 'auto' | 'cpu' | 'cuda'` (default `'auto'`); `LocalNativeSessionConfig.translationDevice?: string`; session config includes `translationDevice`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to the settings store test (mirror however `asrDevice` is tested; if no such test exists, create `src/stores/settingsStore.translationDevice.test.ts`):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { useSettingsStore } from './settingsStore';
+
+describe('translationDevice setting', () => {
+  it('defaults to auto', () => {
+    expect(useSettingsStore.getState().translationDevice).toBe('auto');
+  });
+  it('is updatable', () => {
+    useSettingsStore.getState().update({ translationDevice: 'cuda' });
+    expect(useSettingsStore.getState().translationDevice).toBe('cuda');
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/stores/settingsStore.translationDevice.test.ts`
+Expected: FAIL (`translationDevice` is `undefined`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/stores/settingsStore.ts`:
+- After the `asrDevice` field (line ~198) add:
+  ```ts
+  translationDevice: 'auto' | 'cpu' | 'cuda'; // override the sidecar's translation device selection
+  ```
+- After the `asrDevice: 'auto',` default (line ~393) add:
+  ```ts
+  translationDevice: 'auto',
+  ```
+- In the session-config builder, after `asrDevice: settings.asrDevice,` (line ~738) add:
+  ```ts
+  translationDevice: settings.translationDevice,
+  ```
+
+In `src/services/interfaces/IClient.ts`, after `asrDevice?: string;` (line ~208) add:
+```ts
+  translationDevice?: string;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/stores/settingsStore.translationDevice.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/stores/settingsStore.ts src/services/interfaces/IClient.ts src/stores/settingsStore.translationDevice.test.ts
+git commit -m "feat(native): translationDevice setting + session config"
+```
+
+---
+
+## Task 7: NativeTranslateClient device arg + LocalNativeClient wiring + resolved store
+
+**Files:**
+- Modify: `src/lib/local-inference/native/NativeTranslateClient.ts`
+- Modify: `src/services/clients/LocalNativeClient.ts`
+- Modify: `src/stores/nativeModelStore.ts` (add `translationResolved` + setter)
+- Test: `src/lib/local-inference/native/NativeTranslateClient.test.ts`
+
+**Interfaces:**
+- Consumes: `LocalNativeSessionConfig.translationDevice` (Task 6); sidecar `ready` reply with `backend/device/computeType` (already in `ReadyMsg`).
+- Produces: `NativeTranslateClient.init(sourceLang, targetLang, modelId?, device?) -> { loadTimeMs, backend?, device?, computeType? }`; `nativeModelStore.translationResolved` state + `setTranslationResolved`.
+
+- [ ] **Step 1: Write the failing test**
+
+Update `FakeWS.send` in `NativeTranslateClient.test.ts` to echo device, and add a test:
+
+```ts
+// In FakeWS.send, the translate_init branch:
+if (msg.type === 'translate_init') queueMicrotask(() =>
+  this.onmessage?.({ data: JSON.stringify({
+    type: 'ready', id: msg.id, loadTimeMs: 3,
+    backend: 'qwen_translate', device: msg.device ?? 'auto', computeType: 'bfloat16' }) }));
+```
+
+```ts
+it('sends device and returns resolved fields', async () => {
+  const c = new NativeTranslateClient();
+  const r = await c.init('es', 'en', 'qwen3-0.6b', 'cuda');
+  expect(r.loadTimeMs).toBe(3);
+  expect(r.device).toBe('cuda');
+  expect(r.backend).toBe('qwen_translate');
+  expect(r.computeType).toBe('bfloat16');
+});
+```
+
+(Keep the existing `inits with langs and translates` test; its `init('es','en')` call still works since `modelId`/`device` are optional and `r.loadTimeMs` is still `3`. Update its assertion from `toEqual({ loadTimeMs: 3 })` to `expect(r.loadTimeMs).toBe(3)` since the return now carries optional resolved fields.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/local-inference/native/NativeTranslateClient.test.ts`
+Expected: FAIL (`init` ignores device / returns only `loadTimeMs`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/lib/local-inference/native/NativeTranslateClient.ts`, replace `init`:
+
+```ts
+  async init(sourceLang: string, targetLang: string, modelId?: string, device?: string):
+      Promise<{ loadTimeMs: number; backend?: string; device?: string; computeType?: string }> {
+    await this.connect();
+    this.onStatus?.('[native-translate] init…');
+    const msg = await this.send({ type: 'translate_init', sourceLang, targetLang, model: modelId, device });
+    const r = msg as Extract<ServerMsg, { type: 'ready' }>;
+    return { loadTimeMs: r.loadTimeMs, backend: r.backend, device: r.device, computeType: r.computeType };
+  }
+```
+
+In `src/stores/nativeModelStore.ts`, mirror `asrResolved`:
+- In the state interface (near line 44): `translationResolved: { model: string; device: string } | null;`
+- In the actions interface (near line 46): `setTranslationResolved: (r: { model: string; device: string } | null) => void;`
+- In the initial state (near line 70): `translationResolved: null,`
+- In the implementation (near line 172): `setTranslationResolved: (r) => set({ translationResolved: r }),`
+- Optional selector (near line 181): `export const useNativeTranslationResolved = () => useNativeModelStore((s) => s.translationResolved);`
+
+In `src/services/clients/LocalNativeClient.ts`, the current flow is:
+
+```ts
+    await this.translate.init(config.sourceLanguage, config.targetLanguage, config.translationModelId);  // line ~55
+    const store = useNativeModelStore.getState();                                                        // line ~56
+    store.setAsrLoading(true);
+```
+
+Replace those two lines so the device is passed and the resolved device is recorded *after* `store` is obtained (avoid referencing `store` before its declaration):
+
+```ts
+    const tr = await this.translate.init(
+      config.sourceLanguage, config.targetLanguage, config.translationModelId, config.translationDevice);
+    const store = useNativeModelStore.getState();
+    store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu' });
+    store.setAsrLoading(true);
+```
+
+(`useNativeModelStore` is already imported and used for `setAsrResolved` just below.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/lib/local-inference/native/NativeTranslateClient.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/NativeTranslateClient.ts src/services/clients/LocalNativeClient.ts src/stores/nativeModelStore.ts src/lib/local-inference/native/NativeTranslateClient.test.ts
+git commit -m "feat(native): translate client sends device, records resolved"
+```
+
+---
+
+## Task 8: Native catalog translation rows
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts` (`NATIVE_TRANSLATION`)
+- Test: `src/lib/local-inference/native/nativeCatalog.test.ts`
+
+**Interfaces:**
+- Consumes: existing `NativeModelOption` type + `resolveNativeTranslation` behavior.
+- Produces: `NATIVE_TRANSLATION` includes `qwen2.5-0.5b`, `qwen3-0.6b`, `qwen3.5-0.8b`, `qwen3.5-2b` rows (plus the existing `''` default + `opus-mt`).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `nativeCatalog.test.ts`:
+
+```ts
+import { NATIVE_TRANSLATION } from './nativeCatalog';
+
+it('exposes the four Qwen translation versions', () => {
+  const ids = NATIVE_TRANSLATION.map((o) => o.id);
+  expect(ids).toEqual(expect.arrayContaining([
+    'qwen2.5-0.5b', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b',
+  ]));
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: FAIL (rows absent).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `src/lib/local-inference/native/nativeCatalog.ts`, replace `NATIVE_TRANSLATION` (lines ~36-39):
+
+```ts
+export const NATIVE_TRANSLATION: NativeModelOption[] = [
+  { id: 'qwen2.5-0.5b', label: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
+  { id: 'qwen3-0.6b', label: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
+  { id: 'qwen3.5-0.8b', label: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
+  { id: 'qwen3.5-2b', label: 'Qwen 3.5 2B', languages: ['multi'], sortOrder: 4 },
+  { id: 'opus-mt', label: 'Opus-MT (fast)', sortOrder: 5 },
+];
+```
+
+Note: the legacy `''` default row is removed in favor of explicit `qwen2.5-0.5b`. Verify `resolveNativeTranslation` (in the same file) still maps an empty/unknown selection to a valid download id — if it special-cased `''`→`'qwen'`, keep that branch so persisted empty selections resolve to `qwen2.5-0.5b`'s download. If a test asserts the `''` row exists, update it to assert `qwen2.5-0.5b` is the recommended default instead.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS (new + existing, after any `''`-row assertion update).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(native): Qwen 2.5/3/3.5 translation rows in native catalog"
+```
+
+---
+
+## Task 9: Translation device UI control
+
+**Files:**
+- Modify: `src/components/Settings/sections/NativeModelManagementSection.tsx`
+- Test: manual (UI) — covered by typecheck + the store/catalog tests above. Optionally extend a component test if one exists.
+
+**Interfaces:**
+- Consumes: `settings.translationDevice` + `update` (Task 6); `gpuTierAvailable(catalog)` (already imported for ASR).
+- Produces: a translation `ModelGroup` device segmented control mirroring the ASR one.
+
+- [ ] **Step 1: Locate the translation ModelGroup**
+
+Find the translation group in `NativeModelManagementSection.tsx` (the `ModelGroup` for translation, analogous to the ASR group at line ~300, that renders translation cards with `'translationModel'`). It currently has no `model-group__device-control`.
+
+- [ ] **Step 2: Add the device control**
+
+Inside the translation `ModelGroup`, immediately before its `renderCards(...)` call, insert a device control identical in structure to the ASR one (lines ~301-335) but bound to `translationDevice`:
+
+```tsx
+        <div className="model-group__device-control">
+          <div className="model-group__device-label">
+            {t('models.computeDevice', 'Compute device')}
+            <Tooltip
+              content={t('models.computeDeviceTooltip', 'Which device runs the translation model. Auto picks the fastest available (GPU when present); CPU works everywhere but is slower for large models; GPU requires a CUDA GPU.')}
+              position="top"
+            >
+              <CircleHelp className="tooltip-trigger" size={14} style={{ marginLeft: '4px', display: 'inline-block', verticalAlign: 'middle' }} />
+            </Tooltip>
+          </div>
+          {(() => {
+            const gpuAvail = gpuTierAvailable(catalog);
+            const deviceValue = settings.translationDevice === 'cuda' && !gpuAvail ? 'auto' : settings.translationDevice;
+            const opts: Array<['auto' | 'cpu' | 'cuda', string]> = [
+              ['auto', t('models.deviceAuto', 'Auto')],
+              ['cpu', t('models.deviceCpu', 'CPU')],
+              ...(gpuAvail ? [['cuda', t('models.deviceGpu', 'GPU')] as ['cuda', string]] : []),
+            ];
+            return (
+              <div className="segmented-control">
+                {opts.map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    className={`segmented-option ${deviceValue === mode ? 'active' : ''}`}
+                    onClick={() => { if (deviceValue !== mode) update({ translationDevice: mode }); }}
+                    disabled={isSessionActive}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            );
+          })()}
+        </div>
+```
+
+(All referenced symbols — `gpuTierAvailable`, `catalog`, `settings`, `update`, `isSessionActive`, `Tooltip`, `CircleHelp`, `t` — are already in scope from the ASR control.)
+
+- [ ] **Step 3: Typecheck + build the renderer**
+
+Run: `npx tsc --noEmit -p tsconfig.json 2>&1 | grep -i "NativeModelManagementSection\|settingsStore\|nativeCatalog\|NativeTranslateClient" || echo "no new type errors in touched files"`
+Expected: no new errors in the touched files (the repo has pre-existing tsc errors; only assert the touched files are clean).
+
+- [ ] **Step 4: Run the renderer test suite for touched areas**
+
+Run: `npx vitest run src/lib/local-inference/native src/stores/settingsStore.translationDevice.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings/sections/NativeModelManagementSection.tsx
+git commit -m "feat(native): translation compute-device control (Auto/CPU/GPU)"
+```
+
+---
+
+## Task 10: GPU smoke tests (opt-in) + verification
+
+**Files:**
+- Test: `sidecar/tests/test_translate_backends.py`
+
+**Interfaces:**
+- Consumes: real transformers + CUDA + downloaded models.
+
+- [ ] **Step 1: Add opt-in GPU smoke tests**
+
+Append to `sidecar/tests/test_translate_backends.py`:
+
+```python
+import os
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads models + needs CUDA)")
+@pytest.mark.parametrize("model_id", ["qwen2.5-0.5b", "qwen3-0.6b"])
+def test_qwen_translate_real_gpu(model_id):
+    from sokuji_sidecar import translate_engine
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id=model_id, source_lang="Spanish", target_lang="English", device="cuda")
+    assert eng.resolved["device"] == "cuda"
+    out, ms = eng.translate("Hola, ¿cómo estás?")
+    assert isinstance(out, str) and out.strip() and ms >= 0
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads models + needs CUDA + qwen3_5)")
+def test_qwen35_translate_real_gpu_if_available():
+    import importlib.util
+    if importlib.util.find_spec("transformers.models.qwen3_5") is None:
+        pytest.skip("transformers lacks qwen3_5 — Qwen3.5 rows self-gate off")
+    from sokuji_sidecar import translate_engine
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id="qwen3.5-0.8b", source_lang="Spanish", target_lang="English", device="cuda")
+    out, _ = eng.translate("Hola, ¿cómo estás?")
+    assert isinstance(out, str) and out.strip()
+```
+
+- [ ] **Step 2: Verify Qwen3.5 class availability in the sidecar venv**
+
+Run: `cd sidecar && python -c "import importlib.util; print('qwen3_5:', importlib.util.find_spec('transformers.models.qwen3_5') is not None)"`
+Expected: prints `qwen3_5: True` or `qwen3_5: False`. If `False`, the two Qwen3.5 rows self-gate off (correct, non-blocking) — note it in the PR description; do not pin transformers in this increment.
+
+- [ ] **Step 3: Run the opt-in GPU smoke locally (if a CUDA box is available)**
+
+Run: `cd sidecar && SOKUJI_RUN_GPU=1 python -m pytest tests/test_translate_backends.py -k real_gpu -v`
+Expected: PASS for `qwen2.5-0.5b` / `qwen3-0.6b`; the Qwen3.5 test PASSES or SKIPS depending on Step 2.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add sidecar/tests/test_translate_backends.py
+git commit -m "test(sidecar): opt-in GPU smoke for native qwen translation"
+```
+
+---
+
+## Final verification
+
+- [ ] **Full sidecar suite:** `cd sidecar && python -m pytest -q` → all pass.
+- [ ] **Renderer touched tests:** `npx vitest run src/lib/local-inference/native src/stores src/services/clients` → all pass.
+- [ ] **Typecheck touched files** are clean (repo has pre-existing tsc errors; only the touched files must be clean).
+- [ ] **Manual smoke (optional):** run the Electron app, start a LOCAL_NATIVE translation session, pick each Qwen version, toggle Auto/CPU/GPU, confirm the `ready` reply's resolved device matches the selection (GPU when CUDA present, CPU fallback otherwise).

--- a/docs/superpowers/specs/2026-06-26-native-qwen-translate-device-design.md
+++ b/docs/superpowers/specs/2026-06-26-native-qwen-translate-device-design.md
@@ -1,0 +1,232 @@
+# Native Qwen Translation: version ladder + device selection Design
+
+## Context
+
+The LOCAL_NATIVE sidecar's translation engine (`sidecar/sokuji_sidecar/translate_engine.py`) currently has **no device selection** and a single hardcoded Qwen default. `init()` takes only `(model_id, source_lang, target_lang)`; for non-Opus-MT models it loads `Qwen/Qwen2.5-0.5B-Instruct` via `AutoModelForCausalLM.from_pretrained(mid, torch_dtype="auto")` with **no `.to(device)`** — so it lands on CPU implicitly, can't use the GPU, and has no AUTO/CPU/GPU control. ASR, by contrast, has a full hardware resolver (`accel.py`) with AUTO/CPU/GPU device selection, a catalog of per-model deployments, graceful GPU→CPU fallback, and a `ready` reply that echoes the resolved backend/device.
+
+This design gives the translation engine **ASR-parity device selection** (AUTO / CPU / GPU) and a **version ladder of selectable Qwen models** mirroring what the browser LOCAL_INFERENCE provider already offers. It is text-only translation; Qwen3.5 is a VLM-class model but is fed text only (no image tokens), exactly as the browser `qwen35` worker does.
+
+### Why mirror LOCAL_INFERENCE's lineup
+
+The browser provider already ships a curated Qwen translation ladder (`src/lib/local-inference/modelManifest.ts`): `qwen2.5-0.5b-translation`, `qwen3-0.6b-translation`, `qwen3.5-0.8b-translation`, `qwen3.5-2b-translation`. The native sidecar should expose the same versions so the two providers are conceptually aligned. The browser uses ONNX exports (`onnx-community/...`); the native sidecar loads **original PyTorch repos** under the official `Qwen/` org via transformers.
+
+## Locked decisions
+
+- **Model lineup** — four native models mapping to original PyTorch repos:
+
+  | Version | Native id | HF repo (PyTorch) | Model class | Thinking handling |
+  |---|---|---|---|---|
+  | 2.5 | `qwen2.5-0.5b` | `Qwen/Qwen2.5-0.5B-Instruct` | `AutoModelForCausalLM` + `AutoTokenizer` | none (2.5 has no thinking mode) |
+  | 3 | `qwen3-0.6b` | `Qwen/Qwen3-0.6B` | `AutoModelForCausalLM` + `AutoTokenizer` | append ` /no_think` to system prompt |
+  | 3.5 | `qwen3.5-0.8b` | `Qwen/Qwen3.5-0.8B` | `Qwen3_5ForConditionalGeneration` + `AutoProcessor` | non-thinking by default |
+  | 3.5 | `qwen3.5-2b` | `Qwen/Qwen3.5-2B` | `Qwen3_5ForConditionalGeneration` + `AutoProcessor` | non-thinking by default |
+
+- **Single transformers backend strategy** — GPU and CPU are both served by transformers (`.to(device)` + dtype). No CTranslate2/GGUF/quantized CPU path in this increment. CPU runs float32 (works, slower on the 2B); GPU runs bfloat16.
+- **Every model gets a CPU floor** — each catalog row carries two deployments: `gpu-cuda` (bfloat16) + `cpu` (float32). So AUTO degrades gracefully to CPU when no GPU, and an explicit CPU override always has a plan to load. (Contrast with ASR's GPU-only speech-LLMs that intentionally `NoUsablePlan` on CPU.)
+- **Maximal reuse of `accel.py`** — the resolver internals are already stage-agnostic; only `resolve()`'s catalog lookup is ASR-specific. We add a translation sibling rather than duplicating the resolver.
+- **Self-gating for Qwen3.5** — the VLM-class backend is reported available only when `transformers.models.qwen3_5` is importable (same pattern as `qwen3asr`/`cohere_asr`). If the installed transformers lacks the class, the two Qwen3.5 rows simply don't appear — no broken card, no hard failure.
+- **Opus-MT untouched** — the existing `OpusMtTranslator` branch (onnxruntime, torch-free, no device concept) stays as-is. The legacy `""`/`"qwen"` default mapping to `Qwen/Qwen2.5-0.5B-Instruct` continues to work.
+- **VRAM reality** — on a 12 GB GPU shared with a GPU ASR model (Qwen3-ASR-1.7B ≈ 5 GB), the small translation models (0.5B/0.6B/0.8B ≈ 1–2 GB) co-reside comfortably; Qwen3.5-2B (≈ 4–5 GB) fits alongside ASR (~10 GB total). Larger models are intentionally excluded.
+
+## Components
+
+### 1. Translation catalog — `sidecar/sokuji_sidecar/catalog.py`
+
+Add a `TranslateModel` dataclass (same shape as `AsrModel`) and lookup functions, alongside the existing ASR catalog.
+
+```python
+@dataclass(frozen=True)
+class TranslateModel:
+    id: str
+    name: str
+    languages: tuple[str, ...]
+    deployments: tuple[Deployment, ...]
+    recommended: bool = False
+    sort_order: int = 99
+
+TRANSLATE_MODELS = [
+    TranslateModel("qwen2.5-0.5b", "Qwen 2.5 0.5B", ("multi",),
+        (Deployment("qwen_translate", "gpu-cuda", "bfloat16", "Qwen/Qwen2.5-0.5B-Instruct", 1.0),
+         Deployment("qwen_translate", "cpu", "float32", "Qwen/Qwen2.5-0.5B-Instruct", 1.0)),
+        recommended=True, sort_order=1),
+    TranslateModel("qwen3-0.6b", "Qwen 3 0.6B", ("multi",),
+        (Deployment("qwen_translate", "gpu-cuda", "bfloat16", "Qwen/Qwen3-0.6B", 1.0),
+         Deployment("qwen_translate", "cpu", "float32", "Qwen/Qwen3-0.6B", 1.0)),
+        recommended=True, sort_order=2),
+    TranslateModel("qwen3.5-0.8b", "Qwen 3.5 0.8B", ("multi",),
+        (Deployment("qwen35_translate", "gpu-cuda", "bfloat16", "Qwen/Qwen3.5-0.8B", 1.0),
+         Deployment("qwen35_translate", "cpu", "float32", "Qwen/Qwen3.5-0.8B", 1.0)),
+        sort_order=3),
+    TranslateModel("qwen3.5-2b", "Qwen 3.5 2B", ("multi",),
+        (Deployment("qwen35_translate", "gpu-cuda", "bfloat16", "Qwen/Qwen3.5-2B", 1.0),
+         Deployment("qwen35_translate", "cpu", "float32", "Qwen/Qwen3.5-2B", 1.0)),
+        sort_order=4),
+]
+
+def translate_models() -> list[TranslateModel]: return TRANSLATE_MODELS
+def translate_model(model_id: str) -> TranslateModel | None: ...
+```
+
+`Deployment` is reused unchanged. `languages=("multi",)` mirrors the ASR convention for "any language".
+
+### 2. Resolver sibling — `sidecar/sokuji_sidecar/accel.py`
+
+`resolve()` currently inlines: catalog lookup + bench-cache assembly + `resolve_deployments` + `NoUsablePlan`. Extract the model-object-driven part into a shared helper, then add a translation entry point. No behavior change to ASR.
+
+```python
+def _resolve_model(model, model_id, override, machine):
+    """Shared: build bench cache for model.deployments, rank, raise NoUsablePlan if empty."""
+    # (moved body of current resolve(), minus the catalog.asr_model lookup)
+
+def resolve(model_id, override="auto", machine=None):       # ASR — unchanged signature
+    from . import catalog
+    model = catalog.asr_model(model_id)
+    if model is None: raise ValueError(f"unknown asr model: {model_id}")
+    return _resolve_model(model, model_id, override, machine or probe())
+
+def resolve_translate(model_id, override="auto", machine=None):   # new
+    from . import catalog
+    model = catalog.translate_model(model_id)
+    if model is None: raise ValueError(f"unknown translate model: {model_id}")
+    return _resolve_model(model, model_id, override, machine or probe())
+```
+
+Extend `_installed()`'s module map with the translation backends:
+
+```python
+"qwen_translate": "transformers",                       # 2.5 / 3 (CausalLM) — always present
+"qwen35_translate": "transformers.models.qwen3_5",      # 3.5 VLM class — self-gates
+```
+
+`resolve_deployments`, `load_with_fallback`, `_tier_available`, `TIER_RANK`/`TIER_DEVICE`, `_apply_bench`, `measure_rtf`, the bench cache, and `probe()` are all reused unchanged.
+
+### 3. Translation backends — `sidecar/sokuji_sidecar/backends.py` (or a new `translate_backends.py`)
+
+Two registered backends exposing a `translate(text, system_prompt, src, tgt, wrap)` method (the translation analogue of `transcribe`), plus the standard `load(model_ref, device, compute_type)` / `unload()` / `is_loaded`. They map `compute_type`→torch dtype and `.to(device)` exactly like the ASR `TransformersBackend`.
+
+```python
+@register_backend
+class QwenTranslateBackend:           # Qwen 2.5 / 3  — CausalLM
+    NAME = "qwen_translate"
+    def load(self, model_ref, device, compute_type):
+        import torch
+        from transformers import AutoModelForCausalLM, AutoTokenizer
+        self._dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+        self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
+        self._model = AutoModelForCausalLM.from_pretrained(
+            model_ref, torch_dtype=self._dtype, local_files_only=True).to(device).eval()
+        self._device, self._ref = device, model_ref
+    def translate(self, text, system_prompt, src, tgt, wrap):
+        sys_p = system_prompt or _default_prompt(src, tgt)
+        if "qwen3" in self._ref.lower():       # Qwen3 thinking-mode off
+            sys_p = f"{sys_p} /no_think"
+        user = f"<transcript>{text}</transcript>" if wrap else text
+        # apply_chat_template + generate(max_new_tokens=512, do_sample=False) + decode
+        # strip any residual <think>…</think> defensively
+
+@register_backend
+class Qwen35TranslateBackend:         # Qwen 3.5  — VLM class, text-only
+    NAME = "qwen35_translate"
+    def load(self, model_ref, device, compute_type):
+        from transformers import Qwen3_5ForConditionalGeneration, AutoProcessor
+        # bf16/fp32 + .to(device); AutoProcessor for the chat template
+    def translate(self, text, system_prompt, src, tgt, wrap):
+        # text-only conversation (no image content); non-thinking by default
+```
+
+GPU OOM / missing class / no CUDA all raise `BackendLoadError` → the resolver's `load_with_fallback` advances to the CPU plan. The CPU deployment for each model guarantees a working fallback.
+
+A shared `_default_prompt(src, tgt)` mirrors the renderer's `buildDefaultLocalPrompt` shape (translator instruction, `<transcript>` wrapping, "output only the translation") so behavior matches the browser provider when the renderer sends an empty system prompt.
+
+### 4. Engine wiring — `sidecar/sokuji_sidecar/translate_engine.py`
+
+```python
+def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
+    self.close()                                   # VRAM hygiene — free prior model first
+    self._src, self._tgt = source_lang, target_lang
+    if model_id and "opus-mt" in model_id:
+        ... # existing OpusMtTranslator branch, no device
+        self.resolved = {"backend": "opus_mt", "device": "cpu", "computeType": "int8"}
+        return ms
+    self._opus = None
+    from . import accel
+    plans = accel.resolve_translate(model_id or "qwen2.5-0.5b", override=device or "auto")
+    self._backend, plan, _notice = accel.load_with_fallback(plans)
+    self.resolved = {"backend": plan.backend, "device": plan.device, "computeType": plan.compute_type}
+    return ms
+
+def translate(self, text, system_prompt="", wrap_transcript=False):
+    if self._opus is not None: ...                 # existing path
+    return self._backend.translate(text, system_prompt, self._src, self._tgt, wrap_transcript), ms
+
+def close(self):
+    if self._backend is not None: self._backend.unload(); self._backend = None
+```
+
+The `translate_init` handler reads `msg.get("device", "auto")`; the `ready` reply merges `self.resolved` (backend/device/computeType) just like ASR's `_h_asr_init`.
+
+Default model id when none is sent changes from `Qwen/Qwen2.5-0.5B-Instruct` (a repo) to the catalog id `qwen2.5-0.5b`. The legacy `""`/`"qwen"` download id mapping in `native_models.py` is preserved for back-compat.
+
+### 5. Download mapping — `sidecar/sokuji_sidecar/native_models.py`
+
+Add `download_specs` rows mapping each native id to its PyTorch repo:
+
+```python
+if model_id == "qwen2.5-0.5b": return {"repos": ["Qwen/Qwen2.5-0.5B-Instruct"], "urls": []}
+if model_id == "qwen3-0.6b":   return {"repos": ["Qwen/Qwen3-0.6B"], "urls": []}
+if model_id == "qwen3.5-0.8b": return {"repos": ["Qwen/Qwen3.5-0.8B"], "urls": []}
+if model_id == "qwen3.5-2b":   return {"repos": ["Qwen/Qwen3.5-2B"], "urls": []}
+```
+
+The existing `""`/`"qwen"` → `Qwen/Qwen2.5-0.5B-Instruct` (overridable via `SOKUJI_TRANSLATE_MODEL`) stays.
+
+### 6. Catalog feed — `sidecar/sokuji_sidecar/accel.py` (`_h_models_catalog`)
+
+The catalog feed currently serves `catalog.asr_models()` only. Extend it to also serve translate models so the renderer can show per-model tier availability. **Decision: add a `kind` field** (`"asr"` default | `"translate"`) to the `models_catalog` message; `_h_models_catalog` selects `catalog.asr_models()` vs `catalog.translate_models()` accordingly and returns the same `{id, name, languages, recommended, tiers}` shape. (A sibling handler was considered but rejected — one handler with a discriminator keeps the per-tier `available` computation in a single place.) The per-tier `available` computation (`d.backend in m.installed and _tier_available(d.tier, m)`) is reused verbatim — this is what greys out GPU tiers on CPU-only boxes and hides self-gated Qwen3.5.
+
+### 7. Renderer (TypeScript)
+
+- **`settingsStore.ts`** — add `translationDevice: 'auto' | 'cpu' | 'cuda'` (default `'auto'`), mirroring `asrDevice`. Plumb through `LocalNativeSessionConfig` (`IClient.ts`) and the session-config builder (the `asrDevice: settings.asrDevice`-style line).
+- **`NativeTranslateClient.ts`** — `init(sourceLang, targetLang, modelId?, device?)` sends `device` on `translate_init`; return the resolved `{backend, device, computeType}` from the `ready` reply (extend `nativeProtocol.ts` if needed).
+- **`LocalNativeClient`** — pass `config.translationDevice` to `translate.init(...)`; record the resolved device back into the store (mirror `setAsrResolved`).
+- **`nativeCatalog.ts`** — replace the single `Qwen LLM` translation row with the four versioned rows (`qwen2.5-0.5b`, `qwen3-0.6b`, `qwen3.5-0.8b`, `qwen3.5-2b`); keep `''`→default resolution for back-compat. Add tier/availability wiring from the translate catalog feed.
+- **UI (`NativeModelManagementSection.tsx`)** — add a translation device segmented control mirroring the ASR one: `cuda` option shown only when a GPU tier is available; disabled while a session is active.
+
+## Data flow
+
+```
+UI device control (translationDevice) ─▶ settingsStore ─▶ LocalNativeSessionConfig
+  ─▶ LocalNativeClient ─▶ NativeTranslateClient.init(src, tgt, modelId, device)
+  ─▶ {translate_init, model, device} over WS
+  ─▶ translate_engine.init ─▶ accel.resolve_translate(model_id, device)
+      ─▶ ranked Plans (gpu-cuda first under AUTO, CPU floor last)
+      ─▶ load_with_fallback ─▶ QwenTranslateBackend | Qwen35TranslateBackend
+  ─▶ ready{backend, device, computeType} echoed to UI
+  ─▶ translate{text, systemPrompt, wrap} ─▶ backend.translate ─▶ translation{...}
+```
+
+## Error handling
+
+- **GPU load failure** (OOM, no CUDA, missing VLM class) → `BackendLoadError` → resolver falls back to the CPU deployment. The `notice` carries the human-readable skip reason.
+- **Unknown model id** → `ValueError` from `resolve_translate` (surfaced as an `error` message to the renderer).
+- **Self-gated Qwen3.5** — if `transformers.models.qwen3_5` is absent, `qwen35_translate` is not in `machine.installed`; both Qwen3.5 deployments are filtered out → `NoUsablePlan` if a Qwen3.5 model is explicitly requested, and the rows are marked unavailable in the catalog feed so the UI hides them.
+- **Model not downloaded** — unchanged: `native_models.status()` returns `absent`; load uses `local_files_only=True` and the renderer gates on download readiness before init.
+
+## Testing
+
+**Sidecar (pytest, mirroring `test_catalog.py` / `test_accel.py` / `test_translate_engine.py`):**
+- Catalog: the four translate models are present with both `gpu-cuda` and `cpu` deployments; `translate_model(id)` lookups work; unknown id → `None`.
+- `resolve_translate`: AUTO → gpu-cuda first on a CUDA machine, cpu-only machine → cpu plan; explicit `cpu`/`cuda` override reorders correctly; GPU-only-class-missing (qwen3.5 self-gate) excludes those rows.
+- Engine: `init(device=...)` calls `resolve_translate` + `load_with_fallback`; `ready` reply includes `resolved`; `close()` unloads the prior backend before re-init (VRAM hygiene); Opus-MT branch still bypasses the resolver.
+- Backend (mocked transformers): `qwen_translate` appends `/no_think` for a Qwen3 ref and not for a 2.5 ref; `wrap` wraps in `<transcript>`; thinking residue is stripped.
+- GPU smoke (behind `SOKUJI_RUN_GPU`, like `test_qwen3asr_real_gpu_smoke`): one per family — load + translate a short sentence on CUDA, assert non-empty output in the target language.
+
+**Renderer (vitest):**
+- `NativeTranslateClient.init` sends `device` on the wire and returns resolved fields.
+- `nativeCatalog` exposes the four translate rows; device control shows `cuda` only when a GPU tier is available.
+- `settingsStore` persists `translationDevice` and plumbs it into the session config.
+
+## Verification notes (resolved during implementation, not blocking design)
+
+- **Does the sidecar venv's transformers (5.13.0.dev0 fork) include `qwen3_5`?** If yes, Qwen3.5 rows light up; if no, they self-gate off and only 2.5/3 are offered. Either way the increment is correct. Verify with `python -c "import importlib.util; print(importlib.util.find_spec('transformers.models.qwen3_5'))"` in the sidecar venv; if absent and Qwen3.5 is wanted now, note the transformers requirement (do not hard-pin in this increment).
+- **Confirm `Qwen/Qwen3.5-0.8B` / `Qwen/Qwen3.5-2B` PyTorch repos** are downloadable (HF research indicates they exist as the base for the onnx-community exports).

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -300,10 +300,12 @@ async def _h_hardware_info(state, msg, _b, conn=None):
 async def _h_models_catalog(state, msg, _b, conn=None):
     from . import catalog
     m = probe()
+    kind = msg.get("kind", "asr")
+    source = catalog.translate_models() if kind == "translate" else catalog.asr_models()
     wanted = msg.get("models")
     if wanted and not isinstance(wanted, list):
         wanted = [wanted]
-    models = catalog.asr_models()
+    models = source
     if wanted:
         models = [x for x in models if x.id in wanted]
     out = []

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -272,6 +272,41 @@ def measure_rtf(backend, plan, model_id: str, machine: Machine, *, force: bool =
         return None
 
 
+# A fixed sentence for the translation throughput benchmark — long enough that decode
+# dominates the first-token/prompt overhead, short enough to keep init snappy.
+BENCH_TRANSLATE_TEXT = "The weather is lovely today, so I think I will go for a long walk in the park this afternoon."
+BENCH_TRANSLATE_SRC = "English"
+BENCH_TRANSLATE_TGT = "French"
+
+
+def measure_tps(backend, plan, model_id: str, machine: Machine, *, force: bool = False):
+    """Best-effort: after one warmup pass, run a fixed sentence through
+    backend.translate and return decode throughput (generated tokens / elapsed
+    seconds). Cached by the same key shape as measure_rtf, namespaced with a
+    'tps:' prefix so it never collides with the RTF entries. One-time per key
+    unless force. Never raises (returns None).
+
+    The warmup matters: the first generation pays one-time CUDA kernel/graph
+    compilation, so timing it would badly understate steady-state throughput."""
+    try:
+        key = "tps:" + _bench_key(machine.fingerprint, model_id, plan.backend, plan.device, plan.compute_type)
+        cache = bench_load()
+        if not force and key in cache:
+            return cache[key]
+        backend.translate(BENCH_TRANSLATE_TEXT, "", BENCH_TRANSLATE_SRC, BENCH_TRANSLATE_TGT, False)  # warmup
+        t0 = time.time()
+        _text, n_new = backend.translate(BENCH_TRANSLATE_TEXT, "", BENCH_TRANSLATE_SRC, BENCH_TRANSLATE_TGT, False)
+        dt = time.time() - t0
+        if dt <= 0 or n_new <= 0:
+            return None
+        tps = n_new / dt
+        cache[key] = tps
+        bench_save(cache)
+        return tps
+    except Exception:
+        return None
+
+
 def _apply_bench(plans: list, bench: dict) -> list:
     """Demote any non-cpu plan whose cached RTF is >= the cpu floor's cached RTF
     (proven not faster than CPU). `bench` maps (backend, device, compute_type) -> rtf."""

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -71,7 +71,11 @@ def _installed() -> frozenset:
             # voxtral_realtime needs BOTH the native voxtral_realtime model (transformers >=5.2;
             # present in our 5.13 fork) AND mistral_common (its processor/tokenizer) — gate on
             # both so a half-installed env doesn't advertise it in the catalog then fail at load().
-            "voxtral_realtime": ("transformers.models.voxtral_realtime", "mistral_common")}
+            "voxtral_realtime": ("transformers.models.voxtral_realtime", "mistral_common"),
+            # translation: 2.5/3 are CausalLM (always present with transformers); 3.5 is the
+            # qwen3_5 VLM class (self-gates off until transformers ships it), used text-only.
+            "qwen_translate": "transformers",
+            "qwen35_translate": "transformers.models.qwen3_5"}
 
     def _ready(spec):
         return all(_has_mod(m) for m in ((spec,) if isinstance(spec, str) else spec))
@@ -163,24 +167,34 @@ def resolve_deployments(model, machine: Machine, override: str = "auto", bench: 
     return plans
 
 
+def _resolve_model(model, model_id: str, override: str, machine: Machine) -> list[Plan]:
+    cache = bench_load()
+    bench = {}
+    for d in model.deployments:
+        device = TIER_DEVICE[d.tier]
+        key = _bench_key(machine.fingerprint, model_id, d.backend, device, d.compute_type)
+        if key in cache:
+            bench[(d.backend, device, d.compute_type)] = cache[key]
+    plans = resolve_deployments(model, machine, override, bench=bench or None)
+    if not plans:
+        raise NoUsablePlan(model_id)
+    return plans
+
+
 def resolve(model_id: str, override: str = "auto", machine: Machine | None = None) -> list[Plan]:
     from . import catalog
     model = catalog.asr_model(model_id)
     if model is None:
         raise ValueError(f"unknown asr model: {model_id}")
-    m = machine or probe()
-    fp = m.fingerprint
-    cache = bench_load()
-    bench = {}
-    for d in model.deployments:
-        device = TIER_DEVICE[d.tier]
-        key = _bench_key(fp, model_id, d.backend, device, d.compute_type)
-        if key in cache:
-            bench[(d.backend, device, d.compute_type)] = cache[key]
-    plans = resolve_deployments(model, m, override, bench=bench or None)
-    if not plans:
-        raise NoUsablePlan(model_id)
-    return plans
+    return _resolve_model(model, model_id, override, machine or probe())
+
+
+def resolve_translate(model_id: str, override: str = "auto", machine: Machine | None = None) -> list[Plan]:
+    from . import catalog
+    model = catalog.translate_model(model_id)
+    if model is None:
+        raise ValueError(f"unknown translate model: {model_id}")
+    return _resolve_model(model, model_id, override, machine or probe())
 
 
 class AllPlansFailed(Exception):

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -113,7 +113,7 @@ TRANSLATE_MODELS: list[TranslateModel] = [
 
 
 def translate_models() -> list[TranslateModel]:
-    return TRANSLATE_MODELS
+    return list(TRANSLATE_MODELS)
 
 
 def translate_model(model_id: str) -> TranslateModel | None:

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -5,6 +5,9 @@ import os
 from dataclasses import dataclass
 
 SENSE_VOICE_REPO = os.environ.get("SOKUJI_ASR_REPO", "FunAudioLLM/SenseVoiceSmall")
+# The default Qwen 2.5 translation repo honours SOKUJI_TRANSLATE_MODEL so the runtime
+# loads the same repo the download/prefetch path fetched (keep these two in sync).
+QWEN25_REPO = os.environ.get("SOKUJI_TRANSLATE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
 
 
 @dataclass(frozen=True)
@@ -102,7 +105,7 @@ def _qwen_translate_row(mid, name, repo, backend, sort_order, recommended=False)
 
 TRANSLATE_MODELS: list[TranslateModel] = [
     _qwen_translate_row("qwen2.5-0.5b", "Qwen 2.5 0.5B",
-                        "Qwen/Qwen2.5-0.5B-Instruct", "qwen_translate", 1, recommended=True),
+                        QWEN25_REPO, "qwen_translate", 1, recommended=True),
     _qwen_translate_row("qwen3-0.6b", "Qwen 3 0.6B",
                         "Qwen/Qwen3-0.6B", "qwen_translate", 2, recommended=True),
     _qwen_translate_row("qwen3.5-0.8b", "Qwen 3.5 0.8B",

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -9,7 +9,7 @@ SENSE_VOICE_REPO = os.environ.get("SOKUJI_ASR_REPO", "FunAudioLLM/SenseVoiceSmal
 
 @dataclass(frozen=True)
 class Deployment:
-    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohere_transformers" | "voxtral_realtime" | "funasr_sensevoice"
+    backend: str        # backend NAME: "ctranslate2" | "sherpa" | "transformers" | "qwen3asr" | "cohere_transformers" | "voxtral_realtime" | "funasr_sensevoice" | "qwen_translate" | "qwen35_translate"
     tier: str           # "cpu" (Phase 0); "gpu-cuda"/... later
     compute_type: str   # "int8" | ...
     artifact: str       # backend.load() model_ref: whisper size, or sherpa repo id
@@ -81,3 +81,40 @@ def asr_models() -> list[AsrModel]:
 
 def asr_model(model_id: str) -> AsrModel | None:
     return next((m for m in ASR_MODELS if m.id == model_id), None)
+
+
+@dataclass(frozen=True)
+class TranslateModel:
+    id: str
+    name: str
+    languages: tuple[str, ...]   # ("multi",) means any language
+    deployments: tuple[Deployment, ...]
+    recommended: bool = False
+    sort_order: int = 99
+
+
+def _qwen_translate_row(mid, name, repo, backend, sort_order, recommended=False):
+    return TranslateModel(mid, name, ("multi",), (
+        Deployment(backend, "gpu-cuda", "bfloat16", repo, 1.0),
+        Deployment(backend, "cpu", "float32", repo, 1.0),
+    ), recommended=recommended, sort_order=sort_order)
+
+
+TRANSLATE_MODELS: list[TranslateModel] = [
+    _qwen_translate_row("qwen2.5-0.5b", "Qwen 2.5 0.5B",
+                        "Qwen/Qwen2.5-0.5B-Instruct", "qwen_translate", 1, recommended=True),
+    _qwen_translate_row("qwen3-0.6b", "Qwen 3 0.6B",
+                        "Qwen/Qwen3-0.6B", "qwen_translate", 2, recommended=True),
+    _qwen_translate_row("qwen3.5-0.8b", "Qwen 3.5 0.8B",
+                        "Qwen/Qwen3.5-0.8B", "qwen35_translate", 3),
+    _qwen_translate_row("qwen3.5-2b", "Qwen 3.5 2B",
+                        "Qwen/Qwen3.5-2B", "qwen35_translate", 4),
+]
+
+
+def translate_models() -> list[TranslateModel]:
+    return TRANSLATE_MODELS
+
+
+def translate_model(model_id: str) -> TranslateModel | None:
+    return next((m for m in TRANSLATE_MODELS if m.id == model_id), None)

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -47,6 +47,14 @@ def download_specs(model_id):
         # format, 8.86GB, unused by transformers) — skip the duplicate.
         return {"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [],
                 "ignore": ["consolidated.safetensors"]}
+    if model_id == "qwen2.5-0.5b":
+        return {"repos": ["Qwen/Qwen2.5-0.5B-Instruct"], "urls": []}
+    if model_id == "qwen3-0.6b":
+        return {"repos": ["Qwen/Qwen3-0.6B"], "urls": []}
+    if model_id == "qwen3.5-0.8b":
+        return {"repos": ["Qwen/Qwen3.5-0.8B"], "urls": []}
+    if model_id == "qwen3.5-2b":
+        return {"repos": ["Qwen/Qwen3.5-2B"], "urls": []}
     return {"repos": [model_id], "urls": []}
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -48,7 +48,8 @@ def download_specs(model_id):
         return {"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [],
                 "ignore": ["consolidated.safetensors"]}
     if model_id == "qwen2.5-0.5b":
-        return {"repos": ["Qwen/Qwen2.5-0.5B-Instruct"], "urls": []}
+        # Honour SOKUJI_TRANSLATE_MODEL so download matches what the catalog/runtime loads.
+        return {"repos": [os.environ.get("SOKUJI_TRANSLATE_MODEL", QWEN_REPO)], "urls": []}
     if model_id == "qwen3-0.6b":
         return {"repos": ["Qwen/Qwen3-0.6B"], "urls": []}
     if model_id == "qwen3.5-0.8b":

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -23,7 +23,7 @@ def _vad_cache_path():
 
 def download_specs(model_id):
     """Map a model id to its download sources: {repos: [..], urls: [..]}."""
-    if not model_id or model_id == "qwen":
+    if not model_id:
         return {"repos": [os.environ.get("SOKUJI_TRANSLATE_MODEL", QWEN_REPO)], "urls": []}
     if "piper" in model_id or "vits" in model_id:
         from .sherpa_tts import PIPER_REPOS

--- a/sidecar/sokuji_sidecar/server.py
+++ b/sidecar/sokuji_sidecar/server.py
@@ -58,9 +58,10 @@ async def _conn(state, ws):
             if reply is not None:
                 await ws.send(json.dumps(reply))
     finally:
-        # A session connection closing is "stop": free the ASR model from VRAM. Only a
-        # connection that started ASR streaming (on_binary set) owns the engine; the
-        # model-management connection has no on_binary, so it leaves the model alone.
+        # A session connection closing is "stop": free that connection's model from VRAM.
+        # Ownership is per-connection: ASR streaming sets on_binary, the translate session
+        # sets owns_translate; the model-management connection sets neither and leaves
+        # models alone. Both engines are process singletons reused on the next init.
         if conn.ctx.get("on_binary") is not None:
             task = conn.ctx.get("stream_task")
             if task is not None:
@@ -69,6 +70,13 @@ async def _conn(state, ws):
             if eng is not None:
                 try:
                     eng.close()
+                except Exception:
+                    pass
+        if conn.ctx.get("owns_translate"):
+            teng = state.get("translate_engine")
+            if teng is not None:
+                try:
+                    teng.close()
                 except Exception:
                     pass
 

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -1,0 +1,127 @@
+"""Translation backend adapters (transformers, text-only). Mirror the ASR
+backends' load()/unload() contract but expose translate() instead of
+transcribe(). Registered into the shared backends registry on import.
+
+  qwen_translate    — Qwen 2.5 / 3, AutoModelForCausalLM (/no_think for Qwen3).
+  qwen35_translate  — Qwen 3.5, Qwen3_5ForConditionalGeneration (VLM class), text-only.
+
+Both support CPU (float32) and GPU (bfloat16) via .to(device)."""
+from .backends import register_backend, BackendLoadError
+
+
+def _default_prompt(src: str, tgt: str) -> str:
+    s = src or "the source language"
+    t = tgt or "the target language"
+    return (f"You are a translator. Translate the text from {s} to {t}. "
+            "Output only the translation, no explanations, no refusal.")
+
+
+def _strip_think(text: str) -> str:
+    """Defensive: drop any <think>…</think> reasoning block a model emits."""
+    if "</think>" in text:
+        return text.split("</think>", 1)[1].strip()
+    return text.strip()
+
+
+@register_backend
+class QwenTranslateBackend:
+    NAME = "qwen_translate"
+
+    def __init__(self):
+        self._model = None
+        self._tok = None
+        self._device = "cpu"
+        self._ref = ""
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            from transformers import AutoModelForCausalLM, AutoTokenizer
+            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+            self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
+            self._model = AutoModelForCausalLM.from_pretrained(
+                model_ref, torch_dtype=dtype, local_files_only=True).to(device).eval()
+            self._device = device
+            self._ref = model_ref
+        except Exception as e:  # missing torch/transformers, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> str:
+        import torch
+        sys_p = system_prompt or _default_prompt(src, tgt)
+        if "qwen3" in self._ref.lower():        # Qwen3 thinking-mode off; Qwen2.5 ignores it
+            sys_p = f"{sys_p} /no_think"
+        user = f"<transcript>{text}</transcript>" if wrap else text
+        messages = [{"role": "system", "content": sys_p},
+                    {"role": "user", "content": user}]
+        prompt = self._tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        inputs = self._tok(prompt, return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
+        gen = out[0][inputs["input_ids"].shape[1]:]
+        return _strip_think(self._tok.decode(gen, skip_special_tokens=True))
+
+    def unload(self) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+
+@register_backend
+class Qwen35TranslateBackend:
+    NAME = "qwen35_translate"
+
+    def __init__(self):
+        self._model = None
+        self._proc = None
+        self._device = "cpu"
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            from transformers import Qwen3_5ForConditionalGeneration, AutoProcessor
+            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+            self._proc = AutoProcessor.from_pretrained(model_ref, local_files_only=True)
+            self._model = Qwen3_5ForConditionalGeneration.from_pretrained(
+                model_ref, dtype=dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing qwen3_5 class, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> str:
+        import torch
+        sys_p = system_prompt or _default_prompt(src, tgt)   # Qwen3.5 is non-thinking by default
+        user = f"<transcript>{text}</transcript>" if wrap else text
+        messages = [{"role": "system", "content": [{"type": "text", "text": sys_p}]},
+                    {"role": "user", "content": [{"type": "text", "text": user}]}]
+        prompt = self._proc.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        inputs = self._proc(text=prompt, return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
+        gen = out[0][inputs["input_ids"].shape[1]:]
+        return _strip_think(self._proc.batch_decode([gen], skip_special_tokens=True)[0])
+
+    def unload(self) -> None:
+        self._model = None
+        self._proc = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -90,17 +90,21 @@ class Qwen35TranslateBackend:
 
     def __init__(self):
         self._model = None
-        self._proc = None
+        self._tok = None
         self._device = "cpu"
 
     def load(self, model_ref: str, device: str, compute_type: str) -> None:
         self._model = None
-        self._proc = None
+        self._tok = None
         try:
             import torch
-            from transformers import Qwen3_5ForConditionalGeneration, AutoProcessor
+            from transformers import Qwen3_5ForConditionalGeneration, AutoTokenizer
             dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
-            self._proc = AutoProcessor.from_pretrained(model_ref, local_files_only=True)
+            # Text-only: drive a plain tokenizer, NOT AutoProcessor. Qwen3.5 is a VLM and
+            # its AutoProcessor eagerly builds Qwen3VLVideoProcessor, which hard-requires
+            # torchvision (no wheel for the sidecar's torch build). The tokenizer carries
+            # the chat template and is all text-only generation needs.
+            self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
             self._model = Qwen3_5ForConditionalGeneration.from_pretrained(
                 model_ref, dtype=dtype, local_files_only=True).to(device).eval()
             self._device = device
@@ -111,18 +115,18 @@ class Qwen35TranslateBackend:
         import torch
         sys_p = system_prompt or _default_prompt(src, tgt)   # Qwen3.5 is non-thinking by default
         user = f"<transcript>{text}</transcript>" if wrap else text
-        messages = [{"role": "system", "content": [{"type": "text", "text": sys_p}]},
-                    {"role": "user", "content": [{"type": "text", "text": user}]}]
-        prompt = self._proc.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-        inputs = self._proc(text=prompt, return_tensors="pt").to(self._device)
+        messages = [{"role": "system", "content": sys_p},
+                    {"role": "user", "content": user}]
+        prompt = self._tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+        inputs = self._tok(prompt, return_tensors="pt").to(self._device)
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         gen = out[0][inputs["input_ids"].shape[1]:]
-        return _clean_output(self._proc.batch_decode([gen], skip_special_tokens=True)[0])
+        return _clean_output(self._tok.decode(gen, skip_special_tokens=True))
 
     def unload(self) -> None:
         self._model = None
-        self._proc = None
+        self._tok = None
         try:
             import torch
             torch.cuda.empty_cache()

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -42,7 +42,7 @@ class QwenTranslateBackend:
             dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
             self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
             self._model = AutoModelForCausalLM.from_pretrained(
-                model_ref, torch_dtype=dtype, local_files_only=True).to(device).eval()
+                model_ref, dtype=dtype, local_files_only=True).to(device).eval()
             self._device = device
             self._ref = model_ref
         except Exception as e:  # missing torch/transformers, no CUDA, OOM → resolver falls back

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -6,7 +6,11 @@ transcribe(). Registered into the shared backends registry on import.
   qwen35_translate  — Qwen 3.5, Qwen3_5ForConditionalGeneration (VLM class), text-only.
 
 Both support CPU (float32) and GPU (bfloat16) via .to(device)."""
+import re
+
 from .backends import register_backend, BackendLoadError
+
+_TRANSCRIPT_TAG = re.compile(r"</?transcript>", re.IGNORECASE)
 
 
 def _default_prompt(src: str, tgt: str) -> str:
@@ -16,10 +20,13 @@ def _default_prompt(src: str, tgt: str) -> str:
             "Output only the translation, no explanations, no refusal.")
 
 
-def _strip_think(text: str) -> str:
-    """Defensive: drop any <think>…</think> reasoning block a model emits."""
+def _clean_output(text: str) -> str:
+    """Clean a model's raw translation output: drop any <think>…</think> reasoning
+    block, then strip stray <transcript>/</transcript> tags. Small Qwen models echo
+    the wrapped input's framing (e.g. trailing '</transcript>') into the output."""
     if "</think>" in text:
-        return text.split("</think>", 1)[1].strip()
+        text = text.split("</think>", 1)[1]
+    text = _TRANSCRIPT_TAG.sub("", text)
     return text.strip()
 
 
@@ -61,7 +68,7 @@ class QwenTranslateBackend:
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         gen = out[0][inputs["input_ids"].shape[1]:]
-        return _strip_think(self._tok.decode(gen, skip_special_tokens=True))
+        return _clean_output(self._tok.decode(gen, skip_special_tokens=True))
 
     def unload(self) -> None:
         self._model = None
@@ -111,7 +118,7 @@ class Qwen35TranslateBackend:
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         gen = out[0][inputs["input_ids"].shape[1]:]
-        return _strip_think(self._proc.batch_decode([gen], skip_special_tokens=True)[0])
+        return _clean_output(self._proc.batch_decode([gen], skip_special_tokens=True)[0])
 
     def unload(self) -> None:
         self._model = None

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -55,7 +55,7 @@ class QwenTranslateBackend:
         except Exception as e:  # missing torch/transformers, no CUDA, OOM → resolver falls back
             raise BackendLoadError(str(e))
 
-    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> str:
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> tuple[str, int]:
         import torch
         sys_p = system_prompt or _default_prompt(src, tgt)
         if "qwen3" in self._ref.lower():        # Qwen3 thinking-mode off; Qwen2.5 ignores it
@@ -68,7 +68,8 @@ class QwenTranslateBackend:
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         gen = out[0][inputs["input_ids"].shape[1]:]
-        return _clean_output(self._tok.decode(gen, skip_special_tokens=True))
+        # Return (text, generated-token count) — the count feeds the tokens/sec benchmark.
+        return _clean_output(self._tok.decode(gen, skip_special_tokens=True)), int(gen.shape[0])
 
     def unload(self) -> None:
         self._model = None
@@ -111,7 +112,7 @@ class Qwen35TranslateBackend:
         except Exception as e:  # missing qwen3_5 class, no CUDA, OOM → resolver falls back
             raise BackendLoadError(str(e))
 
-    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> str:
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> tuple[str, int]:
         import torch
         sys_p = system_prompt or _default_prompt(src, tgt)   # Qwen3.5 is non-thinking by default
         user = f"<transcript>{text}</transcript>" if wrap else text
@@ -122,7 +123,8 @@ class Qwen35TranslateBackend:
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         gen = out[0][inputs["input_ids"].shape[1]:]
-        return _clean_output(self._tok.decode(gen, skip_special_tokens=True))
+        # Return (text, generated-token count) — the count feeds the tokens/sec benchmark.
+        return _clean_output(self._tok.decode(gen, skip_special_tokens=True)), int(gen.shape[0])
 
     def unload(self) -> None:
         self._model = None

--- a/sidecar/sokuji_sidecar/translate_engine.py
+++ b/sidecar/sokuji_sidecar/translate_engine.py
@@ -1,56 +1,65 @@
 import time
+from . import translate_backends  # noqa: F401 — registers qwen_translate/qwen35_translate
 
 
 class TranslateEngine:
     def __init__(self):
         self._tok = None
         self._model = None
-        self._opus = None       # torch-free onnxruntime opus-mt path
+        self._opus = None
+        self._backend = None
         self._src = ""
         self._tgt = ""
+        self.resolved = None
 
-    def init(self, model_id=None, source_lang="", target_lang=""):
-        import os
+    def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
         t0 = time.time()
+        self.close()                       # VRAM hygiene: free any prior model first
         self._src, self._tgt = source_lang, target_lang
         if model_id and "opus-mt" in model_id:
             from .opus_mt import OpusMtTranslator
             onnx_repo = model_id if "/" in model_id else f"Xenova/{model_id}"
             self._opus = OpusMtTranslator(onnx_repo)
+            self.resolved = {"backend": "opus_mt", "device": "cpu", "computeType": "int8"}
             return int((time.time() - t0) * 1000)
-        # Not an Opus-MT model: clear any previously loaded Opus translator so
-        # translate() doesn't keep taking the Opus branch on the next session.
         self._opus = None
-        from transformers import AutoModelForCausalLM, AutoTokenizer  # lazy: torch pulled here
-        mid = model_id or os.environ.get("SOKUJI_TRANSLATE_MODEL", "Qwen/Qwen2.5-0.5B-Instruct")
-        self._tok = AutoTokenizer.from_pretrained(mid, local_files_only=True)
-        self._model = AutoModelForCausalLM.from_pretrained(mid, torch_dtype="auto", local_files_only=True)
+        from . import accel
+        plans = accel.resolve_translate(model_id or "qwen2.5-0.5b", override=device or "auto")
+        self._backend, plan, _notice = accel.load_with_fallback(plans)
+        self.resolved = {"backend": plan.backend, "device": plan.device,
+                         "computeType": plan.compute_type}
         return int((time.time() - t0) * 1000)
 
     def translate(self, text, system_prompt="", wrap_transcript=False):
         t0 = time.time()
-        if not text.strip():        # empty/whitespace → nothing to translate
+        if not text.strip():
             return "", 0
         if self._opus is not None:
             return self._opus.translate(text), int((time.time() - t0) * 1000)
-        sys_prompt = system_prompt or (
-            f"Translate the following text from {self._src} to {self._tgt}. "
-            "Output only the translation, no explanations.")
-        user_content = f"<transcript>{text}</transcript>" if wrap_transcript else text
-        messages = [{"role": "system", "content": sys_prompt},
-                    {"role": "user", "content": user_content}]
-        prompt = self._tok.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
-        inputs = self._tok(prompt, return_tensors="pt")
-        out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
-        gen = out[0][inputs["input_ids"].shape[1]:]
-        translated = self._tok.decode(gen, skip_special_tokens=True).strip()
-        return translated, int((time.time() - t0) * 1000)
+        out = self._backend.translate(text, system_prompt, self._src, self._tgt, wrap_transcript)
+        return out, int((time.time() - t0) * 1000)
+
+    def close(self):
+        if self._backend is not None:
+            try:
+                self._backend.unload()
+            except Exception:
+                pass
+            self._backend = None
+        self._opus = None
+        self._tok = None
+        self._model = None
 
 
 async def _h_translate_init(state, msg, _b, conn=None):
     ms = state["translate_engine"].init(
-        msg.get("model"), msg.get("sourceLang", ""), msg.get("targetLang", ""))
-    return {"type": "ready", "id": msg.get("id"), "loadTimeMs": ms}, None
+        msg.get("model"), msg.get("sourceLang", ""), msg.get("targetLang", ""),
+        msg.get("device", "auto"))
+    reply = {"type": "ready", "id": msg.get("id"), "loadTimeMs": ms}
+    resolved = getattr(state["translate_engine"], "resolved", None)
+    if resolved:
+        reply.update(resolved)
+    return reply, None
 
 
 async def _h_translate(state, msg, _b, conn=None):

--- a/sidecar/sokuji_sidecar/translate_engine.py
+++ b/sidecar/sokuji_sidecar/translate_engine.py
@@ -58,6 +58,10 @@ async def _h_translate_init(state, msg, _b, conn=None):
     ms = state["translate_engine"].init(
         msg.get("model"), msg.get("sourceLang", ""), msg.get("targetLang", ""),
         msg.get("device", "auto"))
+    # This connection owns the translate model: closing it frees the model from VRAM
+    # (mirrors the ASR streaming connection's on_binary ownership in server._conn).
+    if conn is not None:
+        conn.ctx["owns_translate"] = True
     reply = {"type": "ready", "id": msg.get("id"), "loadTimeMs": ms}
     resolved = getattr(state["translate_engine"], "resolved", None)
     if resolved:

--- a/sidecar/sokuji_sidecar/translate_engine.py
+++ b/sidecar/sokuji_sidecar/translate_engine.py
@@ -26,8 +26,11 @@ class TranslateEngine:
         from . import accel
         plans = accel.resolve_translate(model_id or "qwen2.5-0.5b", override=device or "auto")
         self._backend, plan, _notice = accel.load_with_fallback(plans)
+        tps = accel.measure_tps(self._backend, plan, model_id or "qwen2.5-0.5b", accel.probe())
         self.resolved = {"backend": plan.backend, "device": plan.device,
                          "computeType": plan.compute_type}
+        if tps is not None:
+            self.resolved["tokensPerSec"] = round(tps, 1)
         return int((time.time() - t0) * 1000)
 
     def translate(self, text, system_prompt="", wrap_transcript=False):
@@ -36,7 +39,7 @@ class TranslateEngine:
             return "", 0
         if self._opus is not None:
             return self._opus.translate(text), int((time.time() - t0) * 1000)
-        out = self._backend.translate(text, system_prompt, self._src, self._tgt, wrap_transcript)
+        out, _n_tokens = self._backend.translate(text, system_prompt, self._src, self._tgt, wrap_transcript)
         return out, int((time.time() - t0) * 1000)
 
     def close(self):

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -503,3 +503,37 @@ def test_voxtral_model_unavailable_without_runtime():
                       fingerprint="testfp")
     plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
     assert plans == []     # GPU-only + runtime absent → no usable deployment
+
+
+def test_resolve_translate_prefers_gpu():
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                 installed=frozenset({"qwen_translate"}))
+    plans = accel.resolve_translate("qwen2.5-0.5b", "auto", m)
+    assert [p.device for p in plans] == ["cuda", "cpu"]
+    assert plans[0].artifact == "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+def test_resolve_translate_cpu_only_machine():
+    m = _machine(installed=frozenset({"qwen_translate"}))
+    plans = accel.resolve_translate("qwen3-0.6b", "auto", m)
+    assert [p.device for p in plans] == ["cpu"]
+
+
+def test_resolve_translate_override_cpu_pins_front():
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                 installed=frozenset({"qwen_translate"}))
+    plans = accel.resolve_translate("qwen3-0.6b", "cpu", m)
+    assert [p.device for p in plans] == ["cpu", "cuda"]
+
+
+def test_resolve_translate_qwen35_self_gates_off():
+    # transformers lacks qwen3_5 → qwen35_translate not installed → no plan.
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                 installed=frozenset({"qwen_translate"}))
+    with pytest.raises(accel.NoUsablePlan):
+        accel.resolve_translate("qwen3.5-0.8b", "auto", m)
+
+
+def test_resolve_translate_unknown_id_raises():
+    with pytest.raises(ValueError):
+        accel.resolve_translate("nope", "auto", _machine())

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -537,3 +537,23 @@ def test_resolve_translate_qwen35_self_gates_off():
 def test_resolve_translate_unknown_id_raises():
     with pytest.raises(ValueError):
         accel.resolve_translate("nope", "auto", _machine())
+
+
+def test_models_catalog_kind_translate_returns_qwen_rows(monkeypatch):
+    monkeypatch.setattr(accel, "probe", lambda force=False: _machine(
+        nvidia=(accel.Gpu("nvidia", "x", 0),), installed=frozenset({"qwen_translate"})))
+    reply, _ = asyncio.run(accel._h_models_catalog(
+        {}, {"type": "models_catalog", "id": 1, "kind": "translate"}, None))
+    ids = [m["id"] for m in reply["models"]]
+    assert "qwen2.5-0.5b" in ids and "qwen3-0.6b" in ids
+    row = next(m for m in reply["models"] if m["id"] == "qwen2.5-0.5b")
+    tiers = {t["tier"]: t["available"] for t in row["tiers"]}
+    assert tiers["gpu-cuda"] is True and tiers["cpu"] is True
+
+
+def test_models_catalog_kind_defaults_to_asr(monkeypatch):
+    monkeypatch.setattr(accel, "probe", lambda force=False: _machine())
+    reply, _ = asyncio.run(accel._h_models_catalog(
+        {}, {"type": "models_catalog", "id": 2}, None))
+    ids = [m["id"] for m in reply["models"]]
+    assert "sense-voice" in ids       # ASR catalog, unchanged default

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -245,6 +245,34 @@ def test_measure_rtf_runs_and_caches(tmp_path, monkeypatch):
     assert accel._bench_key(m.fingerprint, "whisper-tiny", "ctranslate2", "cpu", "int8") in cache
 
 
+def test_measure_tps_warms_up_benchmarks_and_caches(tmp_path, monkeypatch):
+    monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
+
+    class _FakeBackend:
+        def __init__(self):
+            self.calls = 0
+
+        def translate(self, text, system_prompt, src, tgt, wrap):
+            self.calls += 1
+            return "bonjour le monde", 12  # 12 "generated" tokens
+
+    m = _machine()
+    plan = accel.Plan("qwen_translate", "gpu-cuda", "cuda", "bfloat16", "repo", 1.0)
+    b = _FakeBackend()
+    tps = accel.measure_tps(b, plan, "qwen2.5-0.5b", m)
+    assert tps is not None and tps > 0
+    assert b.calls == 2  # one warmup pass + one timed pass
+
+    # cached under a 'tps:'-namespaced key so it never collides with RTF entries
+    cache = accel.bench_load()
+    assert any(k.startswith("tps:") for k in cache)
+
+    # second call serves from cache — backend untouched, same value
+    b2 = _FakeBackend()
+    assert accel.measure_tps(b2, plan, "qwen2.5-0.5b", m) == tps
+    assert b2.calls == 0
+
+
 def test_apply_bench_demotes_slow_gpu():
     cpu = accel.Plan("ctranslate2", "cpu", "cpu", "int8", "tiny", 1.0)
     gpu = accel.Plan("ctranslate2", "gpu-cuda", "cuda", "float16", "tiny", 1.0)

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -94,3 +94,33 @@ def test_voxtral_realtime_row():
     d = m.deployments[0]
     assert (d.backend, d.tier, d.compute_type, d.artifact) == \
         ("voxtral_realtime", "gpu-cuda", "bfloat16", "mistralai/Voxtral-Mini-4B-Realtime-2602")
+
+
+def test_translate_models_have_deployments_and_cpu_floor():
+    for m in catalog.translate_models():
+        assert m.deployments, f"{m.id} has no deployments"
+        assert m.languages, f"{m.id} has no languages"
+        assert any(d.tier == "cpu" for d in m.deployments), f"{m.id} lacks a cpu floor"
+        for d in m.deployments:
+            assert d.backend in {"qwen_translate", "qwen35_translate"}
+
+
+def test_translate_model_ids_unique_and_lookup():
+    ids = [m.id for m in catalog.translate_models()]
+    assert len(ids) == len(set(ids))
+    assert catalog.translate_model("does-not-exist") is None
+
+
+def test_translate_rows_map_to_qwen_repos():
+    expected = {
+        "qwen2.5-0.5b": ("qwen_translate", "Qwen/Qwen2.5-0.5B-Instruct"),
+        "qwen3-0.6b": ("qwen_translate", "Qwen/Qwen3-0.6B"),
+        "qwen3.5-0.8b": ("qwen35_translate", "Qwen/Qwen3.5-0.8B"),
+        "qwen3.5-2b": ("qwen35_translate", "Qwen/Qwen3.5-2B"),
+    }
+    for mid, (backend, repo) in expected.items():
+        m = catalog.translate_model(mid)
+        assert m is not None, f"missing {mid}"
+        tiers = [(d.backend, d.tier, d.compute_type, d.artifact) for d in m.deployments]
+        assert (backend, "gpu-cuda", "bfloat16", repo) in tiers
+        assert (backend, "cpu", "float32", repo) in tiers

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -36,6 +36,14 @@ def test_download_specs_cohere():
         {"repos": ["AEmotionStudio/cohere-transcribe-03-2026-models"], "urls": []}
 
 
+def test_download_specs_qwen25_honours_translate_model_env(monkeypatch):
+    # SOKUJI_TRANSLATE_MODEL overrides the default Qwen 2.5 repo for BOTH the implicit
+    # default ('') and the explicit id, so download matches what the catalog/runtime loads.
+    monkeypatch.setenv('SOKUJI_TRANSLATE_MODEL', 'acme/custom-translate')
+    assert nm.download_specs('')['repos'] == ['acme/custom-translate']
+    assert nm.download_specs('qwen2.5-0.5b')['repos'] == ['acme/custom-translate']
+
+
 def test_download_raises_when_no_files_resolved(monkeypatch):
     """A repo whose files cannot be listed must NOT silently report 'ready'.
 

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -6,8 +6,11 @@ from sokuji_sidecar import server
 
 
 def test_download_specs_mapping():
+    # Empty id is the implicit default → Qwen 2.5 0.5B; the explicit id maps the same.
     assert nm.download_specs('')['repos'] == [nm.QWEN_REPO]
-    assert nm.download_specs('qwen')['repos'] == [nm.QWEN_REPO]
+    assert nm.download_specs('qwen2.5-0.5b')['repos'] == [nm.QWEN_REPO]
+    # The legacy 'qwen' alias was dropped — it now falls through to a bare repo id.
+    assert nm.download_specs('qwen')['repos'] == ['qwen']
     assert nm.download_specs('whisper-tiny')['repos'] == ['Systran/faster-whisper-tiny']
     assert nm.download_specs('csukuangfj/vits-piper-en_US-amy-low')['repos'] == ['csukuangfj/vits-piper-en_US-amy-low']
     sv = nm.download_specs('sense-voice')

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -236,3 +236,11 @@ def test_model_size_excludes_ignored_files(monkeypatch):
     monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
     nm._SIZE_CACHE.clear()
     assert nm.model_size("voxtral-mini-4b-realtime") == 8_000_001_000  # consolidated excluded
+
+
+def test_download_specs_qwen_translate_repos():
+    from sokuji_sidecar import native_models as nm
+    assert nm.download_specs("qwen2.5-0.5b")["repos"] == ["Qwen/Qwen2.5-0.5B-Instruct"]
+    assert nm.download_specs("qwen3-0.6b")["repos"] == ["Qwen/Qwen3-0.6B"]
+    assert nm.download_specs("qwen3.5-0.8b")["repos"] == ["Qwen/Qwen3.5-0.8B"]
+    assert nm.download_specs("qwen3.5-2b")["repos"] == ["Qwen/Qwen3.5-2B"]

--- a/sidecar/tests/test_server_conn.py
+++ b/sidecar/tests/test_server_conn.py
@@ -132,3 +132,82 @@ def test_feeder_exception_sends_error_and_keeps_connection():
         reply = json.loads(sent)
         assert reply["type"] == "error"
         assert "feeder failed" in reply["message"]
+
+
+def test_translate_connection_close_frees_engine():
+    """A connection that ran translate_init owns the translate model; closing it must
+    free that model from VRAM (mirrors the ASR on_binary ownership)."""
+    from sokuji_sidecar import translate_engine
+
+    closed = {"n": 0}
+
+    class FakeTranslate:
+        resolved = {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
+
+        def init(self, *a, **k):
+            return 5
+
+        def close(self):
+            closed["n"] += 1
+
+    state = {"translate_engine": FakeTranslate(), "handlers": {}}
+    translate_engine.register(state)
+
+    class IterWS:
+        def __init__(self, messages):
+            self._msgs = iter(messages)
+            self.sent = []
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._msgs)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def send(self, d):
+            self.sent.append(d)
+
+    ws = IterWS([json.dumps({"type": "translate_init", "id": 1, "sourceLang": "ja", "targetLang": "en"})])
+    asyncio.run(_conn(state, ws))
+    assert closed["n"] == 1  # translate model freed when its connection closed
+
+
+def test_non_translate_connection_does_not_free_engine():
+    """A connection that never ran translate_init (e.g. model-management) must NOT
+    close the shared translate engine on disconnect."""
+    from sokuji_sidecar import translate_engine
+
+    closed = {"n": 0}
+
+    class FakeTranslate:
+        def close(self):
+            closed["n"] += 1
+
+    async def _ping(state, msg, _b, conn=None):
+        return {"type": "pong", "id": msg.get("id")}, None
+
+    state = {"translate_engine": FakeTranslate(), "handlers": {"noop": _ping}}
+
+    class IterWS:
+        def __init__(self, messages):
+            self._msgs = iter(messages)
+            self.sent = []
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            try:
+                return next(self._msgs)
+            except StopIteration:
+                raise StopAsyncIteration
+
+        async def send(self, d):
+            self.sent.append(d)
+
+    ws = IterWS([json.dumps({"type": "noop", "id": 1})])
+    asyncio.run(_conn(state, ws))
+    assert closed["n"] == 0  # engine untouched — this connection never owned it

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -25,8 +25,10 @@ def _fake_tok(captured):
 
 def _fake_model():
     model = MagicMock()
+    gen_tokens = MagicMock()
+    gen_tokens.shape = [7]                                       # 7 "generated" tokens → int-able count
     gen_out = MagicMock()
-    gen_out.__getitem__ = MagicMock(return_value=MagicMock())  # out[0]
+    gen_out.__getitem__ = MagicMock(return_value=gen_tokens)     # out[0][slice] → gen_tokens
     model.generate.return_value = [gen_out]
     return model
 
@@ -101,8 +103,9 @@ def test_qwen35_text_only_uses_tokenizer_string_content():
     b._tok = _fake_tok(captured)
     b._model = _fake_model()
     b._device = "cpu"
-    out = b.translate("hi", "", "Japanese", "English", wrap=True)
+    out, n_tokens = b.translate("hi", "", "Japanese", "English", wrap=True)
     assert out == "translated"
+    assert n_tokens == 7                                   # generated-token count for the tps benchmark
     sys_msg = next(m for m in captured if m["role"] == "system")
     user_msg = next(m for m in captured if m["role"] == "user")
     # string content, not the multimodal [{"type": "text", ...}] list form

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+import os
 import pytest
 from sokuji_sidecar import translate_backends as tb
 from sokuji_sidecar import backends
@@ -82,3 +83,28 @@ def test_qwen35_load_raises_when_class_missing(monkeypatch):
     b = tb.Qwen35TranslateBackend()
     with pytest.raises(backends.BackendLoadError):
         b.load("Qwen/Qwen3.5-0.8B", "cuda", "bfloat16")
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads models + needs CUDA)")
+@pytest.mark.parametrize("model_id", ["qwen2.5-0.5b", "qwen3-0.6b"])
+def test_qwen_translate_real_gpu(model_id):
+    from sokuji_sidecar import translate_engine
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id=model_id, source_lang="Spanish", target_lang="English", device="cuda")
+    assert eng.resolved["device"] == "cuda"
+    out, ms = eng.translate("Hola, ¿cómo estás?")
+    assert isinstance(out, str) and out.strip() and ms >= 0
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
+                    reason="set SOKUJI_RUN_GPU=1 (downloads models + needs CUDA + qwen3_5)")
+def test_qwen35_translate_real_gpu_if_available():
+    import importlib.util
+    if importlib.util.find_spec("transformers.models.qwen3_5") is None:
+        pytest.skip("transformers lacks qwen3_5 — Qwen3.5 rows self-gate off")
+    from sokuji_sidecar import translate_engine
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id="qwen3.5-0.8b", source_lang="Spanish", target_lang="English", device="cuda")
+    out, _ = eng.translate("Hola, ¿cómo estás?")
+    assert isinstance(out, str) and out.strip()

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -92,6 +92,24 @@ def test_qwen35_load_raises_when_class_missing(monkeypatch):
         b.load("Qwen/Qwen3.5-0.8B", "cuda", "bfloat16")
 
 
+def test_qwen35_text_only_uses_tokenizer_string_content():
+    # Qwen3.5 is a VLM, but we translate text only. The backend must drive a plain
+    # tokenizer with string ChatML content — NOT AutoProcessor, whose video processor
+    # hard-requires torchvision (unavailable for the sidecar's torch build).
+    captured = []
+    b = tb.Qwen35TranslateBackend()
+    b._tok = _fake_tok(captured)
+    b._model = _fake_model()
+    b._device = "cpu"
+    out = b.translate("hi", "", "Japanese", "English", wrap=True)
+    assert out == "translated"
+    sys_msg = next(m for m in captured if m["role"] == "system")
+    user_msg = next(m for m in captured if m["role"] == "user")
+    # string content, not the multimodal [{"type": "text", ...}] list form
+    assert isinstance(sys_msg["content"], str)
+    assert user_msg["content"] == "<transcript>hi</transcript>"
+
+
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
                     reason="set SOKUJI_RUN_GPU=1 (downloads models + needs CUDA)")
 @pytest.mark.parametrize("model_id", ["qwen2.5-0.5b", "qwen3-0.6b"])

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock
+import pytest
+from sokuji_sidecar import translate_backends as tb
+from sokuji_sidecar import backends
+
+
+class FakeInputs(dict):
+    def to(self, device):
+        return self
+
+
+def _fake_tok(captured):
+    tok = MagicMock()
+
+    def apply_chat_template(messages, **kw):
+        captured.clear()
+        captured.extend(messages)
+        return "PROMPT"
+    tok.apply_chat_template.side_effect = apply_chat_template
+    tok.side_effect = lambda prompt, **kw: FakeInputs(input_ids=MagicMock(shape=[1, 5]))
+    tok.decode.return_value = "translated"
+    return tok
+
+
+def _fake_model():
+    model = MagicMock()
+    gen_out = MagicMock()
+    gen_out.__getitem__ = MagicMock(return_value=MagicMock())  # out[0]
+    model.generate.return_value = [gen_out]
+    return model
+
+
+def test_backends_are_registered():
+    assert backends._BACKENDS.get("qwen_translate") is tb.QwenTranslateBackend
+    assert backends._BACKENDS.get("qwen35_translate") is tb.Qwen35TranslateBackend
+
+
+def test_default_prompt_mentions_langs():
+    p = tb._default_prompt("Japanese", "English")
+    assert "Japanese" in p and "English" in p and "only" in p.lower()
+
+
+def test_strip_think_removes_block():
+    assert tb._strip_think("<think>reasoning</think>  hello") == "hello"
+    assert tb._strip_think("plain") == "plain"
+
+
+def test_qwen3_appends_no_think_and_wraps():
+    captured = []
+    b = tb.QwenTranslateBackend()
+    b._tok = _fake_tok(captured)
+    b._model = _fake_model()
+    b._device = "cpu"
+    b._ref = "Qwen/Qwen3-0.6B"
+    b.translate("hi", "", "Japanese", "English", wrap=True)
+    sys_msg = next(m for m in captured if m["role"] == "system")
+    user_msg = next(m for m in captured if m["role"] == "user")
+    assert sys_msg["content"].endswith("/no_think")
+    assert user_msg["content"] == "<transcript>hi</transcript>"
+
+
+def test_qwen25_no_no_think_and_bare():
+    captured = []
+    b = tb.QwenTranslateBackend()
+    b._tok = _fake_tok(captured)
+    b._model = _fake_model()
+    b._device = "cpu"
+    b._ref = "Qwen/Qwen2.5-0.5B-Instruct"
+    b.translate("hi", "", "Japanese", "English", wrap=False)
+    sys_msg = next(m for m in captured if m["role"] == "system")
+    user_msg = next(m for m in captured if m["role"] == "user")
+    assert "/no_think" not in sys_msg["content"]
+    assert user_msg["content"] == "hi"
+
+
+def test_qwen35_load_raises_when_class_missing(monkeypatch):
+    # Simulate a transformers without Qwen3_5ForConditionalGeneration.
+    import sys
+    fake_transformers = MagicMock()
+    del fake_transformers.Qwen3_5ForConditionalGeneration  # attribute access raises AttributeError
+    monkeypatch.setitem(sys.modules, "transformers", fake_transformers)
+    b = tb.Qwen35TranslateBackend()
+    with pytest.raises(backends.BackendLoadError):
+        b.load("Qwen/Qwen3.5-0.8B", "cuda", "bfloat16")

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -41,9 +41,16 @@ def test_default_prompt_mentions_langs():
     assert "Japanese" in p and "English" in p and "only" in p.lower()
 
 
-def test_strip_think_removes_block():
-    assert tb._strip_think("<think>reasoning</think>  hello") == "hello"
-    assert tb._strip_think("plain") == "plain"
+def test_clean_output_removes_think_block():
+    assert tb._clean_output("<think>reasoning</think>  hello") == "hello"
+    assert tb._clean_output("plain") == "plain"
+
+
+def test_clean_output_strips_transcript_tags():
+    # Small Qwen models echo the input's <transcript> framing into the output.
+    assert tb._clean_output("The weather today is nice.</transcript>") == "The weather today is nice."
+    assert tb._clean_output("<transcript>hi</transcript>") == "hi"
+    assert tb._clean_output("<think>x</think> Hello</transcript>") == "Hello"
 
 
 def test_qwen3_appends_no_think_and_wraps():

--- a/sidecar/tests/test_translate_engine.py
+++ b/sidecar/tests/test_translate_engine.py
@@ -5,8 +5,10 @@ from sokuji_sidecar import server, translate_engine
 
 
 class FakeTranslate:
-    def init(self, model_id=None, source_lang="", target_lang=""):
+    def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
         self.langs = (source_lang, target_lang)
+        self.device = device
+        self.resolved = {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
         return 21
 
     def translate(self, text, system_prompt="", wrap_transcript=False):
@@ -23,7 +25,7 @@ def test_translate_init():
     st = make_state()
     reply, _ = asyncio.run(server.handle_message(
         st, json.dumps({"type": "translate_init", "id": 1, "sourceLang": "ja", "targetLang": "en"})))
-    assert reply == {"type": "ready", "id": 1, "loadTimeMs": 21}
+    assert reply["type"] == "ready" and reply["id"] == 1 and reply["loadTimeMs"] == 21
     assert st["translate_engine"].langs == ("ja", "en")
 
 
@@ -36,129 +38,60 @@ def test_translate_returns_translation():
                      "sourceText": "hola", "translatedText": "<hola>", "inferenceTimeMs": 8}
 
 
-def _make_fake_tok(captured_messages):
-    """Build a fake tokenizer that records the messages list passed to
-    apply_chat_template so tests can assert on user content."""
-    tok = MagicMock()
-    def apply_chat_template(messages, **kw):
-        captured_messages.clear()
-        captured_messages.extend(messages)
-        return "PROMPT"
-    tok.apply_chat_template.side_effect = apply_chat_template
-    tok.return_value = {"input_ids": MagicMock(shape=[1, 5])}
-    tok.side_effect = lambda prompt, **kw: {"input_ids": MagicMock(shape=[1, 5])}
-    return tok
+def test_translate_init_echoes_device_and_resolved():
+    st = make_state()
+    reply, _ = asyncio.run(server.handle_message(
+        st, json.dumps({"type": "translate_init", "id": 1, "sourceLang": "ja",
+                        "targetLang": "en", "device": "cuda"})))
+    assert reply["type"] == "ready" and reply["id"] == 1 and reply["loadTimeMs"] == 21
+    assert reply["backend"] == "qwen_translate"
+    assert reply["device"] == "cuda"
+    assert reply["computeType"] == "bfloat16"
+    assert st["translate_engine"].device == "cuda"
 
 
-def _make_fake_model():
-    """Build a fake causal LM whose generate() returns a tensor-like object."""
-    model = MagicMock()
-    gen_ids = MagicMock()
-    gen_ids.__getitem__ = lambda self, key: MagicMock()  # out[0][...]
-    model.generate.return_value = [gen_ids]
-    return model
-
-
-def _patch_transformers(captured_messages, tok=None, model=None):
-    """Return a context manager patching AutoTokenizer and AutoModelForCausalLM
-    inside translate_engine so no real model files are needed.  Both fakes
-    accept **kwargs (incl. local_files_only) without complaint."""
-    fake_tok = tok or _make_fake_tok(captured_messages)
-    fake_model = model or _make_fake_model()
-
-    class FakeTokClass:
-        @staticmethod
-        def from_pretrained(mid, **kwargs):
-            return fake_tok
-
-    class FakeModelClass:
-        @staticmethod
-        def from_pretrained(mid, **kwargs):
-            return fake_model
-
-    return patch.multiple(
-        "sokuji_sidecar.translate_engine",
-        **{
-            "__import__": None,  # not used; we patch names directly below
-        }
-    )
-
-
-def test_opus_to_qwen_switch_clears_opus(monkeypatch):
-    """After switching from an Opus model back to the default Qwen model,
-    _opus must be None so translate() uses the Qwen path.
-
-    init() imports both opus_mt and transformers lazily via `from … import …`
-    so we patch via sys.modules — the approach that works regardless of whether
-    the symbols are already cached at module level.
-    """
-    import sys
-    captured = []
-    fake_tok = _make_fake_tok(captured)
-    fake_model = _make_fake_model()
-
-    # --- Fake opus_mt sub-module ---
-    fake_opus_instance = MagicMock()
-    fake_opus_class = MagicMock(return_value=fake_opus_instance)
-    fake_opus_mt_mod = MagicMock()
-    fake_opus_mt_mod.OpusMtTranslator = fake_opus_class
-
-    # --- Fake transformers module ---
-    fake_transformers_mod = MagicMock()
-    fake_transformers_mod.AutoTokenizer.from_pretrained = lambda mid, **kw: fake_tok
-    fake_transformers_mod.AutoModelForCausalLM.from_pretrained = lambda mid, **kw: fake_model
-
-    monkeypatch.setitem(sys.modules, "sokuji_sidecar.opus_mt", fake_opus_mt_mod)
-    monkeypatch.setitem(sys.modules, "transformers", fake_transformers_mod)
+def test_init_uses_resolver_and_sets_resolved(monkeypatch):
+    from sokuji_sidecar import accel
+    fake_backend = MagicMock()
+    fake_plan = MagicMock(backend="qwen_translate", device="cuda", compute_type="bfloat16")
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "load_with_fallback", lambda plans: (fake_backend, fake_plan, None))
 
     eng = translate_engine.TranslateEngine()
+    eng.init(model_id="qwen2.5-0.5b", source_lang="ja", target_lang="en", device="cuda")
+    assert eng.resolved == {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
+    assert eng._backend is fake_backend
 
-    # Step 1: init with opus-mt model → _opus must be set.
-    eng.init(model_id="Xenova/opus-mt-ja-en", source_lang="ja", target_lang="en")
-    assert eng._opus is not None, "_opus should be set after opus-mt init"
-
-    # Step 2: switch to the default Qwen model → _opus must be cleared.
-    eng.init(model_id=None, source_lang="ja", target_lang="en")
-    assert eng._opus is None, "_opus must be cleared after switching to Qwen model"
+    fake_backend.translate.return_value = "hola->hi"
+    out, ms = eng.translate("hola", wrap_transcript=True)
+    fake_backend.translate.assert_called_once_with("hola", "", "ja", "en", True)
+    assert out == "hola->hi" and ms >= 0
 
 
-def test_wrap_transcript_wraps_user_content(monkeypatch):
-    """In the Qwen branch, user message must be <transcript>…</transcript>
-    when wrap_transcript=True, and bare text when False."""
-    captured = []
-    fake_tok = _make_fake_tok(captured)
-    fake_model = _make_fake_model()
-    # Make tok(prompt) return something with input_ids
-    input_ids_mock = MagicMock()
-    input_ids_mock.shape = [1, 5]
-    fake_tok.return_value = {"input_ids": input_ids_mock}
-    # Make model.generate return something indexable
-    gen_out = MagicMock()
-    gen_slice = MagicMock()
-    gen_out.__getitem__ = MagicMock(return_value=gen_slice)
-    gen_slice.__getitem__ = MagicMock(return_value=MagicMock())
-    fake_model.generate.return_value = [gen_out]
-    # Make decode return a string
-    fake_tok.decode.return_value = "translated"
+def test_close_unloads_prior_backend_before_reinit(monkeypatch):
+    from sokuji_sidecar import accel
+    first, second = MagicMock(), MagicMock()
+    plan = MagicMock(backend="qwen_translate", device="cpu", compute_type="float32")
+    backends_iter = iter([(first, plan, None), (second, plan, None)])
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "load_with_fallback", lambda plans: next(backends_iter))
 
+    eng = translate_engine.TranslateEngine()
+    eng.init(model_id="qwen2.5-0.5b", source_lang="ja", target_lang="en")
+    eng.init(model_id="qwen3-0.6b", source_lang="ja", target_lang="en")
+    first.unload.assert_called_once()   # prior backend freed before loading the next
+    assert eng._backend is second
+
+
+def test_translate_delegates_to_backend_when_loaded():
     eng = translate_engine.TranslateEngine()
     eng._opus = None
-    eng._tok = fake_tok
-    eng._model = fake_model
-    eng._src = "Japanese"
-    eng._tgt = "English"
-
-    # wrap_transcript=True → user content should be wrapped
-    eng.translate("hello", wrap_transcript=True)
-    user_msgs_wrapped = [m for m in captured if m["role"] == "user"]
-    assert user_msgs_wrapped[0]["content"] == "<transcript>hello</transcript>", \
-        f"expected wrapped content, got: {user_msgs_wrapped[0]['content']!r}"
-
-    # wrap_transcript=False → user content should be bare text
-    eng.translate("hello", wrap_transcript=False)
-    user_msgs_bare = [m for m in captured if m["role"] == "user"]
-    assert user_msgs_bare[0]["content"] == "hello", \
-        f"expected bare content, got: {user_msgs_bare[0]['content']!r}"
+    eng._backend = MagicMock()
+    eng._backend.translate.return_value = "translated"
+    eng._src, eng._tgt = "Japanese", "English"
+    out, _ = eng.translate("hello", wrap_transcript=True)
+    eng._backend.translate.assert_called_once_with("hello", "", "Japanese", "English", True)
+    assert out == "translated"
 
 
 def test_wrap_transcript_not_applied_to_opus(monkeypatch):
@@ -172,6 +105,41 @@ def test_wrap_transcript_not_applied_to_opus(monkeypatch):
     result, _ = eng.translate("hello", wrap_transcript=True)
     fake_opus.translate.assert_called_once_with("hello")  # raw, not wrapped
     assert result == "translated"
+
+
+def test_opus_to_qwen_switch_clears_opus(monkeypatch):
+    """After switching from an Opus model back to the default Qwen model,
+    _opus must be None so translate() uses the Qwen path.
+
+    Step 1 patches sys.modules for opus_mt; Step 2 patches accel functions
+    since the Qwen branch now goes through the resolver/backend path.
+    """
+    import sys
+    from sokuji_sidecar import accel
+
+    # --- Fake opus_mt sub-module ---
+    fake_opus_instance = MagicMock()
+    fake_opus_class = MagicMock(return_value=fake_opus_instance)
+    fake_opus_mt_mod = MagicMock()
+    fake_opus_mt_mod.OpusMtTranslator = fake_opus_class
+
+    # --- Fake backend for Qwen path ---
+    fake_backend = MagicMock()
+    fake_plan = MagicMock(backend="qwen_translate", device="cpu", compute_type="float32")
+
+    monkeypatch.setitem(sys.modules, "sokuji_sidecar.opus_mt", fake_opus_mt_mod)
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "load_with_fallback", lambda plans: (fake_backend, fake_plan, None))
+
+    eng = translate_engine.TranslateEngine()
+
+    # Step 1: init with opus-mt model → _opus must be set.
+    eng.init(model_id="Xenova/opus-mt-ja-en", source_lang="ja", target_lang="en")
+    assert eng._opus is not None, "_opus should be set after opus-mt init"
+
+    # Step 2: switch to the default Qwen model → _opus must be cleared.
+    eng.init(model_id=None, source_lang="ja", target_lang="en")
+    assert eng._opus is None, "_opus must be cleared after switching to Qwen model"
 
 
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_TRANSLATE_MODEL"),

--- a/sidecar/tests/test_translate_engine.py
+++ b/sidecar/tests/test_translate_engine.py
@@ -56,13 +56,15 @@ def test_init_uses_resolver_and_sets_resolved(monkeypatch):
     fake_plan = MagicMock(backend="qwen_translate", device="cuda", compute_type="bfloat16")
     monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
     monkeypatch.setattr(accel, "load_with_fallback", lambda plans: (fake_backend, fake_plan, None))
+    # Isolate from the real tps benchmark/cache so resolved is deterministic here.
+    monkeypatch.setattr(accel, "measure_tps", lambda *a, **k: None)
 
     eng = translate_engine.TranslateEngine()
     eng.init(model_id="qwen2.5-0.5b", source_lang="ja", target_lang="en", device="cuda")
     assert eng.resolved == {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
     assert eng._backend is fake_backend
 
-    fake_backend.translate.return_value = "hola->hi"
+    fake_backend.translate.return_value = ("hola->hi", 5)   # (text, generated-token count)
     out, ms = eng.translate("hola", wrap_transcript=True)
     fake_backend.translate.assert_called_once_with("hola", "", "ja", "en", True)
     assert out == "hola->hi" and ms >= 0
@@ -87,7 +89,7 @@ def test_translate_delegates_to_backend_when_loaded():
     eng = translate_engine.TranslateEngine()
     eng._opus = None
     eng._backend = MagicMock()
-    eng._backend.translate.return_value = "translated"
+    eng._backend.translate.return_value = ("translated", 5)   # (text, generated-token count)
     eng._src, eng._tgt = "Japanese", "English"
     out, _ = eng.translate("hello", wrap_transcript=True)
     eng._backend.translate.assert_called_once_with("hello", "", "Japanese", "English", True)

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -13,6 +13,7 @@ import {
   hardwareGated,
   gpuTierAvailable,
   formatRtf,
+  formatTps,
   type NativeModelCardSpec,
   type NativeSelection,
 } from '../../../lib/local-inference/native/nativeCatalog';
@@ -25,7 +26,12 @@ import {
   useNativeModelSizes,
   useNativeModelErrors,
   useNativeAsrResolved,
+  useNativeTranslationResolved,
 } from '../../../stores/nativeModelStore';
+
+// The resolved plan a card may display: device + one speed metric. ASR carries an
+// rtf ("Nx realtime"), translation carries tokensPerSec ("N tok/s"); never both.
+type CardResolved = { model: string; device: string; rtf?: number; tokensPerSec?: number };
 import { ModelGroup, RecommendedOthers, ModelStorageFooter } from './ModelManagementControls';
 
 type Stage = 'asrModel' | 'translationModel' | 'ttsModel';
@@ -37,8 +43,9 @@ const NativeModelCard: React.FC<{
   autoSelected: boolean;
   disabled: boolean;
   incompatible?: boolean;
+  resolved?: CardResolved | null;
   onSelect: () => void;
-}> = ({ spec, selected, autoSelected, disabled, incompatible = false, onSelect }) => {
+}> = ({ spec, selected, autoSelected, disabled, incompatible = false, resolved = null, onSelect }) => {
   const { t } = useTranslation();
   const statuses = useNativeModelStatuses();
   const progress = useNativeModelProgress();
@@ -49,7 +56,6 @@ const NativeModelCard: React.FC<{
   const deleteModel = useNativeModelStore((s) => s.deleteModel);
 
   const noDownload = spec.downloadId === null;
-  const resolved = useNativeAsrResolved();
   const catalog = useNativeCatalog();
   const info = noDownload ? undefined : catalog[spec.downloadId as string];
   const activeTier = info?.tiers.find((x) => x.available) ?? info?.tiers[0];
@@ -94,19 +100,25 @@ const NativeModelCard: React.FC<{
                 {spec.note && <span className="model-card__lang-tag">{spec.note}</span>}
               </div>
               {(() => {
-                // One tier tag: for the model that just ran, show the RESOLVED device + measured
-                // rtf (ground truth — also catches a GPU→CPU fallback); otherwise the catalog's
-                // capability tier. Avoids two redundant "GPU CUDA" tags on the active card.
+                // One tier tag: for the model that just ran, show the RESOLVED device + its measured
+                // speed metric (ground truth — also catches a GPU→CPU fallback); otherwise the
+                // catalog's capability tier. Avoids two redundant "GPU CUDA" tags on the active card.
+                // Speed metric differs by stage: ASR shows rtf ("Nx realtime"), translation shows
+                // tokensPerSec ("N tok/s"); the resolved object carries whichever applies.
                 const showResolved = !!resolved && resolved.model === spec.selectId;
                 const tier = showResolved
                   ? (resolved!.device === 'cpu' ? 'cpu' : `gpu-${resolved!.device}`)
                   : activeTier?.tier;
                 if (!tier) return null;
                 const tl = tierLabel(tier);
-                const rtf = showResolved && resolved!.rtf !== undefined ? ` · ${formatRtf(resolved!.rtf)}` : '';
+                let metric = '';
+                if (showResolved) {
+                  if (resolved!.rtf !== undefined) metric = ` · ${formatRtf(resolved!.rtf)}`;
+                  else if (resolved!.tokensPerSec !== undefined) metric = ` · ${formatTps(resolved!.tokensPerSec)}`;
+                }
                 return (
                   <span className="model-card__lang-tag">
-                    <TierIcon tier={tier} size={10} />{tl.label}{rtf}
+                    <TierIcon tier={tier} size={10} />{tl.label}{metric}
                   </span>
                 );
               })()}
@@ -194,6 +206,9 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   const catalog = useNativeCatalog();
   const statuses = useNativeModelStatuses();
   const sizes = useNativeModelSizes();
+  // Per-stage resolved plan (device + speed metric) from the last session ready.
+  const asrResolved = useNativeAsrResolved();
+  const translationResolved = useNativeTranslationResolved();
   const refresh = useNativeModelStore((s) => s.refresh);
   const refreshSizes = useNativeModelStore((s) => s.refreshSizes);
   const refreshCatalog = useNativeModelStore((s) => s.refreshCatalog);
@@ -267,17 +282,23 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   };
 
   // Recommended / Others split via the shared primitive; cards stay native-specific.
-  const renderCards = (cards: NativeModelCardSpec[], isSelected: (c: NativeModelCardSpec) => boolean, field: Stage) => (
-    <RecommendedOthers
-      items={cards}
-      isRecommended={(c) => !!c.recommended}
-      renderItem={(c) => (
-        <NativeModelCard key={c.selectId || 'auto'} spec={c} disabled={isSessionActive}
-          selected={isSelected(c)} autoSelected={autoSelectedStages[field]}
-          onSelect={() => selectCard(field, c.selectId)} />
-      )}
-    />
-  );
+  const renderCards = (cards: NativeModelCardSpec[], isSelected: (c: NativeModelCardSpec) => boolean, field: Stage) => {
+    // Feed each card the resolved plan for its stage so the active model shows the
+    // measured device + speed metric (ASR rtf / translation tok/s). TTS has none.
+    const resolvedForField = field === 'asrModel' ? asrResolved
+      : field === 'translationModel' ? translationResolved : null;
+    return (
+      <RecommendedOthers
+        items={cards}
+        isRecommended={(c) => !!c.recommended}
+        renderItem={(c) => (
+          <NativeModelCard key={c.selectId || 'auto'} spec={c} disabled={isSessionActive}
+            selected={isSelected(c)} autoSelected={autoSelectedStages[field]} resolved={resolvedForField}
+            onSelect={() => selectCard(field, c.selectId)} />
+        )}
+      />
+    );
+  };
 
   // Storage footer: bytes used ≈ sum of download sizes for cached models (deduped by repo id).
   const usedBytes = useMemo(() => {

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -352,6 +352,40 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
       </ModelGroup>
 
       <ModelGroup id="model-translation" title={t('models.translationModels', 'Translation')}>
+        <div className="model-group__device-control">
+          <div className="model-group__device-label">
+            {t('models.computeDevice', 'Compute device')}
+            <Tooltip
+              content={t('models.computeDeviceTooltip', 'Which device runs the translation model. Auto picks the fastest available (GPU when present); CPU works everywhere but is slower for large models; GPU requires a CUDA GPU.')}
+              position="top"
+            >
+              <CircleHelp className="tooltip-trigger" size={14} style={{ marginLeft: '4px', display: 'inline-block', verticalAlign: 'middle' }} />
+            </Tooltip>
+          </div>
+          {(() => {
+            const gpuAvail = gpuTierAvailable(catalog);
+            const deviceValue = settings.translationDevice === 'cuda' && !gpuAvail ? 'auto' : settings.translationDevice;
+            const opts: Array<['auto' | 'cpu' | 'cuda', string]> = [
+              ['auto', t('models.deviceAuto', 'Auto')],
+              ['cpu', t('models.deviceCpu', 'CPU')],
+              ...(gpuAvail ? [['cuda', t('models.deviceGpu', 'GPU')] as ['cuda', string]] : []),
+            ];
+            return (
+              <div className="segmented-control">
+                {opts.map(([mode, label]) => (
+                  <button
+                    key={mode}
+                    className={`segmented-option ${deviceValue === mode ? 'active' : ''}`}
+                    onClick={() => { if (deviceValue !== mode) update({ translationDevice: mode }); }}
+                    disabled={isSessionActive}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            );
+          })()}
+        </div>
         {renderCards(translationCards, (c) => settings.translationModel === c.selectId, 'translationModel')}
       </ModelGroup>
 

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -223,7 +223,7 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   useEffect(() => {
     refresh(allDownloadIds);
     refreshSizes(allDownloadIds);
-    refreshCatalog();   // per-machine tier availability for the ASR badges
+    refreshCatalog();   // per-machine tier availability for the ASR + translation badges
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [refreshKey]);
 

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -105,7 +105,9 @@ const NativeModelCard: React.FC<{
                 // catalog's capability tier. Avoids two redundant "GPU CUDA" tags on the active card.
                 // Speed metric differs by stage: ASR shows rtf ("Nx realtime"), translation shows
                 // tokensPerSec ("N tok/s"); the resolved object carries whichever applies.
-                const showResolved = !!resolved && resolved.model === spec.selectId;
+                // Match selectId OR downloadId: translation resolves to the artifact id, so Opus-MT's
+                // resolved model is its HF repo (= downloadId), not the 'opus-mt' selectId.
+                const showResolved = !!resolved && (resolved.model === spec.selectId || resolved.model === spec.downloadId);
                 const tier = showResolved
                   ? (resolved!.device === 'cpu' ? 'cpu' : `gpu-${resolved!.device}`)
                   : activeTier?.tier;

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -356,7 +356,7 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
           <div className="model-group__device-label">
             {t('models.computeDevice', 'Compute device')}
             <Tooltip
-              content={t('models.computeDeviceTooltip', 'Which device runs the translation model. Auto picks the fastest available (GPU when present); CPU works everywhere but is slower for large models; GPU requires a CUDA GPU.')}
+              content={t('models.computeDeviceTooltipTranslation', 'Which device runs the translation model. Auto picks the fastest available (GPU when present); CPU works everywhere but is slower for large models; GPU requires a CUDA GPU.')}
               position="top"
             >
               <CircleHelp className="tooltip-trigger" size={14} style={{ marginLeft: '4px', display: 'inline-block', verticalAlign: 'middle' }} />

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -1832,8 +1832,9 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
     // The speed slider is meaningful only when the target language has a native
     // voice (text-only is the common textOnly toggle, not a per-stage Off option).
     const ttsActive = hasNativeTts(localNativeSettings.targetLanguage);
-    // Custom prompts only reach the Qwen LLM path; Opus-MT ('opus-mt') ignores them.
-    const promptSupported = localNativeSettings.translationModel === '';
+    // Custom prompts reach the Qwen LLM path (every Qwen version card); only Opus-MT
+    // ignores them. Exclude opus-mt rather than enumerate Qwen ids so future versions stay supported.
+    const promptSupported = localNativeSettings.translationModel !== 'opus-mt';
 
     return (
       <>

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -105,10 +105,15 @@ export class NativeModelClient {
     return msg as Extract<ServerMsg, { type: 'hardware_info_result' }>;
   }
 
-  /** Query the per-machine model catalog (languages, recommended, tier availability). */
-  async modelsCatalog(models?: string[]): Promise<NativeModelInfo[]> {
+  /** Query the per-machine model catalog (languages, recommended, tier availability).
+   *  `kind` selects the ASR catalog (default) or the translation catalog — they are
+   *  separate model lists sidecar-side, so callers fetch each independently. */
+  async modelsCatalog(models?: string[], kind?: 'asr' | 'translate'): Promise<NativeModelInfo[]> {
     await this.connect();
-    const msg = await this.send(models ? { type: 'models_catalog', models } : { type: 'models_catalog' });
+    const payload: { type: 'models_catalog'; models?: string[]; kind?: 'asr' | 'translate' } = { type: 'models_catalog' };
+    if (models) payload.models = models;
+    if (kind) payload.kind = kind;
+    const msg = await this.send(payload);
     return (msg as Extract<ServerMsg, { type: 'models_catalog_result' }>).models;
   }
 

--- a/src/lib/local-inference/native/NativeTranslateClient.test.ts
+++ b/src/lib/local-inference/native/NativeTranslateClient.test.ts
@@ -13,7 +13,9 @@ class FakeWS {
   send(d: any) {
     const msg = JSON.parse(d);
     if (msg.type === 'translate_init') queueMicrotask(() =>
-      this.onmessage?.({ data: JSON.stringify({ type: 'ready', id: msg.id, loadTimeMs: 3 }) }));
+      this.onmessage?.({ data: JSON.stringify({
+        type: 'ready', id: msg.id, loadTimeMs: 3,
+        backend: 'qwen_translate', device: msg.device ?? 'auto', computeType: 'bfloat16' }) }));
     if (msg.type === 'translate') queueMicrotask(() =>
       this.onmessage?.({ data: JSON.stringify({
         type: 'translation', id: msg.id, sourceText: msg.text,
@@ -47,9 +49,18 @@ describe('NativeTranslateClient', () => {
   it('inits with langs and translates', async () => {
     const c = new NativeTranslateClient();
     const r = await c.init('es', 'en');
-    expect(r).toEqual({ loadTimeMs: 3 });
+    expect(r.loadTimeMs).toBe(3);
     const res = await c.translate('hola');
     expect(res).toEqual({ sourceText: 'hola', translatedText: 'HOLA', inferenceTimeMs: 4 });
+  });
+
+  it('sends device and returns resolved fields', async () => {
+    const c = new NativeTranslateClient();
+    const r = await c.init('es', 'en', 'qwen3-0.6b', 'cuda');
+    expect(r.loadTimeMs).toBe(3);
+    expect(r.device).toBe('cuda');
+    expect(r.backend).toBe('qwen_translate');
+    expect(r.computeType).toBe('bfloat16');
   });
 });
 

--- a/src/lib/local-inference/native/NativeTranslateClient.ts
+++ b/src/lib/local-inference/native/NativeTranslateClient.ts
@@ -53,11 +53,13 @@ export class NativeTranslateClient {
     return new Promise((resolve, reject) => { this.pending.set(id, { resolve, reject }); this.ws!.send(JSON.stringify({ ...payload, id })); });
   }
 
-  async init(sourceLang: string, targetLang: string, modelId?: string): Promise<{ loadTimeMs: number }> {
+  async init(sourceLang: string, targetLang: string, modelId?: string, device?: string):
+      Promise<{ loadTimeMs: number; backend?: string; device?: string; computeType?: string }> {
     await this.connect();
     this.onStatus?.('[native-translate] init…');
-    const msg = await this.send({ type: 'translate_init', sourceLang, targetLang, model: modelId });
-    return { loadTimeMs: (msg as Extract<ServerMsg, { type: 'ready' }>).loadTimeMs };
+    const msg = await this.send({ type: 'translate_init', sourceLang, targetLang, model: modelId, device });
+    const r = msg as Extract<ServerMsg, { type: 'ready' }>;
+    return { loadTimeMs: r.loadTimeMs, backend: r.backend, device: r.device, computeType: r.computeType };
   }
 
   async translate(text: string, systemPrompt = '', wrapTranscript = false): Promise<TranslationResult> {

--- a/src/lib/local-inference/native/NativeTranslateClient.ts
+++ b/src/lib/local-inference/native/NativeTranslateClient.ts
@@ -54,12 +54,12 @@ export class NativeTranslateClient {
   }
 
   async init(sourceLang: string, targetLang: string, modelId?: string, device?: string):
-      Promise<{ loadTimeMs: number; backend?: string; device?: string; computeType?: string }> {
+      Promise<{ loadTimeMs: number; backend?: string; device?: string; computeType?: string; tokensPerSec?: number }> {
     await this.connect();
     this.onStatus?.('[native-translate] init…');
     const msg = await this.send({ type: 'translate_init', sourceLang, targetLang, model: modelId, device });
     const r = msg as Extract<ServerMsg, { type: 'ready' }>;
-    return { loadTimeMs: r.loadTimeMs, backend: r.backend, device: r.device, computeType: r.computeType };
+    return { loadTimeMs: r.loadTimeMs, backend: r.backend, device: r.device, computeType: r.computeType, tokensPerSec: r.tokensPerSec };
   }
 
   async translate(text: string, systemPrompt = '', wrapTranscript = false): Promise<TranslationResult> {

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -32,9 +32,15 @@ describe('nativeCatalog', () => {
     expect(resolveNativeTranslation('Qwen/Qwen2.5-0.5B-Instruct', 'a', 'b')).toBe('Qwen/Qwen2.5-0.5B-Instruct');
   });
 
+  it('exposes the four Qwen translation versions plus opus-mt', () => {
+    const ids = nativeTranslationCards('zh', 'en').map((c) => c.selectId);
+    // '' is the Qwen 2.5 0.5B default (back-compat); the rest are explicit versions
+    expect(ids).toEqual(['', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'opus-mt']);
+  });
+
   it('exposes ASR + translation options', () => {
     expect(NATIVE_ASR.map((m) => m.id)).toContain('sense-voice');
-    expect(NATIVE_TRANSLATION.map((m) => m.id)).toEqual(['', 'opus-mt']);
+    expect(NATIVE_TRANSLATION.map((m) => m.id)).toEqual(['', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'opus-mt']);
   });
 
   it('language compatibility + ASR auto-select', () => {
@@ -60,8 +66,9 @@ describe('nativeCatalog', () => {
     expect(nativeAsrCards('de').map((c) => c.selectId)).not.toContain('sense-voice');
 
     const tr = nativeTranslationCards('zh', 'en');
-    expect(tr[0]).toMatchObject({ selectId: '', downloadId: 'qwen' });
-    expect(tr[1]).toMatchObject({ selectId: 'opus-mt', downloadId: 'Xenova/opus-mt-zh-en' });
+    expect(tr[0]).toMatchObject({ selectId: '', downloadId: 'qwen' });            // Qwen 2.5 0.5B default (unchanged ids)
+    expect(tr[1]).toMatchObject({ selectId: 'qwen3-0.6b', downloadId: 'qwen3-0.6b' });
+    expect(tr[tr.length - 1]).toMatchObject({ selectId: 'opus-mt', downloadId: 'Xenova/opus-mt-zh-en' });
 
     const tts = nativeTtsCards('en');
     expect(tts[0]).toMatchObject({ selectId: 'csukuangfj/vits-piper-en_US-amy-low', downloadId: 'csukuangfj/vits-piper-en_US-amy-low', recommended: true });

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -34,13 +34,13 @@ describe('nativeCatalog', () => {
 
   it('exposes the four Qwen translation versions plus opus-mt', () => {
     const ids = nativeTranslationCards('zh', 'en').map((c) => c.selectId);
-    // '' is the Qwen 2.5 0.5B default (back-compat); the rest are explicit versions
-    expect(ids).toEqual(['', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'opus-mt']);
+    // qwen2.5-0.5b is the recommended default; the rest are explicit versions + opus-mt
+    expect(ids).toEqual(['qwen2.5-0.5b', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'opus-mt']);
   });
 
   it('exposes ASR + translation options', () => {
     expect(NATIVE_ASR.map((m) => m.id)).toContain('sense-voice');
-    expect(NATIVE_TRANSLATION.map((m) => m.id)).toEqual(['', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'opus-mt']);
+    expect(NATIVE_TRANSLATION.map((m) => m.id)).toEqual(['qwen2.5-0.5b', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'opus-mt']);
   });
 
   it('language compatibility + ASR auto-select', () => {
@@ -66,7 +66,7 @@ describe('nativeCatalog', () => {
     expect(nativeAsrCards('de').map((c) => c.selectId)).not.toContain('sense-voice');
 
     const tr = nativeTranslationCards('zh', 'en');
-    expect(tr[0]).toMatchObject({ selectId: '', downloadId: 'qwen' });            // Qwen 2.5 0.5B default (unchanged ids)
+    expect(tr[0]).toMatchObject({ selectId: 'qwen2.5-0.5b', downloadId: 'qwen2.5-0.5b' });            // Qwen 2.5 0.5B recommended default
     expect(tr[1]).toMatchObject({ selectId: 'qwen3-0.6b', downloadId: 'qwen3-0.6b' });
     expect(tr[tr.length - 1]).toMatchObject({ selectId: 'opus-mt', downloadId: 'Xenova/opus-mt-zh-en' });
 
@@ -101,17 +101,17 @@ describe('nativeCatalog', () => {
   });
 
   describe('autoSelectNative', () => {
-    const cur = (over = {}) => ({ asrModel: 'sense-voice', translationModel: '', ttsModel: '', ...over });
+    const cur = (over = {}) => ({ asrModel: 'sense-voice', translationModel: 'qwen2.5-0.5b', ttsModel: '', ...over });
     const downloaded = (...ids: string[]) => (id: string | null) => id === null || ids.includes(id);
     const none = () => false;
 
     it('keeps a valid, downloaded selection (no change)', () => {
-      expect(autoSelectNative('zh', 'en', cur(), downloaded('sense-voice', 'qwen'))).toBeNull();
+      expect(autoSelectNative('zh', 'en', cur(), downloaded('sense-voice', 'qwen2.5-0.5b'))).toBeNull();
     });
 
     it('drops an ASR model that no longer supports the source language', () => {
       // sense-voice does not support German → switch to the best downloaded compatible (whisper-base)
-      const r = autoSelectNative('de', 'en', cur({ asrModel: 'sense-voice' }), downloaded('whisper-base', 'qwen'));
+      const r = autoSelectNative('de', 'en', cur({ asrModel: 'sense-voice' }), downloaded('whisper-base', 'qwen2.5-0.5b'));
       expect(r).toMatchObject({ asrModel: 'whisper-base' });
     });
 
@@ -121,9 +121,9 @@ describe('nativeCatalog', () => {
     });
 
     it('falls back from a not-downloaded opus-mt to whatever is downloaded for this pair', () => {
-      // user picked opus-mt zh→en but only qwen is cached → revert to Qwen ('')
-      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'sense-voice', translationModel: 'opus-mt' }), downloaded('sense-voice', 'qwen'));
-      expect(r).toMatchObject({ translationModel: '' });
+      // user picked opus-mt zh→en but only qwen2.5 is cached → revert to Qwen 2.5
+      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'sense-voice', translationModel: 'opus-mt' }), downloaded('sense-voice', 'qwen2.5-0.5b'));
+      expect(r).toMatchObject({ translationModel: 'qwen2.5-0.5b' });
     });
 
     it('reverse pair: opus-mt downloaded one way is absent the other way', () => {
@@ -133,30 +133,30 @@ describe('nativeCatalog', () => {
       expect(autoSelectNative('zh', 'en', cur({ translationModel: 'opus-mt' }), isDl)).toBeNull();
       // reverse direction: downloadId becomes opus-mt-en-zh (absent) → reverts to Qwen
       const rev = autoSelectNative('en', 'zh', cur({ asrModel: 'whisper-base', translationModel: 'opus-mt' }), downloaded('whisper-base', 'Xenova/opus-mt-zh-en'));
-      expect(rev).toMatchObject({ translationModel: '' });
+      expect(rev).toMatchObject({ translationModel: 'qwen2.5-0.5b' });
     });
 
     it('resets a stale cross-language TTS voice to Auto', () => {
-      const r = autoSelectNative('en', 'de', cur({ asrModel: 'whisper-base', ttsModel: 'csukuangfj/vits-piper-en_US-amy-low' }), downloaded('whisper-base', 'qwen'));
+      const r = autoSelectNative('en', 'de', cur({ asrModel: 'whisper-base', ttsModel: 'csukuangfj/vits-piper-en_US-amy-low' }), downloaded('whisper-base', 'qwen2.5-0.5b'));
       expect(r?.ttsModel).toBe('');
     });
 
     it('migrates a legacy "off" TTS choice to Auto', () => {
-      const r = autoSelectNative('zh', 'en', cur({ ttsModel: 'off' }), downloaded('sense-voice', 'qwen'));
+      const r = autoSelectNative('zh', 'en', cur({ ttsModel: 'off' }), downloaded('sense-voice', 'qwen2.5-0.5b'));
       expect(r?.ttsModel).toBe('');
     });
 
     it('applies recalled history when its models are downloaded for this pair', () => {
       // history for zh→en prefers whisper-small; it is downloaded → recall overrides the default
-      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'sense-voice' }), downloaded('whisper-small', 'qwen'),
-        { asrModel: 'whisper-small', translationModel: '', ttsModel: '' });
+      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'sense-voice' }), downloaded('whisper-small', 'qwen2.5-0.5b'),
+        { asrModel: 'whisper-small', translationModel: 'qwen2.5-0.5b', ttsModel: '' });
       expect(r).toMatchObject({ asrModel: 'whisper-small' });
     });
 
     it('ignores recalled history whose model is not downloaded', () => {
       // recall wants whisper-small but only sense-voice is cached → keep sense-voice
-      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'sense-voice' }), downloaded('sense-voice', 'qwen'),
-        { asrModel: 'whisper-small', translationModel: '', ttsModel: '' });
+      const r = autoSelectNative('zh', 'en', cur({ asrModel: 'sense-voice' }), downloaded('sense-voice', 'qwen2.5-0.5b'),
+        { asrModel: 'whisper-small', translationModel: 'qwen2.5-0.5b', ttsModel: '' });
       expect(r?.asrModel ?? 'sense-voice').toBe('sense-voice');
     });
 
@@ -166,14 +166,14 @@ describe('nativeCatalog', () => {
       // cohere (GPU-only, sorted first) + sense-voice both downloaded, but cohere is gated
       // here → must pick sense-voice, never the unrunnable cohere.
       const r = autoSelectNative('zh', 'en', cur({ asrModel: '' }),
-        downloaded('cohere-transcribe-03-2026', 'sense-voice', 'qwen'), null, gatesCohere);
+        downloaded('cohere-transcribe-03-2026', 'sense-voice', 'qwen2.5-0.5b'), null, gatesCohere);
       expect(r?.asrModel).toBe('sense-voice');
     });
 
     it('reconciles away a remembered ASR that is now hardware-gated', () => {
       // the current selection IS the GPU-only cohere but this machine can't run it → replace it
       const r = autoSelectNative('zh', 'en', cur({ asrModel: 'cohere-transcribe-03-2026' }),
-        downloaded('cohere-transcribe-03-2026', 'sense-voice', 'qwen'), null, gatesCohere);
+        downloaded('cohere-transcribe-03-2026', 'sense-voice', 'qwen2.5-0.5b'), null, gatesCohere);
       expect(r?.asrModel).toBe('sense-voice');
     });
   });

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickNativeTts, hasNativeTts, nativeTtsVoices, resolveNativeTts, resolveNativeTranslation, NATIVE_ASR, NATIVE_TRANSLATION, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, autoSelectNative, tierLabel, hardwareGated, gpuTierAvailable, formatRtf } from './nativeCatalog';
+import { pickNativeTts, hasNativeTts, nativeTtsVoices, resolveNativeTts, resolveNativeTranslation, NATIVE_ASR, NATIVE_TRANSLATION, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, autoSelectNative, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps } from './nativeCatalog';
 import type { NativeModelInfo } from './nativeProtocol';
 
 describe('nativeCatalog', () => {
@@ -268,5 +268,13 @@ describe('nativeCatalog', () => {
     expect(formatRtf(0.015)).toBe('67× realtime');
     expect(formatRtf(1)).toBe('1× realtime');
     expect(formatRtf(0)).toBe('realtime');
+  });
+
+  it('formatTps renders tokens/sec, empty for invalid', () => {
+    expect(formatTps(130.5)).toBe('131 tok/s');
+    expect(formatTps(59.4)).toBe('59 tok/s');
+    expect(formatTps(0)).toBe('');
+    expect(formatTps(NaN)).toBe('');
+    expect(formatTps(-5)).toBe('');
   });
 });

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -182,6 +182,13 @@ export function formatRtf(rtf: number): string {
   return `${Math.round(1 / rtf)}× realtime`;
 }
 
+/** Human label for a measured translation throughput. tps 130.5 → "130 tok/s".
+ *  Empty string for a non-positive/invalid value (caller omits the metric). */
+export function formatTps(tps: number): string {
+  if (!(tps > 0) || !Number.isFinite(tps)) return '';
+  return `${Math.round(tps)} tok/s`;
+}
+
 /** Display label for a hardware tier string from the sidecar models_catalog. */
 export function tierLabel(tier: string): { label: string; accel: boolean } {
   switch (tier) {

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -34,8 +34,11 @@ export const NATIVE_ASR: NativeModelOption[] = [
 ];
 
 export const NATIVE_TRANSLATION: NativeModelOption[] = [
-  { id: '', label: 'Qwen LLM', languages: ['multi'], recommended: true, sortOrder: 0 },
-  { id: 'opus-mt', label: 'Opus-MT (fast)', sortOrder: 1 },
+  { id: '', label: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
+  { id: 'qwen3-0.6b', label: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
+  { id: 'qwen3.5-0.8b', label: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
+  { id: 'qwen3.5-2b', label: 'Qwen 3.5 2B', languages: ['multi'], sortOrder: 4 },
+  { id: 'opus-mt', label: 'Opus-MT (fast)', sortOrder: 5 },
 ];
 
 /** recommended-first, then sortOrder. Shared by the compatible/incompatible splits. */
@@ -226,8 +229,13 @@ export function nativeAsrIncompatibleCards(srcLang: string): NativeModelCardSpec
 
 export function nativeTranslationCards(src: string, tgt: string): NativeModelCardSpec[] {
   return [
-    { selectId: '', downloadId: 'qwen', name: 'Qwen LLM', languages: ['multi'], recommended: true, sortOrder: 0 },
-    { selectId: 'opus-mt', downloadId: `Xenova/opus-mt-${src}-${tgt}`, name: 'Opus-MT (fast)', languages: [src, tgt], sortOrder: 1 },
+    // Qwen 2.5 0.5B keeps selectId ''/downloadId 'qwen' for back-compat (persisted
+    // settings + legacy download id both resolve to Qwen/Qwen2.5-0.5B-Instruct).
+    { selectId: '', downloadId: 'qwen', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
+    { selectId: 'qwen3-0.6b', downloadId: 'qwen3-0.6b', name: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
+    { selectId: 'qwen3.5-0.8b', downloadId: 'qwen3.5-0.8b', name: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
+    { selectId: 'qwen3.5-2b', downloadId: 'qwen3.5-2b', name: 'Qwen 3.5 2B', languages: ['multi'], sortOrder: 4 },
+    { selectId: 'opus-mt', downloadId: `Xenova/opus-mt-${src}-${tgt}`, name: 'Opus-MT (fast)', languages: [src, tgt], sortOrder: 5 },
   ];
 }
 

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -34,7 +34,7 @@ export const NATIVE_ASR: NativeModelOption[] = [
 ];
 
 export const NATIVE_TRANSLATION: NativeModelOption[] = [
-  { id: '', label: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
+  { id: 'qwen2.5-0.5b', label: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
   { id: 'qwen3-0.6b', label: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
   { id: 'qwen3.5-0.8b', label: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
   { id: 'qwen3.5-2b', label: 'Qwen 3.5 2B', languages: ['multi'], sortOrder: 4 },
@@ -135,8 +135,9 @@ export function resolveNativeTts(choice: string, targetLanguage: string): string
 
 /**
  * Resolve the translation model id from the settings choice:
- *  - 'opus-mt'  -> Xenova/opus-mt-<src>-<tgt> (onnxruntime, torch-free)
- *  - ''         -> undefined (sidecar defaults to the Qwen LLM)
+ *  - 'opus-mt'      -> Xenova/opus-mt-<src>-<tgt> (onnxruntime, torch-free)
+ *  - a Qwen id      -> passed through unchanged (e.g. 'qwen2.5-0.5b', 'qwen3-0.6b')
+ *  - '' (no choice) -> undefined; the sidecar then defaults to qwen2.5-0.5b
  */
 export function resolveNativeTranslation(choice: string, src: string, tgt: string): string | undefined {
   if (choice === 'opus-mt') return `Xenova/opus-mt-${src}-${tgt}`;
@@ -145,14 +146,14 @@ export function resolveNativeTranslation(choice: string, src: string, tgt: strin
 
 /**
  * The native model ids a given config requires (for download/readiness). Always
- * an ASR model + a translation model (Qwen LLM default), plus a TTS model when
- * speech output is on. '' translation resolves to the 'qwen' download id.
+ * an ASR model + a translation model, plus a TTS model when speech output is on.
+ * An empty translation choice falls back to the qwen2.5-0.5b download id.
  */
 export function requiredNativeModels(
   asrModel: string, translationChoice: string, ttsChoice: string, src: string, tgt: string,
   textOnly = false
 ): string[] {
-  const ids = [asrModel, resolveNativeTranslation(translationChoice, src, tgt) || 'qwen'];
+  const ids = [asrModel, resolveNativeTranslation(translationChoice, src, tgt) || 'qwen2.5-0.5b'];
   // TTS is only required when speech output is on (text-only skips it entirely).
   if (!textOnly) {
     const tts = resolveNativeTts(ttsChoice, tgt);
@@ -229,9 +230,7 @@ export function nativeAsrIncompatibleCards(srcLang: string): NativeModelCardSpec
 
 export function nativeTranslationCards(src: string, tgt: string): NativeModelCardSpec[] {
   return [
-    // Qwen 2.5 0.5B keeps selectId ''/downloadId 'qwen' for back-compat (persisted
-    // settings + legacy download id both resolve to Qwen/Qwen2.5-0.5B-Instruct).
-    { selectId: '', downloadId: 'qwen', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
+    { selectId: 'qwen2.5-0.5b', downloadId: 'qwen2.5-0.5b', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
     { selectId: 'qwen3-0.6b', downloadId: 'qwen3-0.6b', name: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
     { selectId: 'qwen3.5-0.8b', downloadId: 'qwen3.5-0.8b', name: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
     { selectId: 'qwen3.5-2b', downloadId: 'qwen3.5-2b', name: 'Qwen 3.5 2B', languages: ['multi'], sortOrder: 4 },

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -182,7 +182,7 @@ export function formatRtf(rtf: number): string {
   return `${Math.round(1 / rtf)}× realtime`;
 }
 
-/** Human label for a measured translation throughput. tps 130.5 → "130 tok/s".
+/** Human label for a measured translation throughput. tps 130.5 → "131 tok/s".
  *  Empty string for a non-positive/invalid value (caller omits the metric). */
 export function formatTps(tps: number): string {
   if (!(tps > 0) || !Number.isFinite(tps)) return '';

--- a/src/lib/local-inference/native/nativeProtocol.ts
+++ b/src/lib/local-inference/native/nativeProtocol.ts
@@ -1,6 +1,6 @@
 // WS message contract between the renderer and the python sidecar (TTS, translation, ASR, model management, hardware info).
 export interface ReadyMsg {
-  type: 'ready'; id: number; sampleRate: number; loadTimeMs: number;
+  type: 'ready'; id: number; sampleRate?: number; loadTimeMs: number;   // sampleRate only on audio (ASR/TTS) ready; translate_init omits it
   backend?: string; device?: string; computeType?: string; rtf?: number; tokensPerSec?: number; fallbackReason?: string;
 }
 export interface NativeTier { tier: string; backend: string; available: boolean; }

--- a/src/lib/local-inference/native/nativeProtocol.ts
+++ b/src/lib/local-inference/native/nativeProtocol.ts
@@ -1,7 +1,7 @@
 // WS message contract between the renderer and the python sidecar (TTS, translation, ASR, model management, hardware info).
 export interface ReadyMsg {
   type: 'ready'; id: number; sampleRate: number; loadTimeMs: number;
-  backend?: string; device?: string; computeType?: string; rtf?: number; fallbackReason?: string;
+  backend?: string; device?: string; computeType?: string; rtf?: number; tokensPerSec?: number; fallbackReason?: string;
 }
 export interface NativeTier { tier: string; backend: string; available: boolean; }
 export interface NativeModelInfo {

--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -32,7 +32,7 @@ describe('LocalNativeClient', () => {
       asrModelId: 'sense-voice', translationModelId: 'opus-mt-es-en',
     } as any);
     expect(m.asr.init).toHaveBeenCalled();
-    expect(m.translate.init).toHaveBeenCalledWith('es', 'en', 'opus-mt-es-en');
+    expect(m.translate.init).toHaveBeenCalledWith('es', 'en', 'opus-mt-es-en', undefined);
 
     await m.asr.onResult({ text: 'hola', durationMs: 100, recognitionTimeMs: 5 });
     await new Promise((r) => setTimeout(r, 0));
@@ -98,7 +98,7 @@ describe('LocalNativeClient', () => {
   });
 
   it('renders partials as one in-progress item and runs the job only on the final', async () => {
-    const translate = { init: async () => {}, translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
+    const translate = { init: async () => ({ device: 'cpu' }), translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
     const asr: any = { init: async () => ({ device: 'cuda' }), feedAudio() {}, flush() {}, dispose() {}, onResult: null, onPartialResult: null, onError: null };
     const client = new LocalNativeClient({ asr, translate });
     const items: any[] = [];
@@ -115,7 +115,7 @@ describe('LocalNativeClient', () => {
   });
 
   it('drops the stale partial after clearConversationItems so the next final still lands', async () => {
-    const translate = { init: async () => {}, translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
+    const translate = { init: async () => ({ device: 'cpu' }), translate: vi.fn(async () => ({ translatedText: 'T', inferenceTimeMs: 1 })), onError: null, dispose() {} };
     const asr: any = { init: async () => ({ device: 'cuda' }), feedAudio() {}, flush() {}, dispose() {}, onResult: null, onPartialResult: null, onError: null };
     const client = new LocalNativeClient({ asr, translate });
     client.setEventHandlers({ onConversationUpdated() {}, onOpen() {}, onRealtimeEvent() {} } as any);
@@ -137,7 +137,7 @@ const fakeAsr = () => ({
   init: async () => ({ loadTimeMs: 5, device: 'cuda', rtf: 0.02 }),
   feedAudio() {}, flush: async () => {}, dispose() {},
 });
-const fakeTr = () => ({ onError: null as any, init: async () => {}, translate: async () => ({ translatedText: 'x', inferenceTimeMs: 1 }), dispose() {} });
+const fakeTr = () => ({ onError: null as any, init: async () => ({ device: 'cpu' }), translate: async () => ({ translatedText: 'x', inferenceTimeMs: 1 }), dispose() {} });
 const fakeTts = () => ({ init: async () => {}, generate: async () => ({ samples: new Float32Array(0), sampleRate: 24000, generationTimeMs: 1 }), dispose() {} });
 
 const cfg: any = {

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -55,7 +55,7 @@ export class LocalNativeClient implements IClient {
     const tr = await this.translate.init(
       config.sourceLanguage, config.targetLanguage, config.translationModelId, config.translationDevice);
     const store = useNativeModelStore.getState();
-    store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu' });
+    store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu', tokensPerSec: tr.tokensPerSec });
     store.setAsrLoading(true);
     try {
       const res = await this.asr.init(config.sourceLanguage, config.asrModelId, 24000, {

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -52,8 +52,10 @@ export class LocalNativeClient implements IClient {
       sourceLanguage: config.sourceLanguage, targetLanguage: config.targetLanguage,
     });
     this.ttsSpeed = config.ttsSpeed ?? 1.0;
-    await this.translate.init(config.sourceLanguage, config.targetLanguage, config.translationModelId);
+    const tr = await this.translate.init(
+      config.sourceLanguage, config.targetLanguage, config.translationModelId, config.translationDevice);
     const store = useNativeModelStore.getState();
+    store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu' });
     store.setAsrLoading(true);
     try {
       const res = await this.asr.init(config.sourceLanguage, config.asrModelId, 24000, {

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -206,6 +206,7 @@ export interface LocalNativeSessionConfig extends BaseSessionConfig {
   turnDetectionMode?: 'Auto' | 'Push-to-Talk' | 'Push-to-Translate';
   wrapTranscript?: boolean;
   asrDevice?: string;
+  translationDevice?: string;
 }
 
 /**

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -45,7 +45,7 @@ describe('requiredNativeModels', () => {
   it('lists asr + translation(+qwen default) + tts when speech on', () => {
     // en target -> piper TTS; '' translation -> qwen
     expect(requiredNativeModels('sense-voice', '', '', 'es', 'en')).toEqual([
-      'sense-voice', 'qwen', 'csukuangfj/vits-piper-en_US-amy-low',
+      'sense-voice', 'qwen2.5-0.5b', 'csukuangfj/vits-piper-en_US-amy-low',
     ]);
     // opus-mt translation, ja target -> no TTS
     expect(requiredNativeModels('whisper-tiny', 'opus-mt', '', 'zh', 'ja')).toEqual([

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -106,3 +106,12 @@ describe('nativeModelStore asr session channel', () => {
     expect(st.asrResolved).toEqual({ model: 'granite-speech-4.1-2b', device: 'cuda', rtf: 0.015 });
   });
 });
+
+describe('nativeModelStore translation session channel', () => {
+  it('tracks the resolved translation plan with measured tokens/sec', () => {
+    const s = useNativeModelStore.getState();
+    s.setTranslationResolved({ model: 'qwen3.5-2b', device: 'cuda', tokensPerSec: 59.4 });
+    expect(useNativeModelStore.getState().translationResolved)
+      .toEqual({ model: 'qwen3.5-2b', device: 'cuda', tokensPerSec: 59.4 });
+  });
+});

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -13,11 +13,16 @@ class FakeWS {
   private emit(o: any) { this.onmessage?.({ data: JSON.stringify(o) }); }
   send(d: any) {
     const msg = JSON.parse(d);
-    if (msg.type === 'models_catalog') queueMicrotask(() =>
-      this.emit({ type: 'models_catalog_result', id: msg.id, models: [
-        { id: 'sense-voice', name: 'SenseVoice', languages: ['zh'], recommended: true,
-          tiers: [{ tier: 'cpu', backend: 'sherpa', available: true }] },
-      ] }));
+    if (msg.type === 'models_catalog') {
+      // The sidecar returns ASR or translation models depending on `kind` (default asr).
+      const models = msg.kind === 'translate'
+        ? [{ id: 'qwen2.5-0.5b', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true,
+             tiers: [{ tier: 'gpu-cuda', backend: 'qwen_translate', available: true },
+                     { tier: 'cpu', backend: 'qwen_translate', available: true }] }]
+        : [{ id: 'sense-voice', name: 'SenseVoice', languages: ['zh'], recommended: true,
+             tiers: [{ tier: 'cpu', backend: 'sherpa', available: true }] }];
+      queueMicrotask(() => this.emit({ type: 'models_catalog_result', id: msg.id, models }));
+    }
     if (msg.type === 'model_delete') queueMicrotask(() =>
       this.emit({ type: 'model_delete_result', id: msg.id, freed: 0 }));
   }
@@ -60,6 +65,16 @@ describe('nativeModelStore.refreshCatalog', () => {
     const cat = useNativeModelStore.getState().catalog;
     expect(cat['sense-voice']).toMatchObject({ recommended: true });
     expect(cat['sense-voice'].tiers[0]).toMatchObject({ tier: 'cpu', available: true });
+  });
+
+  it('also fetches the translation catalog so translation cards get tier badges', async () => {
+    await useNativeModelStore.getState().refreshCatalog();
+    const cat = useNativeModelStore.getState().catalog;
+    // ASR and translation models coexist (ids never collide) in one catalog map.
+    expect(cat['sense-voice']).toBeTruthy();
+    expect(cat['qwen2.5-0.5b']).toBeTruthy();
+    expect(cat['qwen2.5-0.5b'].tiers).toContainEqual(
+      expect.objectContaining({ tier: 'gpu-cuda', available: true }));
   });
 });
 

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -42,8 +42,11 @@ interface NativeModelStore {
   asrLoading: boolean;
   /** The resolved ASR plan from the last session `ready` (device + measured rtf). */
   asrResolved: { model: string; device: string; rtf?: number } | null;
+  /** The resolved translation plan from the last session `ready` (model + device). */
+  translationResolved: { model: string; device: string } | null;
   setAsrLoading: (v: boolean) => void;
   setAsrResolved: (r: { model: string; device: string; rtf?: number } | null) => void;
+  setTranslationResolved: (r: { model: string; device: string } | null) => void;
 }
 
 // Singleton management connection (separate from session-stage clients).
@@ -68,6 +71,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
   modelPreferences: {},
   asrLoading: false,
   asrResolved: null,
+  translationResolved: null,
 
   refreshCatalog: async (models) => {
     try {
@@ -170,6 +174,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
 
   setAsrLoading: (v) => set({ asrLoading: v }),
   setAsrResolved: (r) => set({ asrResolved: r }),
+  setTranslationResolved: (r) => set({ translationResolved: r }),
 }));
 
 export const useNativeModelStatuses = () => useNativeModelStore((s) => s.statuses);
@@ -179,3 +184,4 @@ export const useNativeModelErrors = () => useNativeModelStore((s) => s.errors);
 export const useNativeCatalog = () => useNativeModelStore((s) => s.catalog);
 export const useNativeAsrLoading = () => useNativeModelStore((s) => s.asrLoading);
 export const useNativeAsrResolved = () => useNativeModelStore((s) => s.asrResolved);
+export const useNativeTranslationResolved = () => useNativeModelStore((s) => s.translationResolved);

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -43,10 +43,10 @@ interface NativeModelStore {
   /** The resolved ASR plan from the last session `ready` (device + measured rtf). */
   asrResolved: { model: string; device: string; rtf?: number } | null;
   /** The resolved translation plan from the last session `ready` (model + device). */
-  translationResolved: { model: string; device: string } | null;
+  translationResolved: { model: string; device: string; tokensPerSec?: number } | null;
   setAsrLoading: (v: boolean) => void;
   setAsrResolved: (r: { model: string; device: string; rtf?: number } | null) => void;
-  setTranslationResolved: (r: { model: string; device: string } | null) => void;
+  setTranslationResolved: (r: { model: string; device: string; tokensPerSec?: number } | null) => void;
 }
 
 // Singleton management connection (separate from session-stage clients).

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -75,7 +75,14 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
 
   refreshCatalog: async (models) => {
     try {
-      const list = await client.modelsCatalog(models);
+      // ASR and translation are separate catalogs sidecar-side; fetch both so
+      // translation cards get tier badges too. Ids never collide, so they merge
+      // into one map. Both share the same per-machine tier-availability data.
+      const [asr, translate] = await Promise.all([
+        client.modelsCatalog(models, 'asr'),
+        client.modelsCatalog(models, 'translate'),
+      ]);
+      const list = [...asr, ...translate];
       set((s) => ({ catalog: { ...s.catalog, ...Object.fromEntries(list.map((m) => [m.id, m])) } }));
     } catch {
       // best-effort — tier badges are cosmetic; sidecar may be down

--- a/src/stores/settingsStore.translationDevice.test.ts
+++ b/src/stores/settingsStore.translationDevice.test.ts
@@ -24,8 +24,8 @@ describe('translationDevice setting', () => {
   it('defaults to auto', () => {
     expect(useSettingsStore.getState().localNative.translationDevice).toBe('auto');
   });
-  it('is updatable', () => {
-    useSettingsStore.getState().updateLocalNative({ translationDevice: 'cuda' });
+  it('is updatable', async () => {
+    await useSettingsStore.getState().updateLocalNative({ translationDevice: 'cuda' });
     expect(useSettingsStore.getState().localNative.translationDevice).toBe('cuda');
   });
 });

--- a/src/stores/settingsStore.translationDevice.test.ts
+++ b/src/stores/settingsStore.translationDevice.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock ServiceFactory (required — settingsStore calls it during updateLocalNative)
+const mockSetSetting = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: vi.fn(() => ({
+      setSetting: mockSetSetting,
+      getSetting: vi.fn(),
+    })),
+  },
+}));
+
+// Mock modelManifest (required — settingsStore imports it at module level)
+vi.mock('../lib/local-inference/modelManifest', async () => {
+  const actual = await vi.importActual('../lib/local-inference/modelManifest');
+  return { ...actual };
+});
+
+// Import after mocking
+const { default: useSettingsStore } = await import('./settingsStore');
+
+describe('translationDevice setting', () => {
+  it('defaults to auto', () => {
+    expect(useSettingsStore.getState().localNative.translationDevice).toBe('auto');
+  });
+  it('is updatable', () => {
+    useSettingsStore.getState().updateLocalNative({ translationDevice: 'cuda' });
+    expect(useSettingsStore.getState().localNative.translationDevice).toBe('cuda');
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -380,7 +380,7 @@ const defaultLocalInferenceSettings: LocalInferenceSettings = {
 
 const defaultLocalNativeSettings: LocalNativeSettings = {
   asrModel: 'sense-voice',
-  translationModel: '',  // auto: opus-mt for the language pair
+  translationModel: 'qwen2.5-0.5b',  // explicit default LLM; opus-mt selectable per language pair
   ttsModel: '',          // '' = Auto (default voice for the target); text-only via the textOnly toggle
   sourceLanguage: 'ja',
   targetLanguage: 'en',

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -196,6 +196,7 @@ export interface LocalNativeSettings {
   useTemplateMode: boolean;            // true = Simple (default), false = Advanced
   systemPrompt: string;                // Advanced-mode prompt (Qwen path only; '' = default)
   asrDevice: 'auto' | 'cpu' | 'cuda'; // override the sidecar's device selection
+  translationDevice: 'auto' | 'cpu' | 'cuda'; // override the sidecar's translation device selection
 }
 
 // Cache Entry
@@ -391,6 +392,7 @@ const defaultLocalNativeSettings: LocalNativeSettings = {
   useTemplateMode: true,
   systemPrompt: '',
   asrDevice: 'auto',
+  translationDevice: 'auto',
 };
 
 // ==================== Store Definition ====================
@@ -736,6 +738,7 @@ function createLocalNativeSessionConfig(
     turnDetectionMode: settings.turnDetectionMode,
     wrapTranscript,
     asrDevice: settings.asrDevice,
+    translationDevice: settings.translationDevice,
   };
 }
 


### PR DESCRIPTION
## Summary

Gives the LOCAL_NATIVE sidecar **text translation** ASR-parity hardware acceleration and model choice:

- **Device selection (AUTO / CPU / GPU)** for translation, mirroring the ASR compute-device control. Runs Qwen on CUDA (bfloat16) or CPU (float32) via the existing `accel.py` resolver + fallback.
- **Qwen version ladder** as selectable cards — Qwen 2.5 0.5B (default), Qwen 3 0.6B, Qwen 3.5 0.8B, Qwen 3.5 2B — alongside the existing Opus-MT option. Text-only; no multimodal.
- **GPU/CUDA tier badges** on translation model cards (previously ASR-only).
- **Tokens/sec** shown on the active translation card after a session resolves it (the translation analogue of ASR's "Nx realtime" RTF).

## Sidecar

- `catalog.py`: `TranslateModel` / `TRANSLATE_MODELS` with per-model `gpu-cuda` + `cpu` deployments; `resolve_translate()` ranks tiers and self-gates on installed backends.
- `translate_backends.py`: two transformers backends — `qwen_translate` (Qwen 2.5/3, `AutoModelForCausalLM`, `/no_think` for Qwen3) and `qwen35_translate` (Qwen 3.5, `Qwen3_5ForConditionalGeneration`). Both return `(text, generated-token-count)`.
- `translate_engine.py`: device-aware `init()` with VRAM-safe re-init; echoes the resolved `{backend, device, computeType}`.
- `accel.measure_tps`: after a warmup pass (cold start pays CUDA graph/kernel compile), benchmarks decode throughput and caches it (same key shape as `measure_rtf`, `tps:`-namespaced).
- `native_models.py`: download specs + `models_catalog` `kind:"translate"`.

## Renderer

- `translationDevice` setting (mirrors `asrDevice`); session config + translate client send it and record the resolved plan.
- `refreshCatalog` now fetches the ASR **and** translation catalogs, so translation cards get tier badges.
- `NativeModelCard` takes the resolved plan as a prop (was ASR-only); the tier tag renders rtf for ASR or `tok/s` for translation.

## Notable fix

Qwen 3.5 is a VLM whose `AutoProcessor` eagerly builds `Qwen3VLVideoProcessor`, which hard-requires torchvision (no wheel for the sidecar's torch build) — this crashed both CPU and GPU init. For text-only translation we drive a plain `AutoTokenizer` instead (the model class itself is not torchvision-gated; the chat template ships as `chat_template.jinja`).

## Testing

- Sidecar: **168 passed, 20 skipped** (`pytest`).
- Renderer: **646 passed** (`vitest run`).
- Real-GPU E2E on an RTX 4070 (Sokuji HF cache): es→en correct on cuda + cpu; tokens/sec — Qwen 2.5 0.5B ~130, Qwen 3.5 0.8B ~72, Qwen 3.5 2B ~59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native translation model options with device selection and richer status details.
  * Added support for showing translation speed and resolved device information in the UI.
* **Bug Fixes**
  * Updated default translation model handling to use a specific Qwen option instead of a generic fallback.
  * Improved catalog lookups so translation and ASR models are fetched separately and displayed correctly.
* **Tests**
  * Expanded coverage for translation backends, model catalogs, device settings, and session readiness responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->