### PR TITLE
feat(native): per-card quant variant (decouple from model selection)

### DIFF
--- a/docs/superpowers/plans/2026-06-27-native-per-card-quant-variant.md
+++ b/docs/superpowers/plans/2026-06-27-native-per-card-quant-variant.md
@@ -1,0 +1,385 @@
+# Native Per-Card Quant Variant Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the translation variant dropdown a per-card download choice (which quant to download), decoupled from active-model selection, with variant-aware download status.
+
+**Architecture:** Replace the single `translationVariant` setting with a per-model map `translationVariantByModel`; the variant pick writes only the map (no model switch, so auto-select never fires); download status becomes variant-aware via a `repo` override on `model_status`.
+
+**Tech Stack:** TypeScript (renderer: Zustand store, React, vitest), Python (sidecar: pytest).
+
+## Global Constraints
+
+- Settings field: `translationVariant?: string` → `translationVariantByModel: Record<string, string>` (per model id, global across directions; default `{}`; no entry → recommended). **No migration.**
+- The variant pick writes ONLY `translationVariantByModel` — never `translationModel`, never `rememberModels`, never `setAutoSelectedStages`.
+- The session-config (`IClient`) field `translationVariant` STAYS; `createLocalNativeSessionConfig` derives it as `translationVariantByModel[translationModel]` (the active model's quant = the load `select_variant` pin).
+- Status is variant-aware: a card is "downloaded" ⟺ its chosen variant's repo is cached. `model_status(model_id, repo=None)` mirrors `download_specs(model_id, repo)`; the request carries an optional `repos` map (absent → default repo, fully backward-compatible).
+- Out of scope: the `autoSelectNative` "not-downloaded manual selection reverts" bug.
+- Renderer tests: `npx vitest run <file>`. Sidecar tests: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest <paths> -v` (system Python; two `test_accel.py` gating tests fail pre-existingly under transformers 4.53.2 — unrelated).
+
+---
+
+### Task 1: Sidecar — variant-aware `model_status`
+
+**Files:**
+- Modify: `sidecar/sokuji_sidecar/native_models.py` (`model_status` + `_h_model_status`)
+- Test: `sidecar/tests/test_native_models.py`
+
+**Interfaces:**
+- Produces: `model_status(model_id, repo=None)` — `repo` override checks the variant repo instead of the default; `_h_model_status` reads a `repos` map from the message (`{modelId: repoOverride}`), default `{}`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `sidecar/tests/test_native_models.py`:
+
+```python
+def test_model_status_repo_override(monkeypatch):
+    from sokuji_sidecar import native_models as nm
+    seen = {}
+
+    def fake_snapshot(repo_id, local_files_only):
+        seen["repo"] = repo_id
+        return "/cache"
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_snapshot)
+    # no .incomplete files → ready; we only assert which repo was checked
+    monkeypatch.setattr("glob.glob", lambda *a, **k: [])
+    nm.model_status("hy-mt2-1.8b", repo="tencent/Hy-MT2-1.8B-FP8")
+    assert seen["repo"] == "tencent/Hy-MT2-1.8B-FP8"   # the variant repo, not the bf16 default
+
+
+def test_h_model_status_applies_repos_map(monkeypatch):
+    import asyncio
+    from sokuji_sidecar import native_models as nm
+    calls = []
+    monkeypatch.setattr(nm, "model_status",
+                        lambda mid, repo=None: (calls.append((mid, repo)), "ready")[1])
+    msg = {"id": 1, "models": ["hy-mt2-1.8b", "sense-voice"],
+           "repos": {"hy-mt2-1.8b": "tencent/Hy-MT2-1.8B-FP8"}}
+    reply, _ = asyncio.run(nm._h_model_status(None, msg, None))
+    assert ("hy-mt2-1.8b", "tencent/Hy-MT2-1.8B-FP8") in calls
+    assert ("sense-voice", None) in calls          # no override → default repo
+    assert reply["statuses"] == {"hy-mt2-1.8b": "ready", "sense-voice": "ready"}
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_native_models.py::test_model_status_repo_override tests/test_native_models.py::test_h_model_status_applies_repos_map -v`
+Expected: FAIL — `model_status()` takes 1 positional arg / `_h_model_status` ignores `repos`.
+
+- [ ] **Step 3: Add the `repo` param + repos map**
+
+In `sidecar/sokuji_sidecar/native_models.py`, change the `model_status` signature line:
+
+```python
+def model_status(model_id, repo=None):
+    """'ready' only if every repo + url is cached locally AND complete, else 'absent'.
+
+    `repo` overrides the model's default repo with a chosen variant's repo (mirrors
+    download_specs), so status reflects the variant the card actually downloads."""
+    import glob
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.constants import HF_HUB_CACHE
+    specs = download_specs(model_id, repo)
+```
+
+(only the `def` line, docstring, and the `download_specs(model_id, repo)` call change — the loop body is unchanged.)
+
+And change `_h_model_status`:
+
+```python
+async def _h_model_status(state, msg, _b, conn=None):
+    repos = msg.get("repos") or {}
+    statuses = {m: model_status(m, repos.get(m)) for m in (msg.get("models") or [])}
+    return {"type": "model_status_result", "id": msg.get("id"), "statuses": statuses}, None
+```
+
+- [ ] **Step 4: Run them to verify they pass**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_native_models.py::test_model_status_repo_override tests/test_native_models.py::test_h_model_status_applies_repos_map -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Regression run**
+
+Run: `cd sidecar && SOKUJI_BENCH_DIR=$(mktemp -d) python -m pytest tests/test_native_models.py -q`
+Expected: all pass (existing status tests still green — default-repo path unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sidecar/sokuji_sidecar/native_models.py sidecar/tests/test_native_models.py
+git commit -m "feat(native): variant-aware model_status (repo override + repos map)"
+```
+
+---
+
+### Task 2: Renderer — per-model variant map + decouple the pick (bug fix)
+
+**Files:**
+- Modify: `src/stores/settingsStore.ts` (field, default, `createLocalNativeSessionConfig`)
+- Modify: `src/components/Settings/sections/NativeModelManagementSection.tsx` (`handlePinVariant`, `pinnedVariantId`, `selectCard`)
+- Test: `src/stores/settingsStore.translationVariant.test.ts`, `src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+
+**Interfaces:**
+- Produces: `LocalNativeSettings.translationVariantByModel: Record<string, string>`; `createLocalNativeSessionConfig` forwards `translationVariantByModel[translationModel]` as the session-config `translationVariant`.
+
+- [ ] **Step 1: Update the settings tests (RED)**
+
+Replace the body of `src/stores/settingsStore.translationVariant.test.ts`'s three `it` blocks with:
+
+```javascript
+  it('is undefined (automatic) by default — empty per-model map', () => {
+    expect(useSettingsStore.getState().localNative.translationVariantByModel).toEqual({});
+    const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
+    expect(cfg.translationVariant).toBeUndefined();
+  });
+
+  it('forwards the active model\'s chosen quant as config.translationVariant', async () => {
+    await useSettingsStore.getState().updateLocalNative({
+      translationModel: 'hy-mt2-7b', translationVariantByModel: { 'hy-mt2-7b': 'fp8' },
+    });
+    const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
+    expect(cfg.translationVariant).toBe('fp8');
+  });
+
+  it('a quant chosen for a NON-active model does not affect the active config', async () => {
+    await useSettingsStore.getState().updateLocalNative({
+      translationModel: 'qwen2.5-0.5b', translationVariantByModel: { 'hy-mt2-7b': 'fp8' },
+    });
+    const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
+    expect(cfg.translationVariant).toBeUndefined();   // active model has no entry
+  });
+```
+
+In `src/components/Settings/sections/NativeModelManagementSection.test.tsx`: add `translationVariantByModel: {}` to the `mockSettings` object, and change the pin test's assertion (line ~165) to:
+
+```javascript
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ translationVariantByModel: { 'hy-mt2-7b': 'fp8' } }));
+    // and it must NOT switch the active model
+    expect(mockUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ translationModel: expect.anything() }));
+```
+
+- [ ] **Step 2: Run them to verify they fail**
+
+Run: `npx vitest run src/stores/settingsStore.translationVariant.test.ts src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+Expected: FAIL — `translationVariantByModel` undefined; pin test still sees `translationModel` write.
+
+- [ ] **Step 3: Swap the settings field + default + session config**
+
+In `src/stores/settingsStore.ts`, replace the `translationVariant?: string;` field (and its comment) in `LocalNativeSettings`:
+
+```typescript
+  // Per-model chosen quant variant (e.g. { 'hy-mt2-1.8b': 'fp8' }). A model with no
+  // entry uses the sidecar's recommended variant. Keyed by model id (global across
+  // language directions); drives which repo the card downloads AND the load pin.
+  translationVariantByModel: Record<string, string>;
+```
+
+In `defaultLocalNativeSettings`, add (e.g. after `ttsModel: ''`):
+
+```typescript
+  translationVariantByModel: {},
+```
+
+In `createLocalNativeSessionConfig`, change the `translationVariant` line:
+
+```typescript
+    translationVariant: settings.translationVariantByModel[settings.translationModel],
+```
+
+- [ ] **Step 4: Decouple the pick in the component**
+
+In `src/components/Settings/sections/NativeModelManagementSection.tsx`:
+
+Remove the stale-pin reset in `selectCard` (the `if (field === 'translationModel' …) { updates.translationVariant = undefined; }` block, ~lines 487-492) — the per-model map has no cross-model leak, so no reset is needed.
+
+Replace `handlePinVariant` (~lines 502-511) with:
+
+```typescript
+  // Pick the download quant for a card — a per-model setting only. Does NOT change
+  // the active translation model (so the auto-select reconcile never fires on a pick).
+  const handlePinVariant = useCallback((selectId: string, variantId: string) => {
+    update({ translationVariantByModel: { ...settings.translationVariantByModel, [selectId]: variantId } });
+  }, [update, settings.translationVariantByModel]);
+```
+
+Replace the `pinnedVariantId` computation (~lines 534-535) with:
+
+```typescript
+          const pinnedVariantId = settings.translationVariantByModel[c.selectId];
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/stores/settingsStore.translationVariant.test.ts src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+Expected: PASS.
+
+- [ ] **Step 6: Typecheck the changed files (no new errors)**
+
+Run: `npx tsc --noEmit 2>&1 | grep -E "settingsStore.ts|NativeModelManagementSection.tsx" || echo "no new errors in changed files"`
+Expected: `no new errors in changed files` (translationVariant references resolved to the new map).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/stores/settingsStore.ts src/components/Settings/sections/NativeModelManagementSection.tsx src/stores/settingsStore.translationVariant.test.ts src/components/Settings/sections/NativeModelManagementSection.test.tsx
+git commit -m "feat(native): per-model quant map; variant pick no longer switches the active model"
+```
+
+---
+
+### Task 3: Renderer — wire variant-aware status
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts` (new pure helper `statusReposFor`)
+- Modify: `src/lib/local-inference/native/NativeModelClient.ts` (`status(models, repos?)`)
+- Modify: `src/stores/nativeModelStore.ts` (`refresh(models, repos?)` + interface)
+- Modify: `src/components/Settings/sections/NativeModelManagementSection.tsx` (compute + pass `statusRepos` to `refresh`)
+- Test: `src/lib/local-inference/native/nativeCatalog.test.ts`
+
+**Interfaces:**
+- Consumes: Task 1's sidecar `repos` map; Task 2's `translationVariantByModel`.
+- Produces: `statusReposFor(ids, variantData, variantByModel): Record<string,string>`; `refresh(models, repos?)`; `client.status(models, repos?)`.
+
+- [ ] **Step 1: Write the failing helper test**
+
+Append to `src/lib/local-inference/native/nativeCatalog.test.ts`:
+
+```javascript
+  describe('statusReposFor', () => {
+    const vd = {
+      'hy-mt2-1.8b': { variants: [
+        { id: 'bfloat16', repo: 'tencent/Hy-MT2-1.8B', computeType: 'bfloat16', sizeBytes: 0, supported: true, reason: '' },
+        { id: 'fp8', repo: 'tencent/Hy-MT2-1.8B-FP8', computeType: 'fp8', sizeBytes: 0, supported: true, reason: '' },
+      ], recommended: 'bfloat16' },
+    };
+    it('maps a card to its chosen variant repo (pinned)', () => {
+      const repos = statusReposFor(['hy-mt2-1.8b', 'sense-voice'], vd, { 'hy-mt2-1.8b': 'fp8' });
+      expect(repos).toEqual({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });   // sense-voice has no variants → omitted
+    });
+    it('falls back to the recommended variant repo when unpinned', () => {
+      const repos = statusReposFor(['hy-mt2-1.8b'], vd, {});
+      expect(repos).toEqual({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B' });
+    });
+  });
+```
+
+Add `statusReposFor` to the test's import line from `./nativeCatalog`.
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: FAIL — `statusReposFor` is not exported.
+
+- [ ] **Step 3: Add the pure helper**
+
+In `src/lib/local-inference/native/nativeCatalog.ts`, add (import `VariantInfo` from `./nativeProtocol` if not already):
+
+```typescript
+/**
+ * The per-model status repo overrides: each card's CHOSEN variant repo (pinned,
+ * else recommended). Cards without variant data are omitted → the sidecar checks
+ * their default repo. Feeds the variant-aware model_status query.
+ */
+export function statusReposFor(
+  ids: string[],
+  variantData: Record<string, { variants: VariantInfo[]; recommended: string }>,
+  variantByModel: Record<string, string>,
+): Record<string, string> {
+  const repos: Record<string, string> = {};
+  for (const id of ids) {
+    const vd = variantData[id];
+    if (!vd) continue;
+    const chosenId = variantByModel[id] ?? vd.recommended;
+    const repo = vd.variants.find((v) => v.id === chosenId)?.repo;
+    if (repo) repos[id] = repo;
+  }
+  return repos;
+}
+```
+
+- [ ] **Step 4: Run the helper test to verify it passes**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Thread `repos` through client + store**
+
+In `src/lib/local-inference/native/NativeModelClient.ts`, change `status`:
+
+```typescript
+  async status(models: string[], repos?: Record<string, string>): Promise<Record<string, NativeModelState>> {
+    await this.connect();
+    const msg = await this.send({ type: 'model_status', models, repos });
+    return (msg as Extract<ServerMsg, { type: 'model_status_result' }>).statuses;
+  }
+```
+
+In `src/stores/nativeModelStore.ts`, change the `refresh` interface declaration (line ~20):
+
+```typescript
+  refresh: (models: string[], repos?: Record<string, string>) => Promise<void>;
+```
+
+and the implementation (line ~93):
+
+```typescript
+  refresh: async (models, repos) => {
+    if (!models.length) return;
+    try {
+      const result = await client.status(models, repos);
+      set((s) => ({ statuses: { ...s.statuses, ...result } }));
+    } catch {
+      // sidecar not available — leave statuses untouched
+    }
+  },
+```
+
+- [ ] **Step 6: Compute and pass `statusRepos` in the component**
+
+In `src/components/Settings/sections/NativeModelManagementSection.tsx`, import `statusReposFor` from `'../../../lib/local-inference/native/nativeCatalog'`, and after `allDownloadIds` is defined (~line 444), add:
+
+```typescript
+  const statusRepos = useMemo(
+    () => statusReposFor(allDownloadIds, variantData, settings.translationVariantByModel),
+    [allDownloadIds, variantData, settings.translationVariantByModel],
+  );
+```
+
+Change the refresh effect (~lines 449-454) so it re-fetches status when the chosen variant changes:
+
+```typescript
+  useEffect(() => {
+    refresh(allDownloadIds, statusRepos);
+    refreshSizes(allDownloadIds);
+    refreshCatalog();
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [refreshKey, JSON.stringify(statusRepos)]);
+```
+
+- [ ] **Step 7: Run renderer suites to verify green**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+Expected: PASS (helper tests + existing component tests; the component now calls `refresh` with the repos map).
+
+- [ ] **Step 8: Typecheck**
+
+Run: `npx tsc --noEmit 2>&1 | grep -E "nativeCatalog.ts|NativeModelClient.ts|nativeModelStore.ts|NativeModelManagementSection.tsx" || echo "no new errors in changed files"`
+Expected: `no new errors in changed files`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts src/lib/local-inference/native/NativeModelClient.ts src/stores/nativeModelStore.ts src/components/Settings/sections/NativeModelManagementSection.tsx
+git commit -m "feat(native): variant-aware download status (per-card chosen-variant repo)"
+```
+
+---
+
+## Notes for the implementer
+
+- **Two `translationVariant`s exist — don't conflate them.** `LocalNativeSettings.translationVariant` (settings) is REMOVED → the map. The `IClient` session-config `translationVariant` (the wire field, consumed by `LocalNativeClient.ts:59`) STAYS; `createLocalNativeSessionConfig` derives it from the map. Only the settings field changes.
+- **`model_status` loop body is unchanged** in Task 1 — only the signature, docstring, and the `download_specs(model_id, repo)` call. Don't rewrite the `.incomplete` cache checks.
+- **`VariantInfo`** is defined in `nativeProtocol.ts` (fields incl. `id`, `repo`, `computeType`, `sizeBytes`, `supported`, `reason`).
+- The decouple (Task 2) is the user-visible bug fix on its own; Task 3 makes the downloaded-badge tell the truth about the chosen quant.

--- a/docs/superpowers/plans/2026-06-27-native-per-card-quant-variant.md
+++ b/docs/superpowers/plans/2026-06-27-native-per-card-quant-variant.md
@@ -383,3 +383,128 @@ git commit -m "feat(native): variant-aware download status (per-card chosen-vari
 - **`model_status` loop body is unchanged** in Task 1 — only the signature, docstring, and the `download_specs(model_id, repo)` call. Don't rewrite the `.incomplete` cache checks.
 - **`VariantInfo`** is defined in `nativeProtocol.ts` (fields incl. `id`, `repo`, `computeType`, `sizeBytes`, `supported`, `reason`).
 - The decouple (Task 2) is the user-visible bug fix on its own; Task 3 makes the downloaded-badge tell the truth about the chosen quant.
+
+---
+
+### Task 4: Make ALL status refreshes variant-aware (fix the readiness-gate Critical)
+
+**Why:** Task 3 wired variant-aware status into only the management section's `refresh(..., statusRepos)`. But `statuses` is a shared map and two other callers refresh it variant-BLIND: the readiness gate (`settingsStore.ts:1295` → `refresh(models)` then `isReady`) and `ProviderSection.tsx`. So a downloaded non-default quant reads as `absent` at the gate → Start stays blocked, and badges flicker. Fix: cache the derived repos in the store so every `refresh(models)` caller is variant-aware automatically — no cross-store coupling.
+
+**Files:**
+- Modify: `src/stores/nativeModelStore.ts` (add `statusRepos` cache + `setStatusRepos`; `refresh` falls back to it)
+- Modify: `src/components/Settings/sections/NativeModelManagementSection.tsx` (push `statusRepos` to the store; fix the stale comment)
+- Test: `src/stores/nativeModelStore.test.ts`
+
+**Interfaces:**
+- Produces: store `statusRepos: Record<string,string>` + `setStatusRepos(repos)`; `refresh(models, repos?)` uses `repos ?? get().statusRepos`.
+
+- [ ] **Step 1: Write the failing store test**
+
+In `src/stores/nativeModelStore.test.ts`, extend `FakeWS.send` to capture+answer `model_status` (add inside the `send` method, after the existing `model_delete` block):
+
+```javascript
+    if (msg.type === 'model_status') {
+      (globalThis as any).__lastStatusRepos = msg.repos;
+      queueMicrotask(() => this.emit({ type: 'model_status_result', id: msg.id,
+        statuses: Object.fromEntries((msg.models || []).map((m: string) => [m, 'ready'])) }));
+    }
+```
+
+Append a new describe block:
+
+```javascript
+describe('nativeModelStore.refresh — variant-aware via cached statusRepos', () => {
+  it('falls back to the cached statusRepos when the caller passes none (gate path)', async () => {
+    useNativeModelStore.getState().setStatusRepos({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
+    await useNativeModelStore.getState().refresh(['hy-mt2-1.8b']);   // no repos arg — the gate's call shape
+    expect((globalThis as any).__lastStatusRepos).toEqual({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
+  });
+
+  it('an explicit repos arg overrides the cache', async () => {
+    useNativeModelStore.getState().setStatusRepos({ 'hy-mt2-1.8b': 'cached' });
+    await useNativeModelStore.getState().refresh(['hy-mt2-1.8b'], { 'hy-mt2-1.8b': 'explicit' });
+    expect((globalThis as any).__lastStatusRepos).toEqual({ 'hy-mt2-1.8b': 'explicit' });
+  });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/stores/nativeModelStore.test.ts`
+Expected: FAIL — `setStatusRepos` is not a function.
+
+- [ ] **Step 3: Add the cache + fallback in the store**
+
+In `src/stores/nativeModelStore.ts`, add to the store interface (near `refresh:`):
+
+```typescript
+  statusRepos: Record<string, string>;
+  setStatusRepos: (repos: Record<string, string>) => void;
+```
+
+Add to the store state (near `statuses: {}`):
+
+```typescript
+  statusRepos: {},
+  setStatusRepos: (repos) => set({ statusRepos: repos }),
+```
+
+Change `refresh` to fall back to the cache:
+
+```typescript
+  refresh: async (models, repos) => {
+    if (!models.length) return;
+    try {
+      const result = await client.status(models, repos ?? get().statusRepos);
+      set((s) => ({ statuses: { ...s.statuses, ...result } }));
+    } catch {
+      // sidecar not available — leave statuses untouched
+    }
+  },
+```
+
+- [ ] **Step 4: Run the store test to verify it passes**
+
+Run: `npx vitest run src/stores/nativeModelStore.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Push statusRepos to the store from the component + fix the stale comment**
+
+In `src/components/Settings/sections/NativeModelManagementSection.tsx`:
+
+Pull the action (near the other `useNativeModelStore((s) => …)` lines, ~387):
+
+```typescript
+  const setStatusRepos = useNativeModelStore((s) => s.setStatusRepos);
+```
+
+In the refresh effect (the one calling `refresh(allDownloadIds, statusRepos)`), publish the map to the store so the gate/ProviderSection refreshes see it — add as the FIRST line of the effect body:
+
+```typescript
+    setStatusRepos(statusRepos);
+```
+
+Replace the now-stale comment above the variant-map memo (the line referencing `settings.translationVariant` "scoped to the SELECTED translation model") with:
+
+```typescript
+  // The manual variant pin is a per-model map (settings.translationVariantByModel),
+  // keyed by model id. Each card reads its own entry; download + load use the same value.
+```
+
+- [ ] **Step 6: Run renderer suites + scoped typecheck**
+
+Run: `npx vitest run src/stores/nativeModelStore.test.ts src/components/Settings/sections/NativeModelManagementSection.test.tsx src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS.
+Run: `npx tsc --noEmit 2>&1 | grep -E "nativeModelStore.ts|NativeModelManagementSection.tsx" | grep -v "onClearAll" || echo "no new errors in changed files"`
+Expected: `no new errors in changed files`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/stores/nativeModelStore.ts src/stores/nativeModelStore.test.ts src/components/Settings/sections/NativeModelManagementSection.tsx
+git commit -m "fix(native): readiness gate honors the chosen quant (cached statusRepos)"
+```
+
+## Note on the residual auto-select bounce (final-review Important #2)
+
+Re-picking the ACTIVE model's quant to an UNdownloaded variant now (correctly) flips its status to `absent`, which can trigger the `autoSelectNative` reconcile to switch the active model. This reduces to the explicitly out-of-scope "not-downloaded manual selection reverts" behavior and is NOT fixed here — the primary flow (pick a quant on a non-active card → download → select → Start) works end-to-end after Task 4. Documented as a known residual for a future auto-select pass.

--- a/docs/superpowers/plans/2026-06-27-native-per-card-quant-variant.md
+++ b/docs/superpowers/plans/2026-06-27-native-per-card-quant-variant.md
@@ -508,3 +508,29 @@ git commit -m "fix(native): readiness gate honors the chosen quant (cached statu
 ## Note on the residual auto-select bounce (final-review Important #2)
 
 Re-picking the ACTIVE model's quant to an UNdownloaded variant now (correctly) flips its status to `absent`, which can trigger the `autoSelectNative` reconcile to switch the active model. This reduces to the explicitly out-of-scope "not-downloaded manual selection reverts" behavior and is NOT fixed here — the primary flow (pick a quant on a non-active card → download → select → Start) works end-to-end after Task 4. Documented as a known residual for a future auto-select pass.
+
+## Task 5 — Cold-start: the gate self-resolves the chosen-variant repo
+
+**Found by the re-review after Task 4.** Task 4's store `statusRepos` cache is only
+published by `NativeModelManagementSection` (mounted only while Settings is open).
+On cold start (app restart with Settings closed), `SettingsInitializer` fires
+`validateApiKey()` for `LOCAL_NATIVE` with the cache still `{}`, so the gate's
+`refresh(models)` checked the catalog DEFAULT (bf16) repo. This gated Start for a
+user who downloaded only the chosen quant — and also broke the AUTOMATIC case
+(recommended = fp8, but a no-override `model_status` checks bf16). The cache is
+necessary but not sufficient; the gate must be self-sufficient.
+
+**Fix:** in `validateApiKey`'s `LOCAL_NATIVE` branch (`settingsStore.ts`), for an
+HY-MT-family active translation model, resolve its chosen variant
+(`pin ?? recommended`) repo via `nativeListVariants` and pass it explicitly to
+`refresh(models, statusRepos)` — reusing the same `statusReposFor` mapping the
+component uses, and the same `resolveNativeTts` reserve id so download/load/gate
+agree. Best-effort: if the sidecar metadata call fails, fall back to the cache.
+
+- [ ] **Step 1 (RED):** `src/stores/settingsStore.nativeGate.test.ts` — gate passes
+  the recommended repo when no pin, the pinned repo when pinned, and no override
+  (→ cache) for a non-HY-MT model.
+- [ ] **Step 2 (GREEN):** import `statusReposFor`; pull `nativeListVariants` from the
+  dynamic `./nativeModelStore` import; resolve + pass `statusRepos` to `refresh`.
+- [ ] **Step 3:** `npx vitest run` the gate test + the Task-1..4 suites — all green.
+- [ ] **Step 4: Commit.**

--- a/docs/superpowers/specs/2026-06-27-native-per-card-quant-variant-design.md
+++ b/docs/superpowers/specs/2026-06-27-native-per-card-quant-variant-design.md
@@ -1,0 +1,197 @@
+# Native Per-Card Quant Variant (decouple download-variant from model selection)
+
+## Problem
+
+The native translation variant picker (FP8 / bf16) conflates two distinct
+actions. Clicking a quant in a card's dropdown calls `handlePinVariant`, which
+writes **both** the variant *and* the active model:
+
+```ts
+update({ translationModel: selectId, translationVariant: variantId });
+```
+
+So picking "FP8" on the HY-MT2 card also makes HY-MT2 the active translation
+model. That model change then triggers the auto-select reconcile effect
+(`NativeModelManagementSection.tsx:459`), which — because the just-picked model
+isn't downloaded yet — bounces the selection to the first already-downloaded
+model (e.g. HY-MT1.5). Net effect: **you cannot choose which quant to download;
+the pick is treated as "use this model now" and gets reverted.**
+
+Root cause: there is a single `translationVariant` setting *scoped to the active
+model* (`pinnedVariantId = cardId === translationModel ? translationVariant :
+undefined`), so the only way to attach a variant to a card is to first make that
+card the active model.
+
+## Goal
+
+Make the variant dropdown a **per-card download choice** — "which quantization
+to download for this model" — independent of which model is active. Picking a
+quant never changes the active model and never triggers auto-select. Each model
+card shows and controls its own chosen quant.
+
+Decided behavior (from brainstorm):
+- **One chosen quant per model.** Picking FP8 makes FP8 the variant this model
+  downloads/uses; a previously-downloaded bf16 is just stale (deletable
+  separately), not auto-used.
+- **Load = downloaded.** A card can only download one variant, so the loaded
+  variant *is* the downloaded one — load reads the same per-model value the
+  download used; no separate load logic.
+- **No migration.** The old single `translationVariant` is removed; any prior
+  pin resets to the model's default (acceptable for this dev-stage feature).
+
+## Non-Goals
+
+- The broader auto-select bug ("a manual selection of a not-yet-downloaded model
+  reverts to a downloaded one"). Decoupling removes its trigger for the variant
+  flow; the reconcile logic in `autoSelectNative` is left untouched here.
+- Multiple variants of one model coexisting on disk with a "use which" switch.
+- Variants for non-translation stages (only HY-MT translation models have them).
+
+## Architecture
+
+Two changes, one in each layer:
+
+1. **Renderer — replace the single pin with a per-model map.** The chosen quant
+   becomes a property of the model id, not of the active selection. The variant
+   dropdown writes only that map; selecting the active model stays a separate
+   action (`selectCard`, the card body).
+2. **Sidecar — make download *status* variant-aware.** Today
+   `model_status(model_id)` checks the *default* (bf16) repo, so a card's
+   "downloaded" badge ignores the chosen quant. Status must check *the chosen
+   variant's* repo, so the card tells the truth about what's on disk and a
+   "ready" model's chosen variant always equals its downloaded variant.
+
+Download already supports a per-variant repo (`download_specs(model_id, repo)` +
+`download(..., repo)`); load already accepts a `select_variant` pin. So those
+two paths just read the new per-model value.
+
+## Data model
+
+`src/stores/settingsStore.ts` — in `LocalNativeSettings`:
+
+```ts
+// REMOVE:
+translationVariant?: string;                       // single pin, scoped to active model
+// ADD:
+translationVariantByModel: Record<string, string>; // modelId -> chosen quant id, e.g. { 'hy-mt2-1.8b': 'fp8' }
+```
+
+- Keyed by model id, **global across language directions** (FP8-ness is a model
+  property, not a pair property). Persisted in settings; default `{}`.
+- A model with no entry uses its **recommended** variant (from `list_variants`).
+- `buildNativeSessionConfig` (settingsStore.ts:739) changes from
+  `translationVariant: settings.translationVariant` to
+  `translationVariant: settings.translationVariantByModel[settings.translationModel]`
+  (the active model's chosen quant — the `select_variant` load pin).
+
+## Components / files
+
+Renderer (`src/`):
+- `stores/settingsStore.ts` — field swap + `buildNativeSessionConfig` + default.
+- `components/Settings/sections/NativeModelManagementSection.tsx` —
+  `handlePinVariant` writes only the map (no model switch); `pinnedVariantId` and
+  the per-card status read the map; the status query passes each card's chosen
+  variant repo.
+- `lib/local-inference/native/NativeModelClient.ts` + `nativeProtocol.ts` — the
+  `model_status` request carries an optional per-model repo override.
+- `stores/nativeModelStore.ts` — `refresh()` builds the per-model repo overrides
+  from the chosen variants and threads them to `client.status`.
+
+Sidecar (`sidecar/sokuji_sidecar/`):
+- `native_models.py` — `model_status(model_id, repo=None)` (repo override mirrors
+  `download_specs`); `_h_model_status` reads a per-model repo map from the msg.
+
+## Variant pick (the decouple)
+
+`handlePinVariant(selectId, variantId)` becomes:
+
+```ts
+update({
+  translationVariantByModel: { ...settings.translationVariantByModel, [selectId]: variantId },
+});
+// NO translationModel write, NO setAutoSelectedStages, NO rememberModels.
+```
+
+`pinnedVariantId` for every card reads the map (not just the active model):
+
+```ts
+const pinnedVariantId = settings.translationVariantByModel[c.selectId];
+```
+
+So each HY-MT card's dropdown shows and controls *its own* chosen quant, and a
+pick never changes `translationModel` → the auto-select effect never fires on a
+variant pick.
+
+## Download
+
+Unchanged. `handleDownload` already calls `download(spec.downloadId,
+chosenVariant?.repo)`, and `chosenVariant` now derives from
+`pinnedVariantId = translationVariantByModel[cardId]` (else recommended). The
+download fetches the chosen variant's repo.
+
+## Status (variant-aware — the new piece)
+
+`model_status` gains a repo override, like `download_specs`:
+
+```python
+def model_status(model_id, repo=None):
+    specs = download_specs(model_id, repo)   # repo=None → default; else the variant repo
+    ...                                       # unchanged cache/incomplete checks
+```
+
+The status request carries an optional per-model repo override map; the handler
+applies it:
+
+```python
+async def _h_model_status(state, msg, _b, conn=None):
+    repos = msg.get("repos") or {}
+    statuses = {m: model_status(m, repos.get(m)) for m in (msg.get("models") or [])}
+    return {"type": "model_status_result", "id": msg.get("id"), "statuses": statuses}, None
+```
+
+Renderer: `nativeModelStore.refresh()` builds `repos` = `{ cardId:
+chosenVariantRepo }` for HY-MT cards whose chosen variant differs from the
+default (from `variantData`/`list_variants`), and passes it via
+`NativeModelClient.status(models, repos)`. A card is "downloaded" ⟺ *its chosen
+variant's* repo is cached; switching the dropdown to an un-fetched quant flips
+the card to "not downloaded".
+
+## Load
+
+No new logic. `resolve_translate` for the active model already takes the
+`select_variant` pin; that pin is now
+`translationVariantByModel[activeModel]` (forwarded through
+`buildNativeSessionConfig`). Because a card only goes "ready" when its chosen
+variant is downloaded, the pinned/chosen variant always equals the on-disk
+variant for a runnable model — so "load = downloaded" holds without detection.
+
+## Testing
+
+Renderer:
+- `handlePinVariant` writes `translationVariantByModel[card]` and leaves
+  `translationModel` unchanged (regression for the bounce bug).
+- `pinnedVariantId` reflects per-card map entries; two different cards can hold
+  different chosen quants simultaneously.
+- `buildNativeSessionConfig` forwards `translationVariantByModel[activeModel]`
+  as `translationVariant`.
+- `refresh` sends a per-model repo override for a card with a non-default chosen
+  variant.
+
+Sidecar:
+- `model_status('hy-mt2-1.8b', repo='tencent/Hy-MT2-1.8B-FP8')` checks the FP8
+  repo (mocked snapshot) — `ready` when the FP8 repo is cached, `absent` when
+  only the default bf16 is.
+- `_h_model_status` applies the `repos` map per model and falls back to the
+  default repo when a model has no override.
+
+## Risks / caveats
+
+- **Status request shape change.** Adding `repos` to `model_status` must stay
+  backward-compatible (absent → default repo for every model), so a renderer
+  that sends no `repos` behaves exactly as today.
+- **The renderer needs each variant's repo to query status.** That comes from
+  `list_variants` (`variantData`); a card whose variants haven't loaded yet
+  queries with the default repo until they do — a brief transient, self-correcting
+  on the next `refresh`.
+- **No migration** means an existing `translationVariant` value is dropped; users
+  with a prior FP8 pin revert to the model default until they re-pick. Accepted.

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -135,12 +135,15 @@ def model_size(model_id):
     return total
 
 
-def model_status(model_id):
-    """'ready' only if every repo + url is cached locally AND complete, else 'absent'."""
+def model_status(model_id, repo=None):
+    """'ready' only if every repo + url is cached locally AND complete, else 'absent'.
+
+    `repo` overrides the model's default repo with a chosen variant's repo (mirrors
+    download_specs), so status reflects the variant the card actually downloads."""
     import glob
     from huggingface_hub import snapshot_download
     from huggingface_hub.constants import HF_HUB_CACHE
-    specs = download_specs(model_id)
+    specs = download_specs(model_id, repo)
     try:
         for repo in specs["repos"]:
             snapshot_download(repo_id=repo, local_files_only=True)
@@ -250,7 +253,8 @@ async def download(model_id, send, should_cancel=None, repo=None):
 
 
 async def _h_model_status(state, msg, _b, conn=None):
-    statuses = {m: model_status(m) for m in (msg.get("models") or [])}
+    repos = msg.get("repos") or {}
+    statuses = {m: model_status(m, repos.get(m)) for m in (msg.get("models") or [])}
     return {"type": "model_status_result", "id": msg.get("id"), "statuses": statuses}, None
 
 

--- a/sidecar/sokuji_sidecar/native_models.py
+++ b/sidecar/sokuji_sidecar/native_models.py
@@ -145,15 +145,15 @@ def model_status(model_id, repo=None):
     from huggingface_hub.constants import HF_HUB_CACHE
     specs = download_specs(model_id, repo)
     try:
-        for repo in specs["repos"]:
-            snapshot_download(repo_id=repo, local_files_only=True)
+        for r in specs["repos"]:
+            snapshot_download(repo_id=r, local_files_only=True)
             # snapshot_download(local_files_only=True) is satisfied by a PARTIAL cache — offline
             # it can't know the repo's full file list, so an interrupted download (e.g. a session
             # started mid-fetch) reads back as 'ready' and then fails to load. A half-fetched blob
             # leaves a '<sha>.<etag>.incomplete' in blobs/. But a *stale* leftover can coexist with
             # the finalized '<sha>' blob (a later resume re-fetched under a different temp name), so
             # only treat it as not-ready when the finalized blob is actually missing.
-            blobs = os.path.join(HF_HUB_CACHE, f"models--{repo.replace('/', '--')}", "blobs")
+            blobs = os.path.join(HF_HUB_CACHE, f"models--{r.replace('/', '--')}", "blobs")
             for inc in glob.glob(os.path.join(blobs, "*.incomplete")):
                 if not os.path.exists(os.path.join(blobs, os.path.basename(inc).split(".")[0])):
                     return "absent"
@@ -165,8 +165,12 @@ def model_status(model_id, repo=None):
         return "absent"
 
 
-def delete_model(model_id):
+def delete_model(model_id, repo=None):
     """Remove a model's cached repos from the HF cache.
+
+    `repo` overrides the model's default repo with a chosen variant's repo
+    (mirrors download_specs / model_status), so deleting an FP8-only HY-MT card
+    actually frees the FP8 cache instead of the unused bf16 default.
 
     Returns the number of bytes freed. Repos are deleted via the hub's cache
     scanner so we only touch fully-managed revisions; a repo shared with another
@@ -178,7 +182,7 @@ def delete_model(model_id):
     offline. It's a 643KB singleton — cheaper to keep than to refcount.
     """
     from huggingface_hub import scan_cache_dir
-    specs = download_specs(model_id)
+    specs = download_specs(model_id, repo)
     wanted = set(specs["repos"])
     freed = 0
     try:
@@ -303,7 +307,8 @@ async def _h_model_cancel(state, msg, _b, conn=None):
 async def _h_model_delete(state, msg, _b, conn=None):
     import asyncio
     model = msg.get("model")
-    freed = await asyncio.to_thread(delete_model, model)
+    repo = msg.get("repo")  # chosen variant's repo (None → model's default repo)
+    freed = await asyncio.to_thread(delete_model, model, repo)
     return {"type": "model_delete_result", "id": msg.get("id"), "model": model, "freed": freed}, None
 
 

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -131,12 +131,41 @@ def test_real_size_of_sense_voice():
 
 
 def test_delete_handler_shape(monkeypatch):
-    monkeypatch.setattr(nm, 'delete_model', lambda m: 4096)
+    monkeypatch.setattr(nm, 'delete_model', lambda m, repo=None: 4096)
     st = {'handlers': {}}
     nm.register(st)
     reply, _ = asyncio.run(server.handle_message(
         st, json.dumps({'type': 'model_delete', 'id': 7, 'model': 'whisper-tiny'})))
     assert reply == {'type': 'model_delete_result', 'id': 7, 'model': 'whisper-tiny', 'freed': 4096}
+
+
+def test_delete_model_honors_variant_repo(monkeypatch):
+    """delete_model must free the CHOSEN variant's repo, not the model's default —
+    otherwise an FP8-only HY-MT download can never be removed (status keeps
+    reporting it cached against the FP8 repo)."""
+    from sokuji_sidecar import native_models as nm
+    seen = {}
+    monkeypatch.setattr(nm, "download_specs",
+                        lambda model_id, repo=None: (seen.update(repo=repo), {"repos": [repo or "default"], "urls": []})[1])
+    monkeypatch.setattr("huggingface_hub.scan_cache_dir", lambda: (_ for _ in ()).throw(RuntimeError("no cache")))
+    nm.delete_model("hy-mt2-7b", repo="tencent/Hy-MT2-7B-FP8")
+    assert seen["repo"] == "tencent/Hy-MT2-7B-FP8"   # the variant repo, not the bf16 default
+
+
+def test_h_model_delete_forwards_repo(monkeypatch):
+    """The model_delete handler threads the per-card chosen-variant repo through
+    to delete_model (mirrors model_status's repo override)."""
+    from sokuji_sidecar import native_models as nm
+    calls = []
+    monkeypatch.setattr(nm, "delete_model",
+                        lambda model_id, repo=None: (calls.append((model_id, repo)), 4096)[1])
+    st = {'handlers': {}}
+    nm.register(st)
+    reply, _ = asyncio.run(server.handle_message(
+        st, json.dumps({'type': 'model_delete', 'id': 7, 'model': 'hy-mt2-7b',
+                        'repo': 'tencent/Hy-MT2-7B-FP8'})))
+    assert ('hy-mt2-7b', 'tencent/Hy-MT2-7B-FP8') in calls
+    assert reply == {'type': 'model_delete_result', 'id': 7, 'model': 'hy-mt2-7b', 'freed': 4096}
 
 
 def test_download_is_nonblocking_and_pushes_completion(monkeypatch):

--- a/sidecar/tests/test_native_models.py
+++ b/sidecar/tests/test_native_models.py
@@ -96,7 +96,7 @@ def test_download_raises_when_no_files_resolved(monkeypatch):
 
 
 def test_status_handler_shape(monkeypatch):
-    monkeypatch.setattr(nm, 'model_status', lambda m: 'ready' if m == 'sense-voice' else 'absent')
+    monkeypatch.setattr(nm, 'model_status', lambda m, repo=None: 'ready' if m == 'sense-voice' else 'absent')
     st = {'handlers': {}}
     nm.register(st)
     reply, _ = asyncio.run(server.handle_message(
@@ -427,3 +427,31 @@ def test_download_specs_hymt15():
     assert "ignore" not in nm.download_specs("hy-mt15-7b")
     # FP8 variant download rides the repo-override path
     assert nm.download_specs("hy-mt15-7b", repo="tencent/HY-MT1.5-7B-FP8")["repos"] == ["tencent/HY-MT1.5-7B-FP8"]
+
+
+def test_model_status_repo_override(monkeypatch):
+    from sokuji_sidecar import native_models as nm
+    seen = {}
+
+    def fake_snapshot(repo_id, local_files_only):
+        seen["repo"] = repo_id
+        return "/cache"
+    monkeypatch.setattr("huggingface_hub.snapshot_download", fake_snapshot)
+    # no .incomplete files → ready; we only assert which repo was checked
+    monkeypatch.setattr("glob.glob", lambda *a, **k: [])
+    nm.model_status("hy-mt2-1.8b", repo="tencent/Hy-MT2-1.8B-FP8")
+    assert seen["repo"] == "tencent/Hy-MT2-1.8B-FP8"   # the variant repo, not the bf16 default
+
+
+def test_h_model_status_applies_repos_map(monkeypatch):
+    import asyncio
+    from sokuji_sidecar import native_models as nm
+    calls = []
+    monkeypatch.setattr(nm, "model_status",
+                        lambda mid, repo=None: (calls.append((mid, repo)), "ready")[1])
+    msg = {"id": 1, "models": ["hy-mt2-1.8b", "sense-voice"],
+           "repos": {"hy-mt2-1.8b": "tencent/Hy-MT2-1.8B-FP8"}}
+    reply, _ = asyncio.run(nm._h_model_status(None, msg, None))
+    assert ("hy-mt2-1.8b", "tencent/Hy-MT2-1.8B-FP8") in calls
+    assert ("sense-voice", None) in calls          # no override → default repo
+    assert reply["statuses"] == {"hy-mt2-1.8b": "ready", "sense-voice": "ready"}

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -55,7 +55,10 @@ const mockSizes: Record<string, number> = {};
 
 const mockListVariants = vi.fn();
 const mockDownload = vi.fn();
+const mockDeleteModel = vi.fn();
 const mockUpdate = vi.fn();
+const mockRefresh = vi.fn().mockResolvedValue(undefined);
+const mockSetStatusRepos = vi.fn();
 
 // ---------------------------------------------------------------------------
 // Module mocks
@@ -84,12 +87,12 @@ vi.mock('../../../stores/nativeModelStore', () => ({
       errors: {},
       catalog: {},
       download: mockDownload,
-      deleteModel: vi.fn(),
+      deleteModel: mockDeleteModel,
       cancelDownload: vi.fn(),
-      refresh: vi.fn().mockResolvedValue(undefined),
+      refresh: mockRefresh,
       refreshSizes: vi.fn().mockResolvedValue(undefined),
       refreshCatalog: vi.fn().mockResolvedValue(undefined),
-      setStatusRepos: vi.fn(),
+      setStatusRepos: mockSetStatusRepos,
       autoSelect: vi.fn().mockReturnValue(null),
       rememberModels: vi.fn(),
       asrLoading: false,
@@ -117,7 +120,11 @@ beforeEach(() => {
   Object.keys(mockSizes).forEach((k) => delete mockSizes[k]);
   mockListVariants.mockResolvedValue({ variants: mockVariants, recommended: 'fp8' });
   mockDownload.mockReset();
+  mockDeleteModel.mockReset();
   mockUpdate.mockReset();
+  mockRefresh.mockReset();
+  mockRefresh.mockResolvedValue(undefined);
+  mockSetStatusRepos.mockReset();
 });
 
 describe('NativeModelManagementSection — HY-MT2 variant card', () => {
@@ -203,6 +210,38 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     const card7b = screen.getByTestId('model-card-hy-mt2-7b');
     expect(within(card7b).queryByTestId('variant-row-fp8')).not.toBeInTheDocument();
     expect(within(card7b).queryByTestId('variant-row-bfloat16')).not.toBeInTheDocument();
+  });
+
+  it('deletes the resolved variant repo, not the default (FP8-only download is removable)', async () => {
+    // Downloaded state: the card collapses to the resolved variant and shows Delete.
+    mockStatuses['hy-mt2-7b'] = 'ready';
+    mockSizes['hy-mt2-7b'] = 8_000_000_000;
+
+    render(<NativeModelManagementSection />);
+    const card7b = await waitFor(() => {
+      const c = screen.getByTestId('model-card-hy-mt2-7b');
+      within(c).getByTestId('variant-resolved-hy-mt2-7b'); // throws until variant data lands
+      return c;
+    });
+
+    fireEvent.click(within(card7b).getByRole('button', { name: /Delete/i }));
+
+    // Delete must target the FP8 repo so the FP8 cache is actually freed.
+    expect(mockDeleteModel).toHaveBeenCalledWith('hy-mt2-7b', 'tencent/Hy-MT2-7B-FP8');
+  });
+
+  it('does not push an empty statusRepos override while variant metadata is still loading', async () => {
+    // listVariants never resolves → variantData stays empty → statusReposFor → {}.
+    mockListVariants.mockReturnValue(new Promise<never>(() => {}));
+
+    render(<NativeModelManagementSection />);
+    await waitFor(() => expect(mockRefresh).toHaveBeenCalled());
+
+    // refresh must never get an empty {} override (which would defeat the store's
+    // `repos ?? cache` fallback and mask an already-downloaded non-default quant)…
+    expect(mockRefresh.mock.calls.every(([, repos]) => repos === undefined)).toBe(true);
+    // …and the empty map must not be persisted into the shared cache the gate reads.
+    expect(mockSetStatusRepos).not.toHaveBeenCalled();
   });
 
   it('downloads the chosen (recommended FP8) variant repo, not the default', async () => {

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -27,6 +27,7 @@ const mockSettings = {
   ttsModel: '',
   asrDevice: 'auto' as const,
   translationDevice: 'auto' as const,
+  translationVariantByModel: {},
 };
 
 const mockVariants: VariantInfo[] = [
@@ -163,7 +164,10 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
 
     // The pin reaches settings (single source of truth feeding both download repo and load).
     expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ translationModel: 'hy-mt2-7b', translationVariant: 'fp8' }));
+      expect.objectContaining({ translationVariantByModel: { 'hy-mt2-7b': 'fp8' } }));
+    // and it must NOT switch the active model
+    expect(mockUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ translationModel: expect.anything() }));
   });
 
   it('HY-MT1.5 cards also expose the quant-variant picker (the gate is the HY-MT family, not only hy-mt2)', async () => {

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -89,6 +89,7 @@ vi.mock('../../../stores/nativeModelStore', () => ({
       refresh: vi.fn().mockResolvedValue(undefined),
       refreshSizes: vi.fn().mockResolvedValue(undefined),
       refreshCatalog: vi.fn().mockResolvedValue(undefined),
+      setStatusRepos: vi.fn(),
       autoSelect: vi.fn().mockReturnValue(null),
       rememberModels: vi.fn(),
       asrLoading: false,

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -335,7 +335,7 @@ const NativeModelCard: React.FC<{
                 <span>{t('models.downloaded', 'Downloaded')}</span>
                 <button
                   className="model-card__btn model-card__btn--delete"
-                  onClick={(e) => { e.stopPropagation(); deleteModel(spec.downloadId as string); }}
+                  onClick={(e) => { e.stopPropagation(); deleteModel(spec.downloadId as string, chosenVariant?.repo); }}
                   disabled={disabled}
                   title={t('models.delete', 'Delete')}
                 >
@@ -450,13 +450,24 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     [allDownloadIds, variantData, settings.translationVariantByModel],
   );
   const refreshKey = allDownloadIds.join('|');
+  // Variant-aware status: re-check downloaded state whenever the model list or the
+  // chosen-variant repos change. Only publish/pass an override once we've actually
+  // resolved repos — an empty {} would poison nativeModelStore's `repos ?? cache`
+  // fallback (and the readiness gate that reads that cache), masking an
+  // already-downloaded non-default quant until — or permanently if — variants load.
   useEffect(() => {
-    setStatusRepos(statusRepos);
-    refresh(allDownloadIds, statusRepos);
-    refreshSizes(allDownloadIds);
-    refreshCatalog();   // per-machine tier availability for the ASR + translation badges
+    const hasOverride = Object.keys(statusRepos).length > 0;
+    if (hasOverride) setStatusRepos(statusRepos);
+    refresh(allDownloadIds, hasOverride ? statusRepos : undefined);
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [refreshKey, JSON.stringify(statusRepos)]);
+  // Sizes + per-machine tier availability are variant-independent — refresh them
+  // only when the model list changes, not on every quant pick.
+  useEffect(() => {
+    refreshSizes(allDownloadIds);
+    refreshCatalog();
+    /* eslint-disable-next-line react-hooks/exhaustive-deps */
+  }, [refreshKey]);
 
   // Auto-select / recall: reconcile the selection whenever statuses or the
   // language pair change, then apply only the fields that actually differ.
@@ -670,7 +681,7 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
       <ModelStorageFooter
         usedMb={usedMb}
         hasModels={readyIds.length > 0}
-        onClearAll={() => Promise.all(readyIds.map((id) => deleteModel(id)))}
+        onClearAll={() => Promise.all(readyIds.map((id) => deleteModel(id, statusRepos[id])))}
         disabled={isSessionActive}
       />
     </div>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -17,6 +17,7 @@ import {
   formatTps,
   resolvedTierState,
   formatMemMb,
+  statusReposFor,
   type NativeModelCardSpec,
   type NativeSelection,
 } from '../../../lib/local-inference/native/nativeCatalog';
@@ -445,13 +446,17 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     () => [...asrCards, ...asrIncompatibleCards, ...translationCards, ...ttsCards]
       .map((c) => c.downloadId).filter((x): x is string => !!x),
     [asrCards, asrIncompatibleCards, translationCards, ttsCards]);
+  const statusRepos = useMemo(
+    () => statusReposFor(allDownloadIds, variantData, settings.translationVariantByModel),
+    [allDownloadIds, variantData, settings.translationVariantByModel],
+  );
   const refreshKey = allDownloadIds.join('|');
   useEffect(() => {
-    refresh(allDownloadIds);
+    refresh(allDownloadIds, statusRepos);
     refreshSizes(allDownloadIds);
     refreshCatalog();   // per-machine tier availability for the ASR + translation badges
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [refreshKey]);
+  }, [refreshKey, JSON.stringify(statusRepos)]);
 
   // Auto-select / recall: reconcile the selection whenever statuses or the
   // language pair change, then apply only the fields that actually differ.

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -484,12 +484,6 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   // remember the full selection for this direction (mirrors ModelManagementSection).
   const selectCard = (field: Stage, selectId: string) => {
     const updates: Partial<LocalNativeSettings> = { [field]: selectId };
-    // Selecting a DIFFERENT translation model clears the variant pin so a stale pin from
-    // the previously-selected model can't leak into the new model's load (which would
-    // resolve a repo that was never downloaded). Re-selecting the same model keeps its pin.
-    if (field === 'translationModel' && selectId !== settings.translationModel) {
-      updates.translationVariant = undefined;
-    }
     update(updates);
     setAutoSelectedStages((prev) => ({ ...prev, [field]: false }));
     const sel: NativeSelection = {
@@ -499,16 +493,11 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
     rememberModels(settings.sourceLanguage, settings.targetLanguage, sel);
   };
 
-  // Pin a variant: select that translation model AND record the variant in settings, so
-  // download (chosen repo) and load (select_variant pin) agree. Mirrors selectCard's
-  // badge-clear + history-remember so a pinned model is treated like a selected one.
+  // Pick the download quant for a card — a per-model setting only. Does NOT change
+  // the active translation model (so the auto-select reconcile never fires on a pick).
   const handlePinVariant = useCallback((selectId: string, variantId: string) => {
-    update({ translationModel: selectId, translationVariant: variantId });
-    setAutoSelectedStages((prev) => ({ ...prev, translationModel: false }));
-    rememberModels(settings.sourceLanguage, settings.targetLanguage, {
-      asrModel: settings.asrModel, translationModel: selectId, ttsModel: settings.ttsModel,
-    });
-  }, [update, rememberModels, settings.asrModel, settings.ttsModel, settings.sourceLanguage, settings.targetLanguage]);
+    update({ translationVariantByModel: { ...settings.translationVariantByModel, [selectId]: variantId } });
+  }, [update, settings.translationVariantByModel]);
 
   // Recommended / Others split via the shared primitive; cards stay native-specific.
   const renderCards = (
@@ -528,11 +517,7 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
         isRecommended={(c) => !!c.recommended}
         renderItem={(c) => {
           const vd = variantMap?.[c.selectId];
-          // The pin only applies to the SELECTED translation model (the one that loads);
-          // other cards show the recommended variant. Reading from settings keeps download
-          // and load on the same variant.
-          const pinnedVariantId = c.selectId === settings.translationModel
-            ? settings.translationVariant : undefined;
+          const pinnedVariantId = settings.translationVariantByModel[c.selectId];
           const vProps: VariantCardProps | undefined = vd ? {
             variants: vd.variants,
             recommendedVariantId: vd.recommended,

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -384,6 +384,7 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   const asrResolved = useNativeAsrResolved();
   const translationResolved = useNativeTranslationResolved();
   const refresh = useNativeModelStore((s) => s.refresh);
+  const setStatusRepos = useNativeModelStore((s) => s.setStatusRepos);
   const refreshSizes = useNativeModelStore((s) => s.refreshSizes);
   const refreshCatalog = useNativeModelStore((s) => s.refreshCatalog);
   const autoSelect = useNativeModelStore((s) => s.autoSelect);
@@ -398,10 +399,8 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
 
   // Variant quant data for multi-variant translation cards (HY-MT: hy-mt2-*/hy-mt15-*), keyed by selectId.
   const [variantData, setVariantData] = useState<Record<string, { variants: VariantInfo[]; recommended: string }>>({});
-  // The manual variant pin lives in settings.translationVariant (scoped to the SELECTED
-  // translation model) so it reaches BOTH download (repo) and load (select_variant pin) —
-  // a local-only pin would leave load on the recommended variant and fail a local_files_only
-  // load of the pinned repo. Non-selected cards show no pin (recommended) until selected.
+  // The manual variant pin is a per-model map (settings.translationVariantByModel),
+  // keyed by model id. Each card reads its own entry; download + load use the same value.
 
   const asrCards = useMemo(() => nativeAsrCards(settings.sourceLanguage), [settings.sourceLanguage]);
   const asrIncompatibleCards = useMemo(
@@ -452,6 +451,7 @@ export const NativeModelManagementSection: React.FC<{ isSessionActive?: boolean 
   );
   const refreshKey = allDownloadIds.join('|');
   useEffect(() => {
+    setStatusRepos(statusRepos);
     refresh(allDownloadIds, statusRepos);
     refreshSizes(allDownloadIds);
     refreshCatalog();   // per-machine tier availability for the ASR + translation badges

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -86,9 +86,9 @@ export class NativeModelClient {
     return new Promise((resolve, reject) => { this.pending.set(id, { resolve, reject }); this.ws!.send(JSON.stringify({ ...payload, id })); });
   }
 
-  async status(models: string[]): Promise<Record<string, NativeModelState>> {
+  async status(models: string[], repos?: Record<string, string>): Promise<Record<string, NativeModelState>> {
     await this.connect();
-    const msg = await this.send({ type: 'model_status', models });
+    const msg = await this.send({ type: 'model_status', models, repos });
     return (msg as Extract<ServerMsg, { type: 'model_status_result' }>).statuses;
   }
 

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -132,10 +132,12 @@ export class NativeModelClient {
     return { variants: r.variants, recommended: r.recommended };
   }
 
-  /** Remove a model from the sidecar's cache; resolves to the bytes freed. */
-  async delete(model: string): Promise<number> {
+  /** Remove a model from the sidecar's cache; resolves to the bytes freed.
+   *  `repo` targets a chosen variant's repo (mirrors download/status), so an
+   *  FP8-only HY-MT card frees the FP8 cache, not the unused bf16 default. */
+  async delete(model: string, repo?: string): Promise<number> {
     await this.connect();
-    const msg = await this.send({ type: 'model_delete', model });
+    const msg = await this.send({ type: 'model_delete', model, repo });
     if (msg.type === 'error') throw new Error(msg.message);
     return (msg as Extract<ServerMsg, { type: 'model_delete_result' }>).freed;
   }

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickNativeTts, hasNativeTts, nativeTtsVoices, resolveNativeTts, resolveNativeTranslation, NATIVE_ASR, NATIVE_TRANSLATION, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, autoSelectNative, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps, estimateNativeMemoryByDevice, formatMemMb, actualNativeMemoryByDevice, resolvedTierState } from './nativeCatalog';
+import { pickNativeTts, hasNativeTts, nativeTtsVoices, resolveNativeTts, resolveNativeTranslation, NATIVE_ASR, NATIVE_TRANSLATION, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, autoSelectNative, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps, estimateNativeMemoryByDevice, formatMemMb, actualNativeMemoryByDevice, resolvedTierState, statusReposFor } from './nativeCatalog';
 import type { NativeModelInfo } from './nativeProtocol';
 
 describe('nativeCatalog', () => {
@@ -434,6 +434,23 @@ describe('nativeCatalog', () => {
       expect(byId['hy-mt2-1.8b'].name).toBe('Hunyuan-MT2 1.8B');
       expect(byId['hy-mt2-7b'].name).toBe('Hunyuan-MT2 7B');
       expect(byId['translategemma-4b'].downloadId).toBe('translategemma-4b'); // selectId == downloadId, like the qwen cards
+    });
+  });
+
+  describe('statusReposFor', () => {
+    const vd = {
+      'hy-mt2-1.8b': { variants: [
+        { id: 'bfloat16', repo: 'tencent/Hy-MT2-1.8B', computeType: 'bfloat16', sizeBytes: 0, supported: true, reason: '' },
+        { id: 'fp8', repo: 'tencent/Hy-MT2-1.8B-FP8', computeType: 'fp8', sizeBytes: 0, supported: true, reason: '' },
+      ], recommended: 'bfloat16' },
+    };
+    it('maps a card to its chosen variant repo (pinned)', () => {
+      const repos = statusReposFor(['hy-mt2-1.8b', 'sense-voice'], vd, { 'hy-mt2-1.8b': 'fp8' });
+      expect(repos).toEqual({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });   // sense-voice has no variants → omitted
+    });
+    it('falls back to the recommended variant repo when unpinned', () => {
+      const repos = statusReposFor(['hy-mt2-1.8b'], vd, {});
+      expect(repos).toEqual({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B' });
     });
   });
 });

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -4,7 +4,7 @@
  * config share one source of truth. TTS languages are limited to the sherpa
  * piper repos confirmed to exist.
  */
-import type { NativeModelInfo } from './nativeProtocol';
+import type { NativeModelInfo, VariantInfo } from './nativeProtocol';
 export interface NativeModelOption {
   id: string;
   label: string;
@@ -277,6 +277,27 @@ export function resolvedTierState(
 export function formatRtf(rtf: number): string {
   if (!(rtf > 0) || !Number.isFinite(rtf)) return 'realtime';
   return `${Math.round(1 / rtf)}× realtime`;
+}
+
+/**
+ * The per-model status repo overrides: each card's CHOSEN variant repo (pinned,
+ * else recommended). Cards without variant data are omitted → the sidecar checks
+ * their default repo. Feeds the variant-aware model_status query.
+ */
+export function statusReposFor(
+  ids: string[],
+  variantData: Record<string, { variants: VariantInfo[]; recommended: string }>,
+  variantByModel: Record<string, string>,
+): Record<string, string> {
+  const repos: Record<string, string> = {};
+  for (const id of ids) {
+    const vd = variantData[id];
+    if (!vd) continue;
+    const chosenId = variantByModel[id] ?? vd.recommended;
+    const repo = vd.variants.find((v) => v.id === chosenId)?.repo;
+    if (repo) repos[id] = repo;
+  }
+  return repos;
 }
 
 /** Human label for a measured translation throughput. tps 130.5 → "131 tok/s".

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -23,6 +23,11 @@ class FakeWS {
              tiers: [{ tier: 'cpu', backend: 'sherpa', available: true }] }];
       queueMicrotask(() => this.emit({ type: 'models_catalog_result', id: msg.id, models }));
     }
+    if (msg.type === 'model_status') {
+      (globalThis as any).__lastStatusRepos = msg.repos;
+      queueMicrotask(() => this.emit({ type: 'model_status_result', id: msg.id,
+        statuses: Object.fromEntries((msg.models || []).map((m: string) => [m, 'ready'])) }));
+    }
     if (msg.type === 'model_delete') queueMicrotask(() =>
       this.emit({ type: 'model_delete_result', id: msg.id, freed: 0 }));
   }
@@ -113,5 +118,19 @@ describe('nativeModelStore translation session channel', () => {
     s.setTranslationResolved({ model: 'qwen3.5-2b', device: 'cuda', tokensPerSec: 59.4 });
     expect(useNativeModelStore.getState().translationResolved)
       .toEqual({ model: 'qwen3.5-2b', device: 'cuda', tokensPerSec: 59.4 });
+  });
+});
+
+describe('nativeModelStore.refresh — variant-aware via cached statusRepos', () => {
+  it('falls back to the cached statusRepos when the caller passes none (gate path)', async () => {
+    useNativeModelStore.getState().setStatusRepos({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
+    await useNativeModelStore.getState().refresh(['hy-mt2-1.8b']);   // no repos arg — the gate's call shape
+    expect((globalThis as any).__lastStatusRepos).toEqual({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
+  });
+
+  it('an explicit repos arg overrides the cache', async () => {
+    useNativeModelStore.getState().setStatusRepos({ 'hy-mt2-1.8b': 'cached' });
+    await useNativeModelStore.getState().refresh(['hy-mt2-1.8b'], { 'hy-mt2-1.8b': 'explicit' });
+    expect((globalThis as any).__lastStatusRepos).toEqual({ 'hy-mt2-1.8b': 'explicit' });
   });
 });

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -38,6 +38,7 @@ beforeEach(() => {
   (globalThis as any).WebSocket = FakeWS as any;
   (globalThis as any).window = (globalThis as any).window ?? {};
   (globalThis as any).window.electron = { invoke: vi.fn().mockResolvedValue({ ok: true, port: 9 }) };
+  (globalThis as any).__lastStatusRepos = undefined;
   useNativeModelStore.setState({ catalog: {} });
 });
 

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -16,6 +16,10 @@ interface NativeModelStore {
   catalog: Record<string, NativeModelInfo>;
   /** Query the sidecar for the per-machine model catalog (best-effort). */
   refreshCatalog: (models?: string[]) => Promise<void>;
+  /** Cached per-model repo overrides (variant repos) pushed by the management section,
+   *  so every refresh() caller (gate, ProviderSection) is automatically variant-aware. */
+  statusRepos: Record<string, string>;
+  setStatusRepos: (repos: Record<string, string>) => void;
   /** Query the sidecar for the cache status of these models (no-op if sidecar down). */
   refresh: (models: string[], repos?: Record<string, string>) => Promise<void>;
   /** Query the sidecar for download sizes (bytes) of these models (best-effort). */
@@ -70,6 +74,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
   errors: {},
   catalog: {},
   modelPreferences: {},
+  statusRepos: {},
   asrLoading: false,
   asrResolved: null,
   translationResolved: null,
@@ -90,10 +95,12 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
     }
   },
 
+  setStatusRepos: (repos) => set({ statusRepos: repos }),
+
   refresh: async (models, repos) => {
     if (!models.length) return;
     try {
-      const result = await client.status(models, repos);
+      const result = await client.status(models, repos ?? get().statusRepos);
       set((s) => ({ statuses: { ...s.statuses, ...result } }));
     } catch {
       // sidecar not available — leave statuses untouched

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -30,7 +30,7 @@ interface NativeModelStore {
   /** Ask the sidecar to stop an in-flight download (takes effect at a file boundary). */
   cancelDownload: (model: string) => Promise<void>;
   /** Delete one model from the sidecar cache (flips its status to absent). */
-  deleteModel: (model: string) => Promise<void>;
+  deleteModel: (model: string, repo?: string) => Promise<void>;
   /** True only if every listed model is cached. */
   isReady: (models: string[]) => boolean;
   /** Persist the chosen models for a language pair/direction. */
@@ -147,13 +147,13 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
     await client.cancel(model);
   },
 
-  deleteModel: async (model) => {
+  deleteModel: async (model, repo) => {
     // Optimistic: hide the model immediately. The sidecar delete is a WS round-trip
     // + an rm of a multi-GB dir, so awaiting it first would freeze the card on
     // "Downloaded" for a noticeable beat (mirrors download()'s optimistic 'downloading').
     set((s) => ({ statuses: { ...s.statuses, [model]: 'absent' } }));
     try {
-      await client.delete(model);
+      await client.delete(model, repo);
     } catch {
       // sidecar refused/unavailable — keep the best-effort 'absent' (the model is
       // hidden either way; readiness re-checks against the real cache on next refresh).

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -17,7 +17,7 @@ interface NativeModelStore {
   /** Query the sidecar for the per-machine model catalog (best-effort). */
   refreshCatalog: (models?: string[]) => Promise<void>;
   /** Query the sidecar for the cache status of these models (no-op if sidecar down). */
-  refresh: (models: string[]) => Promise<void>;
+  refresh: (models: string[], repos?: Record<string, string>) => Promise<void>;
   /** Query the sidecar for download sizes (bytes) of these models (best-effort). */
   refreshSizes: (models: string[]) => Promise<void>;
   /** Download one model, streaming progress into the store. `repo` selects a chosen
@@ -90,10 +90,10 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
     }
   },
 
-  refresh: async (models) => {
+  refresh: async (models, repos) => {
     if (!models.length) return;
     try {
-      const result = await client.status(models);
+      const result = await client.status(models, repos);
       set((s) => ({ statuses: { ...s.statuses, ...result } }));
     } catch {
       // sidecar not available — leave statuses untouched

--- a/src/stores/settingsStore.nativeGate.test.ts
+++ b/src/stores/settingsStore.nativeGate.test.ts
@@ -1,0 +1,105 @@
+/**
+ * The LOCAL_NATIVE readiness gate (validateApiKey) must check the CHOSEN quant
+ * variant's repo — even on cold start, when the Settings panel (which normally
+ * publishes statusRepos) has never mounted this session. The gate therefore
+ * resolves the active translation model's variant itself (pin ?? recommended)
+ * via listVariants and passes that repo explicitly to refresh.
+ *
+ * Without this, the gate falls back to the catalog DEFAULT repo (e.g. bf16) and
+ * gates Start for a user who only downloaded the recommended/pinned quant.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider } from '../types/Provider';
+import type { VariantInfo } from '../lib/local-inference/native/nativeProtocol';
+
+// ServiceFactory is touched during updateLocalNative/persist — stub it.
+vi.mock('../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: vi.fn(() => ({
+      setSetting: vi.fn().mockResolvedValue(undefined),
+      getSetting: vi.fn(),
+    })),
+  },
+}));
+
+// Force the Electron branch of the gate.
+vi.mock('../utils/environment', async () => {
+  const actual = await vi.importActual<typeof import('../utils/environment')>('../utils/environment');
+  return { ...actual, isElectron: () => true };
+});
+
+// Stub the native store + variant lookup the gate dynamically imports.
+const mockRefresh = vi.fn().mockResolvedValue(undefined);
+const mockIsReady = vi.fn().mockReturnValue(true);
+const mockListVariants = vi.fn();
+vi.mock('./nativeModelStore', () => ({
+  useNativeModelStore: { getState: () => ({ refresh: mockRefresh, isReady: mockIsReady }) },
+  nativeListVariants: (...a: unknown[]) => mockListVariants(...a),
+}));
+
+const { default: useSettingsStore } = await import('./settingsStore');
+
+const VARIANTS: VariantInfo[] = [
+  { id: 'fp8', computeType: 'fp8', repo: 'tencent/Hy-MT2-7B-FP8', sizeBytes: 8e9, supported: true },
+  { id: 'bfloat16', computeType: 'bfloat16', repo: 'tencent/Hy-MT2-7B', sizeBytes: 15e9, supported: true },
+];
+
+function setNative(over: Record<string, unknown>) {
+  useSettingsStore.setState({
+    provider: Provider.LOCAL_NATIVE,
+    localNative: {
+      ...useSettingsStore.getState().localNative,
+      asrModel: 'sense-voice', sourceLanguage: 'zh', targetLanguage: 'en',
+      translationVariantByModel: {}, ...over,
+    },
+  } as any);
+}
+
+function reposArg(): unknown {
+  return mockRefresh.mock.calls[0]?.[1];
+}
+
+beforeEach(() => {
+  mockRefresh.mockClear();
+  mockIsReady.mockClear();
+  mockListVariants.mockReset();
+  mockListVariants.mockResolvedValue({ variants: VARIANTS, recommended: 'fp8' });
+  (globalThis as any).window = (globalThis as any).window ?? {};
+  (globalThis as any).window.electron = { invoke: vi.fn().mockResolvedValue({ ok: true }) };
+});
+
+describe('LOCAL_NATIVE gate is variant-aware on cold start', () => {
+  it('checks the recommended variant repo (not the default) when no pin is set', async () => {
+    setNative({ translationModel: 'hy-mt2-7b' });
+    await useSettingsStore.getState().validateApiKey();
+
+    expect(mockRefresh).toHaveBeenCalled();
+    expect(reposArg()).toEqual({ 'hy-mt2-7b': 'tencent/Hy-MT2-7B-FP8' });
+  });
+
+  it('honors an explicit pin over the recommended variant', async () => {
+    setNative({ translationModel: 'hy-mt2-7b', translationVariantByModel: { 'hy-mt2-7b': 'bfloat16' } });
+    await useSettingsStore.getState().validateApiKey();
+
+    expect(reposArg()).toEqual({ 'hy-mt2-7b': 'tencent/Hy-MT2-7B' });
+  });
+
+  it('also resolves the HY-MT1.5 family (the prefix gate is hy-mt, not hy-mt2)', async () => {
+    setNative({ translationModel: 'hy-mt15-7b' });
+    await useSettingsStore.getState().validateApiKey();
+
+    expect(mockListVariants).toHaveBeenCalledWith('hy-mt15-7b', expect.anything(), expect.anything());
+    expect(reposArg()).toEqual({ 'hy-mt15-7b': 'tencent/Hy-MT2-7B-FP8' });
+  });
+
+  it('does not fetch variants for a non-HY-MT translation model (repos left to the cache)', async () => {
+    setNative({ translationModel: 'qwen2.5-0.5b' });
+    await useSettingsStore.getState().validateApiKey();
+
+    // The block is skipped entirely; refresh is called once with no explicit
+    // override, so it falls back to the store's statusRepos cache.
+    expect(mockListVariants).not.toHaveBeenCalled();
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+    expect(reposArg()).toBeUndefined();
+  });
+});

--- a/src/stores/settingsStore.translationVariant.test.ts
+++ b/src/stores/settingsStore.translationVariant.test.ts
@@ -21,25 +21,25 @@ vi.mock('../lib/local-inference/modelManifest', async () => {
 const { default: useSettingsStore, createLocalNativeSessionConfig } = await import('./settingsStore');
 
 describe('translationVariant pin reaches the session config (download/load agree)', () => {
-  it('is undefined (automatic) by default', () => {
-    expect(useSettingsStore.getState().localNative.translationVariant).toBeUndefined();
+  it('is undefined (automatic) by default — empty per-model map', () => {
+    expect(useSettingsStore.getState().localNative.translationVariantByModel).toEqual({});
     const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
     expect(cfg.translationVariant).toBeUndefined();
   });
 
-  it('a pinned variant is forwarded as config.translationVariant for load select_variant(pin)', async () => {
+  it('forwards the active model\'s chosen quant as config.translationVariant', async () => {
     await useSettingsStore.getState().updateLocalNative({
-      translationModel: 'hy-mt2-7b', translationVariant: 'fp8',
+      translationModel: 'hy-mt2-7b', translationVariantByModel: { 'hy-mt2-7b': 'fp8' },
     });
     const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
-    // Load's _h_translate_init pins on config.translationVariant; it MUST equal the variant
-    // the download fetched (fp8), else local_files_only load of the recommended repo fails.
     expect(cfg.translationVariant).toBe('fp8');
   });
 
-  it('clearing the pin (undefined) returns the config to automatic', async () => {
-    await useSettingsStore.getState().updateLocalNative({ translationVariant: undefined });
+  it('a quant chosen for a NON-active model does not affect the active config', async () => {
+    await useSettingsStore.getState().updateLocalNative({
+      translationModel: 'qwen2.5-0.5b', translationVariantByModel: { 'hy-mt2-7b': 'fp8' },
+    });
     const cfg = createLocalNativeSessionConfig(useSettingsStore.getState().localNative, '');
-    expect(cfg.translationVariant).toBeUndefined();
+    expect(cfg.translationVariant).toBeUndefined();   // active model has no entry
   });
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -18,7 +18,7 @@ import {
 } from '../services/interfaces/IClient';
 import { getTtsModelsForLanguage, getManifestEntry, getTranslationModel, estimateModelMemoryByDevice } from '../lib/local-inference/modelManifest';
 import { buildDefaultLocalPrompt } from '../lib/local-inference/prompts';
-import { resolveNativeTts, resolveNativeTranslation, requiredNativeModels, NATIVE_ASR, supportsLanguage } from '../lib/local-inference/native/nativeCatalog';
+import { resolveNativeTts, resolveNativeTranslation, requiredNativeModels, NATIVE_ASR, supportsLanguage, statusReposFor } from '../lib/local-inference/native/nativeCatalog';
 import { isElectron } from '../utils/environment';
 import { useModelStore, type ParticipantModelStatus } from './modelStore';
 import useSessionStore from './sessionStore';
@@ -1291,8 +1291,28 @@ const useSettingsStore = create<SettingsStore>()(
           // Gate on the selected stage models being downloaded into the sidecar cache.
           // TTS is dropped from the requirement when text-only is on.
           const models = requiredNativeModels(s.asrModel, s.translationModel, s.ttsModel, s.sourceLanguage, s.targetLanguage, get().textOnly);
-          const { useNativeModelStore } = await import('./nativeModelStore');
-          await useNativeModelStore.getState().refresh(models);
+          const { useNativeModelStore, nativeListVariants } = await import('./nativeModelStore');
+          // Resolve the active translation model's CHOSEN variant repo (pin ??
+          // recommended) so the gate checks the right quant even on cold start —
+          // the Settings panel, which normally publishes statusRepos, may never
+          // have mounted this session. Only HY-MT-family cards ship multiple
+          // quants; everything else uses its single default repo (no override).
+          let statusRepos: Record<string, string> | undefined;
+          if (s.translationModel.startsWith('hy-mt')) {
+            try {
+              const reserveTtsId = resolveNativeTts(s.ttsModel, s.targetLanguage) || null;
+              const vd = await nativeListVariants(s.translationModel, s.asrModel || null, reserveTtsId);
+              const resolved = statusReposFor([s.translationModel], { [s.translationModel]: vd }, s.translationVariantByModel);
+              // Only override when resolution actually produced a repo; an empty
+              // map ({}) is truthy and would defeat refresh's `repos ?? cache`
+              // fallback (e.g. a malformed listVariants response).
+              if (Object.keys(resolved).length > 0) statusRepos = resolved;
+            } catch {
+              // Best-effort: sidecar metadata unavailable → fall back to the
+              // store's statusRepos cache (default-variant status).
+            }
+          }
+          await useNativeModelStore.getState().refresh(models, statusRepos);
           ready = asrCompatible && useNativeModelStore.getState().isReady(models);
           message = ready ? ''
             : !asrCompatible ? i18n.t('settings.localNativeAsrIncompatible', 'Select a speech-recognition model for the source language')

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -183,10 +183,10 @@ export interface LocalInferenceSettings {
 export interface LocalNativeSettings {
   asrModel: string;          // sidecar ASR model id (e.g. 'sense-voice', 'whisper-tiny')
   translationModel: string;  // '' (auto) | LLM id (e.g. 'qwen2.5-0.5b')
-  // Manual quant-variant pin for the SELECTED translation model (e.g. 'fp8'). undefined
-  // = automatic (the sidecar's select_variant picks the recommended variant). Scoped to
-  // translationModel: changing the model resets this so a stale pin can't leak.
-  translationVariant?: string;
+  // Per-model chosen quant variant (e.g. { 'hy-mt2-1.8b': 'fp8' }). A model with no
+  // entry uses the sidecar's recommended variant. Keyed by model id (global across
+  // language directions); drives which repo the card downloads AND the load pin.
+  translationVariantByModel: Record<string, string>;
   ttsModel: string;          // '' = Auto (default voice) | a specific piper voice id
   sourceLanguage: string;
   targetLanguage: string;
@@ -397,6 +397,7 @@ const defaultLocalNativeSettings: LocalNativeSettings = {
   systemPrompt: '',
   asrDevice: 'auto',
   translationDevice: 'auto',
+  translationVariantByModel: {},
 };
 
 // ==================== Store Definition ====================
@@ -736,7 +737,7 @@ export function createLocalNativeSessionConfig(
     translationModelId: resolveNativeTranslation(settings.translationModel),
     // Manual variant pin → load's select_variant(pin=...) so LOAD resolves the same
     // variant DOWNLOAD fetched (else local_files_only load fails on a missing repo).
-    translationVariant: settings.translationVariant,
+    translationVariant: settings.translationVariantByModel[settings.translationModel],
     ttsModelId: resolveNativeTts(settings.ttsModel, settings.targetLanguage),
     ttsSpeed: settings.ttsSpeed,
     vadThreshold: settings.vadThreshold,


### PR DESCRIPTION
## Summary

Decouples the per-card quant-variant dropdown (bf16 / FP8) from active-model selection in the Electron `LOCAL_NATIVE` translation provider. Picking a quant on a model card now only chooses **which quantization to download** for that card — it no longer switches the active translation model. Download status and the readiness gate are made variant-aware so a downloaded non-default quant is correctly recognized.

Builds on `native-sidecar`; this PR also carries the two feature doc commits (spec + plan) that were committed locally on `native-sidecar` but never pushed.

## Motivation

Previously, clicking FP8 on an HY-MT card did nothing useful: the pick didn't stick and the active model "bounced" back to the auto-selected one. The intent was always "choose which quant to download," not "select this model to use." This PR makes that the actual behavior.

## What changed

- **Data model:** `translationVariant?: string` (global) → `translationVariantByModel: Record<modelId, variant>` in `LocalNativeSettings`. The per-session IClient wire-field `translationVariant` stays (now derived from the active model's entry). No migration — old configs load the map as `{}` via `loadProviderSettings`' per-key default fallback.
- **Decouple the pick:** choosing a variant writes only `translationVariantByModel[cardId]`; it never touches the active `translationModel` or triggers auto-select.
- **Variant-aware status (sidecar):** `model_status` accepts an optional per-model `repos` override so a card's "downloaded?" reflects the chosen variant's repo. Renderer sends the chosen-variant repos via a `statusReposFor` helper.
- **Readiness gate honors the chosen quant:** `nativeModelStore` gains a `statusRepos` cache so all `refresh()` callers (including the Start gate and ProviderSection) are variant-aware, not just the settings panel.
- **Cold-start gate fix:** the gate (`validateApiKey`) now self-resolves the active HY-MT model's chosen variant (`pin ?? recommended`) repo via `listVariants` and passes it explicitly to `refresh()`, so Start is correctly enabled even on app restart when the settings panel never mounted to populate the cache.

## Review history

Two independent final reviews (opus) were run. The first found a Critical: the readiness gate was variant-blind on cold start (the cache is only populated while Settings is open) — gating Start for a downloaded non-default/recommended quant. This is fixed by the cold-start commit, and confirmed resolved end-to-end by the second final review with no remaining Critical/Important issues.

## Testing

- New/updated unit tests: `settingsStore.nativeGate.test.ts` (gate resolves recommended / pinned / HY-MT1.5 family / non-HY-MT), `nativeModelStore.test.ts`, `NativeModelManagementSection.test.tsx`, `settingsStore.translationVariant.test.ts`, sidecar `model_status` tests.
- Full suite: 684/685 pass. The one failing test (`LocalNativeClient.test.ts`) is pre-existing on `native-sidecar` (a `translate.init` arg-count mismatch from an earlier commit) and is untouched by this PR.
- Manually verified in the Electron app on an RTX 4070: variant pick no longer switches the active model; download fetches the chosen-variant repo; cold-start Start gate honors the chosen quant.

## Notes / out of scope

- Re-picking the **active** model's quant to an undownloaded variant can still trigger the pre-existing `autoSelectNative` "not-downloaded reverts" bounce. Documented as a known residual for a future auto-select pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-model translation variant selection is now supported, so each card can keep its own chosen download variant.
  * The app now shows variant-aware download/readiness status for native models.

* **Bug Fixes**
  * Switching the active model no longer clears variant choices for other cards.
  * Readiness checks now use the selected variant’s download state, improving accuracy on startup and during refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->