### PR TITLE
feat(native): quant-variant + FP8, translation backends, resolved-memory display

### DIFF
--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -4,3 +4,4 @@ websockets==13.1
 sentencepiece==0.2.0
 huggingface_hub==0.26.2
 compressed-tensors
+psutil

--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -3,3 +3,4 @@ numpy==2.1.3
 websockets==13.1
 sentencepiece==0.2.0
 huggingface_hub==0.26.2
+compressed-tensors

--- a/sidecar/sokuji_sidecar/__main__.py
+++ b/sidecar/sokuji_sidecar/__main__.py
@@ -1,3 +1,7 @@
+import os
+# Reduce CUDA allocator fragmentation when loading large quantized models (e.g. FP8).
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
 import asyncio, json, sys
 from .server import serve
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -540,6 +540,41 @@ def _apply_bench(plans: list, bench: dict) -> list:
     return fast + slow
 
 
+async def _h_list_variants(state, msg, _b, conn=None):
+    from . import catalog, native_models
+    m = probe()
+    model = catalog.translate_model(msg.get("model"))
+    if model is None:
+        return {"type": "error", "id": msg.get("id"), "message": "unknown model"}, None
+    reserve = sum((native_models.model_size(msg.get(k)) or 0)
+                  for k in ("asrId", "ttsId") if msg.get(k))
+    chosen = select_variant(model, m, reserve, pin=msg.get("pin"))
+    gpu = m.nvidia[0] if m.nvidia else None
+    budget = (gpu.vram_mb * 1024 * 1024 - reserve - _VRAM_CONTEXT_BYTES) if (gpu and gpu.vram_mb) else 0
+    variants = []
+    for d in model.deployments:
+        if d.tier == "cpu":
+            continue
+        need = _est_bytes(d)
+        if d.backend not in m.installed or not _format_ready(d.compute_type):
+            supported, reason = False, "runtime not installed"
+        elif gpu is None or not gpu.vram_mb or gpu.capability is None:
+            supported, reason = False, "no usable GPU"
+        elif d.min_capability is not None and gpu.capability < d.min_capability:
+            supported, reason = False, f"needs compute capability {d.min_capability}"
+        elif need is None:
+            supported, reason = False, "size unknown"
+        elif need * _VRAM_WEIGHT_FACTOR > budget:
+            supported, reason = False, "too big for available VRAM"
+        else:
+            supported, reason = True, "fits"
+        variants.append({"id": d.compute_type, "computeType": d.compute_type,
+                         "repo": d.artifact, "sizeBytes": need or 0,
+                         "supported": supported, "reason": reason})
+    return {"type": "list_variants_result", "id": msg.get("id"),
+            "variants": variants, "recommended": chosen.compute_type}, None
+
+
 async def _h_hardware_info(state, msg, _b, conn=None):
     m = probe()
     return {"type": "hardware_info_result", "id": msg.get("id"),
@@ -572,4 +607,5 @@ async def _h_models_catalog(state, msg, _b, conn=None):
 
 def register(state: dict):
     state.setdefault("handlers", {}).update(
-        {"hardware_info": _h_hardware_info, "models_catalog": _h_models_catalog})
+        {"hardware_info": _h_hardware_info, "models_catalog": _h_models_catalog,
+         "list_variants": _h_list_variants})

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -549,6 +549,10 @@ async def _h_list_variants(state, msg, _b, conn=None):
     reserve = sum((native_models.model_size(msg.get(k)) or 0)
                   for k in ("asrId", "ttsId") if msg.get(k))
     chosen = select_variant(model, m, reserve, pin=msg.get("pin"))
+    # select_variant can return None for a model with no cpu floor (none today, but
+    # resolve_translate guards the same case) — never dereference chosen.compute_type then.
+    if chosen is None:
+        return {"type": "error", "id": msg.get("id"), "message": "no runnable variant"}, None
     gpu = m.nvidia[0] if m.nvidia else None
     budget = (gpu.vram_mb * 1024 * 1024 - reserve - _VRAM_CONTEXT_BYTES) if (gpu and gpu.vram_mb) else 0
     variants = []

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -19,6 +19,7 @@ class Gpu:
     vendor: str
     name: str
     vram_mb: int
+    capability: tuple[int, int] | None = None
 
 
 @dataclass(frozen=True)
@@ -33,10 +34,24 @@ class Machine:
     fingerprint: str
 
 
-def _nvidia_gpus() -> tuple[Gpu, ...]:
+def _cuda_count() -> int:
     from ctranslate2 import get_cuda_device_count
-    n = get_cuda_device_count()
-    return tuple(Gpu("nvidia", "", 0) for _ in range(n))
+    return get_cuda_device_count()
+
+
+def _nvidia_gpus() -> tuple[Gpu, ...]:
+    n = _cuda_count()
+    gpus = []
+    for i in range(n):
+        vram_mb, cap = 0, None
+        try:
+            import torch
+            vram_mb = int(torch.cuda.get_device_properties(i).total_memory // (1024 * 1024))
+            cap = tuple(torch.cuda.get_device_capability(i))  # (major, minor)
+        except Exception:
+            pass
+        gpus.append(Gpu("nvidia", "", vram_mb, cap))
+    return tuple(gpus)
 
 
 def _apple_silicon() -> bool:

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -210,12 +210,25 @@ def resolve(model_id: str, override: str = "auto", machine: Machine | None = Non
     return _resolve_model(model, model_id, override, machine or probe())
 
 
-def resolve_translate(model_id: str, override: str = "auto", machine: Machine | None = None) -> list[Plan]:
+def resolve_translate(model_id: str, override: str = "auto", machine: Machine | None = None,
+                      reserved_bytes: int = 0, pin: str | None = None) -> list[Plan]:
     from . import catalog
     model = catalog.translate_model(model_id)
     if model is None:
         raise ValueError(f"unknown translate model: {model_id}")
-    return _resolve_model(model, model_id, override, machine or probe())
+    machine = machine or probe()
+    if override == "auto":
+        chosen = select_variant(model, machine, reserved_bytes, pin)
+        cpu = next((d for d in model.deployments if d.tier == "cpu"), None)
+        picks = [chosen] + ([cpu] if cpu is not None and cpu is not chosen else [])
+        # Keep only deployments whose backend is actually installed on this machine.
+        picks = [d for d in picks if d is not None and d.backend in machine.installed]
+        if not picks:
+            raise NoUsablePlan(model_id)
+        return [Plan(d.backend, d.tier, TIER_DEVICE[d.tier], d.compute_type, d.artifact, d.rank)
+                for d in picks]
+    # explicit device override: unchanged tier-pinning path
+    return _resolve_model(model, model_id, override, machine)
 
 
 class AllPlansFailed(Exception):

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -454,6 +454,63 @@ def measure_tps(backend, plan, model_id: str, machine: Machine, *, force: bool =
         return None
 
 
+# Higher = better quality. Future formats slot in (int4, nvfp4) without touching callers.
+_VARIANT_QUALITY = {"bfloat16": 3.0, "float16": 3.0, "fp8": 2.0, "int4": 1.5, "nvfp4": 1.8}
+
+# Extra runtime/library a compute_type needs beyond its backend NAME being installed.
+_FORMAT_MODULE = {"fp8": "compressed_tensors"}
+
+
+def _format_ready(compute_type: str) -> bool:
+    """Return True when the runtime library required by `compute_type` is importable.
+    Most compute types need nothing extra; fp8 requires compressed_tensors."""
+    mod = _FORMAT_MODULE.get(compute_type)
+    return True if mod is None else _has_mod(mod)
+
+
+def _est_bytes(d) -> int | None:
+    """Return the estimated VRAM footprint of deployment `d` in bytes.
+    Uses d.est_bytes when set, otherwise falls back to native_models.model_size
+    (reads the artifact's on-disk weight files). Returns None when unknown."""
+    from . import native_models
+    if d.est_bytes is not None:
+        return d.est_bytes
+    return native_models.model_size(d.artifact)
+
+
+def select_variant(model, machine: Machine, reserved_bytes: int, pin: str | None = None):
+    """Pick the best downloadable variant of `model` for this machine. Deterministic:
+    same (model, machine, reserved_bytes, pin) → same Deployment. Falls back to the
+    CPU floor when no GPU variant fits, the GPU/estimate is unknown, or a format's
+    runtime is missing. `pin` (a compute_type) forces that variant when it's valid."""
+    gpu = machine.nvidia[0] if machine.nvidia else None
+    cpu_floor = next((d for d in model.deployments if d.tier == "cpu"), None)
+
+    def candidate(d) -> bool:
+        if d.tier == "cpu":
+            return False
+        if d.backend not in machine.installed or not _format_ready(d.compute_type):
+            return False
+        if gpu is None or not gpu.vram_mb or gpu.capability is None:
+            return False
+        if d.min_capability is not None and gpu.capability < d.min_capability:
+            return False
+        need = _est_bytes(d)
+        if need is None:
+            return False
+        budget = gpu.vram_mb * 1024 * 1024 - reserved_bytes - _VRAM_CONTEXT_BYTES
+        return need * _VRAM_WEIGHT_FACTOR <= budget
+
+    cands = [d for d in model.deployments if candidate(d)]
+    if pin is not None:
+        pinned = next((d for d in cands if d.compute_type == pin), None)
+        if pinned is not None:
+            return pinned
+    if cands:
+        return max(cands, key=lambda d: (_VARIANT_QUALITY.get(d.compute_type, 0.0), d.rank))
+    return cpu_floor
+
+
 def _apply_bench(plans: list, bench: dict) -> list:
     """Demote any non-cpu plan whose cached RTF is >= the cpu floor's cached RTF
     (proven not faster than CPU). `bench` maps (backend, device, compute_type) -> rtf."""

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -321,6 +321,15 @@ def _model_weight_bytes(artifact: str):
 _VRAM_WEIGHT_FACTOR = 1.2
 _VRAM_CONTEXT_BYTES = 1 << 30  # ~1 GiB
 
+# FP8 (compressed-tensors naive-quantized) has no FP8 matmul kernel in transformers,
+# so weights are dequantized per-forward at inference — peak VRAM ~1.5x weights, not
+# the 1.2x that applies to bf16/f16. Per-format override table; missing → _VRAM_WEIGHT_FACTOR.
+_VARIANT_WEIGHT_FACTOR = {"fp8": 1.5}
+
+
+def _weight_factor(compute_type: str) -> float:
+    return _VARIANT_WEIGHT_FACTOR.get(compute_type, _VRAM_WEIGHT_FACTOR)
+
 
 def _gib(n: float) -> str:
     return f"{n / (1 << 30):.1f}"
@@ -348,7 +357,7 @@ def load_with_fallback(plans: list):
         # BEFORE the load matters: torch's allocator reports ~0 free after an OOM.
         free = _cuda_free_bytes() if plan.device == "cuda" else None
         need = _model_weight_bytes(plan.artifact) if plan.device == "cuda" else None
-        budget = (need * _VRAM_WEIGHT_FACTOR + _VRAM_CONTEXT_BYTES) if need is not None else None
+        budget = (need * _weight_factor(plan.compute_type) + _VRAM_CONTEXT_BYTES) if need is not None else None
         if plan.device == "cuda" and has_cpu_fallback and free is not None and budget is not None:
             if free < budget:
                 notice = (f"cuda skipped (needs ~{_gib(budget)} GiB, "
@@ -512,7 +521,7 @@ def select_variant(model, machine: Machine, reserved_bytes: int, pin: str | None
         if need is None:
             return False
         budget = gpu.vram_mb * 1024 * 1024 - reserved_bytes - _VRAM_CONTEXT_BYTES
-        return need * _VRAM_WEIGHT_FACTOR <= budget
+        return need * _weight_factor(d.compute_type) <= budget
 
     cands = [d for d in model.deployments if candidate(d)]
     if pin is not None:
@@ -568,7 +577,7 @@ async def _h_list_variants(state, msg, _b, conn=None):
             supported, reason = False, f"needs compute capability {d.min_capability}"
         elif need is None:
             supported, reason = False, "size unknown"
-        elif need * _VRAM_WEIGHT_FACTOR > budget:
+        elif need * _weight_factor(d.compute_type) > budget:
             supported, reason = False, "too big for available VRAM"
         else:
             supported, reason = True, "fits"

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -19,6 +19,8 @@ class Deployment:
     compute_type: str   # "int8" | ...
     artifact: str       # backend.load() model_ref: whisper size, or sherpa repo id
     rank: float         # tie-breaker within a tier (higher = preferred)
+    min_capability: tuple[int, int] | None = None   # min CUDA compute cap for a GPU variant
+    est_bytes: int | None = None                     # footprint estimate; None → model_size(artifact)
 
 
 @dataclass(frozen=True)
@@ -112,6 +114,15 @@ def _llm_translate_row(mid, name, repo, backend, sort_order, recommended=False):
     ), recommended=recommended, sort_order=sort_order)
 
 
+def _with_fp8(row, fp8_repo):
+    """Return a copy of a TranslateModel row with a gpu-cuda fp8 variant appended."""
+    fp8 = Deployment(row.deployments[0].backend, "gpu-cuda", "fp8", fp8_repo, 1.0,
+                     min_capability=(8, 9))
+    return TranslateModel(row.id, row.name, row.languages,
+                          row.deployments + (fp8,),
+                          recommended=row.recommended, sort_order=row.sort_order)
+
+
 TRANSLATE_MODELS: list[TranslateModel] = [
     _llm_translate_row("qwen2.5-0.5b", "Qwen 2.5 0.5B",
                        QWEN25_REPO, "qwen_translate", 1, recommended=True),
@@ -123,10 +134,12 @@ TRANSLATE_MODELS: list[TranslateModel] = [
                        "Qwen/Qwen3.5-2B", "qwen35_translate", 4),
     _llm_translate_row("translategemma-4b", "TranslateGemma 4B",
                        "google/translategemma-4b-it", "gemma_translate", 5),
-    _llm_translate_row("hy-mt2-1.8b", "Hunyuan-MT2 1.8B",
-                       "tencent/Hy-MT2-1.8B", "hunyuan_translate", 6),
-    _llm_translate_row("hy-mt2-7b", "Hunyuan-MT2 7B",
-                       "tencent/Hy-MT2-7B", "hunyuan_translate", 7),
+    _with_fp8(_llm_translate_row("hy-mt2-1.8b", "Hunyuan-MT2 1.8B",
+                                 "tencent/Hy-MT2-1.8B", "hunyuan_translate", 6),
+              "tencent/Hy-MT2-1.8B-FP8"),
+    _with_fp8(_llm_translate_row("hy-mt2-7b", "Hunyuan-MT2 7B",
+                                 "tencent/Hy-MT2-7B", "hunyuan_translate", 7),
+              "tencent/Hy-MT2-7B-FP8"),
 ]
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -73,13 +73,19 @@ def _base_specs(model_id):
     return {"repos": [model_id], "urls": []}
 
 
-def download_specs(model_id):
+def download_specs(model_id, repo=None):
     """Map a model id to its download sources: {repos: [..], urls: [..]}.
 
     Every ASR-catalog model gets the shared silero VAD appended (see module
     docstring); non-ASR ids (translation, TTS) do not. The id is matched against
     the ASR catalog by exact id, so a bare HF repo id (e.g. the raw SenseVoice
-    repo passed to model_status) is treated as non-ASR and gets no VAD."""
+    repo passed to model_status) is treated as non-ASR and gets no VAD.
+
+    `repo` overrides the model's default repo with a chosen variant's repo (the
+    variant id resolves to a sibling repo). Variants are translation-only and
+    never need the VAD, so the override short-circuits before the VAD logic."""
+    if repo:
+        return {"repos": [repo], "urls": []}
     spec = _base_specs(model_id)
     if _asr_model(model_id) is not None and VAD_URL not in spec["urls"]:
         spec = {**spec, "urls": [*spec["urls"], VAD_URL]}

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -182,8 +182,12 @@ def _download_url(url):
         urllib.request.urlretrieve(url, dst)
 
 
-async def download(model_id, send, should_cancel=None):
+async def download(model_id, send, should_cancel=None, repo=None):
     """Download every file for a model, awaiting `send({model_progress})` per file.
+
+    `repo` overrides the model's default repo with a chosen variant's repo (e.g. an
+    FP8 quant) — threaded through to `download_specs` so the fetched repo matches
+    exactly what the deterministic load-path `select_variant` will load.
 
     Returns 'ready' when complete or 'cancelled' if `should_cancel()` became true
     between files. hf_hub_download runs in a worker thread that cannot be killed
@@ -194,7 +198,7 @@ async def download(model_id, send, should_cancel=None):
     import asyncio
     from huggingface_hub import HfApi, hf_hub_download
     cancelled = (lambda: bool(should_cancel and should_cancel()))
-    specs = download_specs(model_id)
+    specs = download_specs(model_id, repo)
     api = HfApi()
     ignore = set(specs.get("ignore", []))
     files = []
@@ -236,12 +240,14 @@ async def _h_model_sizes(state, msg, _b, conn=None):
     return {"type": "model_sizes_result", "id": msg.get("id"), "sizes": sizes}, None
 
 
-async def _run_download(state, model, conn):
+async def _run_download(state, model, conn, repo=None):
     """Background download task: streams progress, then pushes a terminal
-    model_download_done (status ready|cancelled) or an error tagged with `model`."""
+    model_download_done (status ready|cancelled) or an error tagged with `model`.
+    `repo` selects a chosen variant's repo when set (default keeps the model's
+    default repo)."""
     event = state.get("cancels", {}).get(model)
     try:
-        status = await download(model, conn.send, should_cancel=(event.is_set if event else None))
+        status = await download(model, conn.send, should_cancel=(event.is_set if event else None), repo=repo)
         await conn.send({"type": "model_download_done", "model": model, "status": status})
     except Exception as e:
         await conn.send({"type": "error", "model": model, "message": str(e)})
@@ -255,10 +261,11 @@ async def _h_model_download(state, msg, _b, conn=None):
     to model_cancel. Completion is pushed via model_download_done, not returned."""
     import asyncio
     model = msg.get("model")
+    repo = msg.get("repo")  # chosen variant's repo (None → model's default repo)
     if conn is None:
         return {"type": "error", "id": msg.get("id"), "message": "no connection"}, None
     state.setdefault("cancels", {})[model] = asyncio.Event()
-    state.setdefault("download_tasks", {})[model] = asyncio.create_task(_run_download(state, model, conn))
+    state.setdefault("download_tasks", {})[model] = asyncio.create_task(_run_download(state, model, conn, repo))
     return None, None
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -202,9 +202,9 @@ async def download(model_id, send, should_cancel=None, repo=None):
     api = HfApi()
     ignore = set(specs.get("ignore", []))
     files = []
-    for repo in specs["repos"]:
+    for r in specs["repos"]:  # `r`, not `repo`, so the variant `repo` param is not shadowed
         try:
-            files.extend((repo, f) for f in api.list_repo_files(repo) if f not in ignore)
+            files.extend((r, f) for f in api.list_repo_files(r) if f not in ignore)
         except Exception:
             pass
     # Never report a no-op download as success: if a model declares repos but none
@@ -215,10 +215,10 @@ async def download(model_id, send, should_cancel=None, repo=None):
             f"no downloadable files for {model_id} (repos {specs['repos']} unreachable)")
     total = len(files) + len(specs["urls"])
     done = 0
