### PR TITLE
refactor(sidecar): remove NVML, source GPU presence from the tc probe (P2)

### DIFF
--- a/docs/superpowers/specs/2026-07-06-sidecar-multiplatform-accel.md
+++ b/docs/superpowers/specs/2026-07-06-sidecar-multiplatform-accel.md
@@ -54,3 +54,24 @@ remains in the codebase.
 2. DML AR-graph RTF vs same-machine CPU (MOSS nano, Qwen3-TTS 0.6B).
 3. VRAM / per-step recompilation behavior on a growing-KV decode loop.
 4. Only if results are unacceptable: revisit AR→CPU routing or model surgery.
+
+## D7 (NVML removal) — known limitation + hardware validation
+
+After P2, NVIDIA presence is derived **solely** from the transcribe.cpp device
+probe (`has_nvidia` = a tc-probe device description contains "nvidia"), replacing
+NVML's driver-level detection. Two consequences to gate the NVIDIA release on:
+
+- **Coupling (Important):** a real NVIDIA box where the tc probe can't enumerate
+  the GPU (no Vulkan ICD, headless, or a CPU-only transcribe-cpp build) but CUDA +
+  `onnxruntime-gpu` *can* will silently route ORT-CUDA TTS and the llama flavor to
+  CPU, with no `fallbackReason`. If a no-Vulkan/headless NVIDIA-CUDA config is in
+  scope, add a secondary presence signal (llama.cpp SM-probe / CUDA-runtime
+  cross-check — P4/P5 territory), else document as a known limitation.
+- **Substring contract (validated on real hardware, 2026-07-06):** on the dev
+  4070 box, `accel.probe().gpus` = `('vulkan', 'NVIDIA GeForce RTX 4070 SUPER',
+  12878610432)`, `has_nvidia()` = True, `device_free_bytes()` = ~11.2 GB — the
+  "nvidia" substring and the tc free-VRAM path hold against ground truth (CI only
+  ever exercised the synthetic string). Re-confirm on Windows+NVIDIA before ship.
+
+Both are consequences of the D7 decision (tc probe as sole device truth), not
+implementation defects; the P2 whole-branch review rated the branch ready to merge.

--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -9,12 +9,9 @@ zstandard==0.23.0
 tokenizers>=0.20
 # Opus-MT translation runtime (CPU int8; ~11x the old ORT numpy loop)
 ctranslate2==4.8.1
-# torch-free audio io / resample / NVIDIA probing (2026-07-04 torch-free spec).
-# nvidia-ml-py talks to the driver's NVML and is a no-op import elsewhere, so it
-# is safe to install on macOS/AMD boxes (probe degrades to "no NVIDIA GPUs").
-# Capped below the next untested major (12.x and 13.x verified on the 4070 box).
+# torch-free audio io / resample (2026-07-04 torch-free spec). GPU probing is
+# NVML-free since 2026-07-06 (D7): device truth = the transcribe.cpp probe.
 soundfile>=0.13
 soxr>=0.5
-nvidia-ml-py>=12.535,<14
 # ASR runtime (ggml family; CPU+Vulkan wheels on linux/win, Metal on macOS)
 transcribe-cpp==0.1.1

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -61,7 +61,9 @@ def _tc_kinds() -> tuple[str, ...]:
 
 def _tc_gpus() -> tuple[tuple[str, str, int], ...]:
     """Stable identity of the non-cpu devices: (kind, name, mem_total)."""
-    return tuple((b.kind, b.description, int(b.memory_total or 0))
+    # Coerce description to str at the source (like memory_total): a None from
+    # the native lib would otherwise crash every has_nvidia/_gpu_vendor consumer.
+    return tuple((b.kind, b.description or "", int(b.memory_total or 0))
                  for b in _tc_devices() if getattr(b, "device_type", "gpu") != "cpu")
 
 
@@ -251,6 +253,10 @@ def _quant_budget_bytes(machine: Machine):
     transient VRAM pressure (that would recommend re-downloads). Runtime
     pressure is placement's job (--fit / cpu fallback), never a silent switch
     to a different model file."""
+    # Largest-device basis: correct for the ~universal single-GPU case. On a rare
+    # dual-DISCRETE-vendor box (AMD + NVIDIA) this can budget a gpu-cuda download
+    # against the non-CUDA card's VRAM — accepted as a documented limitation
+    # (per-tier/vendor budgeting is out of P2's NVML-removal scope).
     total = max((t for _k, _n, t in machine.gpus), default=0)
     return total or None
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -16,64 +16,24 @@ from .backends import make_backend, BackendLoadError
 
 
 @dataclass(frozen=True)
-class Gpu:
-    vendor: str
-    name: str
-    vram_mb: int
-    capability: tuple[int, int] | None = None
-
-
-@dataclass(frozen=True)
 class Machine:
     os: str
     arch: str
     cpu_cores: int
-    nvidia: tuple[Gpu, ...]
     apple_silicon: bool
     dml_adapters: tuple[str, ...]
     installed: frozenset
     fingerprint: str
     # Accelerator kinds transcribe.cpp reports on this machine ("vulkan",
     # "metal", "cuda", "cpu") — the ground truth for the gpu-vulkan/gpu-metal
-    # tiers (covers AMD/Intel via Vulkan where the NVML/DML probes see nothing).
+    # tiers (covers AMD/Intel via Vulkan).
     tc_kinds: tuple[str, ...] = ()
-    # STABLE GPU identity from the same probe: (kind, name, mem_total_bytes)
-    # per accelerator device. Volatile mem_free is intentionally NOT here (the
-    # Machine is cached + fingerprinted) — planners read device_free_bytes()
-    # fresh at plan time instead.
+    # STABLE GPU identity from the same probe: (kind, description, mem_total)
+    # per accelerator device. NVIDIA presence = has_nvidia() over these
+    # descriptions. Volatile mem_free is intentionally NOT here (the Machine
+    # is cached + fingerprinted) — planners read device_free_bytes() fresh at
+    # plan time instead.
     gpus: tuple[tuple[str, str, int], ...] = ()
-
-
-def _nvidia_gpus() -> tuple[Gpu, ...]:
-    """Enumerate NVIDIA GPUs via NVML (nvidia-ml-py). Torch-free: NVML ships
-    with the driver, so this works in a venv with no CUDA runtime installed.
-    Any failure (no driver, no pynvml) degrades to 'no GPUs'."""
-    try:
-        import pynvml
-        pynvml.nvmlInit()
-    except Exception:
-        return ()
-    try:
-        gpus = []
-        for i in range(pynvml.nvmlDeviceGetCount()):
-            h = pynvml.nvmlDeviceGetHandleByIndex(i)
-            vram_mb = int(pynvml.nvmlDeviceGetMemoryInfo(h).total // (1024 * 1024))
-            try:
-                cap = tuple(pynvml.nvmlDeviceGetCudaComputeCapability(h))
-            except Exception:
-                cap = None
-            name = pynvml.nvmlDeviceGetName(h)
-            if isinstance(name, bytes):
-                name = name.decode("utf-8", "replace")
-            gpus.append(Gpu("nvidia", name, vram_mb, cap))
-        return tuple(gpus)
-    except Exception:
-        return ()
-    finally:
-        try:
-            pynvml.nvmlShutdown()
-        except Exception:
-            pass
 
 
 def _apple_silicon() -> bool:
@@ -187,7 +147,6 @@ def probe(force: bool = False) -> Machine:
     global _MACHINE
     if _MACHINE is not None and not force:
         return _MACHINE
-    nvidia = _safe(_nvidia_gpus, ())
     apple = _safe(_apple_silicon, False)
     dml = _safe(_dml_adapters, ())
     installed = _safe(_installed, frozenset())
@@ -196,12 +155,11 @@ def probe(force: bool = False) -> Machine:
     fp_src = (f"{platform.system()}|{platform.machine()}|{int(apple)}|"
               f"{','.join(sorted(dml))}|{','.join(sorted(installed))}|"
               f"{','.join(tc_kinds)}|"
-              f"{','.join(f'{k}:{n}:{t}' for k, n, t in tc_gpus)}|"
-              f"{len(nvidia)}:{','.join(g.name for g in nvidia)}")
+              f"{','.join(f'{k}:{n}:{t}' for k, n, t in tc_gpus)}")
     fp = hashlib.blake2s(fp_src.encode(), digest_size=6).hexdigest()   # 12 hex chars
     _MACHINE = Machine(
         os=platform.system(), arch=platform.machine(), cpu_cores=os.cpu_count() or 1,
-        nvidia=nvidia, apple_silicon=apple, dml_adapters=dml, installed=installed,
+        apple_silicon=apple, dml_adapters=dml, installed=installed,
         fingerprint=fp, tc_kinds=tc_kinds, gpus=tc_gpus)
     return _MACHINE
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -115,9 +115,9 @@ def has_nvidia(machine: Machine) -> bool:
 
 def device_free_bytes():
     """FRESH free memory (bytes) of the primary accelerator device, or None
-    when there is none. transcribe.cpp's probe is primary (vendor-agnostic,
-    device-wide); NVML is the fallback when the wheel is missing. Volatile by
-    design — call at plan/load time, never cache in Machine."""
+    when there is none (tc wheel absent, or no accelerator device). Volatile
+    by design — call at plan/load time, never cache in Machine. Callers treat
+    None as 'skip VRAM gating/measurement'."""
     try:
         for b in _tc_devices():
             if getattr(b, "device_type", "gpu") != "cpu":
@@ -126,7 +126,7 @@ def device_free_bytes():
                     return free
     except Exception:
         pass
-    return _cuda_free_bytes()
+    return None
 
 
 def ram_free_bytes():
@@ -519,30 +519,6 @@ class AllPlansFailed(Exception):
     """Every plan failed to load, including the CPU floor."""
 
 
-def _cuda_free_bytes():
-    """Free VRAM (bytes) on the first NVIDIA device via NVML, or None when the
-    driver/pynvml is absent. Device-wide free (like cudaMemGetInfo), so VRAM
-    held by other processes (e.g. llama-server) is correctly excluded.
-    Best-effort: any failure degrades to None so callers skip gating."""
-    try:
-        import pynvml
-        pynvml.nvmlInit()
-    except Exception:
-        return None
-    try:
-        if pynvml.nvmlDeviceGetCount() < 1:
-            return None
-        h = pynvml.nvmlDeviceGetHandleByIndex(0)
-        return int(pynvml.nvmlDeviceGetMemoryInfo(h).free)
-    except Exception:
-        return None
-    finally:
-        try:
-            pynvml.nvmlShutdown()
-        except Exception:
-            pass
-
-
 def _rss_bytes():
     """Best-effort resident set size of this process, in bytes. Linux reads
     /proc/self/status (VmRSS, KiB); other platforms fall back to
@@ -664,7 +640,7 @@ def load_with_fallback(plans: list):
         # handles memory itself via partial offload, so a rough weights-vs-free-VRAM
         # guess here would only wrongly route a fittable model to CPU.
         is_llamacpp = plan.backend.startswith("llamacpp_")
-        free = _cuda_free_bytes() if (plan.device == "cuda" and not is_llamacpp) else None
+        free = device_free_bytes() if (plan.device == "cuda" and not is_llamacpp) else None
         need = _model_weight_bytes(plan.artifact) if (plan.device == "cuda" and not is_llamacpp) else None
         budget = (need * _weight_factor(plan.compute_type) + _VRAM_CONTEXT_BYTES) if need is not None else None
         if plan.device == "cuda" and has_cpu_fallback and free is not None and budget is not None:

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -287,17 +287,14 @@ _TC_RESIDENT_FACTOR = 1.15
 
 def _quant_budget_bytes(machine: Machine):
     """The STABLE per-machine basis for quant selection: the primary device's
