### PR TITLE
feat(native): Opus-MT pair translation (13 pairs) + download efficiency fixes

### DIFF
--- a/docs/superpowers/plans/2026-06-27-native-opus-mt-pair-translation.md
+++ b/docs/superpowers/plans/2026-06-27-native-opus-mt-pair-translation.md
@@ -1,0 +1,465 @@
+# Native Opus-MT Pair Translation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add 13 high-usage Opus-MT language pairs to the LOCAL_NATIVE sidecar as a first-class PyTorch MarianMT translate backend (GPU bf16 + CPU floor) with per-pair, opt-in model cards.
+
+**Architecture:** A new `opus_translate` backend (`AutoModelForSeq2SeqLM`, direct `generate()`) sits beside the existing LLM translate backends and reuses the catalog → `resolve_translate` → `load_with_fallback` machinery. Source weights come from `Helsinki-NLP/opus-mt-{src}-{tgt}` (one repo = weights + tokenizer). The renderer gains pair-specific cards filtered by the active source→target language.
+
+**Tech Stack:** Python (sidecar: transformers MarianMT, pytest), TypeScript (renderer: nativeCatalog, vitest).
+
+## Global Constraints
+
+- Backend name: `opus_translate`. Self-gates on `transformers` (MarianMT is core — no `trust_remote_code`, no special module).
+- All model/tokenizer loads use `local_files_only=True` (offline-first; per PR #265 review).
+- No FP8 / quantized variants for Opus-MT (bf16 is ~300 MB).
+- Source repos: `Helsinki-NLP/opus-mt-{src}-{tgt}` (NOT the `Xenova/*` ONNX exports).
+- The 13 pairs (id tokens): `ru-en`, `zh-en`, `en-zh`, `hu-en`, `en-es`, `en-ar`, `en-ru`, `es-en`, `en-vi`, `ar-en`, `ja-en`, `en-jap`, `ko-en`.
+- `ja`/`jap`: the id/repo for en→ja keeps the Helsinki "jap" token (`opus-mt-en-jap`), but the renderer match-codes use canonical `ja`. ja→en is `opus-mt-ja-en`.
+- Renderer language matching uses bare ISO codes via the existing module-private `canonLang` (the native picker emits bare codes like `'en'`/`'zh'`/`'ja'`).
+- Opus-MT is opt-in: never a default; the recommended Qwen 2.5 0.5B stays default.
+- Sidecar test env: prefix pytest with `SOKUJI_BENCH_DIR=$(mktemp -d)`. Two unrelated `test_accel.py` gating tests (`voxtral_realtime`, `hunyuan_translate`) fail under system Python (transformers version) — that is pre-existing and not caused by this work.
+
+---
+
+### Task 1: `opus_translate` backend + install gate (sidecar)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/translate_backends.py` (append a new backend class)
+- Modify: `sidecar/sokuji_sidecar/accel.py` (add `opus_translate` to `_installed` mods dict, ~line 99)
+- Test: `sidecar/tests/test_translate_backends.py` (append), `sidecar/tests/test_accel.py` (append)
+
+**Interfaces:**
+- Produces: `translate_backends.OpusTranslateBackend` with `NAME = "opus_translate"`, registered into `backends._BACKENDS`. Methods match the existing backend contract: `load(model_ref, device, compute_type)`, `translate(text, system_prompt, src, tgt, wrap) -> (str, int)`, `unload()`, `is_loaded` property.
+- Consumes: `backends.register_backend`, `backends.BackendLoadError` (already imported in the module).
+
+- [ ] **Step 1: Write the failing backend test**
+
+Append to `sidecar/tests/test_translate_backends.py` (reuses the file's existing `FakeInputs`):
+
+```python
+def test_opus_backend_registered():
+    assert backends._BACKENDS.get("opus_translate") is tb.OpusTranslateBackend
+
+
+def test_opus_translate_runs_seq2seq_and_ignores_prompt():
+    import torch  # noqa: F401  (translate imports torch internally)
+    b = tb.OpusTranslateBackend()
+    # Seq2seq generate returns the translation tokens directly (no input slice).
+    seq = MagicMock()
+    seq.shape = [4]                     # 4 output tokens → int-able count
+    model = MagicMock()
+    model.generate.return_value = [seq]
+    tok = MagicMock()
+    tok.side_effect = lambda text, **kw: FakeInputs(input_ids=MagicMock(shape=[1, 3]))
+    tok.decode.return_value = "  translated  "
+    b._model = model
+    b._tok = tok
+    b._device = "cpu"
+    out, n = b.translate("hello", "ignored-prompt", "ja", "en", True)
+    assert out == "translated"          # stripped
+    assert n == 4
+    assert model.generate.called
+    # Marian is pair-baked: no chat template is ever applied.
+    assert not tok.apply_chat_template.called
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_translate_backends.py::test_opus_backend_registered tests/test_translate_backends.py::test_opus_translate_runs_seq2seq_and_ignores_prompt -v`
+Expected: FAIL — `AttributeError: module ... has no attribute 'OpusTranslateBackend'`.
+
+- [ ] **Step 3: Implement the backend**
+
+Append to `sidecar/sokuji_sidecar/translate_backends.py`:
+
+```python
+@register_backend
+class OpusTranslateBackend:
+    NAME = "opus_translate"
+
+    def __init__(self):
+        self._model = None
+        self._tok = None
+        self._device = "cpu"
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            # MarianMT is a small seq2seq model, core to transformers (no
+            # trust_remote_code, no VLM processor). bf16 on GPU, float32 on CPU.
+            from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+            self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
+            self._model = AutoModelForSeq2SeqLM.from_pretrained(
+                model_ref, dtype=dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing torch/transformers, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> tuple[str, int]:
+        # The translation direction is baked into the model — system_prompt, src,
+        # tgt and wrap are intentionally ignored. generate() emits only the
+        # translation tokens (no input prefix to slice off).
+        import torch
+        inputs = self._tok(text, return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
+        seq = out[0]
+        return self._tok.decode(seq, skip_special_tokens=True).strip(), int(seq.shape[-1])
+
+    def unload(self) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+```
+
+- [ ] **Step 4: Run the backend test to verify it passes**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_translate_backends.py::test_opus_backend_registered tests/test_translate_backends.py::test_opus_translate_runs_seq2seq_and_ignores_prompt -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Write the failing install-gate test**
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_opus_translate_self_gates_on_transformers(monkeypatch):
+    from sokuji_sidecar import accel
+    real = accel.importlib.util.find_spec
+
+    def present(name, *a, **k):
+        if name == "transformers":
+            return object()
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", present)
+    assert "opus_translate" in accel._installed()
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_accel.py::test_opus_translate_self_gates_on_transformers -v`
+Expected: FAIL — `opus_translate` not in the installed set.
+
+- [ ] **Step 7: Add the gate**
+
+In `sidecar/sokuji_sidecar/accel.py`, inside the `mods` dict in `_installed()` (right after the `qwen_translate` entry, ~line 96), add:
+
+```python
+            # Opus-MT MarianMT: AutoModelForSeq2SeqLM is core transformers (always
+            # present with transformers), so this self-gates on transformers alone.
+            "opus_translate": "transformers",
+```
+
+- [ ] **Step 8: Run the gate test to verify it passes**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_accel.py::test_opus_translate_self_gates_on_transformers -v`
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/translate_backends.py sidecar/sokuji_sidecar/accel.py sidecar/tests/test_translate_backends.py sidecar/tests/test_accel.py
+git commit -m "feat(native): opus_translate MarianMT backend + install gate"
+```
+
+---
+
+### Task 2: Catalog rows + download mapping (sidecar)
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/catalog.py` (add `_opus_row` helper + 13 rows to `TRANSLATE_MODELS`)
+- Modify: `sidecar/sokuji_sidecar/native_models.py` (add `opus-mt-*` branch to `_base_specs`)
+- Test: `sidecar/tests/test_catalog.py` (append), `sidecar/tests/test_native_models.py` (append), `sidecar/tests/test_accel.py` (append)
+
+**Interfaces:**
+- Consumes: `catalog.TranslateModel`, `catalog.Deployment` (already defined in the module), the `opus_translate` backend name from Task 1.
+- Produces: `catalog.translate_model("opus-mt-zh-en")` returns a `TranslateModel` with backend `opus_translate` and `[gpu-cuda bf16, cpu float32]` deployments; `native_models.download_specs("opus-mt-zh-en")` returns `{"repos": ["Helsinki-NLP/opus-mt-zh-en"], "urls": []}`.
+
+- [ ] **Step 1: Write the failing catalog + resolver tests**
+
+Append to `sidecar/tests/test_catalog.py`:
+
+```python
+def test_opus_rows_present_with_expected_shape():
+    from sokuji_sidecar import catalog
+    m = catalog.translate_model("opus-mt-zh-en")
+    assert m is not None
+    assert m.name == "Opus-MT (zh → en)"
+    backends = {d.backend for d in m.deployments}
+    tiers = [d.tier for d in m.deployments]
+    assert backends == {"opus_translate"}
+    assert tiers == ["gpu-cuda", "cpu"]            # no fp8 variant
+    assert all(d.artifact == "Helsinki-NLP/opus-mt-zh-en" for d in m.deployments)
+
+
+def test_opus_en_ja_uses_jap_repo_but_ja_display():
+    from sokuji_sidecar import catalog
+    m = catalog.translate_model("opus-mt-en-jap")
+    assert m is not None
+    assert m.name == "Opus-MT (en → ja)"           # display maps jap→ja
+    assert m.deployments[0].artifact == "Helsinki-NLP/opus-mt-en-jap"
+
+
+def test_all_13_opus_pairs_registered():
+    from sokuji_sidecar import catalog
+    ids = {m.id for m in catalog.translate_models()}
+    for pid in ["opus-mt-ru-en", "opus-mt-zh-en", "opus-mt-en-zh", "opus-mt-hu-en",
+                "opus-mt-en-es", "opus-mt-en-ar", "opus-mt-en-ru", "opus-mt-es-en",
+                "opus-mt-en-vi", "opus-mt-ar-en", "opus-mt-ja-en", "opus-mt-en-jap",
+                "opus-mt-ko-en"]:
+        assert pid in ids, pid
+```
+
+Append to `sidecar/tests/test_accel.py`:
+
+```python
+def test_resolve_translate_opus_prefers_gpu_then_cpu(monkeypatch):
+    from sokuji_sidecar import accel
+    # Same fixture shape as test_resolve_translate_prefers_gpu: stub format
+    # readiness + size estimate so select_variant picks the GPU deterministically
+    # without a network size lookup.
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
+    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288, (8, 9)),),
+                 installed=frozenset({"opus_translate"}))
+    plans = accel.resolve_translate("opus-mt-zh-en", "auto", m)
+    assert [p.device for p in plans] == ["cuda", "cpu"]
+    assert all(p.backend == "opus_translate" for p in plans)
+    assert plans[0].artifact == "Helsinki-NLP/opus-mt-zh-en"
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_catalog.py -k opus tests/test_accel.py::test_resolve_translate_opus_prefers_gpu_then_cpu -v`
+Expected: FAIL — `translate_model` returns `None` / `unknown translate model`.
+
+- [ ] **Step 3: Add the helper + rows**
+
+In `sidecar/sokuji_sidecar/catalog.py`, after `_with_fp8` (~line 124) and before `TRANSLATE_MODELS`, add:
+
+```python
+# Opus-MT display: the en→ja repo keeps Helsinki's "jap" token, but the card
+# should read "ja". Only this one code is remapped for the label.
+_OPUS_DISP = {"jap": "ja"}
+
+
+def _opus_disp(code):
+    return _OPUS_DISP.get(code, code)
+
+
+def _opus_row(src, tgt, sort_order):
+    mid = f"opus-mt-{src}-{tgt}"
+    repo = f"Helsinki-NLP/{mid}"
+    name = f"Opus-MT ({_opus_disp(src)} → {_opus_disp(tgt)})"
+    return TranslateModel(mid, name, (src, tgt), (
+        Deployment("opus_translate", "gpu-cuda", "bfloat16", repo, 1.0),
+        Deployment("opus_translate", "cpu", "float32", repo, 1.0),
+    ), sort_order=sort_order)
+```
+
+Then, inside the `TRANSLATE_MODELS` list, append these 13 rows after the `hy-mt2-7b` row (keep the closing `]`):
+
+```python
+    _opus_row("ru", "en", 20),
+    _opus_row("zh", "en", 21),
+    _opus_row("en", "zh", 22),
+    _opus_row("hu", "en", 23),
+    _opus_row("en", "es", 24),
+    _opus_row("en", "ar", 25),
+    _opus_row("en", "ru", 26),
+    _opus_row("es", "en", 27),
+    _opus_row("en", "vi", 28),
+    _opus_row("ar", "en", 29),
+    _opus_row("ja", "en", 30),
+    _opus_row("en", "jap", 31),
+    _opus_row("ko", "en", 32),
+```
+
+- [ ] **Step 4: Run the catalog + resolver tests to verify they pass**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_catalog.py -k opus tests/test_accel.py::test_resolve_translate_opus_prefers_gpu_then_cpu -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Write the failing download-spec test**
+
+Append to `sidecar/tests/test_native_models.py`:
+
+```python
+def test_download_specs_opus_maps_to_helsinki_repo():
+    from sokuji_sidecar import native_models as nm
+    assert nm.download_specs("opus-mt-zh-en") == {"repos": ["Helsinki-NLP/opus-mt-zh-en"], "urls": []}
+    assert nm.download_specs("opus-mt-en-jap") == {"repos": ["Helsinki-NLP/opus-mt-en-jap"], "urls": []}
+```
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_native_models.py::test_download_specs_opus_maps_to_helsinki_repo -v`
+Expected: FAIL — falls through to `{"repos": ["opus-mt-zh-en"], ...}`.
+
+- [ ] **Step 7: Add the download mapping**
+
+In `sidecar/sokuji_sidecar/native_models.py`, inside `_base_specs(model_id)`, add this branch near the other translation ids (before the final `return {"repos": [model_id], "urls": []}`):
+
+```python
+    if model_id.startswith("opus-mt-"):
+        return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": []}
+```
+
+- [ ] **Step 8: Run the download-spec test to verify it passes**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_native_models.py::test_download_specs_opus_maps_to_helsinki_repo -v`
+Expected: PASS.
+
+- [ ] **Step 9: Run the full sidecar translate/catalog/native_models suites for regressions**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_catalog.py tests/test_native_models.py tests/test_translate_backends.py -q`
+Expected: all pass (no new failures; the pre-existing `test_accel.py` gating failures are not in this set).
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/catalog.py sidecar/sokuji_sidecar/native_models.py sidecar/tests/test_catalog.py sidecar/tests/test_native_models.py sidecar/tests/test_accel.py
+git commit -m "feat(native): catalog rows + download mapping for 13 Opus-MT pairs"
+```
+
+---
+
+### Task 3: Renderer pair-specific cards (`nativeCatalog.ts`)
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts` (add `NATIVE_OPUS_PAIRS` + rewrite `nativeTranslationCards`)
+- Test: `src/lib/local-inference/native/nativeCatalog.test.ts` (update one existing assertion + add new ones)
+
+**Interfaces:**
+- Consumes: the module-private `canonLang` and the `NativeModelCardSpec` interface (both already in the file).
+- Produces: `nativeTranslationCards(src, tgt)` returns the 7 multilingual cards always, plus any Opus-MT card whose canonicalized `src`→`tgt` matches the arguments. Card ids match the sidecar catalog ids from Task 2 (e.g. `opus-mt-zh-en`).
+
+- [ ] **Step 1: Update the existing exact-match test + add new pair tests**
+
+In `src/lib/local-inference/native/nativeCatalog.test.ts`, change the assertion in the test `'exposes the four Qwen translation versions plus the speech-LLM translators'` (currently the exact 7-id `toEqual` for `nativeTranslationCards('zh', 'en')`) to expect the appended pair card:
+
+```javascript
+    expect(ids).toEqual(['qwen2.5-0.5b', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'translategemma-4b', 'hy-mt2-1.8b', 'hy-mt2-7b', 'opus-mt-zh-en']);
+```
+
+Then add a new `it(...)` block inside the top-level `describe('nativeCatalog', ...)`:
+
+```javascript
+  describe('Opus-MT pair cards', () => {
+    it('appends the matching pair card after the multilingual models', () => {
+      const ids = nativeTranslationCards('zh', 'en').map((c) => c.selectId);
+      expect(ids).toContain('opus-mt-zh-en');
+      expect(ids.indexOf('opus-mt-zh-en')).toBeGreaterThan(ids.indexOf('hy-mt2-7b')); // opt-in, after defaults
+    });
+
+    it('shows only the pair matching the active direction', () => {
+      const enJa = nativeTranslationCards('en', 'ja').map((c) => c.selectId);
+      expect(enJa).toContain('opus-mt-en-jap');   // id keeps Helsinki "jap"
+      expect(enJa).not.toContain('opus-mt-ja-en'); // reverse direction hidden
+      const jaEn = nativeTranslationCards('ja', 'en').map((c) => c.selectId);
+      expect(jaEn).toContain('opus-mt-ja-en');
+      expect(jaEn).not.toContain('opus-mt-en-jap');
+    });
+
+    it('shows no Opus-MT card for an unsupported pair', () => {
+      const ids = nativeTranslationCards('de', 'fr').map((c) => c.selectId);
+      expect(ids.some((id) => id.startsWith('opus-mt-'))).toBe(false);
+    });
+
+    it('opus cards keep downloadId === selectId', () => {
+      const opus = nativeTranslationCards('zh', 'en').filter((c) => c.selectId.startsWith('opus-mt-'));
+      expect(opus.length).toBeGreaterThan(0);
+      expect(opus.every((c) => c.downloadId === c.selectId)).toBe(true);
+    });
+  });
+```
+
+- [ ] **Step 2: Run the renderer tests to verify they fail**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: FAIL — `opus-mt-zh-en` absent (the current `nativeTranslationCards` ignores its args and returns only the 7 multilingual cards).
+
+- [ ] **Step 3: Add the pair list + rewrite `nativeTranslationCards`**
+
+In `src/lib/local-inference/native/nativeCatalog.ts`, add this list immediately above the existing `nativeTranslationCards` function (~line 333):
+
+```typescript
+/**
+ * Opus-MT pair models (PostHog-used pairs). One pair = one card; opt-in, shown
+ * only when the active source→target matches. `src`/`tgt` are canonical bare
+ * codes for matching the picker; `id` matches the sidecar catalog id (keeps the
+ * Helsinki "jap" token for en→ja). Sorted after the multilingual models.
+ */
+const NATIVE_OPUS_PAIRS: { id: string; name: string; src: string; tgt: string; sortOrder: number }[] = [
+  { id: 'opus-mt-ru-en', name: 'Opus-MT (ru → en)', src: 'ru', tgt: 'en', sortOrder: 20 },
+  { id: 'opus-mt-zh-en', name: 'Opus-MT (zh → en)', src: 'zh', tgt: 'en', sortOrder: 21 },
+  { id: 'opus-mt-en-zh', name: 'Opus-MT (en → zh)', src: 'en', tgt: 'zh', sortOrder: 22 },
+  { id: 'opus-mt-hu-en', name: 'Opus-MT (hu → en)', src: 'hu', tgt: 'en', sortOrder: 23 },
+  { id: 'opus-mt-en-es', name: 'Opus-MT (en → es)', src: 'en', tgt: 'es', sortOrder: 24 },
+  { id: 'opus-mt-en-ar', name: 'Opus-MT (en → ar)', src: 'en', tgt: 'ar', sortOrder: 25 },
+  { id: 'opus-mt-en-ru', name: 'Opus-MT (en → ru)', src: 'en', tgt: 'ru', sortOrder: 26 },
+  { id: 'opus-mt-es-en', name: 'Opus-MT (es → en)', src: 'es', tgt: 'en', sortOrder: 27 },
+  { id: 'opus-mt-en-vi', name: 'Opus-MT (en → vi)', src: 'en', tgt: 'vi', sortOrder: 28 },
+  { id: 'opus-mt-ar-en', name: 'Opus-MT (ar → en)', src: 'ar', tgt: 'en', sortOrder: 29 },
+  { id: 'opus-mt-ja-en', name: 'Opus-MT (ja → en)', src: 'ja', tgt: 'en', sortOrder: 30 },
+  { id: 'opus-mt-en-jap', name: 'Opus-MT (en → ja)', src: 'en', tgt: 'ja', sortOrder: 31 },
+  { id: 'opus-mt-ko-en', name: 'Opus-MT (ko → en)', src: 'ko', tgt: 'en', sortOrder: 32 },
+];
+```
+
+Then replace the body of `nativeTranslationCards` (the function currently named `nativeTranslationCards(_src, _tgt)`) with:
+
+```typescript
+export function nativeTranslationCards(src: string, tgt: string): NativeModelCardSpec[] {
+  const base: NativeModelCardSpec[] = [
+    { selectId: 'qwen2.5-0.5b', downloadId: 'qwen2.5-0.5b', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
+    { selectId: 'qwen3-0.6b', downloadId: 'qwen3-0.6b', name: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
+    { selectId: 'qwen3.5-0.8b', downloadId: 'qwen3.5-0.8b', name: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
+    { selectId: 'qwen3.5-2b', downloadId: 'qwen3.5-2b', name: 'Qwen 3.5 2B', languages: ['multi'], sortOrder: 4 },
+    { selectId: 'translategemma-4b', downloadId: 'translategemma-4b', name: 'TranslateGemma 4B', languages: ['multi'], sortOrder: 6 },
+    { selectId: 'hy-mt2-1.8b', downloadId: 'hy-mt2-1.8b', name: 'Hunyuan-MT2 1.8B', languages: ['multi'], sortOrder: 7 },
+    { selectId: 'hy-mt2-7b', downloadId: 'hy-mt2-7b', name: 'Hunyuan-MT2 7B', languages: ['multi'], sortOrder: 8 },
+  ];
+  const wantSrc = canonLang(src);
+  const wantTgt = canonLang(tgt);
+  const opus: NativeModelCardSpec[] = NATIVE_OPUS_PAIRS
+    .filter((p) => canonLang(p.src) === wantSrc && canonLang(p.tgt) === wantTgt)
+    .map((p) => ({
+      selectId: p.id, downloadId: p.id, name: p.name,
+      languages: [p.src, p.tgt], sortOrder: p.sortOrder,
+    }));
+  return [...base, ...opus];
+}
+```
+
+- [ ] **Step 4: Run the renderer tests to verify they pass**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS (all `nativeCatalog` tests, including the updated exact-match test and the new `Opus-MT pair cards` block).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(native): pair-specific Opus-MT cards in the translation picker"
+```
+
+---
+
+## Notes for the implementer
+
+- **Why `_src`/`_tgt` became `src`/`tgt`:** the old `nativeTranslationCards` ignored its arguments (underscore-prefixed). Task 3 makes them meaningful. The caller (`ProviderSection.tsx:128`) already passes `localNative.sourceLanguage`/`targetLanguage`, so no caller change is needed.
+- **No `resolve_translate` change:** opus rows have no FP8 variant; the existing `select_variant` + CPU-floor path handles a variant-less model. If `resolve_translate` raises for an opus id, check `select_variant`'s no-variant handling rather than special-casing opus.
+- **Per-pair Helsinki repo existence** is assumed (all 13 were used in the field via the WASM provider's ONNX exports, which were converted from these Helsinki repos). If a download fails for a specific pair at runtime, that single pair's repo id needs verifying — it does not change the design.
+- **`sentencepiece` runtime dep:** `MarianTokenizer` (loaded by `AutoTokenizer` for these repos) requires `sentencepiece` in the sidecar venv. The unit tests mock the tokenizer, so they won't catch its absence. Before a real session, verify it imports: `cd sidecar && python -c "import sentencepiece"`. If it fails, add `sentencepiece` to `sidecar/requirements.txt` (it is likely already a transitive dep of the existing translators, but confirm).

--- a/docs/superpowers/specs/2026-06-27-native-opus-mt-pair-translation-design.md
+++ b/docs/superpowers/specs/2026-06-27-native-opus-mt-pair-translation-design.md
@@ -1,0 +1,211 @@
+# Native Opus-MT Pair Translation (13 pairs)
+
+## Problem
+
+The LOCAL_NATIVE (Electron sidecar) provider offers only multilingual LLM
+translators (Qwen 0.5/0.6/0.8/2B, TranslateGemma-4B, HY-MT2-1.8B/7B). Legacy
+Opus-MT was removed from the sidecar in `9cec5236` (merged via PR #272) because
+the multilingual models cover its language pairs.
+
+PostHog usage (`translation_session_start`, project "sokuji") contradicts the
+assumption that nobody needs the small pair-specific models: in the last 365
+days ~20 users actively selected `opus-mt-*` models across 25 directional pairs,
+led by `ru-en` (166 sessions / 27 users), `zh-en` (115 / 20), `en-zh` (101 / 19).
+Opus-MT models are tiny (~300 MB) and pair-baked, so they start fast and run on
+low-end hardware where a 1.8B+ LLM is painful. Today the native provider has no
+way to offer them.
+
+## Goal
+
+Re-add Opus-MT to the sidecar as a first-class **PyTorch MarianMT** translate
+backend (GPU bf16 with CPU floor), unified with the existing gemma/hunyuan
+backend pattern — NOT the deleted torch-free ONNX path. Expose the high-usage
+pairs as **one model = one model card** (opt-in, shown only for the matching
+source→target language pair), mirroring how the WASM `local_inference` provider
+presents Opus-MT.
+
+Scope is the **13 pairs** above a ≈≥4-users/30-day cutoff:
+`ru-en`, `zh-en`, `en-zh`, `hu-en`, `en-es`, `en-ar`, `en-ru`, `es-en`,
+`en-vi`, `ar-en`, `ja-en`, `en-jap`, `ko-en`.
+
+## Non-Goals
+
+- **HY-MT1.5-1.8B** — split to its own spec; its native runtime (PyTorch repo /
+  arch vs the ONNX-only `onnx-community/HY-MT1.5-1.8B-ONNX` the app ships) is
+  unverified.
+- Resurrecting the deleted ONNX `opus_mt.py` (torch-free onnxruntime path).
+- FP8 / quantized variants for Marian (the bf16 model is already ~300 MB).
+- Multilingual Opus aggregates (`opus-mt-en-ROMANCE`, etc.).
+- The long-tail pairs below the cutoff (`en-it`, `nl-en`, `fr-en`, `it-en`,
+  `es-fr`, `vi-en`, `en-de`, `th-en`, `ru-es`, `en-hi`, `es-ru`).
+
+## Architecture
+
+Opus-MT becomes a sibling backend to the LLM translators, with three differences
+that fall out of MarianMT being a small **seq2seq** model rather than a CausalLM:
+
+1. **Model class**: `AutoModelForSeq2SeqLM` (Marian), not `AutoModelForCausalLM`.
+2. **Inference**: direct `model.generate(**tokenizer(text))` → decode. No chat
+   template, no system prompt, no `<transcript>` wrapping — translation direction
+   is baked into the model, so `system_prompt` / `wrap_transcript` are ignored.
+3. **Source repos**: `Helsinki-NLP/opus-mt-{src}-{tgt}` — the original PyTorch
+   weights + SentencePiece tokenizer in a single repo (the `Xenova/*` ids the
+   WASM app uses are ONNX exports and are not used here).
+
+Everything else reuses the existing machinery: catalog rows with
+`gpu-cuda`+`cpu` deployments, `resolve_translate` → `load_with_fallback`
+(GPU-preferred, CPU floor), `download_specs`, and the renderer card list.
+
+### Why MarianMT over the deleted ONNX backend
+
+The user chose the PyTorch/GPU path to keep a single translate-backend shape.
+MarianMT is built into `transformers` (no `trust_remote_code`, no `auto_map`),
+loads on GPU in bf16 at ~300 MB, and reuses `load_with_fallback` for the
+GPU→CPU step. The deleted ONNX backend hand-rolled KV-cache plumbing and was
+CPU-only; dropping it removes that maintenance surface.
+
+## Components / files
+
+Sidecar (`sidecar/sokuji_sidecar/`):
+- `translate_backends.py` — new `OpusTranslateBackend` (NAME `opus_translate`).
+- `catalog.py` — `_opus_row(src, tgt)` helper + 13 rows in the translate catalog.
+- `native_models.py` — `download_specs` mapping for `opus-mt-*`.
+- `accel.py` — register `opus_translate` in `_installed` (gate on `transformers`).
+  No `resolve_translate` change expected: opus rows flow through the existing
+  variant/None-guarded path.
+
+Renderer (`src/lib/local-inference/native/`):
+- `nativeCatalog.ts` — add `sourceLang`/`targetLang` to the translation card
+  type; add 13 Opus-MT entries; filter them by language pair in
+  `nativeTranslationCards`.
+
+Tests: `sidecar/tests/test_translate_backends.py`, `test_catalog.py`,
+`test_native_models.py`; `src/lib/local-inference/native/nativeCatalog.test.ts`.
+
+## Catalog rows
+
+A data-driven helper that builds a `TranslateModel` directly (it cannot reuse
+`_llm_translate_row`, which hardcodes `languages=("multi",)`), with no
+FP8/variant wrapping:
+
+```python
+def _opus_row(src, tgt, sort_order):
+    mid = f"opus-mt-{src}-{tgt}"
+    repo = f"Helsinki-NLP/{mid}"
+    return TranslateModel(mid, f"Opus-MT ({src} → {tgt})", (src, tgt), (
+        Deployment("opus_translate", "gpu-cuda", "bfloat16", repo, 1.0),
+        Deployment("opus_translate", "cpu", "float32", repo, 1.0),
+    ), sort_order=sort_order)
+```
+
+13 rows for the pairs listed in Goal, sorted after the multilingual LLMs. The id
+keeps the Helsinki "jap" quirk (`opus-mt-ja-en`, `opus-mt-en-jap`); the catalog
+`languages` are the bare pair (`("ja","en")`) — documentary only, since the
+sidecar `TranslateModel` carries no direction and language filtering happens in
+the renderer.
+
+## Download mapping
+
+`download_specs(model_id)` for an `opus-mt-*` id returns the single Helsinki repo:
+
+```python
+if model_id.startswith("opus-mt-"):
+    return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": []}
+```
+
+No VAD url (translation, not ASR). One repo carries both weights and tokenizer.
+
+## Backend: `OpusTranslateBackend` (NAME = `opus_translate`)
+
+```python
+class OpusTranslateBackend:
+    NAME = "opus_translate"
+
+    def load(self, repo, device, compute_type):
+        import torch
+        from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+        dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+        self._tok = AutoTokenizer.from_pretrained(repo, local_files_only=True)
+        self._model = AutoModelForSeq2SeqLM.from_pretrained(
+            repo, dtype=dtype, local_files_only=True).to(device).eval()
+        self._device = device
+
+    def translate(self, text, system_prompt, src, tgt, wrap_transcript):
+        # Marian is pair-baked: prompt/src/tgt/wrap are ignored.
+        import torch
+        enc = self._tok(text, return_tensors="pt").to(self._device)
+        with torch.no_grad():
+            out = self._model.generate(**enc, max_new_tokens=512)
+        n = int(out.shape[-1])
+        return self._tok.decode(out[0], skip_special_tokens=True).strip(), n
+
+    def unload(self): ...  # standard: drop refs, empty cache
+```
+
+- `local_files_only=True` on both loads (offline-first, per the #265 review).
+- Gates on `transformers` in `accel._installed` — MarianMT is core, so it is
+  effectively always installed; the catalog gate keeps the rows from appearing
+  only if `transformers` is somehow absent.
+
+## Renderer: pair-specific cards
+
+`nativeCatalog.ts` today lists translation models with `languages: ['multi']`
+only. Add directional fields and pair filtering:
+
+```ts
+// card type gains:
+sourceLang?: string;  // canonical, e.g. 'ja'
+targetLang?: string;  // canonical, e.g. 'en'
+
+// 13 entries, e.g.:
+{ id: 'opus-mt-ja-en', label: 'Opus-MT (ja → en)',
+  languages: ['ja','en'], sourceLang: 'ja', targetLang: 'en', sortOrder: 20 }
+{ id: 'opus-mt-en-jap', label: 'Opus-MT (en → ja)',
+  languages: ['en','ja'], sourceLang: 'en', targetLang: 'ja', sortOrder: 21 }
+```
+
+`nativeTranslationCards(src, tgt)` returns the multilingual LLMs (always) plus
+any Opus-MT card where `canonLang(sourceLang) === canonLang(src)` and
+`canonLang(targetLang) === canonLang(tgt)`. Opus-MT is opt-in: never the default
+(the recommended Qwen stays default), shown only for the active language pair —
+matching the WASM `local_inference` picker. `canonLang` must map the locale
+codes seen in the field (`cmn-CN`/`zh_CN`→`zh`, `en-US`→`en`, `ru-RU`→`ru`,
+`es-US`→`es`) for the 9 pair languages (zh, en, ru, ja, ko, es, ar, vi, hu).
+
+## VRAM, degrade, and forward compatibility
+
+Marian bf16 is ~300 MB → fits any CUDA GPU with room to spare; the
+ASR+TTS VRAM reserve already computed by `resolve_translate` dominates. The
+`cpu` floor deployment guarantees a working plan on CPU-only machines (fp32,
+still fast for short utterances). `memoryBytes` / `fallbackReason` reporting
+flows through `load_measured` unchanged.
+
+## Testing
+
+Sidecar:
+- `OpusTranslateBackend.load/translate` with a mocked `AutoModelForSeq2SeqLM`
+  + tokenizer (assert generate→decode path, prompt/wrap ignored).
+- `resolve_translate('opus-mt-zh-en', 'auto', machine_with_gpu)` → `[cuda, cpu]`
+  plans, backend `opus_translate`, no variant.
+- `download_specs('opus-mt-zh-en')` → `{repos: ['Helsinki-NLP/opus-mt-zh-en']}`.
+- `accel._installed()` includes `opus_translate` when `transformers` present.
+
+Renderer:
+- `nativeTranslationCards('ja','en')` includes `opus-mt-ja-en` and excludes
+  `opus-mt-en-jap`; a non-Opus pair (e.g. `de`→`fr`) includes none.
+- `canonLang` maps the field locale codes for the 9 pair languages.
+
+## Risks / caveats
+
+- **Helsinki repo id verification**: implementation must confirm each of the 13
+  `Helsinki-NLP/opus-mt-{src}-{tgt}` repos resolves (mostly 1:1 with the WASM id
+  minus the `Xenova/` prefix; the `ja`/`jap` quirk is already encoded). A missing
+  repo means dropping or remapping that one pair.
+- **Tokenizer deps**: MarianTokenizer needs `sentencepiece` in the sidecar venv;
+  confirm it is present (it is a transitive dep of the existing translators, but
+  verify).
+- **Language-code normalization**: the field emitted both bare and locale codes;
+  the renderer filter must canonicalize or pair cards silently won't appear.
+- **`ja` vs `jap`**: PostHog also showed a legacy `opus-mt-jap-en` id; it folds
+  into `opus-mt-ja-en` (same logical pair). We ship only `opus-mt-ja-en` (ja→en)
+  and `opus-mt-en-jap` (en→ja).

--- a/docs/superpowers/specs/2026-06-27-native-opus-mt-pair-translation-design.md
+++ b/docs/superpowers/specs/2026-06-27-native-opus-mt-pair-translation-design.md
@@ -106,14 +106,19 @@ the renderer.
 
 ## Download mapping
 
-`download_specs(model_id)` for an `opus-mt-*` id returns the single Helsinki repo:
+`download_specs(model_id)` for an `opus-mt-*` id returns the single Helsinki repo
+plus an `ignore` list that skips the non-PyTorch framework weights (Helsinki repos
+ship the same model in 4 frameworks; the backend loads only `pytorch_model.bin`):
 
 ```python
 if model_id.startswith("opus-mt-"):
-    return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": []}
+    return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": [],
+            "ignore": ["tf_model.h5", "rust_model.ot", "flax_model.msgpack"]}
 ```
 
 No VAD url (translation, not ASR). One repo carries both weights and tokenizer.
+The `ignore` patterns are honored by the download filter (`native_models._ignored`,
+fnmatch-based), cutting each pair's download by 50-80% (e.g. en-zh: 1446MB → 301MB).
 
 ## Backend: `OpusTranslateBackend` (NAME = `opus_translate`)
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -92,6 +92,9 @@ def _installed() -> frozenset:
             # qwen3_5 VLM class (self-gates off until transformers ships it), used text-only.
             "qwen_translate": "transformers",
             "qwen35_translate": "transformers.models.qwen3_5",
+            # Opus-MT MarianMT: AutoModelForSeq2SeqLM is core transformers (always
+            # present with transformers), so this self-gates on transformers alone.
+            "opus_translate": "transformers",
             # TranslateGemma uses the Gemma-3 multimodal class (text-only here); HY-MT2 is the
             # native hunyuan_v1_dense CausalLM. Both ship in transformers 5.13; self-gate off on
             # an older transformers that lacks the module.

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -123,6 +123,25 @@ def _with_fp8(row, fp8_repo):
                           recommended=row.recommended, sort_order=row.sort_order)
 
 
+# Opus-MT display: the en→ja repo keeps Helsinki's "jap" token, but the card
+# should read "ja". Only this one code is remapped for the label.
+_OPUS_DISP = {"jap": "ja"}
+
+
+def _opus_disp(code):
+    return _OPUS_DISP.get(code, code)
+
+
+def _opus_row(src, tgt, sort_order):
+    mid = f"opus-mt-{src}-{tgt}"
+    repo = f"Helsinki-NLP/{mid}"
+    name = f"Opus-MT ({_opus_disp(src)} → {_opus_disp(tgt)})"
+    return TranslateModel(mid, name, (src, tgt), (
+        Deployment("opus_translate", "gpu-cuda", "bfloat16", repo, 1.0),
+        Deployment("opus_translate", "cpu", "float32", repo, 1.0),
+    ), sort_order=sort_order)
+
+
 TRANSLATE_MODELS: list[TranslateModel] = [
     _llm_translate_row("qwen2.5-0.5b", "Qwen 2.5 0.5B",
                        QWEN25_REPO, "qwen_translate", 1, recommended=True),
@@ -140,6 +159,19 @@ TRANSLATE_MODELS: list[TranslateModel] = [
     _with_fp8(_llm_translate_row("hy-mt2-7b", "Hunyuan-MT2 7B",
                                  "tencent/Hy-MT2-7B", "hunyuan_translate", 7),
               "tencent/Hy-MT2-7B-FP8"),
+    _opus_row("ru", "en", 20),
+    _opus_row("zh", "en", 21),
+    _opus_row("en", "zh", 22),
+    _opus_row("hu", "en", 23),
+    _opus_row("en", "es", 24),
+    _opus_row("en", "ar", 25),
+    _opus_row("en", "ru", 26),
+    _opus_row("es", "en", 27),
+    _opus_row("en", "vi", 28),
+    _opus_row("ar", "en", 29),
+    _opus_row("ja", "en", 30),
+    _opus_row("en", "jap", 31),
+    _opus_row("ko", "en", 32),
 ]
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -70,6 +70,8 @@ def _base_specs(model_id):
         # train/ holds only training scripts (deepspeed/llama-factory) — skip; weights only.
         repo = "tencent/Hy-MT2-1.8B" if model_id == "hy-mt2-1.8b" else "tencent/Hy-MT2-7B"
         return {"repos": [repo], "urls": [], "ignore": ["train/*"]}
+    if model_id.startswith("opus-mt-"):
+        return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": []}
     return {"repos": [model_id], "urls": []}
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -71,7 +71,12 @@ def _base_specs(model_id):
         repo = "tencent/Hy-MT2-1.8B" if model_id == "hy-mt2-1.8b" else "tencent/Hy-MT2-7B"
         return {"repos": [repo], "urls": [], "ignore": ["train/*"]}
     if model_id.startswith("opus-mt-"):
-        return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": []}
+        # Helsinki repos ship the SAME model in 4 frameworks; the opus_translate
+        # backend loads only pytorch_model.bin. Skip the TF/Rust/Flax weights
+        # (exact filenames — the download filter is `f not in ignore`, not glob),
+        # which are 50-80% of the repo (e.g. en-zh: 1446MB → 301MB).
+        return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": [],
+                "ignore": ["tf_model.h5", "rust_model.ot", "flax_model.msgpack"]}
     return {"repos": [model_id], "urls": []}
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -11,10 +11,18 @@ ASR-catalog model (not just SenseVoice), guaranteeing a single-model offline
 install is self-sufficient. It's a 643KB global singleton at sokuji-vad/, so
 delete_model() never removes it — another installed model may still need it.
 """
+import fnmatch
 import os
 
 from .asr_engine import VAD_URL
 from .catalog import asr_model as _asr_model
+
+
+def _ignored(filename, patterns):
+    """True if `filename` matches any ignore pattern. fnmatch globs (`*` spans
+    `/`, so `train/*` matches `train/a/b.py`); an exact filename like
+    `tf_model.h5` matches only itself. Used to filter the download + size file set."""
+    return any(fnmatch.fnmatch(filename, p) for p in patterns)
 
 QWEN_REPO = "Qwen/Qwen2.5-0.5B-Instruct"
 SENSE_VOICE_REPO = "FunAudioLLM/SenseVoiceSmall"
@@ -67,14 +75,14 @@ def _base_specs(model_id):
     if model_id == "translategemma-4b":
         return {"repos": ["google/translategemma-4b-it"], "urls": []}
     if model_id in ("hy-mt2-1.8b", "hy-mt2-7b"):
-        # train/ holds only training scripts (deepspeed/llama-factory) — skip; weights only.
+        # Skip the training scripts (train/, deepspeed/llama-factory) and the
+        # README images (imgs/) — weights + tokenizer + config only.
         repo = "tencent/Hy-MT2-1.8B" if model_id == "hy-mt2-1.8b" else "tencent/Hy-MT2-7B"
-        return {"repos": [repo], "urls": [], "ignore": ["train/*"]}
+        return {"repos": [repo], "urls": [], "ignore": ["train/*", "imgs/*"]}
     if model_id.startswith("opus-mt-"):
         # Helsinki repos ship the SAME model in 4 frameworks; the opus_translate
         # backend loads only pytorch_model.bin. Skip the TF/Rust/Flax weights
-        # (exact filenames — the download filter is `f not in ignore`, not glob),
-        # which are 50-80% of the repo (e.g. en-zh: 1446MB → 301MB).
+        # (exact filenames), which are 50-80% of the repo (en-zh: 1446MB → 301MB).
         return {"repos": [f"Helsinki-NLP/{model_id}"], "urls": [],
                 "ignore": ["tf_model.h5", "rust_model.ot", "flax_model.msgpack"]}
     return {"repos": [model_id], "urls": []}
@@ -115,7 +123,7 @@ def model_size(model_id):
     for repo in specs["repos"]:
         try:
             info = api.repo_info(repo, files_metadata=True)
-            total += sum((s.size or 0) for s in (info.siblings or []) if s.rfilename not in ignore)
+            total += sum((s.size or 0) for s in (info.siblings or []) if not _ignored(s.rfilename, ignore))
         except Exception:
             pass
     total += len(specs["urls"]) * _SILERO_VAD_BYTES
@@ -211,7 +219,7 @@ async def download(model_id, send, should_cancel=None, repo=None):
     files = []
     for r in specs["repos"]:  # `r`, not `repo`, so the variant `repo` param is not shadowed
         try:
-            files.extend((r, f) for f in api.list_repo_files(r) if f not in ignore)
+            files.extend((r, f) for f in api.list_repo_files(r) if not _ignored(f, ignore))
         except Exception:
             pass
     # Never report a no-op download as success: if a model declares repos but none

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -312,7 +312,9 @@ class OpusTranslateBackend:
         # tgt and wrap are intentionally ignored. generate() emits only the
         # translation tokens (no input prefix to slice off).
         import torch
-        inputs = self._tok(text, return_tensors="pt").to(self._device)
+        # Marian's learned positional embeddings cap at 512 — truncate over-long
+        # input rather than crash (real-time ASR segments are short; this is a hedge).
+        inputs = self._tok(text, return_tensors="pt", truncation=True).to(self._device)
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         seq = out[0]

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -314,7 +314,8 @@ class OpusTranslateBackend:
         import torch
         # Marian's learned positional embeddings cap at 512 — truncate over-long
         # input rather than crash (real-time ASR segments are short; this is a hedge).
-        inputs = self._tok(text, return_tensors="pt", truncation=True).to(self._device)
+        # max_length is explicit so we don't depend on the tokenizer's model_max_length.
+        inputs = self._tok(text, return_tensors="pt", truncation=True, max_length=512).to(self._device)
         with torch.inference_mode():
             out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
         seq = out[0]

--- a/sidecar/sokuji_sidecar/translate_backends.py
+++ b/sidecar/sokuji_sidecar/translate_backends.py
@@ -6,6 +6,7 @@ transcribe(). Registered into the shared backends registry on import.
   qwen35_translate   — Qwen 3.5, Qwen3_5ForConditionalGeneration (VLM class), text-only.
   hunyuan_translate  — HY-MT2 1.8B / 7B, AutoModelForCausalLM (hunyuan_v1_dense, native).
   gemma_translate    — TranslateGemma 4B, Gemma3ForConditionalGeneration (VLM class), text-only.
+  opus_translate     — MarianMT seq2seq, AutoModelForSeq2SeqLM (pair-baked direction).
 
 All support CPU (float32) and GPU (bfloat16) via .to(device)."""
 import re
@@ -266,6 +267,56 @@ class GemmaTranslateBackend:
             out = self._model.generate(**inputs, max_new_tokens=256, do_sample=False)
         gen = out[0][inputs["input_ids"].shape[1]:]
         return _clean_output(self._tok.decode(gen, skip_special_tokens=True)), int(gen.shape[0])
+
+    def unload(self) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            torch.cuda.empty_cache()
+        except Exception:
+            pass
+
+    @property
+    def is_loaded(self) -> bool:
+        return self._model is not None
+
+
+@register_backend
+class OpusTranslateBackend:
+    NAME = "opus_translate"
+
+    def __init__(self):
+        self._model = None
+        self._tok = None
+        self._device = "cpu"
+
+    def load(self, model_ref: str, device: str, compute_type: str) -> None:
+        self._model = None
+        self._tok = None
+        try:
+            import torch
+            # MarianMT is a small seq2seq model, core to transformers (no
+            # trust_remote_code, no VLM processor). bf16 on GPU, float32 on CPU.
+            from transformers import AutoModelForSeq2SeqLM, AutoTokenizer
+            dtype = torch.bfloat16 if compute_type == "bfloat16" else torch.float32
+            self._tok = AutoTokenizer.from_pretrained(model_ref, local_files_only=True)
+            self._model = AutoModelForSeq2SeqLM.from_pretrained(
+                model_ref, dtype=dtype, local_files_only=True).to(device).eval()
+            self._device = device
+        except Exception as e:  # missing torch/transformers, no CUDA, OOM → resolver falls back
+            raise BackendLoadError(str(e))
+
+    def translate(self, text: str, system_prompt: str, src: str, tgt: str, wrap: bool) -> tuple[str, int]:
+        # The translation direction is baked into the model — system_prompt, src,
+        # tgt and wrap are intentionally ignored. generate() emits only the
+        # translation tokens (no input prefix to slice off).
+        import torch
+        inputs = self._tok(text, return_tensors="pt").to(self._device)
+        with torch.inference_mode():
+            out = self._model.generate(**inputs, max_new_tokens=512, do_sample=False)
+        seq = out[0]
+        return self._tok.decode(seq, skip_special_tokens=True).strip(), int(seq.shape[-1])
 
     def unload(self) -> None:
         self._model = None

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -882,3 +882,18 @@ def test_opus_translate_self_gates_on_transformers(monkeypatch):
         return real(name, *a, **k)
     monkeypatch.setattr(accel.importlib.util, "find_spec", present)
     assert "opus_translate" in accel._installed()
+
+
+def test_resolve_translate_opus_prefers_gpu_then_cpu(monkeypatch):
+    from sokuji_sidecar import accel
+    # Same fixture shape as test_resolve_translate_prefers_gpu: stub format
+    # readiness + size estimate so select_variant picks the GPU deterministically
+    # without a network size lookup.
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
+    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288, (8, 9)),),
+                 installed=frozenset({"opus_translate"}))
+    plans = accel.resolve_translate("opus-mt-zh-en", "auto", m)
+    assert [p.device for p in plans] == ["cuda", "cpu"]
+    assert all(p.backend == "opus_translate" for p in plans)
+    assert plans[0].artifact == "Helsinki-NLP/opus-mt-zh-en"

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -870,3 +870,15 @@ def test_load_with_fallback_fp8_factor_gates_cuda(monkeypatch):
     backend, plan, notice = accel.load_with_fallback([fp8_plan, cpu_pl])
     assert plan.device == "cpu" and attempted == ["cpu"]
     assert notice and "CPU" in notice
+
+
+def test_opus_translate_self_gates_on_transformers(monkeypatch):
+    from sokuji_sidecar import accel
+    real = accel.importlib.util.find_spec
+
+    def present(name, *a, **k):
+        if name == "transformers":
+            return object()
+        return real(name, *a, **k)
+    monkeypatch.setattr(accel.importlib.util, "find_spec", present)
+    assert "opus_translate" in accel._installed()

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -114,7 +114,8 @@ def test_translate_models_have_deployments_and_cpu_floor():
         assert m.languages, f"{m.id} has no languages"
         assert any(d.tier == "cpu" for d in m.deployments), f"{m.id} lacks a cpu floor"
         for d in m.deployments:
-            assert d.backend in {"qwen_translate", "qwen35_translate", "gemma_translate", "hunyuan_translate"}
+            assert d.backend in {"qwen_translate", "qwen35_translate", "gemma_translate",
+                                 "hunyuan_translate", "opus_translate"}
 
 
 def test_translate_model_ids_unique_and_lookup():
@@ -180,3 +181,33 @@ def test_gemma_has_no_fp8_variant():
     from sokuji_sidecar import catalog
     g = catalog.translate_model("translategemma-4b")
     assert not any(d.compute_type == "fp8" for d in g.deployments)
+
+
+def test_opus_rows_present_with_expected_shape():
+    from sokuji_sidecar import catalog
+    m = catalog.translate_model("opus-mt-zh-en")
+    assert m is not None
+    assert m.name == "Opus-MT (zh → en)"
+    backends = {d.backend for d in m.deployments}
+    tiers = [d.tier for d in m.deployments]
+    assert backends == {"opus_translate"}
+    assert tiers == ["gpu-cuda", "cpu"]            # no fp8 variant
+    assert all(d.artifact == "Helsinki-NLP/opus-mt-zh-en" for d in m.deployments)
+
+
+def test_opus_en_ja_uses_jap_repo_but_ja_display():
+    from sokuji_sidecar import catalog
+    m = catalog.translate_model("opus-mt-en-jap")
+    assert m is not None
+    assert m.name == "Opus-MT (en → ja)"           # display maps jap→ja
+    assert m.deployments[0].artifact == "Helsinki-NLP/opus-mt-en-jap"
+
+
+def test_all_13_opus_pairs_registered():
+    from sokuji_sidecar import catalog
+    ids = {m.id for m in catalog.translate_models()}
+    for pid in ["opus-mt-ru-en", "opus-mt-zh-en", "opus-mt-en-zh", "opus-mt-hu-en",
+                "opus-mt-en-es", "opus-mt-en-ar", "opus-mt-en-ru", "opus-mt-es-en",
+                "opus-mt-en-vi", "opus-mt-ar-en", "opus-mt-ja-en", "opus-mt-en-jap",
+                "opus-mt-ko-en"]:
+        assert pid in ids, pid

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -192,6 +192,7 @@ def test_opus_rows_present_with_expected_shape():
     tiers = [d.tier for d in m.deployments]
     assert backends == {"opus_translate"}
     assert tiers == ["gpu-cuda", "cpu"]            # no fp8 variant
+    assert [d.compute_type for d in m.deployments] == ["bfloat16", "float32"]
     assert all(d.artifact == "Helsinki-NLP/opus-mt-zh-en" for d in m.deployments)
 
 

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -362,3 +362,9 @@ def test_h_model_download_passes_repo_through(monkeypatch):
 
     asyncio.run(scenario())
     assert captured["repo"] == "tencent/Hy-MT2-7B-FP8"
+
+
+def test_download_specs_opus_maps_to_helsinki_repo():
+    from sokuji_sidecar import native_models as nm
+    assert nm.download_specs("opus-mt-zh-en") == {"repos": ["Helsinki-NLP/opus-mt-zh-en"], "urls": []}
+    assert nm.download_specs("opus-mt-en-jap") == {"repos": ["Helsinki-NLP/opus-mt-en-jap"], "urls": []}

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -232,6 +232,23 @@ def test_existing_specs_have_no_ignore_key():
     assert "ignore" not in nm.download_specs("qwen3-asr-1.7b")
 
 
+def test_hy_mt2_ignores_train_and_imgs_dirs():
+    # HY-MT2 repos ship training scripts (train/) + README images (imgs/) the
+    # CausalLM never loads; both are directory globs.
+    for mid in ("hy-mt2-1.8b", "hy-mt2-7b"):
+        assert nm.download_specs(mid)["ignore"] == ["train/*", "imgs/*"]
+
+
+def test_ignored_filter_is_glob_aware():
+    # Directory globs match nested files (fnmatch '*' spans '/'); exact filenames
+    # match only themselves; non-matches pass through.
+    assert nm._ignored("train/deepspeed/train.py", ["train/*", "imgs/*"])
+    assert nm._ignored("imgs/overview.png", ["train/*", "imgs/*"])
+    assert not nm._ignored("model.safetensors", ["train/*", "imgs/*"])
+    assert nm._ignored("tf_model.h5", ["tf_model.h5", "rust_model.ot"])     # exact
+    assert not nm._ignored("pytorch_model.bin", ["tf_model.h5", "rust_model.ot"])
+
+
 def test_download_honors_ignore_list(monkeypatch):
     """The ignore list keeps consolidated.safetensors out of the fetched file set,
     so transformers' model.safetensors is fetched but the 8.86GB duplicate is not."""
@@ -255,6 +272,31 @@ def test_download_honors_ignore_list(monkeypatch):
     assert status == "ready"
     assert "consolidated.safetensors" not in fetched
     assert "model.safetensors" in fetched and "tekken.json" in fetched
+
+
+def test_download_glob_excludes_nested_dirs(monkeypatch):
+    """A directory glob (train/*) keeps nested training files out of the fetch —
+    the exact-match filter this replaced would have downloaded them."""
+    import huggingface_hub
+    fetched = []
+
+    class _Api:
+        def list_repo_files(self, repo):
+            return ["model.safetensors", "config.json",
+                    "train/train.py", "train/deepspeed/ds.json", "imgs/overview.png"]
+
+    monkeypatch.setattr(nm, "download_specs", lambda m, repo=None: {
+        "repos": ["r"], "urls": [], "ignore": ["train/*", "imgs/*"]})
+    monkeypatch.setattr(huggingface_hub, "HfApi", _Api)
+    monkeypatch.setattr(huggingface_hub, "hf_hub_download",
+                        lambda repo, fname: fetched.append(fname))
+
+    async def send(_m):
+        pass
+
+    status = asyncio.run(nm.download("hy-mt2-1.8b", send))
+    assert status == "ready"
+    assert fetched == ["model.safetensors", "config.json"]   # nested train/ + imgs/ excluded
 
 
 def test_model_size_excludes_ignored_files(monkeypatch):
@@ -301,10 +343,10 @@ def test_download_specs_new_translate_models():
     assert nm.download_specs("translategemma-4b")["repos"] == ["google/translategemma-4b-it"]
     h18 = nm.download_specs("hy-mt2-1.8b")
     assert h18["repos"] == ["tencent/Hy-MT2-1.8B"]
-    assert h18["ignore"] == ["train/*"]
+    assert h18["ignore"] == ["train/*", "imgs/*"]
     h7 = nm.download_specs("hy-mt2-7b")
     assert h7["repos"] == ["tencent/Hy-MT2-7B"]
-    assert h7["ignore"] == ["train/*"]
+    assert h7["ignore"] == ["train/*", "imgs/*"]
 
 
 def test_download_specs_variant_repo_override():

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -366,5 +366,11 @@ def test_h_model_download_passes_repo_through(monkeypatch):
 
 def test_download_specs_opus_maps_to_helsinki_repo():
     from sokuji_sidecar import native_models as nm
-    assert nm.download_specs("opus-mt-zh-en") == {"repos": ["Helsinki-NLP/opus-mt-zh-en"], "urls": []}
-    assert nm.download_specs("opus-mt-en-jap") == {"repos": ["Helsinki-NLP/opus-mt-en-jap"], "urls": []}
+    _ignore = ["tf_model.h5", "rust_model.ot", "flax_model.msgpack"]
+    assert nm.download_specs("opus-mt-zh-en") == {
+        "repos": ["Helsinki-NLP/opus-mt-zh-en"], "urls": [], "ignore": _ignore}
+    assert nm.download_specs("opus-mt-en-jap") == {
+        "repos": ["Helsinki-NLP/opus-mt-en-jap"], "urls": [], "ignore": _ignore}
+    # The non-PyTorch framework weights are excluded from the download file list.
+    for f in _ignore:
+        assert f in nm.download_specs("opus-mt-zh-en")["ignore"]

--- a/sidecar/tests/test_translate_backends.py
+++ b/sidecar/tests/test_translate_backends.py
@@ -271,3 +271,29 @@ def test_gemma_translate_real_gpu():
     out, ms = eng.translate("こんにちは、お元気ですか？")
     assert isinstance(out, str) and out.strip() and ms >= 0
     eng.close()
+
+
+def test_opus_backend_registered():
+    assert backends._BACKENDS.get("opus_translate") is tb.OpusTranslateBackend
+
+
+def test_opus_translate_runs_seq2seq_and_ignores_prompt():
+    import torch  # noqa: F401  (translate imports torch internally)
+    b = tb.OpusTranslateBackend()
+    # Seq2seq generate returns the translation tokens directly (no input slice).
+    seq = MagicMock()
+    seq.shape = [4]                     # 4 output tokens → int-able count
+    model = MagicMock()
+    model.generate.return_value = [seq]
+    tok = MagicMock()
+    tok.side_effect = lambda text, **kw: FakeInputs(input_ids=MagicMock(shape=[1, 3]))
+    tok.decode.return_value = "  translated  "
+    b._model = model
+    b._tok = tok
+    b._device = "cpu"
+    out, n = b.translate("hello", "ignored-prompt", "ja", "en", True)
+    assert out == "translated"          # stripped
+    assert n == 4
+    assert model.generate.called
+    # Marian is pair-baked: no chat template is ever applied.
+    assert not tok.apply_chat_template.called

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -33,8 +33,8 @@ describe('nativeCatalog', () => {
 
   it('exposes the four Qwen translation versions plus the speech-LLM translators', () => {
     const ids = nativeTranslationCards('zh', 'en').map((c) => c.selectId);
-    // qwen2.5-0.5b is the recommended default; the rest are explicit versions + TranslateGemma/HY-MT2
-    expect(ids).toEqual(['qwen2.5-0.5b', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'translategemma-4b', 'hy-mt2-1.8b', 'hy-mt2-7b']);
+    // qwen2.5-0.5b is the recommended default; the rest are explicit versions + TranslateGemma/HY-MT2 + opus-mt pair
+    expect(ids).toEqual(['qwen2.5-0.5b', 'qwen3-0.6b', 'qwen3.5-0.8b', 'qwen3.5-2b', 'translategemma-4b', 'hy-mt2-1.8b', 'hy-mt2-7b', 'opus-mt-zh-en']);
   });
 
   it('exposes ASR + translation options', () => {
@@ -376,6 +376,34 @@ describe('nativeCatalog', () => {
     });
     it('returns null for no resolved', () => {
       expect(resolvedTierState(null)).toBeNull();
+    });
+  });
+
+  describe('Opus-MT pair cards', () => {
+    it('appends the matching pair card after the multilingual models', () => {
+      const ids = nativeTranslationCards('zh', 'en').map((c) => c.selectId);
+      expect(ids).toContain('opus-mt-zh-en');
+      expect(ids.indexOf('opus-mt-zh-en')).toBeGreaterThan(ids.indexOf('hy-mt2-7b')); // opt-in, after defaults
+    });
+
+    it('shows only the pair matching the active direction', () => {
+      const enJa = nativeTranslationCards('en', 'ja').map((c) => c.selectId);
+      expect(enJa).toContain('opus-mt-en-jap');   // id keeps Helsinki "jap"
+      expect(enJa).not.toContain('opus-mt-ja-en'); // reverse direction hidden
+      const jaEn = nativeTranslationCards('ja', 'en').map((c) => c.selectId);
+      expect(jaEn).toContain('opus-mt-ja-en');
+      expect(jaEn).not.toContain('opus-mt-en-jap');
+    });
+
+    it('shows no Opus-MT card for an unsupported pair', () => {
+      const ids = nativeTranslationCards('de', 'fr').map((c) => c.selectId);
+      expect(ids.some((id) => id.startsWith('opus-mt-'))).toBe(false);
+    });
+
+    it('opus cards keep downloadId === selectId', () => {
+      const opus = nativeTranslationCards('zh', 'en').filter((c) => c.selectId.startsWith('opus-mt-'));
+      expect(opus.length).toBeGreaterThan(0);
+      expect(opus.every((c) => c.downloadId === c.selectId)).toBe(true);
     });
   });
 

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -330,8 +330,30 @@ export function nativeAsrIncompatibleCards(srcLang: string): NativeModelCardSpec
   return incompatibleNativeAsr(srcLang).map(asrToCard);
 }
 
-export function nativeTranslationCards(_src: string, _tgt: string): NativeModelCardSpec[] {
-  return [
+/**
+ * Opus-MT pair models (PostHog-used pairs). One pair = one card; opt-in, shown
+ * only when the active source→target matches. `src`/`tgt` are canonical bare
+ * codes for matching the picker; `id` matches the sidecar catalog id (keeps the
+ * Helsinki "jap" token for en→ja). Sorted after the multilingual models.
+ */
+const NATIVE_OPUS_PAIRS: { id: string; name: string; src: string; tgt: string; sortOrder: number }[] = [
+  { id: 'opus-mt-ru-en', name: 'Opus-MT (ru → en)', src: 'ru', tgt: 'en', sortOrder: 20 },
+  { id: 'opus-mt-zh-en', name: 'Opus-MT (zh → en)', src: 'zh', tgt: 'en', sortOrder: 21 },
+  { id: 'opus-mt-en-zh', name: 'Opus-MT (en → zh)', src: 'en', tgt: 'zh', sortOrder: 22 },
+  { id: 'opus-mt-hu-en', name: 'Opus-MT (hu → en)', src: 'hu', tgt: 'en', sortOrder: 23 },
+  { id: 'opus-mt-en-es', name: 'Opus-MT (en → es)', src: 'en', tgt: 'es', sortOrder: 24 },
+  { id: 'opus-mt-en-ar', name: 'Opus-MT (en → ar)', src: 'en', tgt: 'ar', sortOrder: 25 },
+  { id: 'opus-mt-en-ru', name: 'Opus-MT (en → ru)', src: 'en', tgt: 'ru', sortOrder: 26 },
+  { id: 'opus-mt-es-en', name: 'Opus-MT (es → en)', src: 'es', tgt: 'en', sortOrder: 27 },
+  { id: 'opus-mt-en-vi', name: 'Opus-MT (en → vi)', src: 'en', tgt: 'vi', sortOrder: 28 },
+  { id: 'opus-mt-ar-en', name: 'Opus-MT (ar → en)', src: 'ar', tgt: 'en', sortOrder: 29 },
+  { id: 'opus-mt-ja-en', name: 'Opus-MT (ja → en)', src: 'ja', tgt: 'en', sortOrder: 30 },
+  { id: 'opus-mt-en-jap', name: 'Opus-MT (en → ja)', src: 'en', tgt: 'ja', sortOrder: 31 },
+  { id: 'opus-mt-ko-en', name: 'Opus-MT (ko → en)', src: 'ko', tgt: 'en', sortOrder: 32 },
+];
+
+export function nativeTranslationCards(src: string, tgt: string): NativeModelCardSpec[] {
+  const base: NativeModelCardSpec[] = [
     { selectId: 'qwen2.5-0.5b', downloadId: 'qwen2.5-0.5b', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true, sortOrder: 1 },
     { selectId: 'qwen3-0.6b', downloadId: 'qwen3-0.6b', name: 'Qwen 3 0.6B', languages: ['multi'], recommended: true, sortOrder: 2 },
     { selectId: 'qwen3.5-0.8b', downloadId: 'qwen3.5-0.8b', name: 'Qwen 3.5 0.8B', languages: ['multi'], sortOrder: 3 },
@@ -340,6 +362,15 @@ export function nativeTranslationCards(_src: string, _tgt: string): NativeModelC
     { selectId: 'hy-mt2-1.8b', downloadId: 'hy-mt2-1.8b', name: 'Hunyuan-MT2 1.8B', languages: ['multi'], sortOrder: 7 },
     { selectId: 'hy-mt2-7b', downloadId: 'hy-mt2-7b', name: 'Hunyuan-MT2 7B', languages: ['multi'], sortOrder: 8 },
   ];
+  const wantSrc = canonLang(src);
+  const wantTgt = canonLang(tgt);
+  const opus: NativeModelCardSpec[] = NATIVE_OPUS_PAIRS
+    .filter((p) => canonLang(p.src) === wantSrc && canonLang(p.tgt) === wantTgt)
+    .map((p) => ({
+      selectId: p.id, downloadId: p.id, name: p.name,
+      languages: [p.src, p.tgt], sortOrder: p.sortOrder,
+    }));
+  return [...base, ...opus];
 }
 
 export function nativeTtsCards(tgt: string): NativeModelCardSpec[] {


### PR DESCRIPTION
## Summary

Adds the 13 most-used Opus-MT language pairs to the native (Electron sidecar) translation provider as a first-class PyTorch MarianMT backend, plus two download-efficiency fixes uncovered along the way.

**Why these 13 pairs:** PostHog `translation_session_start` data shows ~20 users actively pick pair-specific `opus-mt-*` models (led by `ru-en`, `zh-en`, `en-zh`) — they're tiny (~300 MB) and start fast on low-end hardware where a 1.8B+ LLM is painful. Opus-MT was removed from the sidecar in #272; this re-adds it the way the WASM `local_inference` provider does it: **one pair = one model card**, opt-in, shown only for the matching source→target.

## What's included

**Feature (spec + plan + 3 TDD tasks):**
- `OpusTranslateBackend` (`opus_translate`) — `AutoModelForSeq2SeqLM` MarianMT, GPU bf16 + CPU fp32 floor, direct `generate()` (no chat template/system prompt — direction is baked in), `local_files_only=True`. Self-gates on `transformers`.
- 13 catalog rows via `_opus_row` + `Helsinki-NLP/opus-mt-{src}-{tgt}` download mapping. No FP8 variants. `resolve_translate` unchanged (opus rides the existing variant/CPU-floor path).
- Pair-specific renderer cards filtered by canonicalized src→tgt; recommended Qwen stays the default. The `ja`/`jap` Helsinki quirk is handled (id/repo keep `jap`, match-codes use `ja`).
- Pairs: `ru-en, zh-en, en-zh, hu-en, en-es, en-ar, en-ru, es-en, en-vi, ar-en, ja-en, en-jap, ko-en`.

**Download-efficiency fixes:**
- **Skip non-PyTorch Opus-MT weights.** Helsinki repos ship the same model in 4 frameworks; we load only `pytorch_model.bin`. Ignoring `tf_model.h5`/`rust_model.ot`/`flax_model.msgpack` cuts each download by 50–80% (`en-zh`: 1446 MB → 301 MB) — **~7.6 GB saved across the 13 pairs** — and corrects the inflated size shown in the UI.
- **Glob-aware ignore filter.** The `ignore` filter was exact-match, so HY-MT2's `train/*` silently matched nothing (the 37-file training dir downloaded all along). Switched to `fnmatch` (exact filenames still match) and added `imgs/*` to HY-MT2. Opus/Voxtral exact ignores are unchanged.

## Testing

- Sidecar: opus backend (mocked seq2seq), `resolve_translate` (gpu→cpu), `download_specs`, install gate, glob filter (incl. end-to-end `download()` excluding nested `train/`/`imgs/`). Suites green (`test_catalog`/`test_native_models`/`test_translate_backends`).
- Renderer: `nativeTranslationCards` direction filtering, opt-in ordering, `downloadId === selectId`, the en-jap/ja-en edge case (47/47).
- Reviewed task-by-task plus a whole-branch review (Ready to merge, no Critical/Important).

## Notes

- This PR also carries the spec + plan docs (not yet on `native-sidecar`).
- **HY-MT1.5** is intentionally out of scope (its own future spec). Finding from this PR's audit: `tencent/HY-MT1.5-1.8B`/`-7B`/`-FP8` native PyTorch repos **do** exist and are clean (no `train/`/`imgs/`), so the remaining open question is just transformers arch support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added native Opus-MT translation support for selected language pairs, with pair-specific translation cards shown only when the chosen source and target match.
  * Expanded supported translation options with additional pair-based native models and improved language-code display for Japanese.

* **Bug Fixes**
  * Improved model selection so the best available native translation option is shown for the active language direction.
  * Updated download handling to better filter unwanted files and support more reliable local model loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->