-    for repo, fname in files:
+    for r, fname in files:
         if cancelled():
             return "cancelled"
-        await asyncio.to_thread(hf_hub_download, repo, fname)
+        await asyncio.to_thread(hf_hub_download, r, fname)
         done += 1
         await send({"type": "model_progress", "model": model_id, "downloaded": done, "total": total})
     for url in specs["urls"]:

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -166,10 +166,17 @@ class HunyuanTranslateBackend:
             # hunyuan_v1_dense is native to transformers 5.13 (no auto_map, no
             # modeling_*.py in the repo) → plain AutoModelForCausalLM, no trust_remote_code.
             from transformers import AutoModelForCausalLM, AutoTokenizer
-            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
             self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
-            self._model = AutoModelForCausalLM.from_pretrained(
-                model_ref, dtype=dtype, local_files_only=True).to(device).eval()
+            if compute_type == "fp8":
+                # Pre-quantized compressed-tensors checkpoint: let its quantization_config
+                # drive loading (dtype="auto"); forcing a dtype would fight the quant.
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_ref, dtype="auto", local_files_only=True)
+            else:
+                dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+                model = AutoModelForCausalLM.from_pretrained(
+                    model_ref, dtype=dtype, local_files_only=True)
+            self._model = model.to(device).eval()
             self._device = device
         except Exception as e:
             raise BackendLoadError(str(e))

--- a/sidecar/sokuji_sidecar/translate_engine.py
+++ b/sidecar/sokuji_sidecar/translate_engine.py
@@ -11,12 +11,14 @@ class TranslateEngine:
         self._tgt = ""
         self.resolved = None
 
-    def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
+    def init(self, model_id=None, source_lang="", target_lang="", device="auto",
+             reserved_bytes=0, pin=None):
         t0 = time.time()
         self.close()                       # VRAM hygiene: free any prior model first
         self._src, self._tgt = source_lang, target_lang
         from . import accel
-        plans = accel.resolve_translate(model_id or "qwen2.5-0.5b", override=device or "auto")
+        plans = accel.resolve_translate(model_id or "qwen2.5-0.5b", override=device or "auto",
+                                        reserved_bytes=reserved_bytes, pin=pin)
         self._backend, plan, notice, mem = accel.load_measured(plans)
         tps = accel.measure_tps(self._backend, plan, model_id or "qwen2.5-0.5b", accel.probe())
         self.resolved = {"backend": plan.backend, "device": plan.device,
@@ -48,9 +50,15 @@ class TranslateEngine:
 
 
 async def _h_translate_init(state, msg, _b, conn=None):
+    from . import native_models
+    reserve = 0
+    for k in ("asrModel", "ttsModel"):
+        mid = msg.get(k)
+        if mid:
+            reserve += native_models.model_size(mid) or 0
     ms = state["translate_engine"].init(
         msg.get("model"), msg.get("sourceLang", ""), msg.get("targetLang", ""),
-        msg.get("device", "auto"))
+        msg.get("device", "auto"), reserved_bytes=reserve, pin=msg.get("variant"))
     # This connection owns the translate model: closing it frees the model from VRAM
     # (mirrors the ASR streaming connection's on_binary ownership in server._conn).
     if conn is not None:

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -639,11 +639,18 @@ def test_fun_asr_mlt_nano_resolves_gpu_and_cpu():
     # explicit cpu override -> cpu plan
     plan_cpu = accel.resolve("fun-asr-mlt-nano", "cpu", m)
     assert plan_cpu[0].tier == "cpu"
-def test_resolve_translate_prefers_gpu():
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+
+
+def test_resolve_translate_prefers_gpu(monkeypatch):
+    # select_variant requires known VRAM + capability to prefer a GPU; the old
+    # stub (vram_mb=0, capability=None) correctly falls back to CPU now.
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
+    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288, (8, 9)),),
                  installed=frozenset({"qwen_translate"}))
     plans = accel.resolve_translate("qwen2.5-0.5b", "auto", m)
-    assert [p.device for p in plans] == ["cuda", "cpu"]
+    assert plans[0].device == "cuda"
+    assert plans[-1].device == "cpu"
     assert plans[0].artifact == "Qwen/Qwen2.5-0.5B-Instruct"
 
 
@@ -796,3 +803,21 @@ def test_select_variant_conservative_when_no_vram(monkeypatch):
     m = _gpu_machine(0, None)                                 # probe couldn't read VRAM
     d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
     assert d.tier == "cpu"                                    # never gamble → cpu floor
+
+
+def test_resolve_translate_uses_selected_variant(monkeypatch):
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
+    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(16 * 1024, (8, 9)))
+    plans = accel.resolve_translate("hy-mt2-7b", override="auto", reserved_bytes=2 * 1024**3)
+    # chosen GPU variant first (fp8), CPU floor last
+    assert plans[0].compute_type == "fp8" and plans[0].device == "cuda"
+    assert plans[-1].device == "cpu"
+
+
+def test_resolve_translate_explicit_device_override_unchanged(monkeypatch):
+    # device override ("cuda"/"cpu") keeps prior tier-pinning behavior, not variant selection
+    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(12 * 1024, (8, 9)))
+    plans = accel.resolve_translate("hy-mt2-7b", override="cpu")
+    assert plans[0].device == "cpu"

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -727,3 +727,72 @@ def test_nvidia_gpus_degrades_when_torch_fails(monkeypatch):
     monkeypatch.setattr(accel, "_cuda_count", lambda: 1)
     gpus = accel._nvidia_gpus()
     assert len(gpus) == 1 and gpus[0].vram_mb == 0 and gpus[0].capability is None
+
+
+# ── select_variant tests ────────────────────────────────────────────────────
+
+
+def _gpu_machine(vram_mb, cap, installed=("hunyuan_translate",)):
+    g = accel.Gpu("nvidia", "", vram_mb, cap)
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=(g,),
+                         apple_silicon=False, dml_adapters=(), installed=frozenset(installed),
+                         fingerprint="t")
+
+
+def _hymt2_7b():
+    from sokuji_sidecar import catalog
+    return catalog.translate_model("hy-mt2-7b")
+
+
+def test_select_variant_picks_fp8_on_ada_when_bf16_too_big(monkeypatch):
+    # est_bytes: bf16 ~15GB, fp8 ~8GB. 16GB Ada, 2GB reserve → budget 13GB; bf16 needs 18GB, fp8 needs 9.6GB
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
+    m = _gpu_machine(16 * 1024, (8, 9))                       # 16GB Ada (e.g. RTX 4080)
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=2 * 1024**3)
+    assert d.compute_type == "fp8"                            # bf16 (15×1.2=18GB) won't fit, fp8 (8×1.2=9.6GB) does
+
+
+def test_select_variant_excludes_fp8_on_ampere(monkeypatch):
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
+    m = _gpu_machine(12 * 1024, (8, 6))                       # Ampere sm_86 → no FP8
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
+    assert d.tier == "cpu"                                    # bf16 too big, fp8 arch-excluded → cpu floor
+
+
+def test_select_variant_fp8_dropped_when_compressed_tensors_absent(monkeypatch):
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: ct != "fp8")
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
+    m = _gpu_machine(12 * 1024, (8, 9))
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
+    assert d.tier == "cpu"                                    # fp8 ungated off, bf16 too big → cpu
+
+
+def test_select_variant_prefers_bf16_when_it_fits(monkeypatch):
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 4, "fp8": 2, "float32": 4}[d.compute_type] * 1024**3)
+    m = _gpu_machine(24 * 1024, (8, 9))
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
+    assert d.compute_type == "bfloat16"                       # both fit → highest quality
+
+
+def test_select_variant_pin_honored_when_valid(monkeypatch):
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 4, "fp8": 2, "float32": 4}[d.compute_type] * 1024**3)
+    m = _gpu_machine(24 * 1024, (8, 9))
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0, pin="fp8")
+    assert d.compute_type == "fp8"                            # pinned despite bf16 fitting
+
+
+def test_select_variant_conservative_when_no_vram(monkeypatch):
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes", lambda d: 4 * 1024**3)
+    m = _gpu_machine(0, None)                                 # probe couldn't read VRAM
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
+    assert d.tier == "cpu"                                    # never gamble → cpu floor

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -828,11 +828,45 @@ def test_list_variants_marks_supported_and_recommended(monkeypatch):
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
-    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(12 * 1024, (8, 9)))
+    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(16 * 1024, (8, 9)))
     monkeypatch.setattr(nm, "model_size", lambda repo: 8 * 1024**3)
     msg = {"type": "list_variants", "id": 1, "model": "hy-mt2-7b", "asrId": None, "ttsId": None}
     reply, _ = asyncio.run(accel._h_list_variants({}, msg, None, None))
     by = {v["computeType"]: v for v in reply["variants"]}
     assert by["fp8"]["supported"] is True and by["fp8"]["repo"] == "tencent/Hy-MT2-7B-FP8"
-    assert by["bfloat16"]["supported"] is False           # 15GB > 12GB budget
+    assert by["bfloat16"]["supported"] is False           # 15GB*1.2=18GB > 15GB budget (16GiB - 1GiB ctx)
     assert reply["recommended"] == "fp8"
+
+
+def test_fp8_weight_factor_larger_than_bf16_in_select_variant(monkeypatch):
+    # FP8 dequantizes at inference time, so peak VRAM is ~1.5x weights (vs 1.2x for bf16).
+    # On 12GiB Ada with no reserve: budget = 12-1 = 11GiB.
+    # fp8 (8GiB * 1.5 = 12GiB) > 11GiB → must fall back to cpu floor.
+    # On 16GiB Ada: budget = 15GiB; fp8 (12GiB) ≤ 15GiB → fp8 chosen.
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
+
+    m12 = _gpu_machine(12 * 1024, (8, 9))
+    d12 = accel.select_variant(_hymt2_7b(), m12, reserved_bytes=0)
+    assert d12.tier == "cpu"  # fp8 8GB*1.5=12GB exceeds 11GB budget
+
+    m16 = _gpu_machine(16 * 1024, (8, 9))
+    d16 = accel.select_variant(_hymt2_7b(), m16, reserved_bytes=0)
+    assert d16.compute_type == "fp8"  # fp8 12GB ≤ 15GB budget on 16GB card
+
+
+def test_load_with_fallback_fp8_factor_gates_cuda(monkeypatch):
+    # An fp8 plan should use factor 1.5; on a 12GiB free machine with 8GiB weights:
+    # budget = 8*1.5 + 1GiB_context = 13GiB > 12GiB free → cuda proactively skipped.
+    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 12 * _GIB)
+    monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: 8 * _GIB)
+    fp8_plan = accel.Plan("hunyuan_translate", "gpu-cuda", "cuda", "fp8", "repo", 1.0)
+    cpu_pl = _plan("cpu")
+    attempted = []
+    class FakeBackend:
+        def load(self, a, device, ct): attempted.append(device); self.loaded = True
+    monkeypatch.setattr(accel, "make_backend", lambda name: FakeBackend())
+    backend, plan, notice = accel.load_with_fallback([fp8_plan, cpu_pl])
+    assert plan.device == "cpu" and attempted == ["cpu"]
+    assert notice and "CPU" in notice

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -821,3 +821,18 @@ def test_resolve_translate_explicit_device_override_unchanged(monkeypatch):
     monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(12 * 1024, (8, 9)))
     plans = accel.resolve_translate("hy-mt2-7b", override="cpu")
     assert plans[0].device == "cpu"
+
+
+def test_list_variants_marks_supported_and_recommended(monkeypatch):
+    from sokuji_sidecar import native_models as nm
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes",
+                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
+    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(12 * 1024, (8, 9)))
+    monkeypatch.setattr(nm, "model_size", lambda repo: 8 * 1024**3)
+    msg = {"type": "list_variants", "id": 1, "model": "hy-mt2-7b", "asrId": None, "ttsId": None}
+    reply, _ = asyncio.run(accel._h_list_variants({}, msg, None, None))
+    by = {v["computeType"]: v for v in reply["variants"]}
+    assert by["fp8"]["supported"] is True and by["fp8"]["repo"] == "tencent/Hy-MT2-7B-FP8"
+    assert by["bfloat16"]["supported"] is False           # 15GB > 12GB budget
+    assert reply["recommended"] == "fp8"

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -703,3 +703,27 @@ def test_new_translate_backends_installed_and_resolvable():
     assert any(p.backend == "hunyuan_translate" for p in plans)
     g = accel.resolve_translate("translategemma-4b", "auto")
     assert any(p.backend == "gemma_translate" for p in g)