-    TOTAL memory. Quant choice only decides WHICH FILE we recommend the user
-    download — and we always run exactly the file the user downloaded — so the
-    basis must never flap with transient VRAM pressure (that would recommend
-    re-downloads). Runtime pressure is placement's job (--fit / cpu fallback),
-    never a silent switch to a different model file."""
+    TOTAL memory, from the transcribe.cpp probe (all vendors). Quant choice
+    only decides WHICH FILE we recommend the user download — and we always run
+    exactly the file the user downloaded — so the basis must never flap with
+    transient VRAM pressure (that would recommend re-downloads). Runtime
+    pressure is placement's job (--fit / cpu fallback), never a silent switch
+    to a different model file."""
     total = max((t for _k, _n, t in machine.gpus), default=0)
-    if total:
-        return total
-    if machine.nvidia and machine.nvidia[0].vram_mb:
-        return machine.nvidia[0].vram_mb << 20
-    return None
+    return total or None
 
 
 def _downloaded_quants(model) -> set:
@@ -932,8 +929,9 @@ def select_variant(model, machine: Machine, reserved_bytes: int, pin: str | None
                    budget_bytes: int | None = None, downloaded: set | None = None):
     """Pick the best downloadable variant of `model` for this machine. Deterministic:
     same (model, machine, reserved_bytes, pin) → same Deployment. Falls back to the
-    CPU floor when no GPU variant fits, the GPU/estimate is unknown, or a format's
-    runtime is missing. `pin` (a compute_type) forces that variant when it's valid.
+    CPU floor when no GPU variant fits, the device memory total is unknown, or a
+    format's runtime is missing. `pin` (a compute_type) forces that variant when
+    it's valid.
 
     llamacpp-backed models (all current LLM translate cards) take a separate,
     VRAM-math-free path: llama-server's --fit handles memory via partial offload,
@@ -941,7 +939,7 @@ def select_variant(model, machine: Machine, reserved_bytes: int, pin: str | None
     if _is_llamacpp(model):
         return _llamacpp_variant_row(model, machine, pin, reserved_bytes, budget_bytes,
                                      downloaded=downloaded)
-    gpu = machine.nvidia[0] if machine.nvidia else None
+    total = _quant_budget_bytes(machine)
     cpu_floor = next((d for d in model.deployments if d.tier == "cpu"), None)
 
     def candidate(d) -> bool:
@@ -949,14 +947,12 @@ def select_variant(model, machine: Machine, reserved_bytes: int, pin: str | None
             return False
         if d.backend not in machine.installed or not _format_ready(d.compute_type):
             return False
-        if gpu is None or not gpu.vram_mb or gpu.capability is None:
-            return False
-        if d.min_capability is not None and gpu.capability < d.min_capability:
+        if total is None or not _tier_available(d.tier, machine):
             return False
         need = _est_bytes(d)
         if need is None:
             return False
-        budget = gpu.vram_mb * 1024 * 1024 - reserved_bytes - _VRAM_CONTEXT_BYTES
+        budget = total - reserved_bytes - _VRAM_CONTEXT_BYTES
         return need * _weight_factor(d.compute_type) <= budget
 
     cands = [d for d in model.deployments if candidate(d)]
@@ -1016,8 +1012,8 @@ async def _h_list_variants(state, msg, _b, conn=None):
                     for ct, d in seen.items()]
         return {"type": "list_variants_result", "id": msg.get("id"),
                 "variants": variants, "recommended": chosen.compute_type}, None
-    gpu = m.nvidia[0] if m.nvidia else None
-    budget = (gpu.vram_mb * 1024 * 1024 - reserve - _VRAM_CONTEXT_BYTES) if (gpu and gpu.vram_mb) else 0
+    total = _quant_budget_bytes(m)
+    budget = (total - reserve - _VRAM_CONTEXT_BYTES) if total else 0
     variants = []
     for d in model.deployments:
         if d.tier == "cpu":
@@ -1025,10 +1021,8 @@ async def _h_list_variants(state, msg, _b, conn=None):
         need = _est_bytes(d)
         if d.backend not in m.installed or not _format_ready(d.compute_type):
             supported, reason = False, "runtime not installed"
-        elif gpu is None or not gpu.vram_mb or gpu.capability is None:
+        elif total is None or not _tier_available(d.tier, m):
             supported, reason = False, "no usable GPU"
-        elif d.min_capability is not None and gpu.capability < d.min_capability:
-            supported, reason = False, f"needs compute capability {d.min_capability}"
         elif need is None:
             supported, reason = False, "size unknown"
         elif need * _weight_factor(d.compute_type) > budget:

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -230,15 +230,16 @@ def _tier_available(tier: str, machine: Machine) -> bool:
     if tier == "cpu":
         return True
     if tier == "gpu-cuda":
-        return bool(machine.nvidia)
+        return has_nvidia(machine)
     if tier == "gpu-metal":
         return machine.apple_silicon or "metal" in machine.tc_kinds
     if tier == "gpu-dml":
         return bool(machine.dml_adapters)
     if tier == "gpu-vulkan":
         # transcribe.cpp's own probe is authoritative (sees AMD/Intel Vulkan
-        # devices the NVML/DML heuristics can't); NVML/DML remain as fallbacks.
-        return "vulkan" in machine.tc_kinds or bool(machine.nvidia or machine.dml_adapters)
+        # devices); NVIDIA-by-description and DML remain as fallbacks.
+        return ("vulkan" in machine.tc_kinds or has_nvidia(machine)
+                or bool(machine.dml_adapters))
     return False
 
 
@@ -1041,13 +1042,28 @@ async def _h_list_variants(state, msg, _b, conn=None):
             "variants": variants, "recommended": chosen.compute_type}, None
 
 
+_GPU_VENDORS = ("nvidia", "amd", "intel", "apple")
+
+
+def _gpu_vendor(description: str) -> str:
+    """Vendor slug parsed from a tc-probe device description (best-effort)."""
+    d = description.lower()
+    for v in _GPU_VENDORS:
+        if v in d:
+            return v
+    return "unknown"
+
+
 async def _h_hardware_info(state, msg, _b, conn=None):
     m = probe()
     return {"type": "hardware_info_result", "id": msg.get("id"),
             "os": m.os, "arch": m.arch, "cpuCores": m.cpu_cores,
-            "gpus": [{"vendor": g.vendor, "name": g.name, "vramMb": g.vram_mb} for g in m.nvidia],
+            # All-vendor gpus[] from the tc probe (Machine.gpus) — NVML only
+            # ever saw NVIDIA, leaving this empty on mac/AMD boxes.
+            "gpus": [{"vendor": _gpu_vendor(name), "name": name,
+                      "vramMb": total >> 20} for _kind, name, total in m.gpus],
             "backendsInstalled": sorted(m.installed),
-            "accelAvailable": bool(m.nvidia or m.apple_silicon or m.dml_adapters)}, None
+            "accelAvailable": bool(m.gpus or m.apple_silicon or m.dml_adapters)}, None
 
 
 async def _h_models_catalog(state, msg, _b, conn=None):

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -105,6 +105,14 @@ def _tc_gpus() -> tuple[tuple[str, str, int], ...]:
                  for b in _tc_devices() if getattr(b, "device_type", "gpu") != "cpu")
 
 
+def has_nvidia(machine: Machine) -> bool:
+    """NVIDIA presence, from the transcribe.cpp probe: any accelerator device
+    whose description names NVIDIA (case-insensitive substring — the D7
+    contract). Replaces the removed NVML enumeration; the tc probe is the
+    single all-vendor device-truth source."""
+    return any("nvidia" in name.lower() for _kind, name, _total in machine.gpus)
+
+
 def device_free_bytes():
     """FRESH free memory (bytes) of the primary accelerator device, or None
     when there is none. transcribe.cpp's probe is primary (vendor-agnostic,

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -420,7 +420,6 @@ def resolve_tts(model_id: str, override: str = "auto", machine: Machine | None =
             model = catalog.TtsModel(
                 id=model_id, name=model_id, languages=("multi",),
                 deployments=(
-                    catalog.Deployment("sherpa_tts", "gpu-cuda", "fp32", model_id, 1.0),
                     catalog.Deployment("sherpa_tts", "cpu", "fp32", model_id, 1.0),
                 ),
                 repos=(model_id,), sample_rate=16000)

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -339,8 +339,9 @@ class TtsModel(_ModelBase):
 
 def _sherpa_tts_row(mid, name, langs, repo, sort_order, sr, urls=(), recommended=False,
                      num_speakers=1, size_bytes=0):
+    # CPU-only by reality: the stock sherpa-onnx wheel bundles a CPU-only ORT
+    # (runtime-verified, D11) — no GPU tier row.
     return TtsModel(mid, name, langs, (
-        Deployment("sherpa_tts", "gpu-cuda", "fp32", repo, 1.0),
         Deployment("sherpa_tts", "cpu", "fp32", repo, 1.0),
     ), repos=(repo,), urls=tuple(urls), sample_rate=sr,
        recommended=recommended, sort_order=sort_order, num_speakers=num_speakers,

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -20,7 +20,6 @@ class Deployment:
     compute_type: str   # quant/dtype label ("q4_k_m", "q8_0", "int8", ...)
     artifact: str       # backend.load() model_ref (repo id or "org/repo/file.gguf")
     rank: float         # tie-breaker within a tier (higher = preferred)
-    min_capability: tuple[int, int] | None = None   # min CUDA compute cap for a GPU variant
     est_bytes: int | None = None                     # footprint estimate; None → model_size(artifact)
 
 

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -86,10 +86,12 @@ def gh_url(asset: str) -> str:
 
 
 def default_flavor() -> str:
-    """The best flavor for this machine (drives the model-download dependency)."""
+    """The best flavor for this machine (drives the model-download dependency):
+    NVIDIA (tc probe) -> cuda, Apple Silicon -> metal, else cpu. AMD/Intel
+    dGPUs stay on cpu until the vulkan flavor lands (P4)."""
     from . import accel
     m = accel.probe()
-    if m.nvidia:
+    if accel.has_nvidia(m):
         return "cuda"
     if m.apple_silicon:
         return "metal"

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -165,8 +165,11 @@ def _metal_config() -> str:
     brand = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"],
                            capture_output=True, text=True, timeout=10).stdout
     parts = brand.split()
-    if len(parts) >= 2 and parts[0] == "Apple" and parts[1][:2].lower() in _METAL_CONFIGS:
-        return parts[1][:2].lower()
+    # Match the WHOLE family token ("M4" -> "m4"), not a 2-char slice: an "M10"
+    # must degrade, not truncate to "m1" and pick the wrong binary.
+    fam = parts[1].lower() if len(parts) >= 2 and parts[0] == "Apple" else ""
+    if fam in _METAL_CONFIGS:
+        return fam
     fallback = _METAL_CONFIGS[-1]
     print(f"[llama_runtime] unknown Apple chip {brand.strip()!r}; "
           f"using the {fallback} binary", file=sys.stderr)

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -153,15 +153,24 @@ def _run_probe(rel: str, workdir: str) -> str:
     return out.stdout.strip().splitlines()[0]
 
 
+_METAL_CONFIGS = ("m1", "m2", "m3", "m4", "m5")   # newest LAST (fallback pick)
+
+
 def _metal_config() -> str:
-    """Apple chip family from the CPU brand string ('Apple M4 Pro' -> 'm4')."""
+    """Apple chip family from the CPU brand string ('Apple M4 Pro' -> 'm4').
+    An unknown/newer chip degrades to the newest known bucket config with a
+    stderr warning instead of raising — newer Apple GPUs run older Metal
+    binaries fine, and refusing to install would brick every future chip
+    until we ship an update (D11)."""
     brand = subprocess.run(["sysctl", "-n", "machdep.cpu.brand_string"],
                            capture_output=True, text=True, timeout=10).stdout
     parts = brand.split()
-    if len(parts) >= 2 and parts[0] == "Apple" and parts[1][:2] in (
-            "M1", "M2", "M3", "M4", "M5"):
+    if len(parts) >= 2 and parts[0] == "Apple" and parts[1][:2].lower() in _METAL_CONFIGS:
         return parts[1][:2].lower()
-    raise BinaryFetchError(f"unsupported Apple chip: {brand.strip()!r}")
+    fallback = _METAL_CONFIGS[-1]
+    print(f"[llama_runtime] unknown Apple chip {brand.strip()!r}; "
+          f"using the {fallback} binary", file=sys.stderr)
+    return fallback
 
 
 def _probe_config(flavor: str) -> str:

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -571,8 +571,8 @@ def test_voxtral_model_unavailable_without_runtime():
 
 
 def test_resolve_translate_prefers_gpu(monkeypatch):
-    # select_variant requires known VRAM + capability to prefer a GPU; the old
-    # stub (vram_mb=0, capability=None) correctly falls back to CPU now.
+    # select_variant needs a GPU with known VRAM (tc-probe total) to prefer a
+    # GPU tier; the 12GB device below qualifies qwen2.5-0.5b for cuda.
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
     m = _machine(gpus=_nv_gpus(12288),
@@ -1609,5 +1609,6 @@ def test_no_nvml_left_in_package():
     import pathlib
     needle = "pyn" + "vml"  # split literal so this guard is not its own grep hit
     pkg = pathlib.Path(accel.__file__).parent
-    hits = [p.name for p in pkg.glob("*.py") if needle in p.read_text()]
+    # rglob so subpackages (qwen3_tts/, moss_tts/, …) are covered, not just top level.
+    hits = [str(p.relative_to(pkg)) for p in pkg.rglob("*.py") if needle in p.read_text()]
     assert hits == []

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -720,53 +720,41 @@ def test_new_translate_backends_installed_and_resolvable():
 # ── select_variant tests ────────────────────────────────────────────────────
 
 
-def _gpu_machine(vram_mb, cap, installed=("hunyuan_translate",)):
-    g = accel.Gpu("nvidia", "", vram_mb, cap)
-    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=(g,),
-                         apple_silicon=False, dml_adapters=(), installed=frozenset(installed),
-                         fingerprint="t")
+def _gpu_machine(vram_mb, installed=("hunyuan_translate",)):
+    return _machine(gpus=_nv_gpus(vram_mb), installed=frozenset(installed))
 
 
 def _hymt2_7b():
     """Synthetic (non-catalog) TranslateModel replicating the pre-llamacpp shape of
-    hy-mt2-7b: a gpu-cuda bf16 variant, a cpu float32 floor, and an Ada-only
-    (min_capability (8,9)) gpu-cuda fp8 variant. The real hy-mt2-7b catalog row
-    moved to llamacpp/GGUF quants (Task 9), which bypasses this VRAM/capability/
-    format-aware logic entirely (see _is_llamacpp in accel.py) — this fixture keeps
-    select_variant's still-live generic (non-llamacpp) path under test."""
+    hy-mt2-7b: a gpu-cuda bf16 variant, a cpu float32 floor, and a gpu-cuda fp8
+    variant. The real hy-mt2-7b catalog row moved to llamacpp/GGUF quants
+    (Task 9), which bypasses this VRAM/format-aware logic entirely (see
+    _is_llamacpp in accel.py) — this fixture keeps select_variant's still-live
+    generic (non-llamacpp) path under test."""
     from sokuji_sidecar import catalog
     return catalog.TranslateModel("hy-mt2-7b-synthetic", "Hunyuan-MT2 7B (synthetic)", ("multi",), (
         catalog.Deployment("hunyuan_translate", "gpu-cuda", "bfloat16", "tencent/Hy-MT2-7B", 1.0),
         catalog.Deployment("hunyuan_translate", "cpu", "float32", "tencent/Hy-MT2-7B", 1.0),
-        catalog.Deployment("hunyuan_translate", "gpu-cuda", "fp8", "tencent/Hy-MT2-7B-FP8", 1.0,
-                           min_capability=(8, 9)),
+        catalog.Deployment("hunyuan_translate", "gpu-cuda", "fp8", "tencent/Hy-MT2-7B-FP8", 1.0),
     ))
 
 
-def test_select_variant_picks_fp8_on_ada_when_bf16_too_big(monkeypatch):
-    # est_bytes: bf16 ~15GB, fp8 ~8GB. 16GB Ada, 2GB reserve → budget 13GB; bf16 needs 18GB, fp8 needs 9.6GB
+def test_select_variant_budget_from_tc_probe_totals(monkeypatch):
+    # est_bytes: bf16 ~15GB, fp8 ~8GB. 16GB device total (tc probe), 2GB
+    # reserve -> budget 13GB; bf16 needs 15x1.2=18GB, fp8 needs 8x1.5=12GB.
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
-    m = _gpu_machine(16 * 1024, (8, 9))                       # 16GB Ada (e.g. RTX 4080)
+    m = _gpu_machine(16 * 1024)
     d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=2 * 1024**3)
-    assert d.compute_type == "fp8"                            # bf16 (15×1.2=18GB) won't fit, fp8 (8×1.2=9.6GB) does
-
-
-def test_select_variant_excludes_fp8_on_ampere(monkeypatch):
-    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
-    monkeypatch.setattr(accel, "_est_bytes",
-                        lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
-    m = _gpu_machine(12 * 1024, (8, 6))                       # Ampere sm_86 → no FP8
-    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
-    assert d.tier == "cpu"                                    # bf16 too big, fp8 arch-excluded → cpu floor
+    assert d.compute_type == "fp8"
 
 
 def test_select_variant_fp8_dropped_when_compressed_tensors_absent(monkeypatch):
     monkeypatch.setattr(accel, "_format_ready", lambda ct: ct != "fp8")
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
-    m = _gpu_machine(12 * 1024, (8, 9))
+    m = _gpu_machine(12 * 1024)
     d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
     assert d.tier == "cpu"                                    # fp8 ungated off, bf16 too big → cpu
 
@@ -775,7 +763,7 @@ def test_select_variant_prefers_bf16_when_it_fits(monkeypatch):
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 4, "fp8": 2, "float32": 4}[d.compute_type] * 1024**3)
-    m = _gpu_machine(24 * 1024, (8, 9))
+    m = _gpu_machine(24 * 1024)
     d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
     assert d.compute_type == "bfloat16"                       # both fit → highest quality
 
@@ -784,7 +772,7 @@ def test_select_variant_pin_honored_when_valid(monkeypatch):
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 4, "fp8": 2, "float32": 4}[d.compute_type] * 1024**3)
-    m = _gpu_machine(24 * 1024, (8, 9))
+    m = _gpu_machine(24 * 1024)
     d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0, pin="fp8")
     assert d.compute_type == "fp8"                            # pinned despite bf16 fitting
 
@@ -792,9 +780,20 @@ def test_select_variant_pin_honored_when_valid(monkeypatch):
 def test_select_variant_conservative_when_no_vram(monkeypatch):
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes", lambda d: 4 * 1024**3)
-    m = _gpu_machine(0, None)                                 # probe couldn't read VRAM
+    m = _gpu_machine(0)                                       # probe couldn't read VRAM
     d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
     assert d.tier == "cpu"                                    # never gamble → cpu floor
+
+
+def test_select_variant_requires_available_gpu_tier(monkeypatch):
+    # A machine with device memory but NO NVIDIA device (AMD seen by the tc
+    # probe) must not pick a gpu-cuda variant just because a total exists.
+    monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
+    monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 << 30)
+    m = _machine(gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),),
+                 installed=frozenset({"hunyuan_translate"}))
+    d = accel.select_variant(_hymt2_7b(), m, reserved_bytes=0)
+    assert d.tier == "cpu"
 
 
 def test_resolve_translate_explicit_device_override_unchanged(monkeypatch):
@@ -802,7 +801,7 @@ def test_resolve_translate_explicit_device_override_unchanged(monkeypatch):
     # selection. hy-mt2-7b's real backend moved to llamacpp_hunyuan (Task 9); the
     # synthetic-model default installed=("hunyuan_translate",) no longer matches it.
     monkeypatch.setattr(accel, "probe", lambda force=False:
-                        _gpu_machine(12 * 1024, (8, 9), installed=("llamacpp_hunyuan",)))
+                        _gpu_machine(12 * 1024, installed=("llamacpp_hunyuan",)))
     plans = accel.resolve_translate("hy-mt2-7b", override="cpu")
     assert plans[0].device == "cpu"
 
@@ -855,7 +854,7 @@ def test_list_variants_marks_supported_and_recommended(monkeypatch):
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
-    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(16 * 1024, (8, 9)))
+    monkeypatch.setattr(accel, "probe", lambda force=False: _gpu_machine(16 * 1024))
     monkeypatch.setattr(nm, "model_size", lambda repo: 8 * 1024**3)
     msg = {"type": "list_variants", "id": 1, "model": model.id, "asrId": None, "ttsId": None}
     reply, _ = asyncio.run(accel._h_list_variants({}, msg, None, None))
@@ -874,11 +873,11 @@ def test_fp8_weight_factor_larger_than_bf16_in_select_variant(monkeypatch):
     monkeypatch.setattr(accel, "_est_bytes",
                         lambda d: {"bfloat16": 15, "fp8": 8, "float32": 15}[d.compute_type] * 1024**3)
 
-    m12 = _gpu_machine(12 * 1024, (8, 9))
+    m12 = _gpu_machine(12 * 1024)
     d12 = accel.select_variant(_hymt2_7b(), m12, reserved_bytes=0)
     assert d12.tier == "cpu"  # fp8 8GB*1.5=12GB exceeds 11GB budget
 
-    m16 = _gpu_machine(16 * 1024, (8, 9))
+    m16 = _gpu_machine(16 * 1024)
     d16 = accel.select_variant(_hymt2_7b(), m16, reserved_bytes=0)
     assert d16.compute_type == "fp8"  # fp8 12GB ≤ 15GB budget on 16GB card
 

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -77,6 +77,20 @@ def test_has_nvidia_false_for_amd():
     assert accel.has_nvidia(m) is False
 
 
+def test_tc_gpus_coerces_none_description(monkeypatch):
+    # A None description from the native lib must not reach has_nvidia/_gpu_vendor
+    # (they call .lower()/`in`) — _tc_gpus coerces it to "" at the source.
+    class B:
+        kind = "vulkan"
+        description = None
+        memory_total = 8 << 30
+        device_type = "gpu"
+    monkeypatch.setattr(accel, "_tc_devices", lambda: [B()])
+    gpus = accel._tc_gpus()
+    assert gpus == (("vulkan", "", 8 << 30),)
+    assert accel.has_nvidia(_machine(gpus=gpus)) is False   # no AttributeError
+
+
 def test_has_nvidia_false_without_devices():
     assert accel.has_nvidia(_machine()) is False
 

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -76,25 +76,6 @@ def test_nvidia_gpus_empty_without_nvml(monkeypatch):
     assert accel._nvidia_gpus() == ()
 
 
-def test_cuda_free_bytes_via_nvml(monkeypatch):
-    fake = _FakeNvml()
-    _install_fake_nvml(monkeypatch, fake)
-    assert accel._cuda_free_bytes() == 9 * 1024 * 1024 * 1024
-    assert fake.inits == 1 and fake.shutdowns == 1
-
-
-def test_cuda_free_bytes_none_without_nvml(monkeypatch):
-    import sys
-    monkeypatch.setitem(sys.modules, "pynvml", None)
-    assert accel._cuda_free_bytes() is None
-
-
-def test_cuda_free_bytes_none_without_devices(monkeypatch):
-    fake = _FakeNvml(count=0)
-    _install_fake_nvml(monkeypatch, fake)
-    assert accel._cuda_free_bytes() is None
-
-
 def test_probe_assembles_machine(monkeypatch):
     monkeypatch.setattr(accel, "_nvidia_gpus", lambda: (accel.Gpu("nvidia", "RTX 4070", 12288),))
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
@@ -247,7 +228,7 @@ _GIB = 1 << 30
 def test_vram_gate_skips_cuda_to_cpu_when_insufficient(monkeypatch):
     # A flexible model (cuda + cpu floor) whose weights can't fit free VRAM is
     # routed straight to CPU — the cuda plan is never even attempted (no OOM).
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 2 * _GIB)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: 2 * _GIB)
     monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: 5 * _GIB)
     attempted = []
     class FakeBackend:
@@ -259,7 +240,7 @@ def test_vram_gate_skips_cuda_to_cpu_when_insufficient(monkeypatch):
 
 
 def test_vram_gate_allows_cuda_when_sufficient(monkeypatch):
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 10 * _GIB)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: 10 * _GIB)
     monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: 4 * _GIB)
     class FakeBackend:
         def load(self, a, device, ct): self.device = device; self.loaded = True
@@ -271,7 +252,7 @@ def test_vram_gate_allows_cuda_when_sufficient(monkeypatch):
 def test_vram_gate_inert_without_estimates(monkeypatch):
     # No CUDA / unknown footprint → gate stays out of the way; the existing
     # try/except path still steps cuda → cpu on a real OOM.
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: None)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: None)
     monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: None)
     class FakeBackend:
         def __init__(self, ok): self.ok = ok
@@ -284,10 +265,23 @@ def test_vram_gate_inert_without_estimates(monkeypatch):
     assert plan.device == "cpu"
 
 
+def test_vram_gate_reads_vendor_agnostic_free(monkeypatch):
+    # The proactive gate must read device_free_bytes (tc probe), never NVML.
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: 2 * _GIB)
+    monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: 5 * _GIB)
+    attempted = []
+    class FakeBackend:
+        def load(self, a, device, ct): attempted.append(device); self.loaded = True
+    monkeypatch.setattr(accel, "make_backend", lambda name: FakeBackend())
+    _b, plan, notice = accel.load_with_fallback([_plan("cuda"), _plan("cpu")])
+    assert plan.device == "cpu" and attempted == ["cpu"]
+    assert notice and "CPU" in notice
+
+
 def test_gpu_only_oom_raises_honest_vram_message(monkeypatch):
     # A GPU-only model (no cpu plan) that OOMs must NOT claim it is "falling
     # back" — there is nowhere to fall back to. Surface an honest VRAM message.
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 1 * _GIB)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: 1 * _GIB)
     class FakeBackend:
         def load(self, a, device, ct):
             raise backends.BackendLoadError("CUDA out of memory. Tried to allocate 54.00 MiB")
@@ -312,7 +306,7 @@ def test_load_measured_reports_vram_delta_for_cuda(monkeypatch):
 
 def test_load_measured_reports_rss_delta_for_cpu(monkeypatch):
     rss = iter([1000 * _GIB // 1000, 1400 * _GIB // 1000])  # +400/1000 GiB
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: None)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: None)
     monkeypatch.setattr(accel, "_rss_bytes", lambda: next(rss))
     monkeypatch.setattr(accel, "load_with_fallback",
                         lambda plans: ("BE", _plan("cpu"), "cuda skipped; using CPU"))
@@ -322,7 +316,7 @@ def test_load_measured_reports_rss_delta_for_cpu(monkeypatch):
 
 
 def test_load_measured_omits_memory_when_unmeasurable(monkeypatch):
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: None)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: None)
     monkeypatch.setattr(accel, "_rss_bytes", lambda: None)
     monkeypatch.setattr(accel, "load_with_fallback",
                         lambda plans: ("BE", _plan("cuda"), None))
@@ -332,7 +326,7 @@ def test_load_measured_omits_memory_when_unmeasurable(monkeypatch):
 
 def test_load_measured_omits_nonpositive_delta(monkeypatch):
     free = iter([2 * _GIB, 3 * _GIB])  # "after" higher than "before" -> delta < 0
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: next(free))
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: next(free))
     monkeypatch.setattr(accel, "load_with_fallback",
                         lambda plans: ("BE", _plan("cuda"), None))
     _b, _p, _n, mem = accel.load_measured([_plan("cuda")])
@@ -885,7 +879,7 @@ def test_fp8_weight_factor_larger_than_bf16_in_select_variant(monkeypatch):
 def test_load_with_fallback_fp8_factor_gates_cuda(monkeypatch):
     # An fp8 plan should use factor 1.5; on a 12GiB free machine with 8GiB weights:
     # budget = 8*1.5 + 1GiB_context = 13GiB > 12GiB free → cuda proactively skipped.
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 12 * _GIB)
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: 12 * _GIB)
     monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: 8 * _GIB)
     fp8_plan = accel.Plan("hunyuan_translate", "gpu-cuda", "cuda", "fp8", "repo", 1.0)
     cpu_pl = _plan("cpu")
@@ -1103,7 +1097,7 @@ def test_resolve_translate_sets_reserved(monkeypatch):
 def test_vram_gate_skipped_for_llamacpp(monkeypatch):
     """The proactive free-VRAM check must not pre-skip llamacpp cuda plans —
     llama-server's --fit handles memory by partial offload."""
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 1 << 30)  # 1 GiB free
+    monkeypatch.setattr(accel, "device_free_bytes", lambda: 1 << 30)  # 1 GiB free
     monkeypatch.setattr(accel, "_model_weight_bytes", lambda a: 8 << 30)
     loaded = []
 
