### PR TITLE
feat(sidecar): offline GPU+CPU Fun-ASR-MLT-Nano ASR backend (31 languages)

### DIFF
--- a/docs/superpowers/plans/2026-06-26-fun-asr-mlt-nano-offline.md
+++ b/docs/superpowers/plans/2026-06-26-fun-asr-mlt-nano-offline.md
@@ -1,0 +1,572 @@
+# Fun-ASR-MLT-Nano (offline) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add the 31-language `FunAudioLLM/Fun-ASR-MLT-Nano-2512` speech-LLM as an offline GPU+CPU ASR backend, by generalizing the existing FunASR SenseVoice backend into a shared config-driven `_FunAsrBackend`.
+
+**Architecture:** Backend-layer-only change. A new `funasr_nano` backend reuses the `funasr.AutoModel` seam (the same one SenseVoice uses) but feeds audio as a temp wav (Fun-ASR-Nano's chat-template input needs a file path, not a bare ndarray) and passes output through unchanged (clean punctuated text, no tags). Catalog/accel/download/renderer rows wire it into the resolver and UI. The WS transport, silero-VAD segmentation, and result envelope are untouched.
+
+**Tech Stack:** Python (funasr 1.3.14, torch cu128, soundfile), pytest; TypeScript renderer catalog + vitest.
+
+## Global Constraints
+
+- **No new pip dependency.** funasr (1.3.14) already ships the `fun_asr_nano` model code; `tiktoken` (the `multilingual.tiktoken` tokenizer) and `soundfile` are already present transitively (funasr / librosa). Do NOT add packages.
+- **`trust_remote_code=True`** is required to load Fun-ASR-Nano (the code is the pinned funasr package's `funasr/models/fun_asr_nano/model.py`, not arbitrary remote code). `remote_code` is NOT needed (verified).
+- **`compute_type` is `float32`** for both tiers — the model loads fp32, 869M params (verified). Do not label it float16/bfloat16.
+- **Both `gpu-cuda` and `cpu` tiers** ship — CPU RTF is 0.22–0.32 (real-time), verified on the dev box.
+- **SenseVoice behavior is preserved byte-for-byte** — the refactor must not change `FunAsrSenseVoiceBackend`'s output, generate kwargs, or device handling.
+- **Input contract: file path.** Fun-ASR-Nano's `data_template` raises on a bare ndarray; feed a temp wav and pass `input=[path]`.
+- **Text-only output**: take `res[0]["text"]` verbatim (already clean + punctuated); do NOT call `rich_transcription_postprocess` (it injects emoji).
+- English-only comments; conventional commits.
+
+## Phase-0 verification (COMPLETED — values below are measured, not assumed)
+
+Run on the dev RTX 4070 (funasr 1.3.14, torch 2.11.0+cu128), feeding the cached
+sherpa SenseVoice test clips (zh/en/ja/ko/yue) as temp wavs:
+
+| device | RTF | load | VRAM | correctness |
+|--------|-----|------|------|-------------|
+| cuda:0 | 0.047–0.100 | ~17 s | 3579 MB peak | all 5 langs correct |
+| cpu    | 0.223–0.317 | ~18 s | —    | all 5 langs correct |
+
+- Model: 869M params, **float32**. `AutoModel(model=REPO, hub="hf", device=dev, trust_remote_code=True, disable_update=True)` loads on both devices.
+- Input: `generate(input=[wav_path], language="auto", use_itn=True)` works; a bare ndarray raises `'NoneType' object is not iterable` in `data_template`.
+- Output keys: `key, text, text_tn, label, ctc_text, ctc_timestamps, timestamps`; `text` is clean punctuated transcript, **no `<|tags|>`**. `language="auto"` auto-detects all 5 correctly.
+- 31-language list (from the model card; no JSON `languages` key exists):
+  `zh, en, yue, ja, ko, vi, id, th, ms, fil, ar, hi, bg, hr, cs, da, nl, et, fi, el, hu, ga, lv, lt, mt, pl, pt, ro, sk, sl, sv`.
+
+## File Structure
+
+- `sidecar/sokuji_sidecar/backends.py` — generalize `FunAsrSenseVoiceBackend` → `_FunAsrBackend` base + `_FunAsrConfig`; add `FunAsrNanoBackend` + temp-wav feed.
+- `sidecar/sokuji_sidecar/catalog.py` — add `FUN_ASR_MLT_REPO` + the `fun-asr-mlt-nano` row.
+- `sidecar/sokuji_sidecar/accel.py` — `_installed()` maps `funasr_nano → funasr`.
+- `sidecar/sokuji_sidecar/native_models.py` — `download_specs("fun-asr-mlt-nano")`.
+- `sidecar/tests/test_backends.py` — extend `_install_fake_funasr`; add Nano tests.
+- `sidecar/tests/test_catalog.py`, `test_accel.py`, `test_native_models.py` — row assertions.
+- `src/lib/local-inference/native/nativeCatalog.ts` (+ `.test.ts`) — renderer row.
+
+---
+
+### Task 1: Generalize backend into shared `_FunAsrBackend` (behavior-preserving)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/backends.py:354-415` (the `_strip_sensevoice_tags` + `FunAsrSenseVoiceBackend` block)
+- Modify: `sidecar/tests/test_backends.py:610-633` (`_install_fake_funasr`)
+
+**Interfaces:**
+- Produces: `_FunAsrConfig(trust_remote_code: bool, feed: str, postprocess: Callable[[str], tuple[str, str|None]])`; `_passthrough(text)->(str, None)`; `_FunAsrBackend` base with `load/transcribe/unload/is_loaded` and `_generate_tempwav`; `FunAsrSenseVoiceBackend(NAME="funasr_sensevoice")` subclass (unchanged behavior).
+- Consumes: existing `AsrResult`, `BackendLoadError`, `register_backend`, `TARGET_RATE`, `_strip_sensevoice_tags`.
+
+- [ ] **Step 1: Update the fake funasr fixture to accept `trust_remote_code` + both generate shapes**
+
+In `sidecar/tests/test_backends.py`, replace the `FakeAutoModel` inside `_install_fake_funasr` (lines 614-623):
+
+```python
+    class FakeAutoModel:
+        def __init__(self, model, hub, device, disable_update, trust_remote_code=False):
+            if fail:
+                raise RuntimeError("funasr load failed")
+            cap["init"] = dict(model=model, hub=hub, device=device,
+                               disable_update=disable_update,
+                               trust_remote_code=trust_remote_code)
+
+        def generate(self, input, **kw):
+            cap["gen"] = dict(n=len(input), **kw)
+            return [] if empty else [{"text": text}]
+```
+
+- [ ] **Step 2: Run the existing SenseVoice backend tests — they must still pass (and now capture trust_remote_code)**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k funasr -q`
+Expected: PASS (the fixture change is backward-compatible; generate still records `fs`/`language`/`use_itn`/`batch_size_s` via `**kw`).
+
+- [ ] **Step 3: Refactor `backends.py` — shared base + SenseVoice subclass**
+
+Add `from typing import Callable` to the imports at the top of `backends.py` (after `from dataclasses import dataclass`). Then replace the block at lines 366-415 (the `@register_backend class FunAsrSenseVoiceBackend: ...` definition) with:
+
+```python
+@dataclass(frozen=True)
+class _FunAsrConfig:
+    trust_remote_code: bool
+    feed: str   # "ndarray" (SenseVoice) | "tempwav" (Fun-ASR-Nano chat-template needs a path)
+    postprocess: Callable[[str], "tuple[str, str | None]"]
+
+
+def _passthrough(text: str) -> "tuple[str, None]":
+    """Fun-ASR-Nano emits clean, natively-punctuated text with no tags."""
+    return text.strip(), None
+
+
+class _FunAsrBackend:
+    """Shared FunASR AutoModel offline backend. Subclasses set NAME + CONFIG.
+    Honors the device given; the cuda guard rejects cuda when torch has no CUDA
+    runtime (FunASR would silently run on CPU) so load_with_fallback steps to the
+    correctly-labelled cpu plan. One generate() per VAD segment."""
+    CONFIG: _FunAsrConfig
+
+    def __init__(self):
+        self._m = None
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._m = None
+        try:
+            from funasr import AutoModel
+            if device == "cuda":
+                import torch
+                if not torch.cuda.is_available():
+                    raise BackendLoadError("cuda requested but torch has no CUDA runtime")
+                dev = "cuda:0"
+            else:
+                dev = device
+            self._m = AutoModel(model=model_ref, hub="hf", device=dev,
+                                trust_remote_code=self.CONFIG.trust_remote_code,
+                                disable_update=True)
+        except BackendLoadError:
+            raise
+        except Exception as e:  # missing funasr, OOM, bad repo → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def transcribe(self, samples, language) -> AsrResult:
+        if self.CONFIG.feed == "tempwav":
+            res = self._generate_tempwav(samples, language)
+        else:
+            res = self._m.generate(input=samples, fs=TARGET_RATE, cache={},
+                                   language=(language or "auto"), use_itn=True,
+                                   batch_size_s=60)
+        if not res or not isinstance(res, list) or "text" not in res[0]:
+            return AsrResult("", None)  # funasr returned nothing (empty/silent segment)
+        text, lang = self.CONFIG.postprocess(res[0]["text"])
+        return AsrResult(text, lang)
+
+    def _generate_tempwav(self, samples, language):
+        # Fun-ASR-Nano's data_template builds its chat-style input from a FILE PATH;
+        # a bare ndarray raises in data_template. Write the VAD segment to a temp wav
+        # and pass the path (the official, verified contract). soundfile ships via librosa.
+        import os
+        import tempfile
+        import soundfile as sf
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        try:
+            sf.write(tmp.name, samples, TARGET_RATE)
+            return self._m.generate(input=[tmp.name],
+                                    language=(language or "auto"), use_itn=True)
+        finally:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
+
+    def unload(self) -> None:
+        self._m = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._m is not None
+
+
+@register_backend
+class FunAsrSenseVoiceBackend(_FunAsrBackend):
+    """FunASR SenseVoiceSmall (PyTorch). model_ref is the HF repo id
+    (FunAudioLLM/SenseVoiceSmall). Serves BOTH gpu-cuda (float32) and cpu
+    (float32) tiers — honors the device it is given (no GPU-only guard).
+    Non-autoregressive encoder+CTC: one generate() per VAD segment. Output
+    lang/emotion/event tags are stripped to a clean transcript."""
+    NAME = "funasr_sensevoice"
+    CONFIG = _FunAsrConfig(trust_remote_code=False, feed="ndarray",
+                           postprocess=_strip_sensevoice_tags)
+```
+
+(Leave `_SV_TAG` and `_strip_sensevoice_tags` at lines 354-363 exactly as they are.)
+
+- [ ] **Step 4: Run the full backend suite — SenseVoice behavior unchanged**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -q`
+Expected: PASS (all existing tests, including the SenseVoice funasr tests, the cuda-guard tests, and empty-result test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/backends.py sidecar/tests/test_backends.py
+git commit -m "refactor(sidecar): generalize FunASR backend into shared _FunAsrBackend"
+```
+
+---
+
+### Task 2: Add `FunAsrNanoBackend` (`funasr_nano`)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/backends.py` (append after `FunAsrSenseVoiceBackend`)
+- Modify: `sidecar/tests/test_backends.py` (append after the SenseVoice funasr tests)
+
+**Interfaces:**
+- Consumes: `_FunAsrBackend`, `_FunAsrConfig`, `_passthrough`, `register_backend`, `_install_fake_funasr`.
+- Produces: `FunAsrNanoBackend(NAME="funasr_nano")` — `trust_remote_code=True`, `feed="tempwav"`, `postprocess=_passthrough`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_backends.py`:
+
+```python
+def test_funasr_nano_config_and_load(monkeypatch):
+    cap = _install_fake_funasr(monkeypatch, text="你好世界")
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    assert b.is_loaded
+    assert cap["init"]["model"] == "FunAudioLLM/Fun-ASR-MLT-Nano-2512"
+    assert cap["init"]["device"] == "cuda:0"
+    assert cap["init"]["trust_remote_code"] is True      # Nano needs remote code
+
+
+def test_funasr_nano_transcribe_feeds_tempwav_path(monkeypatch):
+    # Fun-ASR-Nano takes a file path, not a bare ndarray: transcribe must call
+    # generate(input=[<path>], ...) WITHOUT the SenseVoice fs/cache/batch_size_s kwargs.
+    cap = _install_fake_funasr(monkeypatch, text="你好世界")
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    out = b.transcribe(np.zeros(16000, np.float32), "zh")
+    assert out.text == "你好世界" and out.language is None   # passthrough, no tags
+    assert cap["gen"]["n"] == 1                  # input is a 1-element list (a path)
+    assert cap["gen"]["language"] == "zh"
+    assert cap["gen"]["use_itn"] is True
+    assert "fs" not in cap["gen"] and "batch_size_s" not in cap["gen"]
+
+
+def test_funasr_nano_rejects_cuda_without_torch_cuda(monkeypatch):
+    cap = _install_fake_funasr(monkeypatch, cuda_available=False)
+    b = backends.make_backend("funasr_nano")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    assert "init" not in cap and not b.is_loaded
+
+
+def test_funasr_nano_honors_cpu(monkeypatch):
+    cap = _install_fake_funasr(monkeypatch, cuda_available=False, text="hi")
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cpu", "float32")
+    assert b.is_loaded and cap["init"]["device"] == "cpu"
+
+
+def test_funasr_nano_empty_result_returns_blank(monkeypatch):
+    _install_fake_funasr(monkeypatch, empty=True)
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    out = b.transcribe(np.zeros(16000, np.float32), None)
+    assert out.text == "" and out.language is None
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k funasr_nano -q`
+Expected: FAIL with `unknown backend: funasr_nano`.
+
+- [ ] **Step 3: Implement the backend**
+
+Append after `FunAsrSenseVoiceBackend` in `backends.py`:
+
+```python
+@register_backend
+class FunAsrNanoBackend(_FunAsrBackend):
+    """FunASR Fun-ASR-Nano family (SenseVoice audio encoder + Qwen3-0.6B LLM
+    decoder). model_ref is the HF repo id (FunAudioLLM/Fun-ASR-MLT-Nano-2512).
+    Serves gpu-cuda (float32) + cpu (float32); both real-time. trust_remote_code
+    loads the fun_asr_nano model code shipped in funasr. Output is clean,
+    natively-punctuated text (no tags). Input is fed as a temp wav because the
+    model's chat-template input is built from a file path, not a bare ndarray."""
+    NAME = "funasr_nano"
+    CONFIG = _FunAsrConfig(trust_remote_code=True, feed="tempwav",
+                           postprocess=_passthrough)
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_backends.py -k funasr -q`
+Expected: PASS (all SenseVoice + Nano tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/backends.py sidecar/tests/test_backends.py
+git commit -m "feat(sidecar): add funasr_nano backend (Fun-ASR-Nano, tempwav feed)"
+```
+
+---
+
+### Task 3: Catalog row + accel install gate
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/catalog.py` (add `FUN_ASR_MLT_REPO` near `SENSE_VOICE_REPO`; add the row to `ASR_MODELS`)
+- Modify: `sidecar/sokuji_sidecar/accel.py` (the `_installed()` mods dict)
+- Modify: `sidecar/tests/test_catalog.py`, `sidecar/tests/test_accel.py`
+
+**Interfaces:**
+- Consumes: `AsrModel`, `Deployment`, backend name `"funasr_nano"`.
+- Produces: catalog id `"fun-asr-mlt-nano"` with two `funasr_nano` deployments (gpu-cuda + cpu, both float32).
+
+- [ ] **Step 1: Write failing catalog test**
+
+Append to `sidecar/tests/test_catalog.py`:
+
+```python
+def test_fun_asr_mlt_nano_row():
+    m = catalog.asr_model("fun-asr-mlt-nano")
+    assert m is not None and m.name == "Fun-ASR MLT Nano"
+    assert m.recommended is True
+    assert len(m.languages) == 31
+    assert m.languages[:6] == ("zh", "en", "yue", "ja", "ko", "vi")
+    assert [(d.backend, d.tier, d.compute_type) for d in m.deployments] == [
+        ("funasr_nano", "gpu-cuda", "float32"),
+        ("funasr_nano", "cpu", "float32"),
+    ]
+    assert all(d.artifact == catalog.FUN_ASR_MLT_REPO for d in m.deployments)
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py::test_fun_asr_mlt_nano_row -q`
+Expected: FAIL (`asr_model("fun-asr-mlt-nano")` is None).
+
+- [ ] **Step 3: Add the constant + row**
+
+In `catalog.py`, after the `SENSE_VOICE_REPO = ...` line add:
+
+```python
+FUN_ASR_MLT_REPO = os.environ.get("SOKUJI_FUNASR_NANO_REPO", "FunAudioLLM/Fun-ASR-MLT-Nano-2512")
+```
+
+Then append this entry to the end of the `ASR_MODELS` list (after the `voxtral-mini-4b-realtime` row):
+
+```python
+    AsrModel("fun-asr-mlt-nano", "Fun-ASR MLT Nano",
+             ("zh", "en", "yue", "ja", "ko", "vi", "id", "th", "ms", "fil", "ar",
+              "hi", "bg", "hr", "cs", "da", "nl", "et", "fi", "el", "hu", "ga",
+              "lv", "lt", "mt", "pl", "pt", "ro", "sk", "sl", "sv"),
+             (Deployment("funasr_nano", "gpu-cuda", "float32", FUN_ASR_MLT_REPO, 1.0),
+              Deployment("funasr_nano", "cpu", "float32", FUN_ASR_MLT_REPO, 1.0)),
+             recommended=True, sort_order=11),
+```
+
+- [ ] **Step 4: Allow the new backend in the catalog backend-set assertion**
+
+In `sidecar/tests/test_catalog.py`, the `test_models_have_deployments_and_languages` test asserts `d.backend in {...}`. Add `"funasr_nano"` to that set.
+
+- [ ] **Step 5: Map the install gate**
+
+In `sidecar/sokuji_sidecar/accel.py`, find the `_installed()` mods dict (it maps `"funasr_sensevoice": "funasr"`) and add the line:
+
+```python
+        "funasr_nano": "funasr",
+```
+
+- [ ] **Step 6: Write failing accel resolve test**
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_fun_asr_mlt_nano_resolves_gpu_and_cpu(monkeypatch):
+    monkeypatch.setattr(accel, "_installed", lambda: frozenset({"funasr_nano"}))
+    # explicit cuda override -> gpu-cuda plan first
+    plan = accel.resolve("fun-asr-mlt-nano", "cuda", _machine_with_cuda())
+    assert plan[0].backend == "funasr_nano" and plan[0].tier == "gpu-cuda"
+    # explicit cpu override -> cpu plan
+    plan_cpu = accel.resolve("fun-asr-mlt-nano", "cpu", _machine_with_cuda())
+    assert plan_cpu[0].tier == "cpu"
+```
+
+> NOTE for the implementer: `test_accel.py` already has a helper to build a machine
+> with a CUDA GPU (used by the existing SenseVoice/Whisper resolve tests). Reuse that
+> exact helper name instead of `_machine_with_cuda()` if it differs — grep the file
+> for the existing resolve tests (e.g. the sense-voice one) and copy its machine setup.
+
+- [ ] **Step 7: Run the catalog + accel suites**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_catalog.py tests/test_accel.py -q`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/catalog.py sidecar/sokuji_sidecar/accel.py \
+        sidecar/tests/test_catalog.py sidecar/tests/test_accel.py
+git commit -m "feat(sidecar): catalog + install gate for fun-asr-mlt-nano"
+```
+
+---
+
+### Task 4: Download spec
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/native_models.py` (the `download_specs` model→repo mapping)
+- Modify: `sidecar/tests/test_native_models.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `download_specs("fun-asr-mlt-nano") == {"repos": ["FunAudioLLM/Fun-ASR-MLT-Nano-2512"], "urls": []}`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `sidecar/tests/test_native_models.py`:
+
+```python
+def test_download_specs_fun_asr_mlt_nano(monkeypatch):
+    monkeypatch.delenv('SOKUJI_FUNASR_NANO_REPO', raising=False)
+    spec = nm.download_specs('fun-asr-mlt-nano')
+    assert spec['repos'] == ['FunAudioLLM/Fun-ASR-MLT-Nano-2512']
+    assert spec['urls'] == []
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_native_models.py::test_download_specs_fun_asr_mlt_nano -q`
+Expected: FAIL (the model id isn't mapped → likely returns the bare id or raises).
+
+- [ ] **Step 3: Add the mapping**
+
+In `native_models.py`, locate `download_specs` and the `sense-voice` branch (it returns `{"repos": [SENSE_VOICE_REPO], "urls": [VAD_URL]}`). Add a sibling branch for the new id. Add a module-level constant near the other repo constants:
+
+```python
+FUN_ASR_MLT_REPO = os.environ.get("SOKUJI_FUNASR_NANO_REPO", "FunAudioLLM/Fun-ASR-MLT-Nano-2512")
+```
+
+and inside `download_specs`, before the generic/fallthrough return:
+
+```python
+    if model_id == "fun-asr-mlt-nano":
+        return {"repos": [FUN_ASR_MLT_REPO], "urls": []}
+```
+
+> NOTE: match the exact branching style already used for `sense-voice` in this
+> function (if/elif chain vs dict). No VAD url — the engine segments upstream.
+
+- [ ] **Step 4: Run the native_models suite**
+
+Run: `cd sidecar && .venv/bin/python -m pytest tests/test_native_models.py -q`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/native_models.py sidecar/tests/test_native_models.py
+git commit -m "feat(sidecar): download spec for fun-asr-mlt-nano"
+```
+
+---
+
+### Task 5: Renderer catalog row
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts` (append to `NATIVE_ASR`)
+- Modify: `src/lib/local-inference/native/nativeCatalog.test.ts`
+
+**Interfaces:**
+- Consumes: the `NativeModelOption` shape already in the file.
+- Produces: a `fun-asr-mlt-nano` option mirroring the sidecar row.
+
+- [ ] **Step 1: Write the failing test**
+
+Append a test inside the `describe('nativeCatalog', ...)` block in `nativeCatalog.test.ts`:
+
+```typescript
+  it('includes fun-asr-mlt-nano as a recommended 31-language ASR option', () => {
+    const m = NATIVE_ASR.find((x) => x.id === 'fun-asr-mlt-nano');
+    expect(m).toBeTruthy();
+    expect(m!.label).toBe('Fun-ASR MLT Nano');
+    expect(m!.recommended).toBe(true);
+    expect(m!.languages).toHaveLength(31);
+    expect(m!.languages.slice(0, 5)).toEqual(['zh', 'en', 'yue', 'ja', 'ko']);
+  });
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: FAIL (no `fun-asr-mlt-nano` row).
+
+- [ ] **Step 3: Add the renderer row**
+
+Append to the `NATIVE_ASR` array in `nativeCatalog.ts` (after the last entry):
+
+```typescript
+  { id: 'fun-asr-mlt-nano', label: 'Fun-ASR MLT Nano', languages: ['zh', 'en', 'yue', 'ja', 'ko', 'vi', 'id', 'th', 'ms', 'fil', 'ar', 'hi', 'bg', 'hr', 'cs', 'da', 'nl', 'et', 'fi', 'el', 'hu', 'ga', 'lv', 'lt', 'mt', 'pl', 'pt', 'ro', 'sk', 'sl', 'sv'], recommended: true, sortOrder: 11 },
+```
+
+> NOTE: if the last existing entry already uses `sortOrder: 11`, use the next
+> integer instead — grep the file for the current max `sortOrder`. Ordering is
+> advisory (the renderer owns card order); just keep it unique.
+
+- [ ] **Step 4: Run the renderer test**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(ui): add fun-asr-mlt-nano to native ASR catalog"
+```
+
+---
+
+### Task 6: Gated GPU smoke test (real model)
+
+**Files:**
+- Modify: `sidecar/tests/test_backends.py` (append a gated smoke test)
+
+**Interfaces:**
+- Consumes: the real `funasr_nano` backend + the cached sherpa SenseVoice test wav.
+
+- [ ] **Step 1: Add the gated smoke test**
+
+Append to `sidecar/tests/test_backends.py`:
+
+```python
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_ASR_MODEL"),
+                    reason="set SOKUJI_RUN_ASR_MODEL=1 (downloads/loads Fun-ASR-MLT-Nano, needs CUDA)")
+def test_funasr_nano_real_transcribe_smoke():
+    import soundfile as sf
+    wav = ("/home/jiangzhuo/.cache/huggingface/hub/"
+           "models--csukuangfj--sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/"
+           "snapshots/2365baeacb507f821a0c8120fcee3d484dba7a07/test_wavs/en.wav")
+    samples, sr = sf.read(wav, dtype="float32")
+    assert sr == 16000
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    out = b.transcribe(samples, "auto")
+    b.unload()
+    assert out.text and "tribal" in out.text.lower()   # verified transcript content
+```
+
+> NOTE: the `os` and `pytest` imports already exist at the top of `test_backends.py`.
+> The wav path is the cached clip used to verify SenseVoice; if absent, the test is
+> simply not run (it's gated off by default).
+
+- [ ] **Step 2: Run it (gated) to confirm the real path works**
+
+Run: `cd sidecar && SOKUJI_RUN_ASR_MODEL=1 .venv/bin/python -m pytest tests/test_backends.py::test_funasr_nano_real_transcribe_smoke -q -s`
+Expected: PASS (loads the model on GPU, transcribes "...tribal chieftain...").
+
+- [ ] **Step 3: Run the whole sidecar suite (ungated) + commit**
+
+Run: `cd sidecar && .venv/bin/python -m pytest -q`
+Expected: PASS (gated smoke test is skipped without the env var).
+
+```bash
+git add sidecar/tests/test_backends.py
+git commit -m "test(sidecar): gated GPU smoke test for funasr_nano"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** Backend generalization (Task 1) ✓; funasr_nano backend + tempwav feed + passthrough (Task 2) ✓; catalog row with gpu+cpu float32 tiers + 31 langs (Task 3) ✓; install gate (Task 3) ✓; download spec (Task 4) ✓; renderer row (Task 5) ✓; gated smoke (Task 6) ✓; SenseVoice preserved (Task 1, regression run) ✓; `trust_remote_code` honest, compute_type float32, no new deps (Global Constraints) ✓. Streaming/vLLM correctly absent (out of scope).
+
+**Placeholder scan:** No "TBD"/"add error handling" placeholders — all code is concrete. Two `> NOTE` callouts ask the implementer to match an existing helper/branch style (machine-builder in test_accel, sense-voice branch in download_specs, max sortOrder) rather than guess; these are grounding instructions, not missing content, because the surrounding style is in files the implementer reads.
+
+**Type consistency:** `_FunAsrConfig(trust_remote_code, feed, postprocess)` is constructed identically in both subclasses; `feed` values `"ndarray"`/`"tempwav"` match the `transcribe` branch; `_passthrough` and `_strip_sensevoice_tags` share the `(str)->(str, str|None)` shape; backend NAME `"funasr_nano"` is identical across catalog, accel, download spec, and tests; `FUN_ASR_MLT_REPO` constant name is identical in catalog and native_models.

--- a/docs/superpowers/plans/2026-06-26-fun-asr-mlt-nano-offline.md
+++ b/docs/superpowers/plans/2026-06-26-fun-asr-mlt-nano-offline.md
@@ -441,7 +441,14 @@ and inside `download_specs`, before the generic/fallthrough return:
 ```
 
 > NOTE: match the exact branching style already used for `sense-voice` in this
-> function (if/elif chain vs dict). No VAD url — the engine segments upstream.
+> function (if/elif chain vs dict).
+>
+> **CORRECTION (PR #270 review):** the `"urls": []` above is wrong. The engine's
+> silero VAD (`silero_vad.onnx`) is a *downloaded* artifact `AsrEngine._init_vad()`
+> loads for every ASR model, so an offline-only install of this model needs it.
+> The shipped code treats the VAD as a shared dependency: `download_specs` appends
+> `VAD_URL` for any ASR-catalog model and `delete_model` keeps the shared file.
+> See the design doc's "Post-implementation correction" note.
 
 - [ ] **Step 4: Run the native_models suite**
 

--- a/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
+++ b/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
@@ -2,7 +2,7 @@
 
 **Date**: 2026-06-26
 **Branch**: `feat/fun-asr-mlt-nano` (off `native-sidecar`)
-**Status**: Approved — implementation plan to follow
+**Status**: Approved; Phase-0 verified — plan at `docs/superpowers/plans/2026-06-26-fun-asr-mlt-nano-offline.md`
 
 ## Summary
 
@@ -120,20 +120,18 @@ class FunAsrNanoBackend(_FunAsrBackend):
 ```python
 AsrModel("fun-asr-mlt-nano", "Fun-ASR MLT Nano",
          (<31-language tuple, pulled verbatim from the model card/config>),
-         (Deployment("funasr_nano", "gpu-cuda", "<dtype from Phase-0>", FUN_ASR_MLT_REPO, 1.0),
-          # cpu tier added ONLY if Phase-0 RTF shows it viable (see Phase 0)
-         ),
-         recommended=True, sort_order=<advisory>)
+         (Deployment("funasr_nano", "gpu-cuda", "float32", FUN_ASR_MLT_REPO, 1.0),
+          Deployment("funasr_nano", "cpu", "float32", FUN_ASR_MLT_REPO, 1.0)),
+         recommended=True, sort_order=11)   # values confirmed by Phase-0 (below)
 ```
 
 - `FUN_ASR_MLT_REPO = os.environ.get("SOKUJI_FUNASR_NANO_REPO", "FunAudioLLM/Fun-ASR-MLT-Nano-2512")`
   — mirrors the `SENSE_VOICE_REPO` override pattern.
-- **`compute_type` labelled from Phase-0's measured dtype**, not guessed (the same
-  honesty fix applied to SenseVoice — no float16-that's-really-float32 label).
-- **Tiers**: `gpu-cuda` is definite. An autoregressive 0.6B decoder is likely not
-  CPU-real-time (peers Qwen3/Granite/Cohere/Voxtral are GPU-only), so the `cpu`
-  tier is **verification-gated**: included only if Phase-0 RTF is acceptable,
-  otherwise GPU-only.
+- **`compute_type` is `float32`** (both tiers) — Phase-0 measured the loaded model
+  at fp32, 869M params (no float16-that's-really-float32 label, the SenseVoice fix).
+- **Tiers**: both `gpu-cuda` AND `cpu` ship. Phase-0 measured CPU RTF 0.22–0.32
+  (real-time) — contrary to the autoregressive-is-GPU-only assumption, the small
+  Qwen3-0.6B decoder on short VAD segments is CPU-viable, so the cpu tier stays in.
 - `recommended=True` (strong Apache-2.0 multilingual, competes with Qwen3-ASR-1.7B
   at half the size). `sort_order` is advisory (the renderer owns card ordering).
 
@@ -162,9 +160,23 @@ Mirror the sidecar row:
 with a matching `nativeCatalog.test.ts` assertion — same lockstep discipline as the
 catalog/renderer pairs already in the tree.
 
-## Phase 0 — verification spike (de-risk gate, matches the SenseVoice pattern)
+## Phase 0 — verification spike (COMPLETED ✅)
 
-Before production code, prove it on the dev GPU (reusing the provisioned venv):
+Run on the dev RTX 4070 (funasr 1.3.14, torch 2.11.0+cu128), feeding the cached
+sherpa SenseVoice test clips (zh/en/ja/ko/yue) as temp wavs:
+
+| device | RTF | load | VRAM | correctness |
+|--------|-----|------|------|-------------|
+| cuda:0 | 0.047–0.100 | ~17 s | 3579 MB peak | all 5 langs correct |
+| cpu    | 0.223–0.317 | ~18 s | —    | all 5 langs correct |
+
+Results: loads via `trust_remote_code=True` (no `remote_code` needed — funasr 1.3.14
+ships `fun_asr_nano/model.py`); **float32, 869M params**; output is clean punctuated
+text with **no `<|tags|>`**; `language="auto"` auto-detects all 5; **input must be a
+file path** (bare ndarray raises in `data_template`) → feed a temp wav; `tiktoken`
+(the `multilingual.tiktoken` tokenizer) is already present via funasr — no new dep.
+
+What was checked (all green):
 
 1. `AutoModel(model="FunAudioLLM/Fun-ASR-MLT-Nano-2512", hub="hf", trust_remote_code=True, device="cuda:0")`
    loads — confirms `model.py` fetch + no missing deps.

--- a/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
+++ b/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
@@ -1,0 +1,212 @@
+# GPU-native Fun-ASR-MLT-Nano (offline) via FunASR — Design
+
+**Date**: 2026-06-26
+**Branch**: `feat/fun-asr-mlt-nano` (off `native-sidecar`)
+**Status**: Approved — implementation plan to follow
+
+## Summary
+
+Add **`Fun-ASR-MLT-Nano-2512`** — a 31-language, ~800M, Apache-2.0 speech-LLM
+(SenseVoice audio encoder + Qwen3-0.6B LLM decoder) — to the native sidecar as an
+**offline** ASR backend, through the same `funasr.AutoModel` seam we just shipped
+for SenseVoice. GPU-native, honoring an explicit device selection. No streaming,
+no vLLM, no engine/transport changes.
+
+## Background & motivation
+
+The sidecar already depends on the `funasr` runtime: `FunAsrSenseVoiceBackend`
+loads `SenseVoiceSmall` via `AutoModel(model=..., hub="hf", device=...)`. The
+Fun-ASR-Nano family is the same FunASR ecosystem, loaded the same way, so adding
+it is an extension of an existing seam rather than a new architecture.
+
+Of the three published variants, **`Fun-ASR-MLT-Nano-2512`** is the right fit for
+a real-time *translation* app: 31 languages, Apache-2.0, ~800M (half the size of
+Qwen3-ASR-1.7B), claiming parity with / better than Whisper-large-v3 on open data.
+
+### The three Fun-ASR-Nano variants (why MLT)
+
+All three share one architecture (SenseVoice encoder + Qwen3-0.6B decoder, ~800M,
+autoregressive, Apache-2.0, native punctuation + ITN). They differ on two axes
+only — runtime packaging and language coverage:
+
+| Model | Loader | Coverage | Role |
+|-------|--------|----------|------|
+| Fun-ASR-Nano-2512 | `funasr AutoModel` (`trust_remote_code`) | Chinese + 7 dialects (Cantonese, Wu, Min, Hakka, Gan, Xiang, Jin) + 26 accents, en, ja | Chinese/dialect depth (CJK) |
+| Fun-ASR-Nano-2512-hf | `transformers` (`AutoModelForSeq2SeqLM`/`pipeline`) | same as base Nano | Same weights, repackaged for transformers |
+| **Fun-ASR-MLT-Nano-2512** | `funasr AutoModel` (`trust_remote_code`, `remote_code="./model.py"`) | **31 languages** (CJK + SE-Asian + Arabic/Hindi + ~20 European) | **Multilingual breadth — chosen** |
+
+`Nano vs MLT` is a coverage trade (dialect depth vs 31-language breadth);
+`Nano vs Nano-hf` is a packaging trade (funasr vs transformers loader of the same
+weights). MLT is funasr-only (no `-hf` twin).
+
+## Runtime decision: offline, not streaming
+
+Streaming exists in the FunASR repo (`funasr/models/fun_asr_nano/inference_vllm_streaming.py`,
+`FunASRNanoStreamingVLLM`) but is **vLLM-only** and **not demonstrated in any
+official Space** (both official Spaces — `Fun-ASR-Nano`, `Fun-ASR-Nano-GPU-Debug`
+— run offline `AutoModel.generate()`). vLLM is a heavy GPU-only dependency that
+would likely conflict with the sidecar's pinned `transformers` PR-fork (used by
+Qwen3-ASR). Therefore: **offline only.** Streaming is explicitly out of scope and
+deferred to a future spike if it ever proves worthwhile.
+
+## What the offline path looks like (grounded in the FunASR code + official Spaces)
+
+| Aspect | Finding | Impact |
+|--------|---------|--------|
+| Output | `res[0]["text"]` is plain text with **native punctuation, no `<\|tags\|>`** | Simpler than SenseVoice — no tag regex; skip `rich_transcription_postprocess` (it injects emoji) to stay text-only |
+| `language` | accepts `"auto"`, ISO (`"zh"`/`"en"`), or names (`"Chinese"`); optional | Pass the renderer's ISO source language through, or `"auto"` |
+| Input | `generate(input=samples, use_itn=True)` accepts a float32 ndarray | Same shape the engine already feeds |
+| VAD / length | without VAD, input capped ~30 s | The engine already segments with silero VAD and feeds short segments — no funasr VAD needed (same as SenseVoice) |
+| `trust_remote_code` | `AutoModel` fetches + executes `model.py` from the HF snapshot | The one real wrinkle vs SenseVoice — the download must pull custom code, and we accept running official Apache-2.0 repo code |
+
+## Design
+
+### Integration seam
+
+Backend-layer-only. `server.py`, `__main__.py`, `asr_engine.py` are **untouched**:
+Fun-ASR-Nano is an offline backend, and the WS transport, silero-VAD segmentation,
+24→16 kHz downsample, and `{type:"result"}` envelope are model-agnostic — exactly
+as with SenseVoice. Touched: `backends.py`, `catalog.py`, `accel.py`,
+`native_models.py`, and the renderer `nativeCatalog.ts` (+ tests).
+
+### 1. Backend — generalize into a shared `FunAsrBackend` (`backends.py`)
+
+A shared base holds **all** logic; SenseVoice and Fun-ASR-Nano are thin
+config-only subclasses. This keeps the `funasr_sensevoice` NAME stable (zero churn
+to the just-merged SenseVoice catalog/tests) while sharing one implementation.
+
+```python
+@dataclass(frozen=True)
+class _FunAsrConfig:
+    trust_remote_code: bool
+    postprocess: Callable[[str], tuple[str, str | None]]   # text -> (clean_text, language|None)
+
+def _passthrough(text: str) -> tuple[str, None]:
+    return text.strip(), None        # Fun-ASR-Nano: already clean, punctuated, no tags
+
+class _FunAsrBackend:
+    """Shared funasr AutoModel offline backend. Subclasses set NAME + CONFIG.
+    Honors the device given; the cuda guard rejects cuda when torch lacks CUDA so
+    load_with_fallback steps to the correctly-labelled cpu plan."""
+    CONFIG: _FunAsrConfig
+    # load(model_ref, device, compute_type):
+    #   cuda guard (shared) -> AutoModel(model=model_ref, hub="hf", device=dev,
+    #       trust_remote_code=self.CONFIG.trust_remote_code, disable_update=True)
+    # transcribe(samples, language):
+    #   res = generate(input=samples, fs=16000, cache={}, language=language or "auto",
+    #                  use_itn=True, batch_size_s=60)
+    #   text, lang = self.CONFIG.postprocess(res[0]["text"]); return AsrResult(text, lang)
+    # unload() / is_loaded: shared
+
+@register_backend
+class FunAsrSenseVoiceBackend(_FunAsrBackend):
+    NAME = "funasr_sensevoice"
+    CONFIG = _FunAsrConfig(trust_remote_code=False, postprocess=_strip_sensevoice_tags)
+
+@register_backend
+class FunAsrNanoBackend(_FunAsrBackend):
+    NAME = "funasr_nano"
+    CONFIG = _FunAsrConfig(trust_remote_code=True, postprocess=_passthrough)
+```
+
+- **Device honored** — no GPU-only guard; the same cuda-fallback guard as SenseVoice.
+- **Output is plain punctuated text** — `_passthrough` (no tag regex).
+- **language** — pass the renderer's ISO code through, or `"auto"`.
+- The generate kwargs are the SenseVoice-proven set; if Phase-0 shows Fun-ASR-Nano
+  rejects any (e.g. `batch_size_s`), the kwargs move into `_FunAsrConfig`.
+
+### 2. Catalog row (`catalog.py`)
+
+```python
+AsrModel("fun-asr-mlt-nano", "Fun-ASR MLT Nano",
+         (<31-language tuple, pulled verbatim from the model card/config>),
+         (Deployment("funasr_nano", "gpu-cuda", "<dtype from Phase-0>", FUN_ASR_MLT_REPO, 1.0),
+          # cpu tier added ONLY if Phase-0 RTF shows it viable (see Phase 0)
+         ),
+         recommended=True, sort_order=<advisory>)
+```
+
+- `FUN_ASR_MLT_REPO = os.environ.get("SOKUJI_FUNASR_NANO_REPO", "FunAudioLLM/Fun-ASR-MLT-Nano-2512")`
+  — mirrors the `SENSE_VOICE_REPO` override pattern.
+- **`compute_type` labelled from Phase-0's measured dtype**, not guessed (the same
+  honesty fix applied to SenseVoice — no float16-that's-really-float32 label).
+- **Tiers**: `gpu-cuda` is definite. An autoregressive 0.6B decoder is likely not
+  CPU-real-time (peers Qwen3/Granite/Cohere/Voxtral are GPU-only), so the `cpu`
+  tier is **verification-gated**: included only if Phase-0 RTF is acceptable,
+  otherwise GPU-only.
+- `recommended=True` (strong Apache-2.0 multilingual, competes with Qwen3-ASR-1.7B
+  at half the size). `sort_order` is advisory (the renderer owns card ordering).
+
+### 3. Install gate & dependencies (`accel.py`, `setup.sh`)
+
+- `accel._installed()` maps `"funasr_nano" → "funasr"` (already installed) so the
+  row only advertises when funasr imports.
+- **No new pip dep expected**, but `trust_remote_code` runs `model.py`, which may
+  import packages the venv lacks. Phase-0 reveals this; if so, append to `setup.sh`.
+
+### 4. Download spec (`native_models.py`)
+
+```python
+download_specs("fun-asr-mlt-nano") -> {"repos": [FUN_ASR_MLT_REPO], "urls": []}
+```
+
+`snapshot_download` already fetches **all** repo files including `model.py` +
+custom code (which `trust_remote_code` then loads from the local snapshot) — no
+special handling, no ignore-list. Existing `model_status` / `model_size` /
+`model_download` / `model_delete` handle it like every other model.
+
+### 5. Renderer catalog (`nativeCatalog.ts` + test)
+
+Mirror the sidecar row:
+`{ id: 'fun-asr-mlt-nano', label: 'Fun-ASR MLT Nano', languages: [<31>], recommended: true, sortOrder: <n> }`
+with a matching `nativeCatalog.test.ts` assertion — same lockstep discipline as the
+catalog/renderer pairs already in the tree.
+
+## Phase 0 — verification spike (de-risk gate, matches the SenseVoice pattern)
+
+Before production code, prove it on the dev GPU (reusing the provisioned venv):
+
+1. `AutoModel(model="FunAudioLLM/Fun-ASR-MLT-Nano-2512", hub="hf", trust_remote_code=True, device="cuda:0")`
+   loads — confirms `model.py` fetch + no missing deps.
+2. Feed float32 ndarrays (zh/en/ja/ko + 2-3 European clips) per-segment → confirm
+   **plain punctuated text, no tags**, correct transcripts.
+3. Confirm `language` accepts ISO codes / `"auto"`.
+4. **Measure GPU + CPU RTF** → decide the cpu tier; record VRAM.
+5. Read the loaded dtype → set the honest `compute_type` label.
+
+Findings feed back into the catalog row (tiers, dtype) and `setup.sh` (deps) before
+any production code lands.
+
+## Testing plan
+
+- **Unit (no model)**: `_passthrough` returns `(clean, None)`; **SenseVoice
+  `_strip_sensevoice_tags` regression** (unchanged); config selection
+  (`funasr_nano` → `trust_remote_code=True`, `funasr_sensevoice` → `False`); shared
+  `load()` passes `trust_remote_code` from config (mock funasr); cuda-guard rejects
+  cuda without torch-CUDA (reuse the fake-funasr fixture); `transcribe` passes
+  `language` through; empty result → blank.
+- **Catalog / accel / native_models**: row present + tiers + languages + backend
+  `funasr_nano`; `_installed` mapping; resolver returns the gpu-cuda plan for
+  `override="cuda"`/`"auto"`; `models_catalog` handler shape; `download_specs` mapping.
+- **Renderer**: `nativeCatalog.test.ts` row.
+- **Backend smoke** (gated on funasr + cuda + `SOKUJI_RUN_ASR_MODEL`): load +
+  transcribe a canned clip.
+
+## Risks & tradeoffs
+
+| Risk | Mitigation |
+|------|-----------|
+| `trust_remote_code` executes repo `model.py` | Official Apache-2.0 FunAudioLLM org; accepted, called out |
+| `model.py` pulls unlisted deps | Phase-0 catches → add to `setup.sh` |
+| CPU not real-time (AR decoder) | cpu tier verification-gated; default GPU-only like peers |
+| Exact 31-language list | Pulled verbatim from card / `config.json`, not guessed |
+| `compute_type` honesty | Labelled from measured dtype |
+| Download size (~0.9–1.6 GB) | Existing model-download UX |
+
+## Out of scope
+
+- Streaming / vLLM (`inference_vllm_streaming.py`, `FunASRNanoStreamingVLLM`).
+- The base `Fun-ASR-Nano-2512` and the `-hf` transformers variant.
+- Emotion / speaker-diarization / timestamps; a separate punctuation model
+  (Fun-ASR-Nano punctuates natively).
+- Translation pairing / renderer UX beyond the catalog row.

--- a/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
+++ b/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
@@ -208,7 +208,7 @@ any production code lands.
 
 | Risk | Mitigation |
 |------|-----------|
-| `trust_remote_code` executes repo `model.py` | Official Apache-2.0 FunAudioLLM org; accepted, called out |
+| `trust_remote_code` executes repo `model.py` | Official Apache-2.0 FunAudioLLM org; accepted, called out. This is the only arbitrary-code path in the backend set; the download/load pull unpinned `main`. Future hardening: pin a known-good `revision=` (e.g. via a `SOKUJI_FUNASR_NANO_REV` knob) so an unreviewed upstream push can't silently execute new code. |
 | `model.py` pulls unlisted deps | Phase-0 catches → add to `setup.sh` |
 | CPU not real-time (AR decoder) | cpu tier verification-gated; default GPU-only like peers |
 | Exact 31-language list | Pulled verbatim from card / `config.json`, not guessed |

--- a/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
+++ b/docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md
@@ -56,7 +56,7 @@ deferred to a future spike if it ever proves worthwhile.
 | Output | `res[0]["text"]` is plain text with **native punctuation, no `<\|tags\|>`** | Simpler than SenseVoice — no tag regex; skip `rich_transcription_postprocess` (it injects emoji) to stay text-only |
 | `language` | accepts `"auto"`, ISO (`"zh"`/`"en"`), or names (`"Chinese"`); optional | Pass the renderer's ISO source language through, or `"auto"` |
 | Input | `generate(input=samples, use_itn=True)` accepts a float32 ndarray | Same shape the engine already feeds |
-| VAD / length | without VAD, input capped ~30 s | The engine already segments with silero VAD and feeds short segments — no funasr VAD needed (same as SenseVoice) |
+| VAD / length | without VAD, input capped ~30 s | The engine already segments with silero VAD and feeds short segments — no funasr *internal* VAD needed (same as SenseVoice). **But** that silero VAD (`silero_vad.onnx`) is a downloaded artifact `AsrEngine._init_vad()` loads for every ASR model, so the model's `download_specs` MUST include `VAD_URL` for an offline-only install — see the correction note below. |
 | `trust_remote_code` | `AutoModel` fetches + executes `model.py` from the HF snapshot | The one real wrinkle vs SenseVoice — the download must pull custom code, and we accept running official Apache-2.0 repo code |
 
 ## Design
@@ -145,13 +145,27 @@ AsrModel("fun-asr-mlt-nano", "Fun-ASR MLT Nano",
 ### 4. Download spec (`native_models.py`)
 
 ```python
-download_specs("fun-asr-mlt-nano") -> {"repos": [FUN_ASR_MLT_REPO], "urls": []}
+download_specs("fun-asr-mlt-nano") -> {"repos": [FUN_ASR_MLT_REPO], "urls": [VAD_URL]}
 ```
 
 `snapshot_download` already fetches **all** repo files including `model.py` +
 custom code (which `trust_remote_code` then loads from the local snapshot) — no
 special handling, no ignore-list. Existing `model_status` / `model_size` /
 `model_download` / `model_delete` handle it like every other model.
+
+> **Post-implementation correction (PR #270 review).** The original design said
+> `"urls": []` here, reasoning that "the engine segments upstream, so no VAD
+> download is needed." That was wrong: `AsrEngine._init_vad()` loads
+> `silero_vad.onnx` for **every** ASR model (offline *and* streaming), and it's a
+> downloaded artifact — so a user who installed only this model and went offline
+> had no VAD and failed at session start. Worse, only SenseVoice declared the VAD,
+> and `delete_model` treated SenseVoice as its "owner" (deleting SenseVoice yanked
+> the VAD out from under the other ASR models). The shipped fix treats the silero
+> VAD as a **shared dependency of all ASR models**: `download_specs` appends
+> `VAD_URL` for any ASR-catalog model (matched via `catalog.asr_model(id)`), and
+> `delete_model` never removes the 643 KB shared singleton. This also closed the
+> identical pre-existing offline gap for whisper / qwen3-asr / cohere / granite /
+> voxtral.
 
 ### 5. Renderer catalog (`nativeCatalog.ts` + test)
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -60,6 +60,7 @@ def _has_mod(mod: str) -> bool:
 def _installed() -> frozenset:
     mods = {"ctranslate2": "faster_whisper", "sherpa": "sherpa_onnx",
             "funasr_sensevoice": "funasr",
+            "funasr_nano": "funasr",
             "onnx": "onnxruntime", "llamacpp": "llama_cpp", "mlx": "mlx_lm",
             "transformers": "transformers",
             # qwen3asr needs the native qwen3_asr model (transformers 5.13.x+); until

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -459,3 +459,16 @@ class FunAsrSenseVoiceBackend(_FunAsrBackend):
     NAME = "funasr_sensevoice"
     CONFIG = _FunAsrConfig(trust_remote_code=False, feed="ndarray",
                            postprocess=_strip_sensevoice_tags)
+
+
+@register_backend
+class FunAsrNanoBackend(_FunAsrBackend):
+    """FunASR Fun-ASR-Nano family (SenseVoice audio encoder + Qwen3-0.6B LLM
+    decoder). model_ref is the HF repo id (FunAudioLLM/Fun-ASR-MLT-Nano-2512).
+    Serves gpu-cuda (float32) + cpu (float32); both real-time. trust_remote_code
+    loads the fun_asr_nano model code shipped in funasr. Output is clean,
+    natively-punctuated text (no tags). Input is fed as a temp wav because the
+    model's chat-template input is built from a file path, not a bare ndarray."""
+    NAME = "funasr_nano"
+    CONFIG = _FunAsrConfig(trust_remote_code=True, feed="tempwav",
+                           postprocess=_passthrough)

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -3,6 +3,7 @@ load()/transcribe()/unload() contract. The only code that touches a framework's
 real API. Heavy frameworks are imported lazily inside load()."""
 import re
 from dataclasses import dataclass
+from typing import Callable
 
 
 @dataclass
@@ -363,14 +364,24 @@ def _strip_sensevoice_tags(text: str) -> tuple[str, str | None]:
     return _SV_TAG.sub("", text).strip(), lang
 
 
-@register_backend
-class FunAsrSenseVoiceBackend:
-    """FunASR SenseVoiceSmall (PyTorch). model_ref is the HF repo id
-    (FunAudioLLM/SenseVoiceSmall). Serves BOTH gpu-cuda (float32) and cpu
-    (float32) tiers — honors the device it is given (no GPU-only guard).
-    Non-autoregressive encoder+CTC: one generate() per VAD segment. Output
-    lang/emotion/event tags are stripped to a clean transcript."""
-    NAME = "funasr_sensevoice"
+@dataclass(frozen=True)
+class _FunAsrConfig:
+    trust_remote_code: bool
+    feed: str   # "ndarray" (SenseVoice) | "tempwav" (Fun-ASR-Nano chat-template needs a path)
+    postprocess: Callable[[str], "tuple[str, str | None]"]
+
+
+def _passthrough(text: str) -> "tuple[str, None]":
+    """Fun-ASR-Nano emits clean, natively-punctuated text with no tags."""
+    return text.strip(), None
+
+
+class _FunAsrBackend:
+    """Shared FunASR AutoModel offline backend. Subclasses set NAME + CONFIG.
+    Honors the device given; the cuda guard rejects cuda when torch has no CUDA
+    runtime (FunASR would silently run on CPU) so load_with_fallback steps to the
+    correctly-labelled cpu plan. One generate() per VAD segment."""
+    CONFIG: _FunAsrConfig
 
     def __init__(self):
         self._m = None
@@ -380,10 +391,6 @@ class FunAsrSenseVoiceBackend:
         try:
             from funasr import AutoModel
             if device == "cuda":
-                # FunASR's AutoModel silently falls back to CPU when torch has no
-                # CUDA runtime; reject the cuda plan here so load_with_fallback steps
-                # to the (correctly labelled) cpu plan instead of mislabelling a CPU
-                # run as cuda. Only an explicit, generic "cuda" maps to cuda:0.
                 import torch
                 if not torch.cuda.is_available():
                     raise BackendLoadError("cuda requested but torch has no CUDA runtime")
@@ -391,6 +398,7 @@ class FunAsrSenseVoiceBackend:
             else:
                 dev = device
             self._m = AutoModel(model=model_ref, hub="hf", device=dev,
+                                trust_remote_code=self.CONFIG.trust_remote_code,
                                 disable_update=True)
         except BackendLoadError:
             raise
@@ -398,13 +406,35 @@ class FunAsrSenseVoiceBackend:
             raise BackendLoadError(str(e))
 
     def transcribe(self, samples, language) -> AsrResult:
-        res = self._m.generate(input=samples, fs=TARGET_RATE, cache={},
-                               language=(language or "auto"), use_itn=True,
-                               batch_size_s=60)
+        if self.CONFIG.feed == "tempwav":
+            res = self._generate_tempwav(samples, language)
+        else:
+            res = self._m.generate(input=samples, fs=TARGET_RATE, cache={},
+                                   language=(language or "auto"), use_itn=True,
+                                   batch_size_s=60)
         if not res or not isinstance(res, list) or "text" not in res[0]:
-            return AsrResult("", None)  # funasr returned nothing (e.g. empty/silent segment)
-        text, lang = _strip_sensevoice_tags(res[0]["text"])
+            return AsrResult("", None)  # funasr returned nothing (empty/silent segment)
+        text, lang = self.CONFIG.postprocess(res[0]["text"])
         return AsrResult(text, lang)
+
+    def _generate_tempwav(self, samples, language):
+        # Fun-ASR-Nano's data_template builds its chat-style input from a FILE PATH;
+        # a bare ndarray raises in data_template. Write the VAD segment to a temp wav
+        # and pass the path (the official, verified contract). soundfile ships via librosa.
+        import os
+        import tempfile
+        import soundfile as sf
+        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        tmp.close()
+        try:
+            sf.write(tmp.name, samples, TARGET_RATE)
+            return self._m.generate(input=[tmp.name],
+                                    language=(language or "auto"), use_itn=True)
+        finally:
+            try:
+                os.unlink(tmp.name)
+            except OSError:
+                pass
 
     def unload(self) -> None:
         self._m = None
@@ -417,3 +447,15 @@ class FunAsrSenseVoiceBackend:
     @property
     def is_loaded(self) -> bool:
         return self._m is not None
+
+
+@register_backend
+class FunAsrSenseVoiceBackend(_FunAsrBackend):
+    """FunASR SenseVoiceSmall (PyTorch). model_ref is the HF repo id
+    (FunAudioLLM/SenseVoiceSmall). Serves BOTH gpu-cuda (float32) and cpu
+    (float32) tiers — honors the device it is given (no GPU-only guard).
+    Non-autoregressive encoder+CTC: one generate() per VAD segment. Output
+    lang/emotion/event tags are stripped to a clean transcript."""
+    NAME = "funasr_sensevoice"
+    CONFIG = _FunAsrConfig(trust_remote_code=False, feed="ndarray",
+                           postprocess=_strip_sensevoice_tags)

--- a/sidecar/sokuji_sidecar/backends.py
+++ b/sidecar/sokuji_sidecar/backends.py
@@ -412,7 +412,7 @@ class _FunAsrBackend:
             res = self._m.generate(input=samples, fs=TARGET_RATE, cache={},
                                    language=(language or "auto"), use_itn=True,
                                    batch_size_s=60)
-        if not res or not isinstance(res, list) or "text" not in res[0]:
+        if not res or not isinstance(res, list) or not isinstance(res[0], dict) or "text" not in res[0]:
             return AsrResult("", None)  # funasr returned nothing (empty/silent segment)
         text, lang = self.CONFIG.postprocess(res[0]["text"])
         return AsrResult(text, lang)

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -5,6 +5,7 @@ import os
 from dataclasses import dataclass
 
 SENSE_VOICE_REPO = os.environ.get("SOKUJI_ASR_REPO", "FunAudioLLM/SenseVoiceSmall")
+FUN_ASR_MLT_REPO = os.environ.get("SOKUJI_FUNASR_NANO_REPO", "FunAudioLLM/Fun-ASR-MLT-Nano-2512")
 
 
 @dataclass(frozen=True)
@@ -72,6 +73,13 @@ ASR_MODELS: list[AsrModel] = [
              (Deployment("voxtral_realtime", "gpu-cuda", "bfloat16",
                          "mistralai/Voxtral-Mini-4B-Realtime-2602", 1.0),),
              recommended=True, sort_order=10),
+    AsrModel("fun-asr-mlt-nano", "Fun-ASR MLT Nano",
+             ("zh", "en", "yue", "ja", "ko", "vi", "id", "th", "ms", "fil", "ar",
+              "hi", "bg", "hr", "cs", "da", "nl", "et", "fi", "el", "hu", "ga",
+              "lv", "lt", "mt", "pl", "pt", "ro", "sk", "sl", "sv"),
+             (Deployment("funasr_nano", "gpu-cuda", "float32", FUN_ASR_MLT_REPO, 1.0),
+              Deployment("funasr_nano", "cpu", "float32", FUN_ASR_MLT_REPO, 1.0)),
+             recommended=True, sort_order=11),
 ]
 
 

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -1,6 +1,7 @@
 """Declarative ASR model catalog: per model, which backends/hardware tiers run
 it and what artifact each needs. Pure data — adding a model is adding a row.
-Whisper rows carry a gpu-cuda (float16) deployment + a cpu (int8) floor; SenseVoice runs on FunASR with gpu-cuda (float16) + cpu (float32) tiers."""
+Whisper rows carry a gpu-cuda (float16) deployment + a cpu (int8) floor; SenseVoice
+and Fun-ASR-MLT-Nano run on FunASR with gpu-cuda + cpu tiers (both float32)."""
 import os
 from dataclasses import dataclass
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -3,10 +3,18 @@
 Each native model id maps to a set of HuggingFace repos (+ the VAD url). status
 checks they're fully cached; download fetches them file-by-file with progress.
 Mirrors LOCAL_INFERENCE's manage-before-use UX, but server-side (HF cache).
+
+The silero VAD (silero_vad.onnx) is a shared runtime dependency of EVERY ASR
+model: AsrEngine._init_vad() loads it for both the offline and streaming paths,
+independent of which recognizer runs. So download_specs() appends it for any
+ASR-catalog model (not just SenseVoice), guaranteeing a single-model offline
+install is self-sufficient. It's a 643KB global singleton at sokuji-vad/, so
+delete_model() never removes it — another installed model may still need it.
 """
 import os
 
 from .asr_engine import VAD_URL
+from .catalog import asr_model as _asr_model
 
 QWEN_REPO = "Qwen/Qwen2.5-0.5B-Instruct"
 SENSE_VOICE_REPO = "FunAudioLLM/SenseVoiceSmall"
@@ -22,8 +30,8 @@ def _vad_cache_path():
     return os.path.join(cache, "silero_vad.onnx")
 
 
-def download_specs(model_id):
-    """Map a model id to its download sources: {repos: [..], urls: [..]}."""
+def _base_specs(model_id):
+    """Per-model repos/ignore, WITHOUT the shared VAD (download_specs adds that)."""
     if not model_id or model_id == "qwen":
         return {"repos": [os.environ.get("SOKUJI_TRANSLATE_MODEL", QWEN_REPO)], "urls": []}
     if "piper" in model_id or "vits" in model_id:
@@ -38,7 +46,7 @@ def download_specs(model_id):
         # Granite speech-LLM ids (catalog) live under the ibm-granite/ org on HF.
         return {"repos": [f"ibm-granite/{model_id}"], "urls": []}
     if model_id == "sense-voice":
-        return {"repos": [os.environ.get("SOKUJI_ASR_REPO", SENSE_VOICE_REPO)], "urls": [VAD_URL]}
+        return {"repos": [os.environ.get("SOKUJI_ASR_REPO", SENSE_VOICE_REPO)], "urls": []}
     if model_id == "fun-asr-mlt-nano":
         return {"repos": [FUN_ASR_MLT_REPO], "urls": []}
     if model_id == "qwen3-asr-1.7b":
@@ -51,6 +59,19 @@ def download_specs(model_id):
         return {"repos": ["mistralai/Voxtral-Mini-4B-Realtime-2602"], "urls": [],
                 "ignore": ["consolidated.safetensors"]}
     return {"repos": [model_id], "urls": []}
+
+
+def download_specs(model_id):
+    """Map a model id to its download sources: {repos: [..], urls: [..]}.
+
+    Every ASR-catalog model gets the shared silero VAD appended (see module
+    docstring); non-ASR ids (translation, TTS) do not. The id is matched against
+    the ASR catalog by exact id, so a bare HF repo id (e.g. the raw SenseVoice
+    repo passed to model_status) is treated as non-ASR and gets no VAD."""
+    spec = _base_specs(model_id)
+    if _asr_model(model_id) is not None and VAD_URL not in spec["urls"]:
+        spec = {**spec, "urls": [*spec["urls"], VAD_URL]}
+    return spec
 
 
 _SILERO_VAD_BYTES = 643854  # silero_vad.onnx (k2-fsa release)
@@ -105,12 +126,16 @@ def model_status(model_id):
 
 
 def delete_model(model_id):
-    """Remove a model's cached repos (+ its VAD file) from the HF cache.
+    """Remove a model's cached repos from the HF cache.
 
     Returns the number of bytes freed. Repos are deleted via the hub's cache
     scanner so we only touch fully-managed revisions; a repo shared with another
     still-needed model is deleted here too — callers should only delete models
     the user explicitly removed.
+
+    The shared silero VAD (sokuji-vad/) is deliberately NOT removed: every ASR
+    model depends on it, so deleting one model must not strand the others
+    offline. It's a 643KB singleton — cheaper to keep than to refcount.
     """
     from huggingface_hub import scan_cache_dir
     specs = download_specs(model_id)
@@ -128,13 +153,6 @@ def delete_model(model_id):
                 revisions.extend(rev.commit_hash for rev in repo.revisions)
         if revisions:
             cache.delete_revisions(*revisions).execute()
-    # Drop the shared VAD file only when removing the model that owns it.
-    if specs["urls"] and os.path.exists(_vad_cache_path()):
-        try:
-            freed += os.path.getsize(_vad_cache_path())
-            os.remove(_vad_cache_path())
-        except OSError:
-            pass
     return freed
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -10,6 +10,7 @@ from .asr_engine import VAD_URL
 
 QWEN_REPO = "Qwen/Qwen2.5-0.5B-Instruct"
 SENSE_VOICE_REPO = "FunAudioLLM/SenseVoiceSmall"
+FUN_ASR_MLT_REPO = os.environ.get("SOKUJI_FUNASR_NANO_REPO", "FunAudioLLM/Fun-ASR-MLT-Nano-2512")
 
 
 def _whisper_size(model_id):
@@ -38,6 +39,8 @@ def download_specs(model_id):
         return {"repos": [f"ibm-granite/{model_id}"], "urls": []}
     if model_id == "sense-voice":
         return {"repos": [os.environ.get("SOKUJI_ASR_REPO", SENSE_VOICE_REPO)], "urls": [VAD_URL]}
+    if model_id == "fun-asr-mlt-nano":
+        return {"repos": [FUN_ASR_MLT_REPO], "urls": []}
     if model_id == "qwen3-asr-1.7b":
         return {"repos": ["bezzam/Qwen3-ASR-1.7B"], "urls": []}
     if model_id == "cohere-transcribe-03-2026":

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -503,3 +503,13 @@ def test_voxtral_model_unavailable_without_runtime():
                       fingerprint="testfp")
     plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
     assert plans == []     # GPU-only + runtime absent → no usable deployment
+
+
+def test_fun_asr_mlt_nano_resolves_gpu_and_cpu():
+    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),), installed=frozenset({"funasr_nano"}))
+    # explicit cuda override -> gpu-cuda plan first
+    plan = accel.resolve("fun-asr-mlt-nano", "cuda", m)
+    assert plan[0].backend == "funasr_nano" and plan[0].tier == "gpu-cuda"
+    # explicit cpu override -> cpu plan
+    plan_cpu = accel.resolve("fun-asr-mlt-nano", "cpu", m)
+    assert plan_cpu[0].tier == "cpu"

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -736,6 +736,53 @@ def test_voxtral_realtime_real_gpu_smoke():
     c.unload()
 
 
+def test_funasr_nano_config_and_load(monkeypatch):
+    cap = _install_fake_funasr(monkeypatch, text="你好世界")
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    assert b.is_loaded
+    assert cap["init"]["model"] == "FunAudioLLM/Fun-ASR-MLT-Nano-2512"
+    assert cap["init"]["device"] == "cuda:0"
+    assert cap["init"]["trust_remote_code"] is True      # Nano needs remote code
+
+
+def test_funasr_nano_transcribe_feeds_tempwav_path(monkeypatch):
+    # Fun-ASR-Nano takes a file path, not a bare ndarray: transcribe must call
+    # generate(input=[<path>], ...) WITHOUT the SenseVoice fs/cache/batch_size_s kwargs.
+    cap = _install_fake_funasr(monkeypatch, text="你好世界")
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    out = b.transcribe(np.zeros(16000, np.float32), "zh")
+    assert out.text == "你好世界" and out.language is None   # passthrough, no tags
+    assert cap["gen"]["n"] == 1                  # input is a 1-element list (a path)
+    assert cap["gen"]["language"] == "zh"
+    assert cap["gen"]["use_itn"] is True
+    assert "fs" not in cap["gen"] and "batch_size_s" not in cap["gen"]
+
+
+def test_funasr_nano_rejects_cuda_without_torch_cuda(monkeypatch):
+    cap = _install_fake_funasr(monkeypatch, cuda_available=False)
+    b = backends.make_backend("funasr_nano")
+    with pytest.raises(backends.BackendLoadError):
+        b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    assert "init" not in cap and not b.is_loaded
+
+
+def test_funasr_nano_honors_cpu(monkeypatch):
+    cap = _install_fake_funasr(monkeypatch, cuda_available=False, text="hi")
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cpu", "float32")
+    assert b.is_loaded and cap["init"]["device"] == "cpu"
+
+
+def test_funasr_nano_empty_result_returns_blank(monkeypatch):
+    _install_fake_funasr(monkeypatch, empty=True)
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    out = b.transcribe(np.zeros(16000, np.float32), None)
+    assert out.text == "" and out.language is None
+
+
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
                     reason="set SOKUJI_RUN_GPU=1 (downloads FunAudioLLM/SenseVoiceSmall ~900MB + the sherpa sense-voice repo for test_wavs; needs CUDA torch + funasr)")
 def test_funasr_sensevoice_real_gpu_and_cpu_smoke():

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -809,3 +809,19 @@ def test_funasr_sensevoice_real_gpu_and_cpu_smoke():
         assert r.language == "en"
         print(f"funasr sensevoice {device} RTF={rtf:.4f} text={r.text!r}")
         b.unload()
+
+
+@pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_ASR_MODEL"),
+                    reason="set SOKUJI_RUN_ASR_MODEL=1 (downloads/loads Fun-ASR-MLT-Nano, needs CUDA)")
+def test_funasr_nano_real_transcribe_smoke():
+    import soundfile as sf
+    wav = ("/home/jiangzhuo/.cache/huggingface/hub/"
+           "models--csukuangfj--sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/"
+           "snapshots/2365baeacb507f821a0c8120fcee3d484dba7a07/test_wavs/en.wav")
+    samples, sr = sf.read(wav, dtype="float32")
+    assert sr == 16000
+    b = backends.make_backend("funasr_nano")
+    b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
+    out = b.transcribe(samples, "auto")
+    b.unload()
+    assert out.text and "tribal" in out.text.lower()   # verified transcript content

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -612,14 +612,15 @@ def _install_fake_funasr(monkeypatch, *, text="<|en|><|NEUTRAL|><|Speech|><|with
     cap = {}
 
     class FakeAutoModel:
-        def __init__(self, model, hub, device, disable_update):
+        def __init__(self, model, hub, device, disable_update, trust_remote_code=False):
             if fail:
                 raise RuntimeError("funasr load failed")
-            cap["init"] = dict(model=model, hub=hub, device=device, disable_update=disable_update)
+            cap["init"] = dict(model=model, hub=hub, device=device,
+                               disable_update=disable_update,
+                               trust_remote_code=trust_remote_code)
 
-        def generate(self, input, fs, cache, language, use_itn, batch_size_s):
-            cap["gen"] = dict(n=len(input), fs=fs, language=language,
-                              use_itn=use_itn, batch_size_s=batch_size_s)
+        def generate(self, input, **kw):
+            cap["gen"] = dict(n=len(input), **kw)
             return [] if empty else [{"text": text}]
 
     fmod = types.ModuleType("funasr")

--- a/sidecar/tests/test_backends.py
+++ b/sidecar/tests/test_backends.py
@@ -814,12 +814,15 @@ def test_funasr_sensevoice_real_gpu_and_cpu_smoke():
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_ASR_MODEL"),
                     reason="set SOKUJI_RUN_ASR_MODEL=1 (downloads/loads Fun-ASR-MLT-Nano, needs CUDA)")
 def test_funasr_nano_real_transcribe_smoke():
-    import soundfile as sf
-    wav = ("/home/jiangzhuo/.cache/huggingface/hub/"
-           "models--csukuangfj--sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17/"
-           "snapshots/2365baeacb507f821a0c8120fcee3d484dba7a07/test_wavs/en.wav")
-    samples, sr = sf.read(wav, dtype="float32")
-    assert sr == 16000
+    # Same idiom as the sensevoice smoke above: snapshot_download the sherpa
+    # sense-voice repo for its test_wavs/en.wav (portable across machines — no
+    # hardcoded cache path), read it via wave, transcribe on cuda.
+    import wave
+    from huggingface_hub import snapshot_download
+    d = snapshot_download("csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17")
+    with wave.open(f"{d}/test_wavs/en.wav", "rb") as w:
+        assert w.getframerate() == 16000
+        samples = np.frombuffer(w.readframes(w.getnframes()), dtype=np.int16).astype(np.float32) / 32768.0
     b = backends.make_backend("funasr_nano")
     b.load("FunAudioLLM/Fun-ASR-MLT-Nano-2512", "cuda", "float32")
     out = b.transcribe(samples, "auto")

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -7,7 +7,8 @@ def test_models_have_deployments_and_languages():
         assert m.languages, f"{m.id} has no languages"
         for d in m.deployments:
             assert d.backend in {"ctranslate2", "sherpa", "transformers", "qwen3asr",
-                                 "cohere_transformers", "voxtral_realtime", "funasr_sensevoice"}
+                                 "cohere_transformers", "voxtral_realtime", "funasr_sensevoice",
+                                 "funasr_nano"}
 
 
 def test_system_has_a_cpu_floor():
@@ -94,3 +95,16 @@ def test_voxtral_realtime_row():
     d = m.deployments[0]
     assert (d.backend, d.tier, d.compute_type, d.artifact) == \
         ("voxtral_realtime", "gpu-cuda", "bfloat16", "mistralai/Voxtral-Mini-4B-Realtime-2602")
+
+
+def test_fun_asr_mlt_nano_row():
+    m = catalog.asr_model("fun-asr-mlt-nano")
+    assert m is not None and m.name == "Fun-ASR MLT Nano"
+    assert m.recommended is True
+    assert len(m.languages) == 31
+    assert m.languages[:6] == ("zh", "en", "yue", "ja", "ko", "vi")
+    assert [(d.backend, d.tier, d.compute_type) for d in m.deployments] == [
+        ("funasr_nano", "gpu-cuda", "float32"),
+        ("funasr_nano", "cpu", "float32"),
+    ]
+    assert all(d.artifact == catalog.FUN_ASR_MLT_REPO for d in m.deployments)

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -15,10 +15,11 @@ def test_download_specs_mapping(monkeypatch):
     assert nm.download_specs('whisper-tiny')['repos'] == ['Systran/faster-whisper-tiny']
     assert nm.download_specs('csukuangfj/vits-piper-en_US-amy-low')['repos'] == ['csukuangfj/vits-piper-en_US-amy-low']
     sv = nm.download_specs('sense-voice')
-    assert sv['repos'] == [nm.SENSE_VOICE_REPO] and len(sv['urls']) == 1
+    assert sv['repos'] == [nm.SENSE_VOICE_REPO] and sv['urls'] == [nm.VAD_URL]
     assert sv['repos'] == ['FunAudioLLM/SenseVoiceSmall']
     opus = nm.download_specs('Xenova/opus-mt-zh-en')
     assert opus['repos'] == ['Xenova/opus-mt-zh-en', 'Helsinki-NLP/opus-mt-zh-en']
+    assert opus['urls'] == []  # translation model: no shared VAD
     # Granite speech-LLM ids must map to their ibm-granite/ HF repo, not the bare id.
     assert nm.download_specs('granite-speech-4.1-2b')['repos'] == ['ibm-granite/granite-speech-4.1-2b']
     assert nm.download_specs('granite-speech-4.1-2b-plus')['repos'] == ['ibm-granite/granite-speech-4.1-2b-plus']
@@ -29,8 +30,37 @@ def test_download_specs_mapping(monkeypatch):
 
 
 def test_download_specs_cohere():
+    # Cohere is an ASR-catalog model, so the shared silero VAD is appended.
     assert native_models.download_specs("cohere-transcribe-03-2026") == \
-        {"repos": ["AEmotionStudio/cohere-transcribe-03-2026-models"], "urls": []}
+        {"repos": ["AEmotionStudio/cohere-transcribe-03-2026-models"], "urls": [nm.VAD_URL]}
+
+
+def test_download_specs_appends_shared_vad_for_asr_models():
+    """The silero VAD is a shared dependency of EVERY ASR model (AsrEngine._init_vad
+    loads it for offline + streaming). download_specs must append it for any ASR
+    model, not just SenseVoice; non-ASR ids (translation/TTS) must NOT get it."""
+    for asr_id in ('sense-voice', 'fun-asr-mlt-nano', 'whisper-tiny', 'qwen3-asr-1.7b',
+                   'voxtral-mini-4b-realtime', 'granite-speech-4.1-2b'):
+        assert nm.download_specs(asr_id)['urls'] == [nm.VAD_URL], asr_id
+    for non_asr in ('', 'qwen', 'Xenova/opus-mt-zh-en', 'csukuangfj/vits-piper-en_US-amy-low'):
+        assert nm.download_specs(non_asr)['urls'] == [], non_asr
+    # voxtral keeps its ignore list alongside the appended VAD url.
+    assert nm.download_specs('voxtral-mini-4b-realtime').get('ignore') == ['consolidated.safetensors']
+
+
+def test_delete_model_keeps_shared_vad(monkeypatch, tmp_path):
+    """Deleting an ASR model must NOT remove the shared silero VAD — another
+    installed ASR model still depends on it."""
+    vad = tmp_path / 'silero_vad.onnx'
+    vad.write_bytes(b'x' * 16)
+
+    def _no_cache():
+        raise RuntimeError('no HF cache in this env')
+
+    monkeypatch.setattr(nm, '_vad_cache_path', lambda: str(vad))
+    monkeypatch.setattr('huggingface_hub.scan_cache_dir', _no_cache)
+    nm.delete_model('fun-asr-mlt-nano')
+    assert vad.exists()  # VAD survives the delete
 
 
 def test_download_raises_when_no_files_resolved(monkeypatch):
@@ -184,7 +214,7 @@ def test_model_status_rejects_interrupted_download(monkeypatch, tmp_path):
 def test_download_specs_voxtral_skips_consolidated():
     spec = nm.download_specs("voxtral-mini-4b-realtime")
     assert spec["repos"] == ["mistralai/Voxtral-Mini-4B-Realtime-2602"]
-    assert spec["urls"] == []
+    assert spec["urls"] == [nm.VAD_URL]  # ASR model → shared VAD appended
     assert spec["ignore"] == ["consolidated.safetensors"]
 
 
@@ -247,4 +277,6 @@ def test_download_specs_fun_asr_mlt_nano(monkeypatch):
     monkeypatch.delenv('SOKUJI_FUNASR_NANO_REPO', raising=False)
     spec = nm.download_specs('fun-asr-mlt-nano')
     assert spec['repos'] == ['FunAudioLLM/Fun-ASR-MLT-Nano-2512']
-    assert spec['urls'] == []
+    # AsrEngine._init_vad() loads silero for the offline path too, so a Nano-only
+    # offline install must pre-fetch the shared VAD (not rely on a session-time download).
+    assert spec['urls'] == [nm.VAD_URL]

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -241,3 +241,10 @@ def test_model_size_excludes_ignored_files(monkeypatch):
     monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
     nm._SIZE_CACHE.clear()
     assert nm.model_size("voxtral-mini-4b-realtime") == 8_000_001_000  # consolidated excluded
+
+
+def test_download_specs_fun_asr_mlt_nano(monkeypatch):
+    monkeypatch.delenv('SOKUJI_FUNASR_NANO_REPO', raising=False)
+    spec = nm.download_specs('fun-asr-mlt-nano')
+    assert spec['repos'] == ['FunAudioLLM/Fun-ASR-MLT-Nano-2512']
+    assert spec['urls'] == []

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -84,8 +84,8 @@ describe('nativeCatalog', () => {
   });
 
   it('splits ASR into compatible / incompatible for a language', () => {
-    // 'de' is not a sense-voice language: sense-voice is incompatible, whisper-* compatible
-    expect(incompatibleNativeAsr('de').map((m) => m.id)).toEqual(['sense-voice']);
+    // 'de' is not a sense-voice language: sense-voice and fun-asr-mlt-nano are incompatible, whisper-* compatible
+    expect(incompatibleNativeAsr('de').map((m) => m.id)).toEqual(['sense-voice', 'fun-asr-mlt-nano']);
     expect(nativeAsrIncompatibleCards('de')[0]).toMatchObject({ selectId: 'sense-voice', downloadId: 'sense-voice' });
     // for a sense-voice language, sense-voice and whisper are compatible; Granite models (no zh) are incompatible
     expect(incompatibleNativeAsr('zh').map((m) => m.id)).toContain('granite-speech-4.1-2b');
@@ -223,6 +223,15 @@ describe('nativeCatalog', () => {
     expect(compatibleNativeAsr('th').map((m) => m.id)).not.toContain('voxtral-mini-4b-realtime');
     // does not displace cohere as the recommended leader for a shared language
     expect(compatibleNativeAsr('zh')[0].id).toBe('cohere-transcribe-03-2026');
+  });
+
+  it('includes fun-asr-mlt-nano as a recommended 31-language ASR option', () => {
+    const m = NATIVE_ASR.find((x) => x.id === 'fun-asr-mlt-nano');
+    expect(m).toBeTruthy();
+    expect(m!.label).toBe('Fun-ASR MLT Nano');
+    expect(m!.recommended).toBe(true);
+    expect(m!.languages).toHaveLength(31);
+    expect(m!.languages.slice(0, 5)).toEqual(['zh', 'en', 'yue', 'ja', 'ko']);
   });
 
   it('maps hardware tiers to display labels', () => {

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -43,6 +43,17 @@ describe('nativeCatalog', () => {
     expect(supportsLanguage({ languages: ['zh', 'en'] }, 'de')).toBe(false);
     expect(supportsLanguage({ languages: ['multi'] }, 'de')).toBe(true);
 
+    // Alias-aware: the picker emits app codes (cantonese/tl) while catalog rows use
+    // ISO codes (yue/fil). Both must resolve to the same model.
+    expect(supportsLanguage({ languages: ['yue'] }, 'cantonese')).toBe(true);
+    expect(supportsLanguage({ languages: ['yue'] }, 'yue')).toBe(true);
+    expect(supportsLanguage({ languages: ['fil'] }, 'tl')).toBe(true);
+    expect(supportsLanguage({ languages: ['fil'] }, 'fil')).toBe(true);
+    // sense-voice (yue) is reachable when the picker selects Cantonese (cantonese)
+    expect(compatibleNativeAsr('cantonese').map((m) => m.id)).toContain('sense-voice');
+    // fun-asr-mlt-nano (fil) is reachable when the picker selects Tagalog (tl)
+    expect(compatibleNativeAsr('tl').map((m) => m.id)).toContain('fun-asr-mlt-nano');
+
     // for a sense-voice language, cohere now leads (recommended, sortOrder 0)
     expect(compatibleNativeAsr('zh').map((m) => m.id)[0]).toBe('cohere-transcribe-03-2026');
     // for an unsupported language, sense-voice drops out → cohere leads (supports de)

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -14,9 +14,26 @@ export interface NativeModelOption {
   sortOrder?: number;
 }
 
-/** `['multi']` matches any language; otherwise the language must be listed. */
+/**
+ * Aliases between the app's source-language values (src/utils/languages.ts) and
+ * the ISO codes the model catalogs use. The picker emits `cantonese`/`tl`, while
+ * catalog rows use `yue`/`fil` (SenseVoice, Qwen3-ASR, Fun-ASR-MLT-Nano). Without
+ * this, selecting Cantonese or Tagalog would mark those models incompatible even
+ * though they support the language. Canonicalize both sides so the convention a
+ * given row uses doesn't matter.
+ */
+const LANG_ALIASES: Record<string, string> = {
+  cantonese: 'yue',
+  tl: 'fil',
+};
+const canonLang = (l: string): string => LANG_ALIASES[l] ?? l;
+
+/** `['multi']` matches any language; otherwise the language must be listed (alias-aware). */
 export function supportsLanguage(opt: { languages?: string[] }, lang: string): boolean {
-  return !!opt.languages && (opt.languages.includes('multi') || opt.languages.includes(lang));
+  if (!opt.languages) return false;
+  if (opt.languages.includes('multi')) return true;
+  const want = canonLang(lang);
+  return opt.languages.some((l) => canonLang(l) === want);
 }
 
 export const NATIVE_ASR: NativeModelOption[] = [

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -31,6 +31,7 @@ export const NATIVE_ASR: NativeModelOption[] = [
   { id: 'granite-speech-4.1-2b-plus', label: 'Granite Speech 4.1 (2B+)', languages: ['en', 'fr', 'de', 'es', 'pt'], sortOrder: 8 },
   { id: 'qwen3-asr-1.7b', label: 'Qwen3-ASR 1.7B', languages: ['zh', 'en', 'ja', 'ko', 'yue', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id'], recommended: true, sortOrder: 9 },
   { id: 'voxtral-mini-4b-realtime', label: 'Voxtral Mini 4B Realtime', languages: ['en', 'fr', 'es', 'de', 'ru', 'zh', 'ja', 'it', 'pt', 'nl', 'ar', 'hi', 'ko'], recommended: true, sortOrder: 10 },
+  { id: 'fun-asr-mlt-nano', label: 'Fun-ASR MLT Nano', languages: ['zh', 'en', 'yue', 'ja', 'ko', 'vi', 'id', 'th', 'ms', 'fil', 'ar', 'hi', 'bg', 'hr', 'cs', 'da', 'nl', 'et', 'fi', 'el', 'hu', 'ga', 'lv', 'lt', 'mt', 'pl', 'pt', 'ro', 'sk', 'sl', 'sv'], recommended: true, sortOrder: 11 },
 ];
 
 export const NATIVE_TRANSLATION: NativeModelOption[] = [


### PR DESCRIPTION
## Summary

Adds **`FunAudioLLM/Fun-ASR-MLT-Nano-2512`** — a 31-language, ~800M, Apache-2.0 speech-LLM (SenseVoice audio encoder + Qwen3-0.6B decoder) — to the native sidecar as an **offline** GPU+CPU ASR backend, by generalizing the existing FunASR SenseVoice backend into a shared `_FunAsrBackend`.

Backend-layer-only change: `server.py`, `__main__.py`, and `asr_engine.py` are untouched (the WS transport, silero-VAD segmentation, and result envelope are model-agnostic).

## What changed
- **`backends.py`** — generalize `FunAsrSenseVoiceBackend` into a shared, config-driven `_FunAsrBackend` (`_FunAsrConfig(trust_remote_code, feed, postprocess)`); SenseVoice preserved byte-for-byte. Add `FunAsrNanoBackend` (`funasr_nano`): `trust_remote_code=True`, output is plain punctuated text (passthrough, no tag-stripping), audio fed as a temp wav (Fun-ASR-Nano's chat-template input needs a file path, not a bare ndarray).
- **`catalog.py`** — `fun-asr-mlt-nano` row: 31 languages, two `funasr_nano` deployments (`gpu-cuda` + `cpu`, both `float32`), `recommended`.
- **`accel.py`** — install gate `funasr_nano → funasr`.
- **`native_models.py`** — download spec for the new model id.
- **`nativeCatalog.ts`** — renderer catalog row (lockstep with the sidecar).
- Gated GPU smoke test for the real model.

## Phase-0 verification (on an RTX 4070)
| device | RTF | VRAM | correctness |
|--------|-----|------|-------------|
| cuda:0 | 0.047–0.100 | 3.6 GB peak | all 5 langs correct |
| cpu    | 0.223–0.317 | — | all 5 langs correct |

Both tiers are real-time (so both ship), float32/869M, clean tag-free output, `language="auto"` works. `funasr` (1.3.14) already ships the model code — no new pip dependency.

## Testing
- Sidecar suite: 153 passed, 18 skipped. Renderer: 28 passed.
- Gated GPU smoke (`SOKUJI_RUN_ASR_MODEL=1`) really transcribed on the 4070 (RTF 0.075).

## Out of scope
Streaming / vLLM (`inference_vllm_streaming.py`) — the only official streaming path is vLLM-gated and undemonstrated; the base `Fun-ASR-Nano` and the `-hf` transformers variant; emotion / speaker / timestamps.

## Notes
`trust_remote_code=True` executes the official Apache-2.0 FunAudioLLM `model.py`; the download/load currently track unpinned `main`. Pinning a known-good `revision=` is noted as future hardening in the spec's Risks table.

Spec: `docs/superpowers/specs/2026-06-26-fun-asr-mlt-nano-offline-design.md`
Plan: `docs/superpowers/plans/2026-06-26-fun-asr-mlt-nano-offline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)