+
+
+def test_nvidia_gpus_populates_vram_and_capability(monkeypatch):
+    import types, sys
+    fake_torch = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(
+            get_device_properties=lambda i: types.SimpleNamespace(total_memory=12 * 1024**3),
+            get_device_capability=lambda i: (8, 9),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "torch", fake_torch)
+    monkeypatch.setattr(accel, "_cuda_count", lambda: 1)
+    gpus = accel._nvidia_gpus()
+    assert len(gpus) == 1
+    assert gpus[0].vram_mb == 12 * 1024  # 12 GiB in MB
+    assert gpus[0].capability == (8, 9)
+
+
+def test_nvidia_gpus_degrades_when_torch_fails(monkeypatch):
+    import sys
+    monkeypatch.setitem(sys.modules, "torch", None)  # import torch → TypeError/ImportError
+    monkeypatch.setattr(accel, "_cuda_count", lambda: 1)
+    gpus = accel._nvidia_gpus()
+    assert len(gpus) == 1 and gpus[0].vram_mb == 0 and gpus[0].capability is None

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -157,3 +157,26 @@ def test_new_llm_translate_rows():
         gpu = next(d for d in h.deployments if d.tier == "gpu-cuda")
         cpu = next(d for d in h.deployments if d.tier == "cpu")
         assert gpu.compute_type == "bfloat16" and cpu.compute_type == "float32"
+
+
+def test_hymt2_has_fp8_variant():
+    from sokuji_sidecar import catalog
+    for mid, fp8_repo in [("hy-mt2-7b", "tencent/Hy-MT2-7B-FP8"),
+                          ("hy-mt2-1.8b", "tencent/Hy-MT2-1.8B-FP8")]:
+        m = catalog.translate_model(mid)
+        fp8 = [d for d in m.deployments if d.compute_type == "fp8"]
+        assert len(fp8) == 1
+        assert fp8[0].tier == "gpu-cuda"
+        assert fp8[0].backend == "hunyuan_translate"
+        assert fp8[0].artifact == fp8_repo
+        assert fp8[0].min_capability == (8, 9)
+        # bf16 + cpu still present, bf16 has no capability gate
+        bf16 = next(d for d in m.deployments if d.tier == "gpu-cuda" and d.compute_type == "bfloat16")
+        assert bf16.min_capability is None
+        assert any(d.tier == "cpu" for d in m.deployments)
+
+
+def test_gemma_has_no_fp8_variant():
+    from sokuji_sidecar import catalog
+    g = catalog.translate_model("translategemma-4b")
+    assert not any(d.compute_type == "fp8" for d in g.deployments)

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -83,7 +83,7 @@ def test_download_raises_when_no_files_resolved(monkeypatch):
         def list_repo_files(self, repo):
             raise RuntimeError(f"RepositoryNotFoundError: {repo}")
 
-    monkeypatch.setattr(nm, 'download_specs', lambda m: {'repos': ['bogus/repo'], 'urls': []})
+    monkeypatch.setattr(nm, 'download_specs', lambda m, repo=None: {'repos': ['bogus/repo'], 'urls': []})
     monkeypatch.setattr(huggingface_hub, 'HfApi', _Api)
 
     sent = []
@@ -142,7 +142,7 @@ def test_delete_handler_shape(monkeypatch):
 def test_download_is_nonblocking_and_pushes_completion(monkeypatch):
     # download runs as a background task; the handler returns nothing (completion
     # is pushed) so the connection stays free to receive model_cancel.
-    async def fake_download(model_id, send, should_cancel=None):
+    async def fake_download(model_id, send, should_cancel=None, repo=None):
         await send({'type': 'model_progress', 'model': model_id, 'downloaded': 1, 'total': 1})
         return 'ready'
     monkeypatch.setattr(nm, 'download', fake_download)
@@ -168,7 +168,7 @@ def test_download_is_nonblocking_and_pushes_completion(monkeypatch):
 
 def test_model_cancel_stops_download_at_file_boundary(monkeypatch):
     # a multi-file download checks should_cancel between files and stops promptly
-    async def fake_download(model_id, send, should_cancel=None):
+    async def fake_download(model_id, send, should_cancel=None, repo=None):
         while True:
             if should_cancel and should_cancel():
                 return 'cancelled'
@@ -242,7 +242,7 @@ def test_download_honors_ignore_list(monkeypatch):
         def list_repo_files(self, repo):
             return ["model.safetensors", "consolidated.safetensors", "config.json", "tekken.json"]
 
-    monkeypatch.setattr(nm, "download_specs", lambda m: {
+    monkeypatch.setattr(nm, "download_specs", lambda m, repo=None: {
         "repos": ["r"], "urls": [], "ignore": ["consolidated.safetensors"]})
     monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
     monkeypatch.setattr(huggingface_hub, "hf_hub_download",
@@ -311,3 +311,54 @@ def test_download_specs_variant_repo_override():
     from sokuji_sidecar import native_models as nm
     spec = nm.download_specs("hy-mt2-7b", repo="tencent/Hy-MT2-7B-FP8")
     assert spec["repos"] == ["tencent/Hy-MT2-7B-FP8"]
+
+
+def test_download_fetches_chosen_variant_repo(monkeypatch):
+    """download(model, send, repo=...) must fetch files from the CHOSEN variant repo,
+    not the model's default — the end-to-end wiring that makes the FP8 quant load."""
+    import huggingface_hub
+    fetched = []
+
+    class _Api:
+        def list_repo_files(self, repo):
+            return [f"{repo}/model.safetensors", "config.json"]
+
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download",
+                        lambda repo, fname: fetched.append((repo, fname)))
+
+    async def send(_m):
+        pass
+
+    status = asyncio.run(nm.download("hy-mt2-7b", send, repo="tencent/Hy-MT2-7B-FP8"))
+    assert status == "ready"
+    # Every fetched file came from the FP8 repo, NOT the default bf16 tencent/Hy-MT2-7B.
+    assert fetched and all(repo == "tencent/Hy-MT2-7B-FP8" for repo, _ in fetched)
+
+
+def test_h_model_download_passes_repo_through(monkeypatch):
+    """The model_download handler reads msg['repo'] and threads it to download(),
+    so the renderer's chosen variant repo reaches the fetch."""
+    captured = {}
+
+    async def fake_download(model_id, send, should_cancel=None, repo=None):
+        captured["repo"] = repo
+        await send({"type": "model_progress", "model": model_id, "downloaded": 1, "total": 1})
+        return "ready"
+    monkeypatch.setattr(nm, "download", fake_download)
+
+    class FakeWS:
+        def __init__(self): self.sent = []
+        async def send(self, d): self.sent.append(d)
+
+    async def scenario():
+        st = {}
+        nm.register(st)
+        conn = server.Conn(FakeWS())
+        await server.handle_message(
+            st, json.dumps({"type": "model_download", "id": 1, "model": "hy-mt2-7b",
+                            "repo": "tencent/Hy-MT2-7B-FP8"}), None, conn)
+        await st["download_tasks"]["hy-mt2-7b"]
+
+    asyncio.run(scenario())
+    assert captured["repo"] == "tencent/Hy-MT2-7B-FP8"

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -305,3 +305,9 @@ def test_download_specs_new_translate_models():
     h7 = nm.download_specs("hy-mt2-7b")
     assert h7["repos"] == ["tencent/Hy-MT2-7B"]
     assert h7["ignore"] == ["train/*"]
+
+
+def test_download_specs_variant_repo_override():
+    from sokuji_sidecar import native_models as nm
+    spec = nm.download_specs("hy-mt2-7b", repo="tencent/Hy-MT2-7B-FP8")
+    assert spec["repos"] == ["tencent/Hy-MT2-7B-FP8"]

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -173,6 +173,39 @@ def test_qwen35_translate_real_gpu_if_available():
     assert isinstance(out, str) and out.strip()
 
 
+def test_hunyuan_fp8_loads_without_forced_dtype(monkeypatch):
+    import sys
+    captured = {}
+    fake = MagicMock()
+    def from_pretrained(ref, **kw):
+        captured.update(kw)
+        return MagicMock(to=lambda d: MagicMock(eval=lambda: MagicMock()))
+    fake.AutoModelForCausalLM.from_pretrained.side_effect = from_pretrained
+    fake.AutoTokenizer.from_pretrained.return_value = MagicMock()
+    monkeypatch.setitem(sys.modules, "transformers", fake)
+    b = tb.HunyuanTranslateBackend()
+    b.load("tencent/Hy-MT2-7B-FP8", "cuda", "fp8")
+    # fp8 → dtype="auto", NOT a forced torch dtype; no trust_remote_code
+    assert captured.get("dtype") == "auto"
+    assert "trust_remote_code" not in captured
+
+
+def test_hunyuan_bf16_still_forces_dtype(monkeypatch):
+    import sys, types
+    captured = {}
+    fake = MagicMock()
+    def from_pretrained(ref, **kw):
+        captured.update(kw)
+        return MagicMock(to=lambda d: MagicMock(eval=lambda: MagicMock()))
+    fake.AutoModelForCausalLM.from_pretrained.side_effect = from_pretrained
+    fake.AutoTokenizer.from_pretrained.return_value = MagicMock()
+    monkeypatch.setitem(sys.modules, "transformers", fake)
+    monkeypatch.setitem(sys.modules, "torch", types.SimpleNamespace(bfloat16="BF16", float32="F32"))
+    b = tb.HunyuanTranslateBackend()
+    b.load("tencent/Hy-MT2-7B", "cuda", "bfloat16")
+    assert captured.get("dtype") == "BF16"
+
+
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_GPU"),
                     reason="set SOKUJI_RUN_GPU=1 (downloads Hy-MT2-1.8B + needs CUDA)")
 def test_hunyuan_translate_real_gpu():

--- a/sidecar/tests/test_translate_engine.py
+++ b/sidecar/tests/test_translate_engine.py
@@ -5,7 +5,8 @@ from sokuji_sidecar import server, translate_engine
 
 
 class FakeTranslate:
-    def init(self, model_id=None, source_lang="", target_lang="", device="auto"):
+    def init(self, model_id=None, source_lang="", target_lang="", device="auto",
+             reserved_bytes=0, pin=None):
         self.langs = (source_lang, target_lang)
         self.device = device
         self.resolved = {"backend": "qwen_translate", "device": "cuda", "computeType": "bfloat16"}
@@ -54,7 +55,7 @@ def test_init_uses_resolver_and_sets_resolved(monkeypatch):
     from sokuji_sidecar import accel
     fake_backend = MagicMock()
     fake_plan = MagicMock(backend="qwen_translate", device="cuda", compute_type="bfloat16")
-    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None, **_: ["plan"])
     monkeypatch.setattr(accel, "load_measured", lambda plans: (fake_backend, fake_plan, None, None))
     # Isolate from the real tps benchmark/cache so resolved is deterministic here.
     monkeypatch.setattr(accel, "measure_tps", lambda *a, **k: None)
@@ -75,7 +76,7 @@ def test_close_unloads_prior_backend_before_reinit(monkeypatch):
     first, second = MagicMock(), MagicMock()
     plan = MagicMock(backend="qwen_translate", device="cpu", compute_type="float32")
     backends_iter = iter([(first, plan, None, None), (second, plan, None, None)])
-    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None, **_: ["plan"])
     monkeypatch.setattr(accel, "load_measured", lambda plans: next(backends_iter))
 
     eng = translate_engine.TranslateEngine()
@@ -99,7 +100,7 @@ def test_init_stores_memory_and_fallback_reason(monkeypatch):
     from sokuji_sidecar import accel
     from unittest.mock import MagicMock
     fake_plan = MagicMock(backend="qwen_translate", device="cpu", compute_type="float32")
-    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None: ["plan"])
+    monkeypatch.setattr(accel, "resolve_translate", lambda mid, override=None, **_: ["plan"])
     monkeypatch.setattr(accel, "load_measured",
                         lambda plans: (MagicMock(), fake_plan, "cuda skipped (needs ~6.1 GiB, 2.1 GiB free); using CPU", 4_200_000_000))
     monkeypatch.setattr(accel, "measure_tps", lambda *a, **k: None)
@@ -107,6 +108,26 @@ def test_init_stores_memory_and_fallback_reason(monkeypatch):
     eng.init(model_id="qwen3.5-2b", source_lang="ja", target_lang="en")
     assert eng.resolved["memoryBytes"] == 4_200_000_000
     assert "using CPU" in eng.resolved["fallbackReason"]
+
+
+def test_translate_init_forwards_reserved_bytes(monkeypatch):
+    import asyncio
+    from sokuji_sidecar import translate_engine as te, native_models as nm
+    seen = {}
+    def fake_init(self, model_id=None, source_lang="", target_lang="", device="auto",
+                  reserved_bytes=0, pin=None):
+        seen["reserved_bytes"] = reserved_bytes
+        self.resolved = {"backend": "x", "device": "cpu", "computeType": "fp8"}
+        return 0
+    monkeypatch.setattr(te.TranslateEngine, "init", fake_init)
+    monkeypatch.setattr(nm, "model_size", lambda mid: {"voxtral-mini-4b-realtime": 8 * 1024**3,
+                                                       "piper-en": 100 * 1024**2}.get(mid, 0))
+    state = {"translate_engine": te.TranslateEngine()}
+    msg = {"type": "translate_init", "id": 1, "model": "hy-mt2-7b",
+           "asrModel": "voxtral-mini-4b-realtime", "ttsModel": "piper-en"}
+    reply, _ = asyncio.run(te._h_translate_init(state, msg, None, None))
+    assert reply["type"] == "ready"
+    assert seen["reserved_bytes"] == 8 * 1024**3 + 100 * 1024**2
 
 
 @pytest.mark.skipif(not os.environ.get("SOKUJI_RUN_TRANSLATE_MODEL"),

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -459,6 +459,71 @@
     display: flex;
     align-items: center;
   }
+
+  // --- Variant chooser (pre-download quant selection for multi-variant models) ---
+
+  &__variant-list {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 4px 0 2px;
+  }
+
+  &__variant-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 4px 8px;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid vars.$border-subtle;
+    border-radius: vars.$radius-sm;
+    cursor: pointer;
+    transition: border-color vars.$transition-fast, background vars.$transition-fast;
+    text-align: left;
+    width: 100%;
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.08);
+      border-color: vars.$border-default;
+    }
+
+    &--chosen {
+      border-color: rgba(vars.$color-primary, 0.6);
+    }
+
+    &:disabled {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+  }
+
+  &__variant-name {
+    font-size: vars.$font-caption;
+    color: vars.$text-secondary;
+    font-weight: vars.$weight-medium;
+
+    .model-card__variant-row--chosen & {
+      color: vars.$color-primary;
+    }
+  }
+
+  &__variant-size {
+    color: vars.$text-muted;
+    font-weight: vars.$weight-normal;
+  }
+
+  // Reuses the same green accent as the model-ok (primary) color token.
+  &__variant-recommended {
+    display: inline-flex;
+    align-items: center;
+    padding: 1px 5px;
+    background: rgba(vars.$color-primary, 0.15);
+    border-radius: 3px;
+    font-size: 10px;
+    color: vars.$color-primary;
+    font-weight: vars.$weight-medium;
+    white-space: nowrap;
+  }
 }
 
 .model-management__storage {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -511,6 +511,10 @@
     background: #1f2225;
     border: 1px solid vars.$border-default;
     border-radius: vars.$radius-sm;
+    // The selectable .model-card sets cursor:pointer, which `cursor` inheritance
+    // leaks onto the menu's plain text (e.g. the CPU note). Reset it here; the
+    // item buttons re-assert their own pointer/not-allowed cursor.
+    cursor: default;
   }
 
   &__variant-item {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -490,9 +490,12 @@
     &:disabled { cursor: not-allowed; opacity: 0.6; }
   }
 