@@ -1211,18 +1205,16 @@ def test_device_free_bytes_prefers_tc(monkeypatch):
     assert accel.device_free_bytes() == 9 << 30
 
 
-def test_device_free_bytes_nvml_fallback(monkeypatch):
+def test_device_free_bytes_none_without_tc(monkeypatch):
     import sys
     monkeypatch.setitem(sys.modules, "transcribe_cpp", None)   # import fails
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: 7 << 30)
-    assert accel.device_free_bytes() == 7 << 30
+    assert accel.device_free_bytes() is None   # no NVML fallback: degrade to None
 
 
 def test_device_free_bytes_none_without_gpu(monkeypatch):
     import sys
     monkeypatch.setitem(sys.modules, "transcribe_cpp", _fake_tc_module([
         _FakeTcDev("cpu", "Ryzen", 64 << 30, 60 << 30, device_type="cpu")]))
-    monkeypatch.setattr(accel, "_cuda_free_bytes", lambda: None)
     assert accel.device_free_bytes() is None
 
 

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -916,7 +916,19 @@ def test_resolve_tts_arbitrary_sherpa_repo_synthesizes_model():
     assert plans, "expected at least one plan for an arbitrary sherpa repo"
     assert all(p.backend == "sherpa_tts" for p in plans)
     assert all(p.artifact == repo for p in plans)
-    assert plans[-1].tier == "cpu"  # cpu floor survives
+    assert [p.tier for p in plans] == ["cpu"]  # sherpa is CPU-only (D11)
+
+
+def test_resolve_tts_sherpa_cards_cpu_only_even_on_gpu_machine():
+    machine = _machine(gpus=_nv_gpus(12288), installed=frozenset({"sherpa_tts"}))
+    # catalog piper card
+    plans = accel.resolve_tts("csukuangfj/vits-piper-en_US-amy-low",
+                              override="auto", machine=machine)
+    assert [p.tier for p in plans] == ["cpu"]
+    # ad-hoc (non-catalog) sherpa-family repo
+    plans = accel.resolve_tts("csukuangfj/vits-piper-en_US-kristin-medium",
+                              override="auto", machine=machine)
+    assert [p.tier for p in plans] == ["cpu"]
 
 
 def test_resolve_tts_unknown_non_sherpa_id_still_raises():

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -132,6 +132,12 @@ def _machine(*, nvidia=(), apple=False, dml=(), installed=frozenset({"transcribe
                          fingerprint="test", tc_kinds=tc, gpus=gpus)
 
 
+def _nv_gpus(vram_mb=0):
+    """tc-probe-shaped NVIDIA device identity: (kind, description, mem_total).
+    vram_mb=0 models a probe that saw the device but no memory figure."""
+    return (("vulkan", "NVIDIA GeForce RTX 4070", vram_mb << 20),)
+
+
 def test_has_nvidia_from_tc_description():
     m = _machine(gpus=(("vulkan", "NVIDIA GeForce RTX 4070", 12 << 30),))
     assert accel.has_nvidia(m) is True
@@ -161,7 +167,7 @@ def _model_cpu_and_cuda():
 
 
 def test_resolve_prefers_gpu_when_nvidia_present():
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     plans = accel.resolve_deployments(_model_cpu_and_cuda(), m)
     assert [p.device for p in plans] == ["cuda", "cpu"]  # GPU first, CPU floor last
 
@@ -172,7 +178,7 @@ def test_resolve_cpu_only_machine_drops_gpu_plan():
 
 
 def test_resolve_override_pins_cpu():
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     plans = accel.resolve_deployments(_model_cpu_and_cuda(), m, override="cpu")
     assert [p.device for p in plans] == ["cpu", "cuda"]  # CPU pinned to front, GPU still present
 
@@ -184,7 +190,7 @@ def test_resolve_gpu_only_model_on_cpu_machine_is_empty():
 
 
 def test_resolve_real_catalog_sense_voice_cpu(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
+    monkeypatch.setattr(accel, "_tc_gpus", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"transcribe_cpp"}))
@@ -334,7 +340,9 @@ def test_load_measured_omits_nonpositive_delta(monkeypatch):
 
 
 def test_hardware_info_handler(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: (accel.Gpu("nvidia", "RTX 4070", 12288),))
+    monkeypatch.setattr(accel, "_tc_gpus",
+                        lambda: (("cuda", "NVIDIA GeForce RTX 4070", 12288 << 20),))
+    monkeypatch.setattr(accel, "_tc_kinds", lambda: ("cpu", "cuda"))
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"ctranslate2", "sherpa"}))
@@ -345,12 +353,29 @@ def test_hardware_info_handler(monkeypatch):
         st, json.dumps({"type": "hardware_info", "id": 7}), None, None))
     assert reply["type"] == "hardware_info_result" and reply["id"] == 7
     assert reply["accelAvailable"] is True