+  // Calm, matches the muted "size" slot on sibling cards; green is reserved for
+  // the chosen row inside the menu, not the always-visible trigger.
   &__variant-trigger-value {
-    color: vars.$color-primary;
+    color: vars.$text-secondary;
     font-weight: vars.$weight-medium;
+    letter-spacing: 0.02em;
   }
 
   &__variant-menu {
@@ -541,34 +544,37 @@
 
   &__variant-check {
     color: vars.$color-primary;
-    font-weight: bold;
+    font-weight: vars.$weight-semibold;
   }
 
+  // Compute type is the primary label of the row → bright + tracked; the chosen
+  // row turns green to reinforce selection.
   &__variant-name {
     font-size: vars.$font-caption;
-    color: vars.$text-secondary;
+    color: vars.$text-primary;
     font-weight: vars.$weight-medium;
+    letter-spacing: 0.02em;
 
     .model-card__variant-item--chosen & {
       color: vars.$color-primary;
     }
   }
 
+  // Secondary metadata: the size trails the compute type, muted and lighter so the
+  // eye lands on the precision first.
   &__variant-size {
     color: vars.$text-muted;
     font-weight: vars.$weight-normal;
+    letter-spacing: normal;
   }
 
-  // Reuses the same green accent as the model-ok (primary) color token.
+  // Plain green text (not a filled pill) keeps the accent meaningful and the menu calm.
   &__variant-recommended {
-    display: inline-flex;
-    align-items: center;
-    padding: 1px 5px;
-    background: rgba(vars.$color-primary, 0.15);
-    border-radius: 3px;
     font-size: 10px;
     color: vars.$color-primary;
     font-weight: vars.$weight-medium;
+    letter-spacing: 0.02em;
+    text-transform: uppercase;
     white-space: nowrap;
   }
 

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -503,7 +503,8 @@
     top: calc(100% + 4px);
     right: 0;
     z-index: 20;
-    min-width: 200px;
+    min-width: 230px;
+    max-width: 320px;
     display: flex;
     flex-direction: column;
     gap: 2px;
@@ -516,7 +517,8 @@
 
   &__variant-item {
     display: flex;
-    align-items: center;
+    // Top-align so a wrapped reason sits neatly beside the one-line name.
+    align-items: flex-start;
     justify-content: space-between;
     gap: 10px;
     padding: 5px 8px;
@@ -549,7 +551,11 @@
 
   // Compute type is the primary label of the row → bright + tracked; the chosen
   // row turns green to reinforce selection.
+  // Precision + size is the primary info → never wraps; the secondary reason on the
+  // right wraps instead. flex-shrink:0 protects it from the reason column.
   &__variant-name {
+    flex: 0 0 auto;
+    white-space: nowrap;
     font-size: vars.$font-caption;
     color: vars.$text-primary;
     font-weight: vars.$weight-medium;
@@ -570,18 +576,25 @@
 
   // Plain green text (not a filled pill) keeps the accent meaningful and the menu calm.
   &__variant-recommended {
+    flex: 0 0 auto;
     font-size: 10px;
     color: vars.$color-primary;
     font-weight: vars.$weight-medium;
     letter-spacing: 0.02em;
-    text-transform: uppercase;
     white-space: nowrap;
+    padding-top: 1px;
   }
 
+  // Verbose reasons ("too big for available VRAM") wrap on the right rather than
+  // forcing the precision/size to break.
   &__variant-unavailable {
+    flex: 1 1 auto;
+    min-width: 0;
     font-size: 10px;
+    line-height: 1.3;
     color: vars.$text-muted;
-    white-space: nowrap;
+    text-align: right;
+    padding-top: 1px;
   }
 
   &__variant-cpu-note {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -518,6 +518,11 @@
     padding: 2px 2px 0;
   }
 
+  &__variant-check {
+    color: vars.$color-primary;
+    font-weight: bold;
+  }
+
   &__variant-name {
     font-size: vars.$font-caption;
     color: vars.$text-secondary;

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -487,14 +487,35 @@
       border-color: vars.$border-default;
     }
 
+    // Strong, unmistakable selection: filled tint + full-color border + left accent bar.
     &--chosen {
-      border-color: rgba(vars.$color-primary, 0.6);
+      border-color: vars.$color-primary;
+      background: rgba(vars.$color-primary, 0.12);
+      box-shadow: inset 2px 0 0 vars.$color-primary;
+    }
+
+    // A variant the machine can't run: greyed and not clickable (the row stays visible
+    // with its size + reason so the user understands why).
+    &--unsupported {
+      opacity: 0.5;
+      cursor: not-allowed;
     }
 
     &:disabled {
-      opacity: 0.6;
       cursor: not-allowed;
     }
+  }
+
+  &__variant-unavailable {
+    font-size: 10px;
+    color: vars.$text-muted;
+    white-space: nowrap;
+  }
+
+  &__variant-cpu-note {
+    font-size: 10px;
+    color: vars.$text-muted;
+    padding: 2px 2px 0;
   }
 
   &__variant-name {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -503,8 +503,7 @@
     top: calc(100% + 4px);
     right: 0;
     z-index: 20;
-    min-width: 230px;
-    max-width: 320px;
+    min-width: 210px;
     display: flex;
     flex-direction: column;
     gap: 2px;
@@ -512,13 +511,11 @@
     background: #1f2225;
     border: 1px solid vars.$border-default;
     border-radius: vars.$radius-sm;
-    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
   }
 
   &__variant-item {
     display: flex;
-    // Top-align so a wrapped reason sits neatly beside the one-line name.
-    align-items: flex-start;
+    align-items: center;
     justify-content: space-between;
     gap: 10px;
     padding: 5px 8px;
@@ -582,19 +579,15 @@
     font-weight: vars.$weight-medium;
     letter-spacing: 0.02em;
     white-space: nowrap;
-    padding-top: 1px;
   }
 
-  // Verbose reasons ("too big for available VRAM") wrap on the right rather than
-  // forcing the precision/size to break.
+  // Terse fixed state — full reason is in the row's title tooltip, so this stays
+  // short and never wraps.
   &__variant-unavailable {
-    flex: 1 1 auto;
-    min-width: 0;
+    flex: 0 0 auto;
     font-size: 10px;
-    line-height: 1.3;
     color: vars.$text-muted;
-    text-align: right;
-    padding-top: 1px;
+    white-space: nowrap;
   }
 
   &__variant-cpu-note {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -581,13 +581,13 @@
     white-space: nowrap;
   }
 
-  // Terse fixed state — full reason is in the row's title tooltip, so this stays
-  // short and never wraps.
+  // Muted "blocked" icon — full reason is in the row's title tooltip. Mirrors the
+  // green "recommended" slot on the opposite end of the state spectrum.
   &__variant-unavailable {
     flex: 0 0 auto;
-    font-size: 10px;
+    display: inline-flex;
+    align-items: center;
     color: vars.$text-muted;
-    white-space: nowrap;
   }
 
   &__variant-cpu-note {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -527,7 +527,9 @@
     width: 100%;
     transition: background vars.$transition-fast;
 
-    &:hover:not(:disabled) { background: rgba(255, 255, 255, 0.06); }
+    // Hover highlight only on selectable rows (unsupported rows use aria-disabled,
+    // not the :disabled pseudo-class, so exclude them by class).
+    &:hover:not(:disabled):not(#{&}--unsupported) { background: rgba(255, 255, 255, 0.06); }
 
     // Selected variant: filled tint + left accent bar — unmistakable.
     &--chosen {
@@ -535,8 +537,8 @@
       box-shadow: inset 2px 0 0 vars.$color-primary;
     }
 
-    // Unsupported: greyed, not clickable (still listed with its size + reason).
-    &--unsupported { opacity: 0.5; }
+    // Unsupported: greyed, not clickable (still listed with its size + blocked icon).
+    &--unsupported { opacity: 0.5; cursor: not-allowed; }
 
     &:disabled { cursor: not-allowed; }
   }

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -462,60 +462,81 @@
 
   // --- Variant chooser (pre-download quant selection for multi-variant models) ---
 
-  &__variant-list {
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    padding: 4px 0 2px;
+  // Dropdown wrapper lives in the header (where the size sits); menu is absolutely
+  // positioned so opening it never grows the card.
+  &__variant-dd {
+    position: relative;
   }
 
-  &__variant-row {
+  &__variant-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    font: inherit;
+    font-size: vars.$font-caption;
+    color: vars.$text-secondary;
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid vars.$border-subtle;
+    border-radius: vars.$radius-sm;
+    padding: 2px 6px;
+    cursor: pointer;
+    transition: border-color vars.$transition-fast, background vars.$transition-fast;
+
+    &:hover:not(:disabled) {
+      border-color: vars.$border-default;
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    &:disabled { cursor: not-allowed; opacity: 0.6; }
+  }
+
+  &__variant-trigger-value {
+    color: vars.$color-primary;
+    font-weight: vars.$weight-medium;
+  }
+
+  &__variant-menu {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    z-index: 20;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 4px;
+    background: #1f2225;
+    border: 1px solid vars.$border-default;
+    border-radius: vars.$radius-sm;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  }
+
+  &__variant-item {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding: 4px 8px;
-    background: rgba(255, 255, 255, 0.04);
-    border: 1px solid vars.$border-subtle;
+    gap: 10px;
+    padding: 5px 8px;
+    background: transparent;
+    border: 0;
     border-radius: vars.$radius-sm;
     cursor: pointer;
-    transition: border-color vars.$transition-fast, background vars.$transition-fast;
     text-align: left;
     width: 100%;
+    transition: background vars.$transition-fast;
 
-    &:hover:not(:disabled) {
-      background: rgba(255, 255, 255, 0.08);
-      border-color: vars.$border-default;
-    }
+    &:hover:not(:disabled) { background: rgba(255, 255, 255, 0.06); }
 
-    // Strong, unmistakable selection: filled tint + full-color border + left accent bar.
+    // Selected variant: filled tint + left accent bar — unmistakable.
     &--chosen {
-      border-color: vars.$color-primary;
       background: rgba(vars.$color-primary, 0.12);
       box-shadow: inset 2px 0 0 vars.$color-primary;
     }
 
-    // A variant the machine can't run: greyed and not clickable (the row stays visible
-    // with its size + reason so the user understands why).
-    &--unsupported {
-      opacity: 0.5;
-      cursor: not-allowed;
-    }
+    // Unsupported: greyed, not clickable (still listed with its size + reason).
+    &--unsupported { opacity: 0.5; }
 
-    &:disabled {
-      cursor: not-allowed;
-    }
-  }
-
-  &__variant-unavailable {
-    font-size: 10px;
-    color: vars.$text-muted;
-    white-space: nowrap;
-  }
-
-  &__variant-cpu-note {
-    font-size: 10px;
-    color: vars.$text-muted;
-    padding: 2px 2px 0;
+    &:disabled { cursor: not-allowed; }
   }
 
   &__variant-check {
@@ -528,7 +549,7 @@
     color: vars.$text-secondary;
     font-weight: vars.$weight-medium;
 
-    .model-card__variant-row--chosen & {
+    .model-card__variant-item--chosen & {
       color: vars.$color-primary;
     }
   }
@@ -549,6 +570,18 @@
     color: vars.$color-primary;
     font-weight: vars.$weight-medium;
     white-space: nowrap;
+  }
+
+  &__variant-unavailable {
+    font-size: 10px;
+    color: vars.$text-muted;
+    white-space: nowrap;
+  }
+
+  &__variant-cpu-note {
+    font-size: 10px;
+    color: vars.$text-muted;
+    padding: 2px 4px;
   }
 }
 

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -145,10 +145,10 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     expect(fp8Row).toBeEnabled();
 
     // bfloat16 is unsupported → listed (so the user sees the option) but disabled.
-    // Inline shows a terse "Won't fit"; the full reason lives in the title tooltip.
+    // A muted "blocked" icon marks it; the full reason lives in the title tooltip.
     const bf16Row = within(card7b).getByTestId('variant-row-bfloat16');
     expect(bf16Row).toBeDisabled();
-    expect(bf16Row).toHaveTextContent("Won't fit");
+    expect(within(bf16Row).getByLabelText("won't fit")).toBeInTheDocument();
     expect(bf16Row).toHaveAttribute('title', 'exceeds budget');
   });
 

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -144,10 +144,12 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     expect(within(fp8Row).getByText('recommended')).toBeInTheDocument();
     expect(fp8Row).toBeEnabled();
 
-    // bfloat16 is unsupported → listed (so the user sees the option + why) but disabled.
+    // bfloat16 is unsupported → listed (so the user sees the option) but disabled.
+    // Inline shows a terse "Won't fit"; the full reason lives in the title tooltip.
     const bf16Row = within(card7b).getByTestId('variant-row-bfloat16');
     expect(bf16Row).toBeDisabled();
-    expect(bf16Row).toHaveTextContent('exceeds budget');
+    expect(bf16Row).toHaveTextContent("Won't fit");
+    expect(bf16Row).toHaveAttribute('title', 'exceeds budget');
   });
 
   it('clicking a supported variant in the menu pins it (writes translationVariant)', async () => {

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -117,7 +117,7 @@ beforeEach(() => {
 });
 
 describe('NativeModelManagementSection — HY-MT2 variant card', () => {
-  it('shows supported FP8 variant with size and recommended badge before download; bfloat16 (unsupported) is not offered', async () => {
+  it('shows supported FP8 variant (enabled, recommended) and the unsupported bfloat16 variant (disabled, with reason) before download', async () => {
     // All statuses absent (default) → pre-download state for hy-mt2-7b.
     render(<NativeModelManagementSection />);
 
@@ -140,8 +140,14 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     // The "recommended" badge should be visible on the FP8 row.
     expect(within(fp8Row).getByText('recommended')).toBeInTheDocument();
 
-    // bfloat16 is unsupported → its row must not appear anywhere on the page.
-    expect(screen.queryByTestId('variant-row-bfloat16')).not.toBeInTheDocument();
+    // The supported fp8 row is enabled (clickable to pin).
+    expect(fp8Row).toBeEnabled();
+
+    // bfloat16 is unsupported → its row IS shown (so the user sees the option + why),
+    // but disabled and labelled with the reason.
+    const bf16Row = within(card7b).getByTestId('variant-row-bfloat16');
+    expect(bf16Row).toBeDisabled();
+    expect(bf16Row).toHaveTextContent('exceeds budget');
   });
 
   it('collapses to resolved variant label after download; no variant chooser buttons', async () => {

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -1,0 +1,169 @@
+/**
+ * Tests for the NativeModelManagementSection variant card UI (Task 9).
+ *
+ * Two states under test:
+ *   1. Pre-download  — supported variants shown with sizes + recommended badge;
+ *                      unsupported variants not offered.
+ *   2. Post-download — collapses to the single resolved variant label + actual size;
+ *                      no individual variant chooser buttons.
+ *
+ * Follows the TierIcon.test.tsx idiom: render, query, assert — no snapshot files.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import { NativeModelManagementSection } from './NativeModelManagementSection';
+import { formatMemMb } from '../../../lib/local-inference/native/nativeCatalog';
+import type { VariantInfo } from '../../../lib/local-inference/native/nativeProtocol';
+
+// ---------------------------------------------------------------------------
+// Stable mock data (names start with "mock" so vitest hoists them alongside vi.mock)
+// ---------------------------------------------------------------------------
+
+const mockSettings = {
+  sourceLanguage: 'ja',
+  targetLanguage: 'en',
+  asrModel: 'sense-voice',
+  translationModel: 'hy-mt2-7b',
+  ttsModel: '',
+  asrDevice: 'auto' as const,
+  translationDevice: 'auto' as const,
+};
+
+const mockVariants: VariantInfo[] = [
+  {
+    id: 'fp8',
+    computeType: 'fp8',
+    repo: 'tencent/Hy-MT2-7B-FP8',
+    sizeBytes: 8e9,
+    supported: true,
+    reason: 'fits in budget',
+  },
+  {
+    id: 'bfloat16',
+    computeType: 'bfloat16',
+    repo: 'tencent/Hy-MT2-7B',
+    sizeBytes: 15e9,
+    supported: false,
+    reason: 'exceeds budget',
+  },
+];
+
+// Mutable store state — mutated per test in beforeEach
+const mockStatuses: Record<string, string> = {};
+const mockSizes: Record<string, number> = {};
+
+const mockListVariants = vi.fn();
+
+// ---------------------------------------------------------------------------
+// Module mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, fallback?: string) => fallback ?? _k }),
+}));
+
+// Tooltip uses FloatingPortal which causes jsdom issues; replace with a passthrough.
+vi.mock('../../Tooltip/Tooltip', () => ({
+  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../../../stores/settingsStore', () => ({
+  useLocalNativeSettings: () => mockSettings,
+  useUpdateLocalNative: () => vi.fn(),
+}));
+
+vi.mock('../../../stores/nativeModelStore', () => ({
+  useNativeModelStore: (sel: Function) =>
+    sel({
+      statuses: mockStatuses,
+      sizes: mockSizes,
+      progress: {},
+      errors: {},
+      catalog: {},
+      download: vi.fn(),
+      deleteModel: vi.fn(),
+      cancelDownload: vi.fn(),
+      refresh: vi.fn().mockResolvedValue(undefined),
+      refreshSizes: vi.fn().mockResolvedValue(undefined),
+      refreshCatalog: vi.fn().mockResolvedValue(undefined),
+      autoSelect: vi.fn().mockReturnValue(null),
+      rememberModels: vi.fn(),
+      asrLoading: false,
+      asrResolved: null,
+      translationResolved: null,
+    }),
+  useNativeModelStatuses: () => ({ ...mockStatuses }),
+  useNativeModelProgress: () => ({}),
+  useNativeModelSizes: () => ({ ...mockSizes }),
+  useNativeModelErrors: () => ({}),
+  useNativeCatalog: () => ({}),
+  useNativeAsrLoading: () => false,
+  useNativeAsrResolved: () => null,
+  useNativeTranslationResolved: () => null,
+  nativeListVariants: (...args: unknown[]) => mockListVariants(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  // Reset mutable state so tests are independent.
+  Object.keys(mockStatuses).forEach((k) => delete mockStatuses[k]);
+  Object.keys(mockSizes).forEach((k) => delete mockSizes[k]);
+  mockListVariants.mockResolvedValue({ variants: mockVariants, recommended: 'fp8' });
+});
+
+describe('NativeModelManagementSection — HY-MT2 variant card', () => {
+  it('shows supported FP8 variant with size and recommended badge before download; bfloat16 (unsupported) is not offered', async () => {
+    // All statuses absent (default) → pre-download state for hy-mt2-7b.
+    render(<NativeModelManagementSection />);
+
+    // After the async listVariants effect resolves, the FP8 variant row must appear.
+    const fp8SizeLabel = formatMemMb(Math.round(8e9 / 1e6));
+
+    await waitFor(() => {
+      // There must be a variant-row button for fp8 on the hy-mt2-7b card.
+      expect(screen.getAllByTestId('variant-row-fp8').length).toBeGreaterThan(0);
+    });
+
+    // The hy-mt2-7b card specifically should have the FP8 row.
+    const card7b = screen.getByTestId('model-card-hy-mt2-7b');
+    const fp8Row = within(card7b).getByTestId('variant-row-fp8');
+    expect(fp8Row).toBeInTheDocument();
+
+    // The row should display the size label.
+    expect(fp8Row).toHaveTextContent(fp8SizeLabel);
+
+    // The "recommended" badge should be visible on the FP8 row.
+    expect(within(fp8Row).getByText('recommended')).toBeInTheDocument();
+
+    // bfloat16 is unsupported → its row must not appear anywhere on the page.
+    expect(screen.queryByTestId('variant-row-bfloat16')).not.toBeInTheDocument();
+  });
+
+  it('collapses to resolved variant label after download; no variant chooser buttons', async () => {
+    // Mark hy-mt2-7b as downloaded with a known byte count.
+    const downloadedBytes = 8_000_000_000;
+    mockStatuses['hy-mt2-7b'] = 'ready';
+    mockSizes['hy-mt2-7b'] = downloadedBytes;
+
+    render(<NativeModelManagementSection />);
+
+    // The resolved label appears only after the async listVariants effect resolves
+    // and sets variantData, triggering a re-render with the resolved computeType.
+    const downloadedSizeLabel = formatMemMb(Math.round(downloadedBytes / 1e6));
+    const resolvedSpan = await waitFor(() => {
+      const card = screen.getByTestId('model-card-hy-mt2-7b');
+      return within(card).getByTestId('variant-resolved-hy-mt2-7b');
+    });
+
+    expect(resolvedSpan).toHaveTextContent('FP8');
+    expect(resolvedSpan).toHaveTextContent(downloadedSizeLabel);
+
+    // No variant chooser buttons should appear on the hy-mt2-7b card after download.
+    const card7b = screen.getByTestId('model-card-hy-mt2-7b');
+    expect(within(card7b).queryByTestId('variant-row-fp8')).not.toBeInTheDocument();
+    expect(within(card7b).queryByTestId('variant-row-bfloat16')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -144,12 +144,12 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     expect(within(fp8Row).getByText('recommended')).toBeInTheDocument();
     expect(fp8Row).toBeEnabled();
 
-    // bfloat16 is unsupported → listed (so the user sees the option) but disabled.
-    // A muted "blocked" icon marks it; the full reason lives in the title tooltip.
+    // bfloat16 is unsupported → listed (so the user sees the option) but not
+    // selectable. It uses aria-disabled (not the disabled attribute) so the row
+    // stays hoverable for the instant tooltip; a muted "blocked" icon marks it.
     const bf16Row = within(card7b).getByTestId('variant-row-bfloat16');
-    expect(bf16Row).toBeDisabled();
+    expect(bf16Row).toHaveAttribute('aria-disabled', 'true');
     expect(within(bf16Row).getByLabelText("won't fit")).toBeInTheDocument();
-    expect(bf16Row).toHaveAttribute('title', 'exceeds budget');
   });
 
   it('clicking a supported variant in the menu pins it (writes translationVariant)', async () => {

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -54,6 +54,7 @@ const mockSizes: Record<string, number> = {};
 
 const mockListVariants = vi.fn();
 const mockDownload = vi.fn();
+const mockUpdate = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -70,7 +71,7 @@ vi.mock('../../Tooltip/Tooltip', () => ({
 
 vi.mock('../../../stores/settingsStore', () => ({
   useLocalNativeSettings: () => mockSettings,
-  useUpdateLocalNative: () => vi.fn(),
+  useUpdateLocalNative: () => mockUpdate,
 }));
 
 vi.mock('../../../stores/nativeModelStore', () => ({
@@ -114,40 +115,53 @@ beforeEach(() => {
   Object.keys(mockSizes).forEach((k) => delete mockSizes[k]);
   mockListVariants.mockResolvedValue({ variants: mockVariants, recommended: 'fp8' });
   mockDownload.mockReset();
+  mockUpdate.mockReset();
 });
 
 describe('NativeModelManagementSection — HY-MT2 variant card', () => {
-  it('shows supported FP8 variant (enabled, recommended) and the unsupported bfloat16 variant (disabled, with reason) before download', async () => {
+  it('header dropdown shows the chosen variant + size; opening it lists supported (enabled) and unsupported (disabled) variants', async () => {
     // All statuses absent (default) → pre-download state for hy-mt2-7b.
     render(<NativeModelManagementSection />);
-
-    // After the async listVariants effect resolves, the FP8 variant row must appear.
     const fp8SizeLabel = formatMemMb(Math.round(8e9 / 1e6));
 
-    await waitFor(() => {
-      // There must be a variant-row button for fp8 on the hy-mt2-7b card.
-      expect(screen.getAllByTestId('variant-row-fp8').length).toBeGreaterThan(0);
+    // The compact dropdown trigger appears in the header, showing the chosen variant + size.
+    const trigger = await waitFor(() => {
+      const card = screen.getByTestId('model-card-hy-mt2-7b');
+      return within(card).getByTestId('variant-dd-hy-mt2-7b');
     });
+    expect(trigger).toHaveTextContent('FP8');
+    expect(trigger).toHaveTextContent(fp8SizeLabel);
 
-    // The hy-mt2-7b card specifically should have the FP8 row.
+    // Variant rows are NOT rendered until the dropdown is opened (keeps the card short).
+    expect(screen.queryByTestId('variant-row-fp8')).not.toBeInTheDocument();
+
+    // Open the menu.
+    fireEvent.click(trigger);
+
     const card7b = screen.getByTestId('model-card-hy-mt2-7b');
     const fp8Row = within(card7b).getByTestId('variant-row-fp8');
-    expect(fp8Row).toBeInTheDocument();
-
-    // The row should display the size label.
     expect(fp8Row).toHaveTextContent(fp8SizeLabel);
-
-    // The "recommended" badge should be visible on the FP8 row.
     expect(within(fp8Row).getByText('recommended')).toBeInTheDocument();
-
-    // The supported fp8 row is enabled (clickable to pin).
     expect(fp8Row).toBeEnabled();
 
-    // bfloat16 is unsupported → its row IS shown (so the user sees the option + why),
-    // but disabled and labelled with the reason.
+    // bfloat16 is unsupported → listed (so the user sees the option + why) but disabled.
     const bf16Row = within(card7b).getByTestId('variant-row-bfloat16');
     expect(bf16Row).toBeDisabled();
     expect(bf16Row).toHaveTextContent('exceeds budget');
+  });
+
+  it('clicking a supported variant in the menu pins it (writes translationVariant)', async () => {
+    render(<NativeModelManagementSection />);
+    const trigger = await waitFor(() =>
+      within(screen.getByTestId('model-card-hy-mt2-7b')).getByTestId('variant-dd-hy-mt2-7b'));
+    fireEvent.click(trigger); // open the menu
+
+    const fp8Row = within(screen.getByTestId('model-card-hy-mt2-7b')).getByTestId('variant-row-fp8');
+    fireEvent.click(fp8Row);
+
+    // The pin reaches settings (single source of truth feeding both download repo and load).
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ translationModel: 'hy-mt2-7b', translationVariant: 'fp8' }));
   });
 
   it('collapses to resolved variant label after download; no variant chooser buttons', async () => {
@@ -182,7 +196,7 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     // Wait for the variant data to land so the download button knows the chosen repo.
     const card7b = await waitFor(() => {
       const c = screen.getByTestId('model-card-hy-mt2-7b');
-      within(c).getByTestId('variant-row-fp8'); // throws until variants render
+      within(c).getByTestId('variant-dd-hy-mt2-7b'); // throws until variant data lands
       return c;
     });
 

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -10,7 +10,7 @@
  * Follows the TierIcon.test.tsx idiom: render, query, assert — no snapshot files.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor, within, fireEvent } from '@testing-library/react';
 import { NativeModelManagementSection } from './NativeModelManagementSection';
 import { formatMemMb } from '../../../lib/local-inference/native/nativeCatalog';
 import type { VariantInfo } from '../../../lib/local-inference/native/nativeProtocol';
@@ -53,6 +53,7 @@ const mockStatuses: Record<string, string> = {};
 const mockSizes: Record<string, number> = {};
 
 const mockListVariants = vi.fn();
+const mockDownload = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -80,7 +81,7 @@ vi.mock('../../../stores/nativeModelStore', () => ({
       progress: {},
       errors: {},
       catalog: {},
-      download: vi.fn(),
+      download: mockDownload,
       deleteModel: vi.fn(),
       cancelDownload: vi.fn(),
       refresh: vi.fn().mockResolvedValue(undefined),
@@ -112,6 +113,7 @@ beforeEach(() => {
   Object.keys(mockStatuses).forEach((k) => delete mockStatuses[k]);
   Object.keys(mockSizes).forEach((k) => delete mockSizes[k]);
   mockListVariants.mockResolvedValue({ variants: mockVariants, recommended: 'fp8' });
+  mockDownload.mockReset();
 });
 
 describe('NativeModelManagementSection — HY-MT2 variant card', () => {
@@ -165,5 +167,24 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     const card7b = screen.getByTestId('model-card-hy-mt2-7b');
     expect(within(card7b).queryByTestId('variant-row-fp8')).not.toBeInTheDocument();
     expect(within(card7b).queryByTestId('variant-row-bfloat16')).not.toBeInTheDocument();
+  });
+
+  it('downloads the chosen (recommended FP8) variant repo, not the default', async () => {
+    // Pre-download state for hy-mt2-7b; FP8 is recommended.
+    render(<NativeModelManagementSection />);
+
+    // Wait for the variant data to land so the download button knows the chosen repo.
+    const card7b = await waitFor(() => {
+      const c = screen.getByTestId('model-card-hy-mt2-7b');
+      within(c).getByTestId('variant-row-fp8'); // throws until variants render
+      return c;
+    });
+
+    // Click the card's Download button.
+    const downloadBtn = within(card7b).getByRole('button', { name: /Download/i });
+    fireEvent.click(downloadBtn);
+
+    // Download must be called with the model's catalog id AND the FP8 variant's repo.
+    expect(mockDownload).toHaveBeenCalledWith('hy-mt2-7b', 'tencent/Hy-MT2-7B-FP8');
   });
 });

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp } from 'lucide-react';
 import Tooltip from '../../Tooltip/Tooltip';
@@ -49,6 +49,93 @@ type VariantCardProps = {
   recommendedVariantId: string;
   pinnedVariantId?: string;
   onPinVariant: (id: string) => void;
+};
+
+/**
+ * Compact quant-variant picker shown in a card header (in place of the size). A trigger
+ * shows the chosen variant + size (e.g. "FP8 · 8.0 GB"); clicking opens a menu listing all
+ * variants with sizes — unsupported ones disabled with a reason, plus a "runs on CPU" note
+ * when no GPU variant fits. A dropdown (rather than an inline button stack) keeps the card
+ * short and scales as more quant formats are added.
+ */
+const VariantDropdown: React.FC<{
+  variantProps: VariantCardProps;
+  chosenVariant?: VariantInfo;
+  disabled: boolean;
+  selectId: string;
+}> = ({ variantProps, chosenVariant, disabled, selectId }) => {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
+    document.addEventListener('mousedown', onDoc);
+    return () => document.removeEventListener('mousedown', onDoc);
+  }, [open]);
+
+  const gpuFits = variantProps.variants.some((v) => v.supported);
+  const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
+  const triggerLabel = chosenVariant
+    ? `${chosenVariant.computeType.toUpperCase()} · ${formatMemMb(Math.round(chosenVariant.sizeBytes / 1e6))}`
+    : 'CPU';
+
+  return (
+    <div className="model-card__variant-dd" ref={ref} onClick={(e) => e.stopPropagation()}>
+      <button
+        type="button"
+        className="model-card__variant-trigger"
+        data-testid={`variant-dd-${selectId}`}
+        disabled={disabled}
+        aria-expanded={open}
+        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
+      >
+        <span className="model-card__variant-trigger-value">{triggerLabel}</span>
+        <ChevronDown size={12} />
+      </button>
+      {open && (
+        <div className="model-card__variant-menu" role="listbox">
+          {variantProps.variants.map((v) => {
+            const isChosen = v.supported && v.id === chosenId;
+            const isRec = v.supported && v.id === variantProps.recommendedVariantId;
+            const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
+            return (
+              <button
+                key={v.id}
+                type="button"
+                role="option"
+                aria-selected={isChosen}
+                data-testid={`variant-row-${v.id}`}
+                className={'model-card__variant-item'
+                  + (isChosen ? ' model-card__variant-item--chosen' : '')
+                  + (!v.supported ? ' model-card__variant-item--unsupported' : '')}
+                disabled={!v.supported}
+                title={v.supported ? undefined : v.reason}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  if (v.supported) { variantProps.onPinVariant(v.id); setOpen(false); }
+                }}
+              >
+                <span className="model-card__variant-name">
+                  {isChosen && <span className="model-card__variant-check" aria-label="selected">✓ </span>}
+                  {v.computeType.toUpperCase()}
+                  <span className="model-card__variant-size"> · {sizeLabel}</span>
+                </span>
+                {isRec && (
+                  <span className="model-card__variant-recommended">recommended</span>
+                )}
+                {!v.supported && (
+                  <span className="model-card__variant-unavailable">{v.reason || "won't fit"}</span>
+                )}
+              </button>
+            );
+          })}
+          {!gpuFits && (
+            <span className="model-card__variant-cpu-note">No GPU variant fits — runs on CPU.</span>
+          )}
+        </div>
+      )}
+    </div>
+  );
 };
 
 // One selectable + downloadable card — reuses ModelManagementSection's model-card__* classes.
@@ -138,14 +225,15 @@ const NativeModelCard: React.FC<{
                 >
                   {resolvedVariantLabel}
                 </span>
-              ) : variantProps ? (
-                // Pre-download multi-variant card: show the chosen variant's size in the
-                // standard model-card__size spot, consistent with single-variant cards.
-                chosenVariant ? (
-                  <span className="model-card__size" data-testid={`variant-size-${spec.selectId}`}>
-                    {formatMemMb(Math.round(chosenVariant.sizeBytes / 1e6))}
-                  </span>
-                ) : null
+              ) : variantProps && !ready ? (
+                // Pre-download multi-variant card: compact dropdown picker, shown in the
+                // standard header size slot (trigger displays the chosen variant + size).
+                <VariantDropdown
+                  variantProps={variantProps}
+                  chosenVariant={chosenVariant}
+                  disabled={disabled}
+                  selectId={spec.selectId}
+                />
               ) : (
                 // Normal single-variant card: raw MB when available.
                 sizeMb !== null && (
@@ -211,49 +299,7 @@ const NativeModelCard: React.FC<{
               )}
             </div>
           </div>
-          {/* Variant chooser: shown pre-download for multi-quant cards. ALL variants are
-              listed with their sizes; ones that don't fit this machine are disabled with a
-              reason, so the choice (and why a variant is unavailable) is transparent. */}
-          {variantProps && !ready && variantProps.variants.length > 0 && (() => {
-            const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
-            const gpuFits = variantProps.variants.some((v) => v.supported);
-            return (
-              <div className="model-card__variant-list">
-                {variantProps.variants.map((v) => {
-                  const isChosen = v.supported && v.id === chosenId;
-                  const isRec = v.supported && v.id === variantProps.recommendedVariantId;
-                  const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
-                  return (
-                    <button
-                      key={v.id}
-                      data-testid={`variant-row-${v.id}`}
-                      className={'model-card__variant-row'
-                        + (isChosen ? ' model-card__variant-row--chosen' : '')
-                        + (!v.supported ? ' model-card__variant-row--unsupported' : '')}
-                      onClick={(e) => { e.stopPropagation(); if (v.supported) variantProps.onPinVariant(v.id); }}
-                      disabled={disabled || !v.supported}
-                      title={v.supported ? undefined : v.reason}
-                    >
-                      <span className="model-card__variant-name">
-                        {isChosen && <span className="model-card__variant-check" aria-label="selected">✓ </span>}
-                        {v.computeType.toUpperCase()}
-                        <span className="model-card__variant-size"> · {sizeLabel}</span>
-                      </span>
-                      {isRec && (
-                        <span className="model-card__variant-recommended">recommended</span>
-                      )}
-                      {!v.supported && (
-                        <span className="model-card__variant-unavailable">{v.reason || "won't fit"}</span>
-                      )}
-                    </button>
-                  );
-                })}
-                {!gpuFits && (
-                  <span className="model-card__variant-cpu-note">No GPU variant fits — will run on CPU.</span>
-                )}
-              </div>
-            );
-          })()}
+          {/* The quant-variant picker now lives in the header (VariantDropdown). */}
 
           <div className="model-card__actions">
             {noDownload ? null : status === 'downloading' ? (

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -124,7 +124,8 @@ const VariantDropdown: React.FC<{
                   <span className="model-card__variant-recommended">recommended</span>
                 )}
                 {!v.supported && (
-                  <span className="model-card__variant-unavailable">{v.reason || "won't fit"}</span>
+                  // Terse at-a-glance state; the full reason lives in the row's title tooltip.
+                  <span className="model-card__variant-unavailable">Won't fit</span>
                 )}
               </button>
             );

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp } from 'lucide-react';
+import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp, Ban } from 'lucide-react';
 import Tooltip from '../../Tooltip/Tooltip';
 import { useLocalNativeSettings, useUpdateLocalNative, type LocalNativeSettings } from '../../../stores/settingsStore';
 import {
@@ -124,8 +124,11 @@ const VariantDropdown: React.FC<{
                   <span className="model-card__variant-recommended">recommended</span>
                 )}
                 {!v.supported && (
-                  // Terse at-a-glance state; the full reason lives in the row's title tooltip.
-                  <span className="model-card__variant-unavailable">Won't fit</span>
+                  // Muted "blocked" glyph mirrors the green "recommended" slot; the full
+                  // reason lives in the row's title tooltip.
+                  <span className="model-card__variant-unavailable" aria-label="won't fit">
+                    <Ban size={13} />
+                  </span>
                 )}
               </button>
             );

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -138,9 +138,17 @@ const NativeModelCard: React.FC<{
                 >
                   {resolvedVariantLabel}
                 </span>
+              ) : variantProps ? (
+                // Pre-download multi-variant card: show the chosen variant's size in the
+                // standard model-card__size spot, consistent with single-variant cards.
+                chosenVariant ? (
+                  <span className="model-card__size" data-testid={`variant-size-${spec.selectId}`}>
+                    {formatMemMb(Math.round(chosenVariant.sizeBytes / 1e6))}
+                  </span>
+                ) : null
               ) : (
-                // Normal card (no variants) or pre-download: show raw MB when available.
-                !variantProps && sizeMb !== null && (
+                // Normal single-variant card: raw MB when available.
+                sizeMb !== null && (
                   <span className="model-card__size">{sizeMb} MB</span>
                 )
               )}
@@ -227,6 +235,7 @@ const NativeModelCard: React.FC<{
                       title={v.supported ? undefined : v.reason}
                     >
                       <span className="model-card__variant-name">
+                        {isChosen && <span className="model-card__variant-check" aria-label="selected">✓ </span>}
                         {v.computeType.toUpperCase()}
                         <span className="model-card__variant-size"> · {sizeLabel}</span>
                       </span>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -203,34 +203,48 @@ const NativeModelCard: React.FC<{
               )}
             </div>
           </div>
-          {/* Variant chooser: shown only pre-download for multi-quant cards. */}
-          {variantProps && !ready && variantProps.variants.some((v) => v.supported) && (
-            <div className="model-card__variant-list">
-              {variantProps.variants.filter((v) => v.supported).map((v) => {
-                const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
-                const isChosen = v.id === chosenId;
-                const isRec = v.id === variantProps.recommendedVariantId;
-                const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
-                return (
-                  <button
-                    key={v.id}
-                    data-testid={`variant-row-${v.id}`}
-                    className={'model-card__variant-row' + (isChosen ? ' model-card__variant-row--chosen' : '')}
-                    onClick={(e) => { e.stopPropagation(); variantProps.onPinVariant(v.id); }}
-                    disabled={disabled}
-                  >
-                    <span className="model-card__variant-name">
-                      {v.computeType.toUpperCase()}
-                      <span className="model-card__variant-size"> · {sizeLabel}</span>
-                    </span>
-                    {isRec && (
-                      <span className="model-card__variant-recommended">recommended</span>
-                    )}
-                  </button>
-                );
-              })}
-            </div>
-          )}
+          {/* Variant chooser: shown pre-download for multi-quant cards. ALL variants are
+              listed with their sizes; ones that don't fit this machine are disabled with a
+              reason, so the choice (and why a variant is unavailable) is transparent. */}
+          {variantProps && !ready && variantProps.variants.length > 0 && (() => {
+            const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
+            const gpuFits = variantProps.variants.some((v) => v.supported);
+            return (
+              <div className="model-card__variant-list">
+                {variantProps.variants.map((v) => {
+                  const isChosen = v.supported && v.id === chosenId;
+                  const isRec = v.supported && v.id === variantProps.recommendedVariantId;
+                  const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
+                  return (
+                    <button
+                      key={v.id}
+                      data-testid={`variant-row-${v.id}`}
+                      className={'model-card__variant-row'
+                        + (isChosen ? ' model-card__variant-row--chosen' : '')
+                        + (!v.supported ? ' model-card__variant-row--unsupported' : '')}
+                      onClick={(e) => { e.stopPropagation(); if (v.supported) variantProps.onPinVariant(v.id); }}
+                      disabled={disabled || !v.supported}
+                      title={v.supported ? undefined : v.reason}
+                    >
+                      <span className="model-card__variant-name">
+                        {v.computeType.toUpperCase()}
+                        <span className="model-card__variant-size"> · {sizeLabel}</span>
+                      </span>
+                      {isRec && (
+                        <span className="model-card__variant-recommended">recommended</span>
+                      )}
+                      {!v.supported && (
+                        <span className="model-card__variant-unavailable">{v.reason || "won't fit"}</span>
+                      )}
+                    </button>
+                  );
+                })}
+                {!gpuFits && (
+                  <span className="model-card__variant-cpu-note">No GPU variant fits — will run on CPU.</span>
+                )}
+              </div>
+            );
+          })()}
 
           <div className="model-card__actions">
             {noDownload ? null : status === 'downloading' ? (

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -108,8 +108,11 @@ const VariantDropdown: React.FC<{
                 className={'model-card__variant-item'
                   + (isChosen ? ' model-card__variant-item--chosen' : '')
                   + (!v.supported ? ' model-card__variant-item--unsupported' : '')}
-                disabled={!v.supported}
-                title={v.supported ? undefined : v.reason}
+                // aria-disabled (not the `disabled` attribute) so the row stays
+                // hoverable — a disabled <button> suppresses pointer events for its
+                // whole subtree, which would block the icon's tooltip. The click
+                // handler already no-ops for unsupported variants.
+                aria-disabled={!v.supported}
                 onClick={(e) => {
                   e.stopPropagation();
                   if (v.supported) { variantProps.onPinVariant(v.id); setOpen(false); }
@@ -125,10 +128,12 @@ const VariantDropdown: React.FC<{
                 )}
                 {!v.supported && (
                   // Muted "blocked" glyph mirrors the green "recommended" slot; the full
-                  // reason lives in the row's title tooltip.
-                  <span className="model-card__variant-unavailable" aria-label="won't fit">
-                    <Ban size={13} />
-                  </span>
+                  // reason shows in an instant (0ms) tooltip on hover.
+                  <Tooltip content={v.reason || "Won't fit"} position="top" icon="none" openDelay={0}>
+                    <span className="model-card__variant-unavailable" aria-label="won't fit">
+                      <Ban size={13} />
+                    </span>
+                  </Tooltip>
                 )}
               </button>
             );

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp } from 'lucide-react';
 import Tooltip from '../../Tooltip/Tooltip';
@@ -29,7 +29,9 @@ import {
   useNativeModelErrors,
   useNativeAsrResolved,
   useNativeTranslationResolved,
+  nativeListVariants,
 } from '../../../stores/nativeModelStore';
+import type { VariantInfo } from '../../../lib/local-inference/native/nativeProtocol';
 
 // The resolved plan a card may display: device + one speed metric + optional memory
 // footprint and fallback reason. ASR carries rtf ("Nx realtime"), translation carries
@@ -40,6 +42,14 @@ import { ModelGroup, RecommendedOthers, ModelStorageFooter } from './ModelManage
 
 type Stage = 'asrModel' | 'translationModel' | 'ttsModel';
 
+/** Props bundle for the optional variant chooser on multi-quant translation cards. */
+type VariantCardProps = {
+  variants: VariantInfo[];
+  recommendedVariantId: string;
+  pinnedVariantId?: string;
+  onPinVariant: (id: string) => void;
+};
+
 // One selectable + downloadable card — reuses ModelManagementSection's model-card__* classes.
 const NativeModelCard: React.FC<{
   spec: NativeModelCardSpec;
@@ -49,7 +59,9 @@ const NativeModelCard: React.FC<{
   incompatible?: boolean;
   resolved?: CardResolved | null;
   onSelect: () => void;
-}> = ({ spec, selected, autoSelected, disabled, incompatible = false, resolved = null, onSelect }) => {
+  /** Present only for translation cards that expose multiple quant variants (hy-mt2-*). */
+  variantProps?: VariantCardProps;
+}> = ({ spec, selected, autoSelected, disabled, incompatible = false, resolved = null, onSelect, variantProps }) => {
   const { t } = useTranslation();
   const statuses = useNativeModelStatuses();
   const progress = useNativeModelProgress();
@@ -88,15 +100,37 @@ const NativeModelCard: React.FC<{
   const bytes = noDownload ? 0 : sizes[spec.downloadId as string];
   const sizeMb = bytes && bytes > 0 ? Math.round(bytes / 1e6) : null;
 
+  // Resolved variant label shown post-download: "FP8 · 7.8 GB"
+  const resolvedVariantLabel = useMemo(() => {
+    if (!variantProps || !ready || sizeMb === null) return null;
+    const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
+    const chosen = variantProps.variants.find((v) => v.id === chosenId);
+    if (!chosen) return null;
+    return `${chosen.computeType.toUpperCase()} · ${formatMemMb(sizeMb)}`;
+  }, [variantProps, ready, sizeMb]);
+
   return (
-    <div className={classNames} onClick={handleClick}>
+    <div className={classNames} data-testid={`model-card-${spec.selectId}`} onClick={handleClick}>
       <div className="model-card__top-row">
         <div className="model-card__radio" />
         <div className="model-card__content">
           <div className="model-card__info">
             <div className="model-card__header">
               <span className="model-card__name">{spec.name}</span>
-              {sizeMb !== null && <span className="model-card__size">{sizeMb} MB</span>}
+              {resolvedVariantLabel !== null ? (
+                // Post-download variant card: show resolved compute type + actual size.
+                <span
+                  className="model-card__size"
+                  data-testid={`variant-resolved-${spec.selectId}`}
+                >
+                  {resolvedVariantLabel}
+                </span>
+              ) : (
+                // Normal card (no variants) or pre-download: show raw MB when available.
+                !variantProps && sizeMb !== null && (
+                  <span className="model-card__size">{sizeMb} MB</span>
+                )
+              )}
             </div>
             <div className="model-card__meta">
               <div className="model-card__languages">
@@ -156,6 +190,35 @@ const NativeModelCard: React.FC<{
               )}
             </div>
           </div>
+          {/* Variant chooser: shown only pre-download for multi-quant cards. */}
+          {variantProps && !ready && variantProps.variants.some((v) => v.supported) && (
+            <div className="model-card__variant-list">
+              {variantProps.variants.filter((v) => v.supported).map((v) => {
+                const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
+                const isChosen = v.id === chosenId;
+                const isRec = v.id === variantProps.recommendedVariantId;
+                const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
+                return (
+                  <button
+                    key={v.id}
+                    data-testid={`variant-row-${v.id}`}
+                    className={'model-card__variant-row' + (isChosen ? ' model-card__variant-row--chosen' : '')}
+                    onClick={(e) => { e.stopPropagation(); variantProps.onPinVariant(v.id); }}
+                    disabled={disabled}
+                  >
+                    <span className="model-card__variant-name">
+                      {v.computeType.toUpperCase()}
+                      <span className="model-card__variant-size"> · {sizeLabel}</span>
+                    </span>
+                    {isRec && (
+                      <span className="model-card__variant-recommended">recommended</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
           <div className="model-card__actions">
             {noDownload ? null : status === 'downloading' ? (
               <div className="model-card__progress">
@@ -240,6 +303,11 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   });
   const [showAllAsr, setShowAllAsr] = useState(false);
 
+  // Variant quant data for multi-variant translation cards (hy-mt2-*), keyed by selectId.
+  const [variantData, setVariantData] = useState<Record<string, { variants: VariantInfo[]; recommended: string }>>({});
+  // User-pinned variant choice per card selectId (overrides the algorithm's recommendation).
+  const [pinnedVariants, setPinnedVariants] = useState<Record<string, string>>({});
+
   const asrCards = useMemo(() => nativeAsrCards(settings.sourceLanguage), [settings.sourceLanguage]);
   const asrIncompatibleCards = useMemo(
     () => nativeAsrIncompatibleCards(settings.sourceLanguage), [settings.sourceLanguage]);
@@ -247,6 +315,31 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     () => nativeTranslationCards(settings.sourceLanguage, settings.targetLanguage),
     [settings.sourceLanguage, settings.targetLanguage]);
   const ttsCards = useMemo(() => nativeTtsCards(settings.targetLanguage), [settings.targetLanguage]);
+
+  // Identify translation cards with multiple quant variants (hy-mt2-*).
+  const hyMt2Ids = useMemo(
+    () => translationCards.filter((c) => c.selectId.startsWith('hy-mt2')).map((c) => c.selectId),
+    [translationCards],
+  );
+
+  // Fetch variant availability for each hy-mt2 card whenever the pipeline context changes
+  // (asrModel/ttsModel determine how much VRAM is reserved for other stages).
+  const variantFetchKey = [hyMt2Ids.join('|'), settings.asrModel, settings.ttsModel].join('::');
+  useEffect(() => {
+    if (hyMt2Ids.length === 0) return;
+    let cancelled = false;
+    for (const id of hyMt2Ids) {
+      nativeListVariants(id, settings.asrModel || null, settings.ttsModel || null)
+        .then((result) => {
+          if (!cancelled) setVariantData((prev) => ({ ...prev, [id]: result }));
+        })
+        .catch(() => {
+          // best-effort: sidecar may be down; variant chooser simply not shown
+        });
+    }
+    return () => { cancelled = true; };
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [variantFetchKey]);
 
   const allDownloadIds = useMemo(
     () => [...asrCards, ...asrIncompatibleCards, ...translationCards, ...ttsCards]
@@ -299,8 +392,20 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     rememberModels(settings.sourceLanguage, settings.targetLanguage, sel);
   };
 
+  // Pin a variant choice for a specific translation card (overrides the algorithm's recommendation).
+  const handlePinVariant = useCallback((selectId: string, variantId: string) => {
+    setPinnedVariants((prev) => ({ ...prev, [selectId]: variantId }));
+  }, []);
+
   // Recommended / Others split via the shared primitive; cards stay native-specific.
-  const renderCards = (cards: NativeModelCardSpec[], isSelected: (c: NativeModelCardSpec) => boolean, field: Stage) => {
+  const renderCards = (
+    cards: NativeModelCardSpec[],
+    isSelected: (c: NativeModelCardSpec) => boolean,
+    field: Stage,
+    variantMap?: Record<string, { variants: VariantInfo[]; recommended: string }>,
+    pinnedMap?: Record<string, string>,
+    onPin?: (selectId: string, variantId: string) => void,
+  ) => {
     // Feed each card the resolved plan for its stage so the active model shows the
     // measured device + speed metric (ASR rtf / translation tok/s). TTS has none.
     const resolvedForField = field === 'asrModel' ? asrResolved
@@ -309,11 +414,21 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
       <RecommendedOthers
         items={cards}
         isRecommended={(c) => !!c.recommended}
-        renderItem={(c) => (
-          <NativeModelCard key={c.selectId || 'auto'} spec={c} disabled={isSessionActive}
-            selected={isSelected(c)} autoSelected={autoSelectedStages[field]} resolved={resolvedForField}
-            onSelect={() => selectCard(field, c.selectId)} />
-        )}
+        renderItem={(c) => {
+          const vd = variantMap?.[c.selectId];
+          const vProps: VariantCardProps | undefined = vd ? {
+            variants: vd.variants,
+            recommendedVariantId: vd.recommended,
+            pinnedVariantId: pinnedMap?.[c.selectId],
+            onPinVariant: (id: string) => onPin?.(c.selectId, id),
+          } : undefined;
+          return (
+            <NativeModelCard key={c.selectId || 'auto'} spec={c} disabled={isSessionActive}
+              selected={isSelected(c)} autoSelected={autoSelectedStages[field]} resolved={resolvedForField}
+              onSelect={() => selectCard(field, c.selectId)}
+              variantProps={vProps} />
+          );
+        }}
       />
     );
   };
@@ -425,7 +540,14 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
             );
           })()}
         </div>
-        {renderCards(translationCards, (c) => settings.translationModel === c.selectId, 'translationModel')}
+        {renderCards(
+          translationCards,
+          (c) => settings.translationModel === c.selectId,
+          'translationModel',
+          variantData,
+          pinnedVariants,
+          handlePinVariant,
+        )}
       </ModelGroup>
 
       <ModelGroup id="model-tts" title={t('models.ttsModels', 'TTS (Text-to-Speech)')}>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -2,13 +2,14 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp } from 'lucide-react';
 import Tooltip from '../../Tooltip/Tooltip';
-import { useLocalNativeSettings, useUpdateLocalNative } from '../../../stores/settingsStore';
+import { useLocalNativeSettings, useUpdateLocalNative, type LocalNativeSettings } from '../../../stores/settingsStore';
 import {
   nativeAsrCards,
   nativeAsrIncompatibleCards,
   nativeTranslationCards,
   nativeTtsCards,
   pickNativeTts,
+  resolveNativeTts,
   tierLabel,
   hardwareGated,
   gpuTierAvailable,
@@ -317,8 +318,10 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
 
   // Variant quant data for multi-variant translation cards (hy-mt2-*), keyed by selectId.
   const [variantData, setVariantData] = useState<Record<string, { variants: VariantInfo[]; recommended: string }>>({});
-  // User-pinned variant choice per card selectId (overrides the algorithm's recommendation).
-  const [pinnedVariants, setPinnedVariants] = useState<Record<string, string>>({});
+  // The manual variant pin lives in settings.translationVariant (scoped to the SELECTED
+  // translation model) so it reaches BOTH download (repo) and load (select_variant pin) —
+  // a local-only pin would leave load on the recommended variant and fail a local_files_only
+  // load of the pinned repo. Non-selected cards show no pin (recommended) until selected.
 
   const asrCards = useMemo(() => nativeAsrCards(settings.sourceLanguage), [settings.sourceLanguage]);
   const asrIncompatibleCards = useMemo(
@@ -335,13 +338,17 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   );
 
   // Fetch variant availability for each hy-mt2 card whenever the pipeline context changes
-  // (asrModel/ttsModel determine how much VRAM is reserved for other stages).
-  const variantFetchKey = [hyMt2Ids.join('|'), settings.asrModel, settings.ttsModel].join('::');
+  // (asrModel/ttsModel determine how much VRAM is reserved for other stages). Pass the
+  // RESOLVED tts id (e.g. 'piper-en') — the same id LOAD's _h_translate_init reserves on —
+  // so download-time and load-time select_variant compute the identical reserve, else a
+  // razor VRAM edge could flip the variant between the two.
+  const reserveTtsId = resolveNativeTts(settings.ttsModel, settings.targetLanguage) || null;
+  const variantFetchKey = [hyMt2Ids.join('|'), settings.asrModel, reserveTtsId].join('::');
   useEffect(() => {
     if (hyMt2Ids.length === 0) return;
     let cancelled = false;
     for (const id of hyMt2Ids) {
-      nativeListVariants(id, settings.asrModel || null, settings.ttsModel || null)
+      nativeListVariants(id, settings.asrModel || null, reserveTtsId)
         .then((result) => {
           if (!cancelled) setVariantData((prev) => ({ ...prev, [id]: result }));
         })
@@ -395,7 +402,14 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   // Explicit user selection: write the choice, clear the Auto-selected flag, and
   // remember the full selection for this direction (mirrors ModelManagementSection).
   const selectCard = (field: Stage, selectId: string) => {
-    update({ [field]: selectId });
+    const updates: Partial<LocalNativeSettings> = { [field]: selectId };
+    // Selecting a DIFFERENT translation model clears the variant pin so a stale pin from
+    // the previously-selected model can't leak into the new model's load (which would
+    // resolve a repo that was never downloaded). Re-selecting the same model keeps its pin.
+    if (field === 'translationModel' && selectId !== settings.translationModel) {
+      updates.translationVariant = undefined;
+    }
+    update(updates);
     setAutoSelectedStages((prev) => ({ ...prev, [field]: false }));
     const sel: NativeSelection = {
       asrModel: settings.asrModel, translationModel: settings.translationModel, ttsModel: settings.ttsModel,
@@ -404,10 +418,16 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     rememberModels(settings.sourceLanguage, settings.targetLanguage, sel);
   };
 
-  // Pin a variant choice for a specific translation card (overrides the algorithm's recommendation).
+  // Pin a variant: select that translation model AND record the variant in settings, so
+  // download (chosen repo) and load (select_variant pin) agree. Mirrors selectCard's
+  // badge-clear + history-remember so a pinned model is treated like a selected one.
   const handlePinVariant = useCallback((selectId: string, variantId: string) => {
-    setPinnedVariants((prev) => ({ ...prev, [selectId]: variantId }));
-  }, []);
+    update({ translationModel: selectId, translationVariant: variantId });
+    setAutoSelectedStages((prev) => ({ ...prev, translationModel: false }));
+    rememberModels(settings.sourceLanguage, settings.targetLanguage, {
+      asrModel: settings.asrModel, translationModel: selectId, ttsModel: settings.ttsModel,
+    });
+  }, [update, rememberModels, settings.asrModel, settings.ttsModel, settings.sourceLanguage, settings.targetLanguage]);
 
   // Recommended / Others split via the shared primitive; cards stay native-specific.
   const renderCards = (
@@ -415,7 +435,6 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     isSelected: (c: NativeModelCardSpec) => boolean,
     field: Stage,
     variantMap?: Record<string, { variants: VariantInfo[]; recommended: string }>,
-    pinnedMap?: Record<string, string>,
     onPin?: (selectId: string, variantId: string) => void,
   ) => {
     // Feed each card the resolved plan for its stage so the active model shows the
@@ -428,10 +447,15 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
         isRecommended={(c) => !!c.recommended}
         renderItem={(c) => {
           const vd = variantMap?.[c.selectId];
+          // The pin only applies to the SELECTED translation model (the one that loads);
+          // other cards show the recommended variant. Reading from settings keeps download
+          // and load on the same variant.
+          const pinnedVariantId = c.selectId === settings.translationModel
+            ? settings.translationVariant : undefined;
           const vProps: VariantCardProps | undefined = vd ? {
             variants: vd.variants,
             recommendedVariantId: vd.recommended,
-            pinnedVariantId: pinnedMap?.[c.selectId],
+            pinnedVariantId,
             onPinVariant: (id: string) => onPin?.(c.selectId, id),
           } : undefined;
           return (
@@ -557,7 +581,6 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
           (c) => settings.translationModel === c.selectId,
           'translationModel',
           variantData,
-          pinnedVariants,
           handlePinVariant,
         )}
       </ModelGroup>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -100,14 +100,26 @@ const NativeModelCard: React.FC<{
   const bytes = noDownload ? 0 : sizes[spec.downloadId as string];
   const sizeMb = bytes && bytes > 0 ? Math.round(bytes / 1e6) : null;
 
+  // The chosen variant (pinned, else recommended) for a multi-variant card — drives
+  // both the resolved label and which repo the download button fetches.
+  const chosenVariant = useMemo(() => {
+    if (!variantProps) return undefined;
+    const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
+    return variantProps.variants.find((v) => v.id === chosenId);
+  }, [variantProps]);
+
   // Resolved variant label shown post-download: "FP8 · 7.8 GB"
   const resolvedVariantLabel = useMemo(() => {
-    if (!variantProps || !ready || sizeMb === null) return null;
-    const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
-    const chosen = variantProps.variants.find((v) => v.id === chosenId);
-    if (!chosen) return null;
-    return `${chosen.computeType.toUpperCase()} · ${formatMemMb(sizeMb)}`;
-  }, [variantProps, ready, sizeMb]);
+    if (!chosenVariant || !ready || sizeMb === null) return null;
+    return `${chosenVariant.computeType.toUpperCase()} · ${formatMemMb(sizeMb)}`;
+  }, [chosenVariant, ready, sizeMb]);
+
+  // The download button fetches the chosen variant's repo (undefined → default repo,
+  // for single-variant cards). Keeps download in lock-step with the variant load.
+  const handleDownload = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    download(spec.downloadId as string, chosenVariant?.repo);
+  };
 
   return (
     <div className={classNames} data-testid={`model-card-${spec.selectId}`} onClick={handleClick}>
@@ -252,7 +264,7 @@ const NativeModelCard: React.FC<{
             ) : (
               <button
                 className="model-card__btn model-card__btn--download"
-                onClick={(e) => { e.stopPropagation(); download(spec.downloadId as string); }}
+                onClick={handleDownload}
                 disabled={disabled || hwGated}
                 title={hwGated ? t('models.requiresGpu', 'Requires a GPU') : t('models.download', 'Download')}
               >

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -244,9 +244,10 @@ const NativeModelCard: React.FC<{
                   selectId={spec.selectId}
                 />
               ) : (
-                // Normal single-variant card: raw MB when available.
+                // Normal single-variant card: GB-aware label (formatMemMb switches
+                // to GB at >= 1024 MB) — never a bare four-digit "MB".
                 sizeMb !== null && (
-                  <span className="model-card__size">{sizeMb} MB</span>
+                  <span className="model-card__size">{formatMemMb(sizeMb)}</span>
                 )
               )}
             </div>

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -26,6 +26,8 @@ interface TooltipProps {
   trigger?: 'hover' | 'click';
   icon?: 'help' | 'info' | 'none';
   maxWidth?: number;
+  /** Hover open delay in ms (default 100). Pass 0 for an instant tooltip. */
+  openDelay?: number;
 }
 
 const Tooltip: React.FC<TooltipProps> = ({
@@ -34,7 +36,8 @@ const Tooltip: React.FC<TooltipProps> = ({
   position = 'top',
   trigger = 'hover',
   icon = 'help',
-  maxWidth = 250
+  maxWidth = 250,
+  openDelay = 100
 }) => {
   const [isOpen, setIsOpen] = useState(false);
   const arrowRef = React.useRef(null);
@@ -64,7 +67,7 @@ const Tooltip: React.FC<TooltipProps> = ({
   // Interaction hooks based on trigger type
   const hover = useHover(context, {
     enabled: trigger === 'hover',
-    delay: { open: 100, close: 0 },
+    delay: { open: openDelay, close: 0 },
     handleClose: safePolygon(),
   });
   

--- a/src/lib/local-inference/native/NativeModelClient.test.ts
+++ b/src/lib/local-inference/native/NativeModelClient.test.ts
@@ -39,6 +39,10 @@ class FakeWS {
         { id: 'sense-voice', name: 'SenseVoice', languages: ['zh', 'en', 'ja', 'ko', 'yue'],
           recommended: true, tiers: [{ tier: 'cpu', backend: 'sherpa', available: true }] },
       ] }));
+    if (msg.type === 'list_variants') queueMicrotask(() =>
+      this.emit({ type: 'list_variants_result', id: msg.id,
+        variants: [{ id: 'fp8', computeType: 'fp8', repo: 'tencent/Hy-MT2-7B-FP8', sizeBytes: 8e9, supported: true, reason: 'fits' }],
+        recommended: 'fp8' }));
   }
   close() {}
   static cancelled = new Set<string>();
@@ -105,6 +109,16 @@ describe('NativeModelClient', () => {
     expect(models).toHaveLength(1);
     expect(models[0]).toMatchObject({ id: 'sense-voice', recommended: true });
     expect(models[0].tiers[0]).toMatchObject({ tier: 'cpu', available: true });
+  });
+
+  it('listVariants returns variants + recommended from the sidecar', async () => {
+    const c = new NativeModelClient();
+    const r = await c.listVariants('hy-mt2-7b', 'voxtral-mini-4b-realtime', null);
+    expect(r.recommended).toBe('fp8');
+    expect(r.variants[0].supported).toBe(true);
+    expect(r.variants[0].id).toBe('fp8');
+    expect(r.variants[0].computeType).toBe('fp8');
+    expect(r.variants[0].sizeBytes).toBe(8e9);
   });
 });
 

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -1,4 +1,4 @@
-import type { ServerMsg, NativeModelState, ModelProgressMsg, ModelDownloadStatus, NativeModelInfo } from './nativeProtocol';
+import type { ServerMsg, NativeModelState, ModelProgressMsg, ModelDownloadStatus, NativeModelInfo, VariantInfo } from './nativeProtocol';
 
 interface DownloadHandle {
   onProgress?: (p: ModelProgressMsg) => void;
@@ -115,6 +115,21 @@ export class NativeModelClient {
     if (kind) payload.kind = kind;
     const msg = await this.send(payload);
     return (msg as Extract<ServerMsg, { type: 'models_catalog_result' }>).models;
+  }
+
+  /** Query available variants (quant levels) for a model, with hardware feasibility info.
+   *  `asrId`/`ttsId` tell the sidecar what is already loaded so it can compute the
+   *  remaining VRAM reserve when evaluating each variant. `pin` pins a specific variant. */
+  async listVariants(model: string, asrId: string | null, ttsId: string | null, pin?: string)
+    : Promise<{ variants: VariantInfo[]; recommended: string }> {
+    await this.connect();
+    const payload: { type: 'list_variants'; model: string; asrId?: string; ttsId?: string; pin?: string } = { type: 'list_variants', model };
+    if (asrId) payload.asrId = asrId;
+    if (ttsId) payload.ttsId = ttsId;
+    if (pin) payload.pin = pin;
+    const msg = await this.send(payload);
+    const r = msg as Extract<ServerMsg, { type: 'list_variants_result' }>;
+    return { variants: r.variants, recommended: r.recommended };
   }
 
   /** Remove a model from the sidecar's cache; resolves to the bytes freed. */

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -141,12 +141,17 @@ export class NativeModelClient {
   }
 
   /** Start a download; resolves 'ready' on completion or 'cancelled' if cancel()
-   *  stopped it. Rejects on a sidecar error tagged with this model. */
-  async download(model: string, onProgress?: (p: ModelProgressMsg) => void): Promise<ModelDownloadStatus> {
+   *  stopped it. Rejects on a sidecar error tagged with this model. `repo` selects
+   *  a chosen variant's repo (the sidecar fetches that repo instead of the model's
+   *  default — keeps download in lock-step with the deterministic variant load). */
+  async download(model: string, onProgress?: (p: ModelProgressMsg) => void, repo?: string): Promise<ModelDownloadStatus> {
     await this.connect();
     return new Promise<ModelDownloadStatus>((resolve, reject) => {
       this.downloads.set(model, { onProgress, resolve, reject });
-      this.ws!.send(JSON.stringify({ type: 'model_download', model, id: this.nextId++ }));
+      const payload: { type: 'model_download'; model: string; id: number; repo?: string } =
+        { type: 'model_download', model, id: this.nextId++ };
+      if (repo) payload.repo = repo;
+      this.ws!.send(JSON.stringify(payload));
     });
   }
 

--- a/src/lib/local-inference/native/NativeTranslateClient.ts
+++ b/src/lib/local-inference/native/NativeTranslateClient.ts
@@ -53,11 +53,19 @@ export class NativeTranslateClient {
     return new Promise((resolve, reject) => { this.pending.set(id, { resolve, reject }); this.ws!.send(JSON.stringify({ ...payload, id })); });
   }
 
-  async init(sourceLang: string, targetLang: string, modelId?: string, device?: string):
-      Promise<{ loadTimeMs: number; backend?: string; device?: string; computeType?: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string }> {
+  async init(
+    sourceLang: string, targetLang: string, modelId?: string, device?: string,
+    asrModel?: string | null, ttsModel?: string | null, variant?: string,
+  ): Promise<{ loadTimeMs: number; backend?: string; device?: string; computeType?: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string }> {
     await this.connect();
     this.onStatus?.('[native-translate] init…');
-    const msg = await this.send({ type: 'translate_init', sourceLang, targetLang, model: modelId, device });
+    const payload: Record<string, unknown> = { type: 'translate_init', sourceLang, targetLang, model: modelId, device };
+    // Pass co-loaded stage IDs and the chosen variant so the sidecar can account
+    // for their VRAM when reserving memory for the translation model.
+    if (asrModel) payload.asrModel = asrModel;
+    if (ttsModel) payload.ttsModel = ttsModel;
+    if (variant) payload.variant = variant;
+    const msg = await this.send(payload);
     const r = msg as Extract<ServerMsg, { type: 'ready' }>;
     return { loadTimeMs: r.loadTimeMs, backend: r.backend, device: r.device, computeType: r.computeType, tokensPerSec: r.tokensPerSec, memoryBytes: r.memoryBytes, fallbackReason: r.fallbackReason };
   }

--- a/src/lib/local-inference/native/nativeProtocol.ts
+++ b/src/lib/local-inference/native/nativeProtocol.ts
@@ -16,6 +16,17 @@ export interface HardwareInfoResultMsg {
 export interface ModelsCatalogResultMsg {
   type: 'models_catalog_result'; id: number; models: NativeModelInfo[];
 }
+export interface VariantInfo {
+  id: string;
+  computeType: string;
+  repo: string;
+  sizeBytes: number;
+  supported: boolean;
+  reason: string;
+}
+export interface ListVariantsResultMsg {
+  type: 'list_variants_result'; id: number; variants: VariantInfo[]; recommended: string;
+}
 export interface OkMsg { type: 'ok'; id: number; }
 export interface ResultMsg { type: 'result'; id: number; sampleRate: number; generationTimeMs: number; samples: number; }
 export interface ErrorMsg { type: 'error'; id?: number; model?: string; message: string; }
@@ -30,4 +41,4 @@ export interface ModelDeleteResultMsg { type: 'model_delete_result'; id: number;
 export interface ModelProgressMsg { type: 'model_progress'; model: string; downloaded: number; total: number; }
 export type ModelDownloadStatus = 'ready' | 'cancelled';
 export interface ModelDownloadDoneMsg { type: 'model_download_done'; model: string; status: ModelDownloadStatus; }
-export type ServerMsg = ReadyMsg | OkMsg | ResultMsg | TranslationMsg | SpeechStartMsg | AsrPartialMsg | AsrResultMsg | ModelStatusResultMsg | ModelSizesResultMsg | ModelDeleteResultMsg | ModelProgressMsg | ModelDownloadDoneMsg | ErrorMsg | HardwareInfoResultMsg | ModelsCatalogResultMsg;
+export type ServerMsg = ReadyMsg | OkMsg | ResultMsg | TranslationMsg | SpeechStartMsg | AsrPartialMsg | AsrResultMsg | ModelStatusResultMsg | ModelSizesResultMsg | ModelDeleteResultMsg | ModelProgressMsg | ModelDownloadDoneMsg | ErrorMsg | HardwareInfoResultMsg | ModelsCatalogResultMsg | ListVariantsResultMsg;

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -55,7 +55,9 @@ export class LocalNativeClient implements IClient {
     const store = useNativeModelStore.getState();
     const initTranslate = async () => {
       const tr = await this.translate.init(
-        config.sourceLanguage, config.targetLanguage, config.translationModelId, config.translationDevice);
+        config.sourceLanguage, config.targetLanguage, config.translationModelId, config.translationDevice,
+        config.asrModelId, config.ttsModelId, config.translationVariant,
+      );
       store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu', tokensPerSec: tr.tokensPerSec, memoryBytes: tr.memoryBytes, fallbackReason: tr.fallbackReason });
     };
     const initAsr = async () => {

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -207,6 +207,8 @@ export interface LocalNativeSessionConfig extends BaseSessionConfig {
   wrapTranscript?: boolean;
   asrDevice?: string;
   translationDevice?: string;
+  /** Pinned quant variant for the translation model (e.g. 'fp8'). Undefined → sidecar auto-selects. */
+  translationVariant?: string;
 }
 
 /**

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -20,8 +20,9 @@ interface NativeModelStore {
   refresh: (models: string[]) => Promise<void>;
   /** Query the sidecar for download sizes (bytes) of these models (best-effort). */
   refreshSizes: (models: string[]) => Promise<void>;
-  /** Download one model, streaming progress into the store. */
-  download: (model: string) => Promise<void>;
+  /** Download one model, streaming progress into the store. `repo` selects a chosen
+   *  variant's repo (the sidecar fetches it instead of the model's default repo). */
+  download: (model: string, repo?: string) => Promise<void>;
   /** Ask the sidecar to stop an in-flight download (takes effect at a file boundary). */
   cancelDownload: (model: string) => Promise<void>;
   /** Delete one model from the sidecar cache (flips its status to absent). */
@@ -109,7 +110,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
     }
   },
 
-  download: async (model) => {
+  download: async (model, repo) => {
     set((s) => ({
       statuses: { ...s.statuses, [model]: 'downloading' },
       progress: { ...s.progress, [model]: { downloaded: 0, total: 0 } },
@@ -117,7 +118,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
     }));
     try {
       const status = await client.download(model, (p) =>
-        set((s) => ({ progress: { ...s.progress, [model]: { downloaded: p.downloaded, total: p.total } } })));
+        set((s) => ({ progress: { ...s.progress, [model]: { downloaded: p.downloaded, total: p.total } } })), repo);
       // 'cancelled' (or a partial fetch) leaves the model incomplete → absent.
       set((s) => ({
         statuses: { ...s.statuses, [model]: status === 'ready' ? 'ready' : 'absent' },

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { NativeModelClient } from '../lib/local-inference/native/NativeModelClient';
-import type { NativeModelState, NativeModelInfo } from '../lib/local-inference/native/nativeProtocol';
+import type { NativeModelState, NativeModelInfo, VariantInfo } from '../lib/local-inference/native/nativeProtocol';
 import { autoSelectNative, hardwareGated, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
 
 export type NativeModelStatus = NativeModelState | 'downloading';
@@ -183,6 +183,14 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
   setAsrResolved: (r) => set({ asrResolved: r }),
   setTranslationResolved: (r) => set({ translationResolved: r }),
 }));
+
+/** Best-effort call to the sidecar's list_variants endpoint.
+ *  Exported at this module boundary so the renderer can mock it in tests. */
+export async function nativeListVariants(
+  model: string, asrId: string | null, ttsId: string | null, pin?: string,
+): Promise<{ variants: VariantInfo[]; recommended: string }> {
+  return client.listVariants(model, asrId, ttsId, pin);
+}
 
 export const useNativeModelStatuses = () => useNativeModelStore((s) => s.statuses);
 export const useNativeModelProgress = () => useNativeModelStore((s) => s.progress);

--- a/src/stores/settingsStore.translationVariant.test.ts
+++ b/src/stores/settingsStore.translationVariant.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock ServiceFactory (required — settingsStore calls it during updateLocalNative)
+const mockSetSetting = vi.fn().mockResolvedValue(undefined);
+vi.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: vi.fn(() => ({
+      setSetting: mockSetSetting,
+      getSetting: vi.fn(),
+    })),
+  },
+}));
+
+// Mock modelManifest (required — settingsStore imports it at module level)
+vi.mock('../lib/local-inference/modelManifest', async () => {
+  const actual = await vi.importActual('../lib/local-inference/modelManifest');
+  return { ...actual };
+});
+
+// Import after mocking
+const { default: useSettingsStore, createLocalNativeSessionConfig } = await import('./settingsStore');
+
+describe('translationVariant pin reaches the session config (download/load agree)', () => {
+  it('is undefined (automatic) by default', () => {
+    expect(useSettingsStore.getState().localNative.translationVariant).toBeUndefined();
+    const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
+    expect(cfg.translationVariant).toBeUndefined();
+  });
+
+  it('a pinned variant is forwarded as config.translationVariant for load select_variant(pin)', async () => {
+    await useSettingsStore.getState().updateLocalNative({
+      translationModel: 'hy-mt2-7b', translationVariant: 'fp8',
+    });
+    const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
+    // Load's _h_translate_init pins on config.translationVariant; it MUST equal the variant
+    // the download fetched (fp8), else local_files_only load of the recommended repo fails.
+    expect(cfg.translationVariant).toBe('fp8');
+  });
+
+  it('clearing the pin (undefined) returns the config to automatic', async () => {
+    await useSettingsStore.getState().updateLocalNative({ translationVariant: undefined });
+    const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
+    expect(cfg.translationVariant).toBeUndefined();
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -183,6 +183,10 @@ export interface LocalInferenceSettings {
 export interface LocalNativeSettings {
   asrModel: string;          // sidecar ASR model id (e.g. 'sense-voice', 'whisper-tiny')
   translationModel: string;  // '' (auto) | LLM id (e.g. 'qwen2.5-0.5b')
+  // Manual quant-variant pin for the SELECTED translation model (e.g. 'fp8'). undefined
+  // = automatic (the sidecar's select_variant picks the recommended variant). Scoped to
+  // translationModel: changing the model resets this so a stale pin can't leak.
+  translationVariant?: string;
   ttsModel: string;          // '' = Auto (default voice) | a specific piper voice id
   sourceLanguage: string;
   targetLanguage: string;
@@ -715,7 +719,7 @@ function createLocalInferenceSessionConfig(
  * resolution live in nativeCatalog. The engine defaults the translate prompt,
  * so instructions are advisory.
  */
-function createLocalNativeSessionConfig(
+export function createLocalNativeSessionConfig(
   settings: LocalNativeSettings,
   systemInstructions: string
 ): LocalNativeSessionConfig {
@@ -730,6 +734,9 @@ function createLocalNativeSessionConfig(
     targetLanguage: settings.targetLanguage,
     asrModelId: settings.asrModel,
     translationModelId: resolveNativeTranslation(settings.translationModel),
+    // Manual variant pin → load's select_variant(pin=...) so LOAD resolves the same
+    // variant DOWNLOAD fetched (else local_files_only load fails on a missing repo).
+    translationVariant: settings.translationVariant,
     ttsModelId: resolveNativeTts(settings.ttsModel, settings.targetLanguage),
     ttsSpeed: settings.ttsSpeed,
     vadThreshold: settings.vadThreshold,


### PR DESCRIPTION
## Summary

Stacks three native local-inference tracks on top of `native-sidecar` (49 commits, ~40 files):

1. **Resolved-memory + degrade display** — engines now report actual per-stage `memoryBytes` + `fallbackReason`; the UI splits the estimate into VRAM + RAM, shows a live tier badge with real usage, and surfaces a degrade chip when a stage was pushed off the GPU. Adds VRAM-aware load order with an honest OOM message.

2. **TranslateGemma + HY-MT2 translation backends** — catalog rows, download specs, `gemma_translate` (text-only) and `hunyuan_translate` backends, picker exposure (incl. the `_installed` gate), and direct text input for `LOCAL_NATIVE`.

3. **Quant-variant selection + FP8 runtime (Track A.1)** — GPU VRAM/compute-capability probe, download-time variant picker (`select_variant` / `list_variants` WS handler), variant-aware download specs, FP8 loading via compressed-tensors in the Hunyuan backend, ASR+TTS VRAM reservation when resolving the translate variant, and a compact variant-picker dropdown on the model card with per-variant sizes.

## Notes

- Base is `native-sidecar`, which is currently ~15 commits ahead of this branch's fork point — a rebase/merge may be needed before landing.
- **Known deferred:** AUTO→CPU fallback for TranslateGemma 4B on 12 GB cards misses the GPU by ~0.3 GB from stacked padding and falls back silently (no `fallbackReason`). Diagnosed and intentionally left unfixed on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