-    assert reply["gpus"][0]["name"] == "RTX 4070"
+    assert reply["gpus"] == [{"vendor": "nvidia",
+                              "name": "NVIDIA GeForce RTX 4070", "vramMb": 12288}]
     assert "sherpa" in reply["backendsInstalled"]
 
 
+def test_hardware_info_reports_amd_gpu_from_tc_probe(monkeypatch):
+    # THE D7 bugfix: gpus[] used to come from NVML, so mac/AMD boxes reported
+    # an empty list. The tc probe sees every vendor.
+    monkeypatch.setattr(accel, "_tc_gpus",
+                        lambda: (("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),))
+    monkeypatch.setattr(accel, "_tc_kinds", lambda: ("cpu", "vulkan"))
+    monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
+    monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
+    monkeypatch.setattr(accel, "_installed", lambda: frozenset())
+    accel.probe(force=True)
+    reply, _ = asyncio.run(accel._h_hardware_info({}, {"id": 1}, None))
+    assert reply["gpus"] == [{"vendor": "amd", "name": "AMD Radeon RX 7800 XT",
+                              "vramMb": 16384}]
+    assert reply["accelAvailable"] is True
+
+
 def test_models_catalog_handler_cpu_machine(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
+    monkeypatch.setattr(accel, "_tc_gpus", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"transcribe_cpp"}))
@@ -377,7 +402,7 @@ def test_models_catalog_handler_cpu_machine(monkeypatch):
 
 
 def test_models_catalog_filter_narrows_results(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
+    monkeypatch.setattr(accel, "_tc_gpus", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"ctranslate2", "sherpa"}))
@@ -391,7 +416,7 @@ def test_models_catalog_filter_narrows_results(monkeypatch):
 
 
 def test_whisper_resolves_vulkan_first_on_nvidia():
-    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288),))
+    m = _machine(gpus=_nv_gpus(12288))
     plans = accel.resolve("whisper-base", machine=m)
     assert [p.device for p in plans] == ["vulkan", "cpu"]
     assert all(p.backend == "transcribe_cpp" and p.compute_type == "q8_0" for p in plans)
@@ -403,13 +428,13 @@ def test_whisper_cpu_only_machine_drops_gpu():
 
 
 def test_whisper_cpu_override_pins_cpu_on_nvidia():
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     plans = accel.resolve("whisper-base", override="cpu", machine=m)
     assert plans[0].device == "cpu"
 
 
 def test_sense_voice_resolves_vulkan_then_cpu_on_nvidia():
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     plans = accel.resolve("sense-voice", machine=m)
     assert [p.device for p in plans] == ["vulkan", "cpu"]
 
@@ -500,7 +525,7 @@ def test_apply_bench_demotes_slow_gpu():
 
 def test_resolve_demotes_gpu_when_cache_says_slower(tmp_path, monkeypatch):
     monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     accel.probe(force=True)
     # seed the cache keyed by the machine we resolve for (m.fingerprint == "test")
     fp = m.fingerprint
@@ -514,7 +539,7 @@ def test_resolve_demotes_gpu_when_cache_says_slower(tmp_path, monkeypatch):
 
 def test_resolve_override_beats_demotion(tmp_path, monkeypatch):
     monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     fp = m.fingerprint
     # cache says cuda is slower than cpu — AUTO would demote, but an explicit
     # override must win (the benchmark never overrides the user's forced device).
@@ -568,18 +593,15 @@ def test_granite_gated_off_without_transformers_installed():
     # has a GPU but transformers not installed → backend filtered → NoUsablePlan
     with pytest.raises(accel.NoUsablePlan):
         accel.resolve("granite-speech-4.1-2b",
-                      machine=_machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+                      machine=_machine(gpus=_nv_gpus(),
                                        installed=frozenset({"ctranslate2"})))
 
 
 def test_qwen3asr_model_unavailable_without_runtime(monkeypatch):
     from sokuji_sidecar import accel, catalog
     # a GPU machine, but qwen3asr backend not installed (transformers lacks qwen3_asr)
-    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
-                      apple_silicon=False, dml_adapters=(),
-                      installed=frozenset({"ctranslate2", "sherpa", "transformers"}),
-                      fingerprint="testfp")
+    m = _machine(gpus=_nv_gpus(12000),
+                 installed=frozenset({"ctranslate2", "sherpa", "transformers"}))
     plans = accel.resolve_deployments(catalog.asr_model("qwen3-asr-1.7b"), m)
     assert plans == []     # gated off: no usable deployment
 
@@ -605,11 +627,8 @@ def test_installed_find_spec_raise_does_not_nuke_whole_set(monkeypatch):
 
 def test_voxtral_model_unavailable_without_runtime():
     from sokuji_sidecar import accel, catalog
-    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                      nvidia=(accel.Gpu(vendor="nvidia", name="x", vram_mb=12000),),
-                      apple_silicon=False, dml_adapters=(),
-                      installed=frozenset({"ctranslate2", "sherpa", "transformers"}),  # no voxtral_realtime
-                      fingerprint="testfp")
+    m = _machine(gpus=_nv_gpus(12000),
+                 installed=frozenset({"ctranslate2", "sherpa", "transformers"}))  # no voxtral_realtime
     plans = accel.resolve_deployments(catalog.asr_model("voxtral-mini-4b-realtime"), m)
     assert plans == []     # GPU-only + runtime absent → no usable deployment
 
@@ -619,7 +638,7 @@ def test_resolve_translate_prefers_gpu(monkeypatch):
     # stub (vram_mb=0, capability=None) correctly falls back to CPU now.
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
-    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288, (8, 9)),),
+    m = _machine(gpus=_nv_gpus(12288),
                  installed=frozenset({"llamacpp_qwen"}))
     plans = accel.resolve_translate("qwen2.5-0.5b", "auto", m)
     assert plans[0].device == "cuda"
@@ -638,7 +657,7 @@ def test_resolve_translate_override_cpu_pins_front():
     # An explicit device override bypasses select_variant/quant-default picking
     # and returns every installed+tier-available deployment (both quants), CPU
     # pinned to the front.
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+    m = _machine(gpus=_nv_gpus(),
                  installed=frozenset({"llamacpp_qwen"}))
     plans = accel.resolve_translate("qwen3-0.6b", "cpu", m)
     assert [p.device for p in plans] == ["cpu", "cpu", "cuda", "cuda"]
@@ -651,7 +670,7 @@ def test_resolve_translate_qwen35_no_longer_self_gates():
     # llamacpp_qwen, an external binary that accel._installed() always reports
     # present (no Python-runtime dependency) — so qwen3.5 resolves like any other
     # LLM translate card, self-gating no longer applies.
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),), installed=accel._installed())
+    m = _machine(gpus=_nv_gpus(), installed=accel._installed())
     plans = accel.resolve_translate("qwen3.5-0.8b", "auto", m)
     assert plans[0].device == "cuda"
     assert any(p.backend == "llamacpp_qwen" for p in plans)
@@ -664,7 +683,7 @@ def test_resolve_translate_unknown_id_raises():
 
 def test_models_catalog_kind_translate_returns_qwen_rows(monkeypatch):
     monkeypatch.setattr(accel, "probe", lambda force=False: _machine(
-        nvidia=(accel.Gpu("nvidia", "x", 0),), installed=frozenset({"llamacpp_qwen"})))
+        gpus=_nv_gpus(), installed=frozenset({"llamacpp_qwen"})))
     reply, _ = asyncio.run(accel._h_models_catalog(
         {}, {"type": "models_catalog", "id": 1, "kind": "translate"}, None))
     ids = [m["id"] for m in reply["models"]]
@@ -794,7 +813,7 @@ def test_resolve_translate_override_honors_quant_pin():
     # _resolve_model's plain tier ranking picked (the rank-default, q4_k_m
     # for qwen3-0.6b, ignoring the pin). override='cpu' + pin='q8_0' must
     # yield ONLY q8_0 rows, cpu pinned to the front.
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+    m = _machine(gpus=_nv_gpus(),
                  installed=frozenset({"llamacpp_qwen"}))
     plans = accel.resolve_translate("qwen3-0.6b", override="cpu", pin="q8_0", machine=m)
     assert [p.device for p in plans] == ["cpu", "cuda"]
@@ -804,7 +823,7 @@ def test_resolve_translate_override_honors_quant_pin():
 def test_resolve_translate_override_without_pin_unchanged():
     # No pin -> unchanged behavior: every installed+tier-available deployment
     # across BOTH quants (mirrors test_resolve_translate_override_cpu_pins_front).
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),),
+    m = _machine(gpus=_nv_gpus(),
                  installed=frozenset({"llamacpp_qwen"}))
     plans = accel.resolve_translate("qwen3-0.6b", override="cpu", machine=m)
     assert {p.compute_type for p in plans} == {"q8_0", "q4_k_m"}
@@ -816,7 +835,7 @@ def test_resolve_translate_override_cuda_sets_reserved(monkeypatch):
     # a first-class UI control) with a stale/zero reserved-bytes figure, so
     # --fit-target would be sized wrong for a llamacpp cuda load.
     from sokuji_sidecar import llama_runtime as rt
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12288, (8, 9)),),
+    m = _machine(gpus=_nv_gpus(12288),
                  installed=frozenset({"llamacpp_qwen"}))
     accel.resolve_translate("qwen3-0.6b", override="cuda", reserved_bytes=654321, machine=m)
     assert rt.get_reserved_bytes() == 654321
@@ -906,7 +925,7 @@ def test_resolve_translate_opus_is_cpu_only(monkeypatch):
     # a gpu-cuda deployment simply doesn't exist for this model any more.
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
-    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288, (8, 9)),),
+    m = _machine(gpus=_nv_gpus(12288),
                  installed=frozenset({"ct2_opus_translate"}))
     plans = accel.resolve_translate("opus-mt-zh-en", "auto", m)
     assert [p.device for p in plans] == ["cpu"]
@@ -918,7 +937,7 @@ def test_resolve_translate_hymt15_prefers_gpu(monkeypatch):
     from sokuji_sidecar import accel
     monkeypatch.setattr(accel, "_format_ready", lambda ct: True)
     monkeypatch.setattr(accel, "_est_bytes", lambda d: 1 * 1024**3)  # 1 GiB, fits any GPU
-    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12288, (8, 9)),),
+    m = _machine(gpus=_nv_gpus(12288),
                  installed=frozenset({"llamacpp_hunyuan"}))
     plans = accel.resolve_translate("hy-mt15-1.8b", "auto", m)
     assert plans[0].device == "cuda"
@@ -929,13 +948,10 @@ def test_resolve_translate_hymt15_prefers_gpu(monkeypatch):
 
 
 def test_resolve_tts_orders_gpu_over_cpu(monkeypatch):
-    from sokuji_sidecar import accel, catalog
+    from sokuji_sidecar import accel
     # a machine with an NVIDIA GPU and both tts backends installed
-    gpu = accel.Gpu("nvidia", "", 12000, (8, 9))
-    machine = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                            nvidia=(gpu,), apple_silicon=False, dml_adapters=(),
-                            installed=frozenset({"sherpa_tts", "moss_onnx"}),
-                            fingerprint="testfp")
+    machine = _machine(gpus=_nv_gpus(12000),
+                       installed=frozenset({"sherpa_tts", "moss_onnx"}))
     plans = accel.resolve_tts("moss-tts-nano", override="auto", machine=machine)
     assert plans[0].tier == "gpu-cuda" and plans[0].device == "cuda"
     assert plans[-1].tier == "cpu"  # cpu floor survives
@@ -943,10 +959,7 @@ def test_resolve_tts_orders_gpu_over_cpu(monkeypatch):
 
 def test_resolve_tts_cpu_only_machine(monkeypatch):
     from sokuji_sidecar import accel
-    machine = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                            nvidia=(), apple_silicon=False, dml_adapters=(),
-                            installed=frozenset({"sherpa_tts", "moss_onnx"}),
-                            fingerprint="testfp2")
+    machine = _machine(installed=frozenset({"sherpa_tts", "moss_onnx"}))
     plans = accel.resolve_tts("moss-tts-nano", override="auto", machine=machine)
     assert [p.tier for p in plans] == ["cpu"]
 
@@ -965,11 +978,8 @@ def test_resolve_tts_arbitrary_sherpa_repo_synthesizes_model():
     # so resolve_tts must synthesize an ad-hoc sherpa_tts model instead of raising.
     from sokuji_sidecar import accel
     repo = "csukuangfj/vits-piper-en_US-libritts_r-medium"
-    machine = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                            nvidia=(accel.Gpu("nvidia", "", 12000, (8, 9)),),
-                            apple_silicon=False, dml_adapters=(),
-                            installed=frozenset({"sherpa_tts", "moss_onnx"}),
-                            fingerprint="testfp-piper")
+    machine = _machine(gpus=_nv_gpus(12000),
+                       installed=frozenset({"sherpa_tts", "moss_onnx"}))
     plans = accel.resolve_tts(repo, override="auto", machine=machine)
     assert plans, "expected at least one plan for an arbitrary sherpa repo"
     assert all(p.backend == "sherpa_tts" for p in plans)
@@ -981,10 +991,7 @@ def test_resolve_tts_unknown_non_sherpa_id_still_raises():
     from sokuji_sidecar import accel
     import pytest
     # An id with no sherpa-family hint must still raise (no blind synthesis).
-    machine = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                            nvidia=(), apple_silicon=False, dml_adapters=(),
-                            installed=frozenset({"sherpa_tts", "moss_onnx"}),
-                            fingerprint="testfp-bad")
+    machine = _machine(installed=frozenset({"sherpa_tts", "moss_onnx"}))
     with pytest.raises(ValueError):
         accel.resolve_tts("some-org/random-llm-model", machine=machine)
 
@@ -1058,11 +1065,8 @@ def test_models_catalog_carries_size_bytes_per_model():
 
 
 def _llm_machine(nvidia=False, apple=False):
-    gpus = (accel.Gpu(vendor="nvidia", name="RTX 4070", vram_mb=12282,
-                      capability=(8, 9)),) if nvidia else ()
-    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=gpus,
-                         apple_silicon=apple, dml_adapters=(),
-                         installed=accel._installed(), fingerprint="test")
+    return _machine(gpus=_nv_gpus(12282) if nvidia else (),
+                    apple=apple, installed=accel._installed())
 
 
 def test_select_variant_llamacpp_default_and_pin():
@@ -1136,7 +1140,7 @@ def test_models_catalog_variant_ids(monkeypatch):
 def test_speech_llms_resolve_vulkan_then_cpu_on_nvidia():
     # granite/qwen3/voxtral/cohere all share the transcribe_cpp rows now —
     # on an NVIDIA box they resolve vulkan first with a cpu floor.
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12288),))
+    m = _machine(gpus=_nv_gpus(12288))
     for mid in ("granite-speech-4.1-2b", "qwen3-asr-1.7b",
                 "voxtral-mini-4b-realtime", "cohere-transcribe-03-2026",
                 "fun-asr-mlt-nano"):
@@ -1237,7 +1241,7 @@ def _gemma():
 
 
 def _gpu_m():
-    return _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12282),),
+    return _machine(gpus=_nv_gpus(12282),
                     installed=frozenset({"llamacpp_gemma", "transcribe_cpp"}))
 
 
@@ -1296,7 +1300,7 @@ def test_resolve_translate_auto_matches_recommendation_basis(monkeypatch):
     # (we always run the downloaded file): a 12GB card recommends+loads q8_0
     # even under transient VRAM pressure (--fit handles placement).
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12282),),
+    m = _machine(gpus=_nv_gpus(12282),
                  installed=frozenset({"llamacpp_gemma"}))
     plans = accel.resolve_translate("translategemma-4b", "auto", machine=m)
     assert plans[0].compute_type == "q8_0" and plans[0].device != "cpu"
@@ -1305,7 +1309,7 @@ def test_resolve_translate_auto_matches_recommendation_basis(monkeypatch):
 def test_resolve_translate_auto_loads_the_downloaded_file(monkeypatch):
     # ... but when the user has (only) q4 downloaded, that IS the model we run.
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: {"q4_k_m"})
-    m = _machine(nvidia=(accel.Gpu("nvidia", "RTX 4070", 12282),),
+    m = _machine(gpus=_nv_gpus(12282),
                  installed=frozenset({"llamacpp_gemma"}))
     plans = accel.resolve_translate("translategemma-4b", "auto", machine=m)
     assert plans[0].compute_type == "q4_k_m"
@@ -1314,11 +1318,7 @@ def test_resolve_translate_auto_loads_the_downloaded_file(monkeypatch):
 def test_list_variants_recommends_on_stable_total(monkeypatch):
     # recommendation keys on mem_total (12GB → q8 recommended) even when the
     # transient free is tiny — download advice must not flap session-to-session.
-    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                      nvidia=(accel.Gpu("nvidia", "RTX 4070", 12282),),
-                      apple_silicon=False, dml_adapters=(),
-                      installed=frozenset({"llamacpp_gemma"}), fingerprint="t",
-                      gpus=(("vulkan", "RTX 4070", 12 << 30),))
+    m = _machine(gpus=_nv_gpus(12288), installed=frozenset({"llamacpp_gemma"}))
     monkeypatch.setattr(accel, "probe", lambda force=False: m)
     monkeypatch.setattr(accel, "device_free_bytes", lambda: 1 << 30)
     import asyncio as _a, json as _j
@@ -1337,7 +1337,7 @@ def test_asr_roomy_budget_upgrades_to_q8(monkeypatch):
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
     # 12 GB card: cohere's q8_0 (2.41GB×1.15) fits → recommend the quality
     # rung. STABLE basis (mem_total) — this is a download recommendation.
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "q8_0" and plans[0].device == "vulkan"
     # one plan per tier — the ladder narrowed to ONE quant
@@ -1347,7 +1347,7 @@ def test_asr_roomy_budget_upgrades_to_q8(monkeypatch):
 def test_asr_tight_budget_keeps_default(monkeypatch):
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
     # a 2 GB card: q8 (2.77GB need) never fits → default stays recommended
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 2048),))
+    m = _machine(gpus=_nv_gpus(2048))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "q4_k_m"
 
@@ -1365,14 +1365,14 @@ def test_asr_unknown_memory_keeps_default_on_gpu(monkeypatch):
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
     # GPU present but no memory reading at all (vram_mb=0, no tc gpus) →
     # conservative default quant
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),))
+    m = _machine(gpus=_nv_gpus())
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "q4_k_m" and plans[0].device == "vulkan"
 
 
 def test_asr_pin_narrows_ladder(monkeypatch):
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 2048),))  # q8 wouldn't fit
+    m = _machine(gpus=_nv_gpus(2048))  # q8 wouldn't fit
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m, pin="q8_0")
     assert all(p.compute_type == "q8_0" for p in plans)   # user's will
 
@@ -1382,7 +1382,7 @@ def test_asr_pin_listed_only_quant_honored(monkeypatch):
     never auto-recommended) but fully pickable in the UI — a pin on them
     must win, not silently fall back to a curated rung."""
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m, pin="f16")
     assert all(p.compute_type == "f16" for p in plans)
 
@@ -1392,7 +1392,7 @@ def test_asr_downloaded_listed_only_quant_loads(monkeypatch):
     quant is a listed-only rung (f16), auto must load it, not resolve to a
     curated quant that isn't on disk."""
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: {"f16"})
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "f16"
 
@@ -1402,20 +1402,19 @@ def test_asr_fresh_recommendation_never_listed_only(monkeypatch):
     # 24GB GPU fits even f16, but the budget walk only considers curated
     # rungs — q8_0 stays the recommendation.
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 24564),))
+    m = _machine(gpus=_nv_gpus(24564))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "q8_0"
 
 
 def test_asr_single_quant_cards_unaffected(monkeypatch):
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     plans = accel.resolve("sense-voice", machine=m)
     assert [p.compute_type for p in plans] == ["q8_0", "q8_0"]
 
 
 def test_models_catalog_exposes_asr_variant_ids_and_deduped_tiers(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"transcribe_cpp", "transcribe_cpp_stream"}))
@@ -1441,14 +1440,14 @@ def test_asr_quant_pick_prefers_downloaded(monkeypatch):
     # a 12GB card would recommend q8_0, but only q4_k_m is in the local cache
     # → we run the model the user downloaded, full stop.
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: {"q4_k_m"})
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "q4_k_m"
 
 
 def test_translate_quant_pick_prefers_downloaded(monkeypatch):
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: {"q4_k_m"})
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),),
+    m = _machine(gpus=_nv_gpus(12282),
                  installed=frozenset({"llamacpp_gemma"}))
     plans = accel.resolve_translate("translategemma-4b", "auto", machine=m)
     assert plans[0].compute_type == "q4_k_m"
@@ -1458,7 +1457,7 @@ def test_quant_pick_ignores_download_state_when_nothing_cached(monkeypatch):
     # fresh machine, nothing downloaded: recommend by the stable basis (the
     # gate then walks the user through downloading that quant)
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     plans = accel.resolve("cohere-transcribe-03-2026", machine=m)
     assert plans[0].compute_type == "q8_0"
 
@@ -1538,8 +1537,7 @@ def test_load_measured_cpu_claims_zero(monkeypatch):
 # ── Phase E5(sidecar): full variant list precomputed in models_catalog ───────
 
 
-def _catalog_reply(monkeypatch, gpus=(), nvidia=(), kind="asr", models=None):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: nvidia)
+def _catalog_reply(monkeypatch, gpus=(), kind="asr", models=None):
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed",
@@ -1585,8 +1583,7 @@ def test_catalog_variants_cpu_only_recommends_smallest(monkeypatch):
 
 def test_catalog_variants_translate_kind_included(monkeypatch):
     # translate needs an NVIDIA/Metal machine (no vulkan llama flavor yet)
-    by_id = _catalog_reply(monkeypatch, gpus=(("vulkan", "RTX 4070", 12 << 30),),
-                           nvidia=(accel.Gpu("nvidia", "RTX 4070", 12282),),
+    by_id = _catalog_reply(monkeypatch, gpus=_nv_gpus(12288),
                            kind="translate", models=["translategemma-4b"])
     v = by_id["translategemma-4b"]["variants"]
     assert [x["id"] for x in v] == ["q8_0", "q4_k_m"]
@@ -1622,7 +1619,7 @@ def test_llamacpp_unified_memory_never_degrades_to_cpu_for_memory():
 def test_translate_auto_demotes_gpu_when_bench_says_cpu_faster(tmp_path, monkeypatch):
     monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),),
+    m = _machine(gpus=_nv_gpus(12282),
                  installed=frozenset({"llamacpp_gemma"}))
     # measured: gpu decodes SLOWER than cpu (tps lower) for the chosen quant
     accel.bench_save({
@@ -1636,7 +1633,7 @@ def test_translate_auto_demotes_gpu_when_bench_says_cpu_faster(tmp_path, monkeyp
 def test_translate_auto_keeps_gpu_without_bench(tmp_path, monkeypatch):
     monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: set())
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),),
+    m = _machine(gpus=_nv_gpus(12282),
                  installed=frozenset({"llamacpp_gemma"}))
     plans = accel.resolve_translate("translategemma-4b", "auto", machine=m)
     assert plans[0].device == "cuda"       # no measurements → estimate order
@@ -1646,7 +1643,7 @@ def test_asr_bench_demotion_uses_quant_keyed_entries(tmp_path, monkeypatch):
     # post-E3 narrowing: plans carry ONE quant; bench keys must match it
     monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
     monkeypatch.setattr(accel, "_downloaded_quants", lambda model: {"q4_k_m"})
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 12282),))
+    m = _machine(gpus=_nv_gpus(12282))
     accel.bench_save({
         accel._bench_key(m.fingerprint, "cohere-transcribe-03-2026", "transcribe_cpp", "vulkan", "q4_k_m"): 0.9,
         accel._bench_key(m.fingerprint, "cohere-transcribe-03-2026", "transcribe_cpp", "cpu", "q4_k_m"): 0.2,

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -132,6 +132,25 @@ def _machine(*, nvidia=(), apple=False, dml=(), installed=frozenset({"transcribe
                          fingerprint="test", tc_kinds=tc, gpus=gpus)
 
 
+def test_has_nvidia_from_tc_description():
+    m = _machine(gpus=(("vulkan", "NVIDIA GeForce RTX 4070", 12 << 30),))
+    assert accel.has_nvidia(m) is True
+
+
+def test_has_nvidia_case_insensitive():
+    m = _machine(gpus=(("cuda", "nVidia geforce rtx 5080", 16 << 30),))
+    assert accel.has_nvidia(m) is True
+
+
+def test_has_nvidia_false_for_amd():
+    m = _machine(gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),))
+    assert accel.has_nvidia(m) is False
+
+
+def test_has_nvidia_false_without_devices():
+    assert accel.has_nvidia(_machine()) is False
+
+
 def _model_cpu_and_cuda():
     # synthetic rows exercising the generic resolver mechanics (tier ranking,
     # override pinning) — backend name only needs to be in `installed`

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -13,102 +13,45 @@ from sokuji_sidecar import server
 os.environ.setdefault("SOKUJI_BENCH_DIR", tempfile.mkdtemp())
 
 
-class _FakeNvml:
-    """Minimal pynvml stand-in: one device, RTX-4070-shaped. Records lifecycle
-    calls so tests can assert init/shutdown pairing."""
-
-    class _Mem:
-        total = 12 * 1024 * 1024 * 1024
-        free = 9 * 1024 * 1024 * 1024
-
-    def __init__(self, name="NVIDIA GeForce RTX 4070", count=1):
-        self._name = name
-        self._count = count
-        self.inits = 0
-        self.shutdowns = 0
-
-    def nvmlInit(self):
-        self.inits += 1
-
-    def nvmlShutdown(self):
-        self.shutdowns += 1
-
-    def nvmlDeviceGetCount(self):
-        return self._count
-
-    def nvmlDeviceGetHandleByIndex(self, i):
-        return i
-
-    def nvmlDeviceGetMemoryInfo(self, h):
-        return self._Mem()
-
-    def nvmlDeviceGetCudaComputeCapability(self, h):
-        return (8, 9)
-
-    def nvmlDeviceGetName(self, h):
-        return self._name
-
-
-def _install_fake_nvml(monkeypatch, fake):
-    import sys
-    monkeypatch.setitem(sys.modules, "pynvml", fake)
-
-
-def test_nvidia_gpus_probe_via_nvml(monkeypatch):
-    # torch is gone: GPU properties (vram, compute capability, name) come from NVML.
-    fake = _FakeNvml()
-    _install_fake_nvml(monkeypatch, fake)
-    gpus = accel._nvidia_gpus()
-    assert gpus == (accel.Gpu("nvidia", "NVIDIA GeForce RTX 4070", 12288, (8, 9)),)
-    assert fake.inits == 1 and fake.shutdowns == 1
-
-
-def test_nvidia_gpus_decodes_bytes_name(monkeypatch):
-    # older NVML bindings return bytes from nvmlDeviceGetName
-    _install_fake_nvml(monkeypatch, _FakeNvml(name=b"NVIDIA GeForce RTX 4070"))
-    gpus = accel._nvidia_gpus()
-    assert gpus[0].name == "NVIDIA GeForce RTX 4070"
-
-
-def test_nvidia_gpus_empty_without_nvml(monkeypatch):
-    import sys
-    monkeypatch.setitem(sys.modules, "pynvml", None)  # import raises ImportError
-    assert accel._nvidia_gpus() == ()
-
-
 def test_probe_assembles_machine(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: (accel.Gpu("nvidia", "RTX 4070", 12288),))
+    monkeypatch.setattr(accel, "_tc_kinds", lambda: ("cpu", "vulkan"))
+    monkeypatch.setattr(accel, "_tc_gpus",
+                        lambda: (("vulkan", "NVIDIA GeForce RTX 4070", 12 << 30),))
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"ctranslate2", "sherpa"}))
     m = accel.probe(force=True)
-    assert m.nvidia and m.nvidia[0].name == "RTX 4070"
+    assert m.gpus == (("vulkan", "NVIDIA GeForce RTX 4070", 12 << 30),)
+    assert accel.has_nvidia(m)
     assert "sherpa" in m.installed
     assert m.fingerprint  # non-empty, stable hash
 
 
 def test_probe_degrades_when_detector_throws(monkeypatch):
-    def boom(): raise RuntimeError("driver broken")
-    monkeypatch.setattr(accel, "_nvidia_gpus", boom)
+    def boom(): raise RuntimeError("probe broken")
+    monkeypatch.setattr(accel, "_tc_gpus", boom)
+    monkeypatch.setattr(accel, "_tc_kinds", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset())
     m = accel.probe(force=True)
-    assert m.nvidia == ()  # broken GPU detection → treated as absent, no crash
+    assert m.gpus == ()  # broken GPU detection → treated as absent, no crash
 
 
 def test_probe_is_cached(monkeypatch):
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
+    monkeypatch.setattr(accel, "_tc_gpus", lambda: ())
+    monkeypatch.setattr(accel, "_tc_kinds", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset())
     first = accel.probe(force=True)
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: (accel.Gpu("nvidia", "x", 0),))
+    monkeypatch.setattr(accel, "_tc_gpus",
+                        lambda: (("vulkan", "NVIDIA x", 1 << 30),))
     assert accel.probe() is first  # cached: no re-probe without force
 
 
-def _machine(*, nvidia=(), apple=False, dml=(), installed=frozenset({"transcribe_cpp", "transcribe_cpp_stream"}), tc=(), gpus=()):
-    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=nvidia,
+def _machine(*, apple=False, dml=(), installed=frozenset({"transcribe_cpp", "transcribe_cpp_stream"}), tc=(), gpus=()):
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
                          apple_silicon=apple, dml_adapters=dml, installed=installed,
                          fingerprint="test", tc_kinds=tc, gpus=gpus)
 
@@ -434,7 +377,7 @@ def test_sense_voice_resolves_vulkan_then_cpu_on_nvidia():
 
 
 def test_vulkan_tier_from_tc_probe_alone():
-    # An AMD/Intel box: no NVML GPUs, no DML — transcribe.cpp's own Vulkan
+    # An AMD/Intel box: no NVIDIA device, no DML — transcribe.cpp's own Vulkan
     # probe is enough to light the gpu-vulkan tier.
     m = _machine(tc=("cpu", "vulkan"))
     plans = accel.resolve("whisper-base", machine=m)
@@ -705,10 +648,6 @@ def test_new_translate_backends_installed_and_resolvable():
     assert any(p.backend == "llamacpp_hunyuan" for p in plans)
     g = accel.resolve_translate("translategemma-4b", "auto")
     assert any(p.backend == "llamacpp_gemma" for p in g)
-
-
-# NVML probe coverage lives at the top of this file (test_nvidia_gpus_probe_via_nvml
-# and friends) — the torch-era probe tests were superseded by them.
 
 
 # ── select_variant tests ────────────────────────────────────────────────────
@@ -1057,14 +996,14 @@ def test_models_catalog_carries_size_bytes_per_model():
 # test that calls it.
 
 
-def _llm_machine(nvidia=False, apple=False):
-    return _machine(gpus=_nv_gpus(12282) if nvidia else (),
+def _llm_machine(gpu=False, apple=False):
+    return _machine(gpus=_nv_gpus(12282) if gpu else (),
                     apple=apple, installed=accel._installed())
 
 
 def test_select_variant_llamacpp_default_and_pin():
     m = catalog.translate_model("translategemma-4b")
-    mach = _llm_machine(nvidia=True)
+    mach = _llm_machine(gpu=True)
     chosen = accel.select_variant(m, mach, reserved_bytes=0, pin=None)
     assert (chosen.compute_type, chosen.tier) == ("q4_k_m", "gpu-cuda")
     pinned = accel.select_variant(m, mach, reserved_bytes=0, pin="q8_0")
@@ -1080,7 +1019,7 @@ def test_select_variant_llamacpp_metal_and_cpu():
 
 
 def test_resolve_translate_same_quant_cpu_floor(monkeypatch):
-    monkeypatch.setattr(accel, "probe", lambda force=False: _llm_machine(nvidia=True))
+    monkeypatch.setattr(accel, "probe", lambda force=False: _llm_machine(gpu=True))
     plans = accel.resolve_translate("hy-mt2-1.8b", pin="q8_0")
     assert [(p.tier, p.compute_type) for p in plans] == [
         ("gpu-cuda", "q8_0"), ("cpu", "q8_0")]
@@ -1088,7 +1027,7 @@ def test_resolve_translate_same_quant_cpu_floor(monkeypatch):
 
 def test_resolve_translate_sets_reserved(monkeypatch):
     from sokuji_sidecar import llama_runtime as rt
-    monkeypatch.setattr(accel, "probe", lambda force=False: _llm_machine(nvidia=True))
+    monkeypatch.setattr(accel, "probe", lambda force=False: _llm_machine(gpu=True))
     accel.resolve_translate("qwen2.5-0.5b", reserved_bytes=123456)
     assert rt.get_reserved_bytes() == 123456
     rt.set_reserved_bytes(0)
@@ -1113,7 +1052,7 @@ def test_vram_gate_skipped_for_llamacpp(monkeypatch):
 
 
 def test_list_variants_dedupes_llamacpp(monkeypatch):
-    monkeypatch.setattr(accel, "probe", lambda force=False: _llm_machine(nvidia=True))
+    monkeypatch.setattr(accel, "probe", lambda force=False: _llm_machine(gpu=True))
     reply, _ = asyncio.run(accel._h_list_variants({}, {"model": "translategemma-4b"}, None, None))
     ids = [v["id"] for v in reply["variants"]]
     assert sorted(ids) == ["q4_k_m", "q8_0"]        # deduped across tiers
@@ -1175,7 +1114,6 @@ def test_machine_gpus_stable_identity(monkeypatch):
         _FakeTcDev("vulkan", "AMD Radeon RX 7800 XT", 16 << 30, 15 << 30),
         _FakeTcDev("cpu", "Ryzen 7", 64 << 30, 60 << 30, device_type="cpu"),
     ]))
-    monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
     monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
     monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
     monkeypatch.setattr(accel, "_installed", lambda: frozenset({"transcribe_cpp"}))
@@ -1190,7 +1128,6 @@ def test_fingerprint_ignores_volatile_free(monkeypatch):
     def probe_with_free(free):
         monkeypatch.setitem(sys.modules, "transcribe_cpp", _fake_tc_module([
             _FakeTcDev("vulkan", "RTX 4070", 12 << 30, free)]))
-        monkeypatch.setattr(accel, "_nvidia_gpus", lambda: ())
         monkeypatch.setattr(accel, "_apple_silicon", lambda: False)
         monkeypatch.setattr(accel, "_dml_adapters", lambda: ())
         monkeypatch.setattr(accel, "_installed", lambda: frozenset())
@@ -1586,7 +1523,7 @@ def test_catalog_variants_translate_kind_included(monkeypatch):
 
 
 def _mac_machine(installed=frozenset({"llamacpp_gemma", "transcribe_cpp"})):
-    return accel.Machine(os="Darwin", arch="arm64", cpu_cores=10, nvidia=(),
+    return accel.Machine(os="Darwin", arch="arm64", cpu_cores=10,
                          apple_silicon=True, dml_adapters=(), installed=installed,
                          fingerprint="mac", tc_kinds=("cpu", "metal"),
                          gpus=(("metal", "Apple M2", 16 << 30),))
@@ -1653,3 +1590,12 @@ def test_catalog_variants_carry_reason_data(monkeypatch):
     # "needs ~X — this machine has Y"
     assert f16["needBytes"] == int(f16["sizeBytes"] * 1.15)
     assert not f16["supported"]
+
+
+def test_no_nvml_left_in_package():
+    # D7: NVML is fully removed — no package module may import the NVML binding.
+    import pathlib
+    needle = "pyn" + "vml"  # split literal so this guard is not its own grep hit
+    pkg = pathlib.Path(accel.__file__).parent
+    hits = [p.name for p in pkg.glob("*.py") if needle in p.read_text()]
+    assert hits == []

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -295,3 +295,13 @@ def test_qwen3_rows_and_capability():
         assert catalog.voice_capability(m) == {"builtin": "named", "custom": "clip", "transcriptRequired": True}
     # MOSS capability unchanged (no extra key)
     assert catalog.voice_capability(catalog.tts_model("moss-tts-nano")) == {"builtin": "named", "custom": "clip"}
+
+
+def test_sherpa_tts_rows_are_cpu_only():
+    # Stock sherpa-onnx wheel is CPU-only (its bundled ORT exposes just
+    # CPUExecutionProvider, runtime-verified) — a gpu-cuda row shows a false
+    # GPU badge and claims phantom VRAM in the cross-stage ledger (D11).
+    for m in catalog.tts_models():
+        for d in m.deployments:
+            if d.backend == "sherpa_tts":
+                assert d.tier == "cpu", m.id

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -196,7 +196,7 @@ def test_windows_job_object_import_is_safe_on_non_windows():
 
 def _probe_machine(gpus=(), apple=False):
     from sokuji_sidecar import accel
-    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=(),
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
                          apple_silicon=apple, dml_adapters=(),
                          installed=frozenset(), fingerprint="t", gpus=gpus)
 

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -248,3 +248,13 @@ def test_metal_config_garbage_brand_degrades_with_warning(monkeypatch, capsys):
     monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
     assert rt._metal_config() == "m5"
     assert "unknown Apple chip" in capsys.readouterr().err
+
+
+def test_metal_config_two_digit_chip_degrades(monkeypatch, capsys):
+    # "M10" must NOT truncate to "m1" (the old [:2] bug); it is unknown to the
+    # config table, so it degrades to the newest known binary.
+    class R:
+        stdout = "Apple M10 Max\n"
+    monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
+    assert rt._metal_config() == "m5"
+    assert "unknown Apple chip" in capsys.readouterr().err

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -192,3 +192,31 @@ def test_windows_job_object_import_is_safe_on_non_windows():
     class _FakeProc:
         _handle = 1234
     assert rt._windows_job_object(_FakeProc()) is None
+
+
+def _probe_machine(gpus=(), apple=False):
+    from sokuji_sidecar import accel
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=(),
+                         apple_silicon=apple, dml_adapters=(),
+                         installed=frozenset(), fingerprint="t", gpus=gpus)
+
+
+def test_default_flavor_cuda_from_tc_probe(monkeypatch):
+    from sokuji_sidecar import accel
+    monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
+        gpus=(("vulkan", "NVIDIA GeForce RTX 4070", 12 << 30),)))
+    assert rt.default_flavor() == "cuda"
+
+
+def test_default_flavor_metal_on_apple(monkeypatch):
+    from sokuji_sidecar import accel
+    monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(apple=True))
+    assert rt.default_flavor() == "metal"
+
+
+def test_default_flavor_cpu_for_non_nvidia_gpu(monkeypatch):
+    # AMD/Intel GPUs get no cuda flavor; the vulkan flavor arrives in P4.
+    from sokuji_sidecar import accel
+    monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
+        gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),)))
+    assert rt.default_flavor() == "cpu"

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -222,11 +222,14 @@ def test_default_flavor_cpu_for_non_nvidia_gpu(monkeypatch):
     assert rt.default_flavor() == "cpu"
 
 
-def test_metal_config_known_chip(monkeypatch):
+@pytest.mark.parametrize("brand,cfg", [
+    ("Apple M1\n", "m1"), ("Apple M2 Pro\n", "m2"), ("Apple M3 Max\n", "m3"),
+    ("Apple M4 Pro\n", "m4"), ("Apple M5 Ultra\n", "m5")])
+def test_metal_config_known_chip(monkeypatch, brand, cfg):
     class R:
-        stdout = "Apple M4 Pro\n"
+        stdout = brand
     monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
-    assert rt._metal_config() == "m4"
+    assert rt._metal_config() == cfg
 
 
 def test_metal_config_unknown_chip_degrades_with_warning(monkeypatch, capsys):

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -220,3 +220,28 @@ def test_default_flavor_cpu_for_non_nvidia_gpu(monkeypatch):
     monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
         gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),)))
     assert rt.default_flavor() == "cpu"
+
+
+def test_metal_config_known_chip(monkeypatch):
+    class R:
+        stdout = "Apple M4 Pro\n"
+    monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
+    assert rt._metal_config() == "m4"
+
+
+def test_metal_config_unknown_chip_degrades_with_warning(monkeypatch, capsys):
+    # D11: a future chip (M6, M7, ...) must not brick binary install — newer
+    # Apple GPUs run the newest known Metal build fine. Warn + degrade.
+    class R:
+        stdout = "Apple M7 Ultra\n"
+    monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
+    assert rt._metal_config() == "m5"
+    assert "unknown Apple chip" in capsys.readouterr().err
+
+
+def test_metal_config_garbage_brand_degrades_with_warning(monkeypatch, capsys):
+    class R:
+        stdout = "\n"
+    monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
+    assert rt._metal_config() == "m5"
+    assert "unknown Apple chip" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

**Removes NVML (`nvidia-ml-py`) entirely** from the native sidecar, routing all NVIDIA/GPU detection through the vendor-agnostic transcribe.cpp device probe. This is **P2** of the multi-platform acceleration refactor (spec decisions **D7** + **D11**), built as 8 incremental commits that each kept the suite green, plus review-fix commits.

## What changed

- New `accel.has_nvidia(machine)` seam — detects NVIDIA via the tc-probe device description (case-insensitive "nvidia"), not NVML.
- All presence consumers rerouted to it: the `gpu-cuda` tier gate, `hardware_info.gpus[]`, and llama.cpp `default_flavor`.
- Quant-budget / variant selection moved onto tc-probe VRAM totals (bytes, unit-consistent with the old MB path); the dead CUDA `min_capability` gating deleted (no shipped card set it).
- Free-VRAM reads unified on `device_free_bytes` (tc probe, `None` when it can't answer — all callers tolerate `None`); `_cuda_free_bytes` deleted.
- `_nvidia_gpus()`, the `Gpu` dataclass, the `Machine.nvidia` field, and the `nvidia-ml-py` pin all removed — **zero NVML/pynvml code remains** (guarded by a new recursive regression test).

**Bonus fix (D7):** `hardware_info.gpus[]` now reports AMD/Intel/Apple GPUs — it was NVML-only and returned an empty array on non-NVIDIA machines.

**Riders (D11):**
- sherpa TTS cards dropped their bogus `gpu-cuda` tier — the stock sherpa-onnx wheel is CPU-only, so that tier produced a false `device=cuda` badge + a phantom VRAM ledger claim. (moss/supertonic/qwen3tts keep their real CUDA tiers.)
- `_metal_config` degrades an unknown/future Apple chip (M6+, Intel Mac) to the newest-known metal binary + a stderr warning, instead of hard-failing the whole model download.

## Verification

- Suite: **426 passed / 13 skipped / 1 failed**. The one failure (`test_qwen_tokenizer::test_golden_parity_with_transformers`) is the pre-existing dirty-dev-venv artifact (leftover `transformers` vs pinned `huggingface_hub`), unrelated to P2 — self-skips in a clean torch-free venv.
- Every task TDD'd and individually reviewed; the whole-branch review rated it **Ready to merge** (no Critical). Test migration preserved or strengthened assertions throughout.
- **Real-hardware validation** (dev 4070 box): `accel.probe().gpus` = `('vulkan', 'NVIDIA GeForce RTX 4070 SUPER', 12878610432)`, `has_nvidia()` = True, `device_free_bytes()` ≈ 11.2 GB — the load-bearing "nvidia" substring and the tc free-VRAM path hold against ground truth.

## Known limitation (documented in the spec, gates the NVIDIA release)

NVIDIA presence now depends on the tc probe enumerating the GPU (via Vulkan). A no-Vulkan/headless NVIDIA-CUDA box would silently route ORT-CUDA TTS + the llama flavor to CPU. This is a consequence of the D7 decision (tc probe as sole device truth), not a defect; re-confirm on Windows+NVIDIA before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hardware detection for GPU-enabled runs, including broader support for device probing and more reliable model/flavor selection.
  * Apple Silicon support now falls back more gracefully on newer or unknown chips.

* **Bug Fixes**
  * Reduced cases where GPU-capable systems could be mistaken for CPU-only.
  * Avoided unsupported GPU routing for some text-to-speech models and tightened memory checks before loading.

* **Documentation**
  * Added guidance on a known hardware validation limitation and shipping check for NVIDIA systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->