### PR TITLE
refactor(sidecar): catalog platforms tags + host-platform deployment filtering (P3)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-p3-catalog-platforms.md
+++ b/docs/superpowers/plans/2026-07-06-p3-catalog-platforms.md
@@ -26,7 +26,7 @@
 - Test: `sidecar/tests/test_catalog.py` (append two functions; file currently ends at `:296`)
 
 **Interfaces:**
-- Produces: `catalog.Deployment` with two new keyword-defaulted fields — `platforms: tuple[str, ...] = ("linux", "windows", "macos")` and `requires_apple_silicon: bool = False`. Task 2/3 consume these attributes. Every existing positional construction (`Deployment(backend, tier, compute_type, artifact, rank, ...)`) is unaffected because the new fields sit after `est_bytes` and all callers pass `min_capability`/`est_bytes` by keyword.
+- Produces: `catalog.Deployment` with two new keyword-defaulted fields — `platforms: tuple[str, ...] = ("linux", "windows", "macos")` and `requires_apple_silicon: bool = False`. Task 2/3 consume these attributes. Every existing positional construction (`Deployment(backend, tier, compute_type, artifact, rank, ...)`) is unaffected because the new fields sit after `est_bytes`, the current last field, and all callers pass `est_bytes` by keyword. (P2 already removed the old `min_capability` field, so `est_bytes` really is the tail.)
 
 - [ ] **Step 1: Write the failing tests** — append to the end of `sidecar/tests/test_catalog.py`:
 
@@ -106,10 +106,19 @@ import asyncio
 from sokuji_sidecar import accel, catalog
 
 
-def _machine(*, apple=False, nvidia=(), installed=frozenset({"be"})):
-    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8, nvidia=nvidia,
+# Machine shape mirrors tests/test_accel.py (post-P2): NVIDIA presence comes
+# from `gpus` device descriptions via accel.has_nvidia (the old `nvidia` field
+# and accel.Gpu class were removed in P2). `gpus` items are (kind, description,
+# mem_total) tuples; `tc_kinds` lists the accelerator kinds the probe reported.
+def _machine(*, apple=False, gpus=(), tc=(), installed=frozenset({"be"})):
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
                          apple_silicon=apple, dml_adapters=(), installed=installed,
-                         fingerprint="pf-test")
+                         fingerprint="pf-test", tc_kinds=tc, gpus=gpus)
+
+
+# An NVIDIA GPU as the tc probe reports it on the dev 4070 box; makes
+# has_nvidia() True → the gpu-vulkan tier is available.
+_NV_GPUS = (("vulkan", "NVIDIA GeForce RTX 4070 SUPER", 12 << 30),)
 
 
 def _asr(*deps):
@@ -161,19 +170,21 @@ def test_resolve_translate_auto_drops_off_platform(monkeypatch):
     # resolve would raise NoUsablePlan instead of falling back to r-all.
     monkeypatch.setattr(accel, "current_platform", lambda: "linux")
     model = catalog.TranslateModel("syn", "Syn", ("multi",), (
-        catalog.Deployment("opus_onnx_translate", "cpu", "int8", "r-win", 1.0, platforms=("windows",)),
-        catalog.Deployment("opus_onnx_translate", "cpu", "int8", "r-all", 1.0),
+        catalog.Deployment("ct2_opus_translate", "cpu", "int8", "r-win", 1.0, platforms=("windows",)),
+        catalog.Deployment("ct2_opus_translate", "cpu", "int8", "r-all", 1.0),
     ))
     monkeypatch.setattr(catalog, "translate_model", lambda mid: model if mid == "syn" else None)
-    m = _machine(installed=frozenset({"opus_onnx_translate"}))
+    m = _machine(installed=frozenset({"ct2_opus_translate"}))
     plans = accel.resolve_translate("syn", "auto", m)
     assert [p.artifact for p in plans] == ["r-all"]
 
 
 def test_linux_real_card_resolution_unchanged(monkeypatch):
     # Regression: a real all-platforms card resolves exactly as before on linux.
+    # whisper-base's tiers are (gpu-vulkan, gpu-metal, cpu); on an NVIDIA-Linux
+    # box gpu-vulkan is available (has_nvidia), gpu-metal is not → vulkan, cpu.
     monkeypatch.setattr(accel, "current_platform", lambda: "linux")
-    m = _machine(nvidia=(accel.Gpu("nvidia", "x", 0),), installed=frozenset({"transcribe_cpp"}))
+    m = _machine(gpus=_NV_GPUS, installed=frozenset({"transcribe_cpp"}))
     plans = accel.resolve("whisper-base", machine=m)
     assert [p.device for p in plans] == ["vulkan", "cpu"]
 ```
@@ -215,26 +226,28 @@ def current_platform() -> str:
 def _dml_adapters() -> tuple[str, ...]:
 ```
 
-- [ ] **Step 3b: Add `_platform_ok()`.** In `sidecar/sokuji_sidecar/accel.py`, replace the tail of `_tier_available` and the `resolve_deployments` header:
+- [ ] **Step 3b: Add `_platform_ok()`.** In `sidecar/sokuji_sidecar/accel.py`, insert the new `_platform_ok` helper between the end of `_tier_available` and the `def resolve_deployments` header. The current tail of `_tier_available` (post-P2 — `has_nvidia(machine)`, no `machine.nvidia`) is:
 
 ```python
     if tier == "gpu-vulkan":
         # transcribe.cpp's own probe is authoritative (sees AMD/Intel Vulkan
-        # devices the NVML/DML heuristics can't); NVML/DML remain as fallbacks.
-        return "vulkan" in machine.tc_kinds or bool(machine.nvidia or machine.dml_adapters)
+        # devices); NVIDIA-by-description and DML remain as fallbacks.
+        return ("vulkan" in machine.tc_kinds or has_nvidia(machine)
+                or bool(machine.dml_adapters))
     return False
 
 
 def resolve_deployments(model, machine: Machine, override: str = "auto", bench: dict | None = None) -> list[Plan]:
 ```
 
-with:
+Replace it with (the `_tier_available` body is unchanged; only the new function is added before `resolve_deployments`):
 
 ```python
     if tier == "gpu-vulkan":
         # transcribe.cpp's own probe is authoritative (sees AMD/Intel Vulkan
-        # devices the NVML/DML heuristics can't); NVML/DML remain as fallbacks.
-        return "vulkan" in machine.tc_kinds or bool(machine.nvidia or machine.dml_adapters)
+        # devices); NVIDIA-by-description and DML remain as fallbacks.
+        return ("vulkan" in machine.tc_kinds or has_nvidia(machine)
+                or bool(machine.dml_adapters))
     return False
 
 

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -1053,6 +1053,8 @@ async def _h_models_catalog(state, msg, _b, conn=None):
         tiers = []
         seen_tiers = set()
         for d in mdl.deployments:
+            if not _platform_ok(d, m):
+                continue                      # off-platform tier (e.g. windows-only gpu-dml on linux)
             if d.tier in seen_tiers:
                 continue                      # multi-quant ladders repeat tiers
             seen_tiers.add(d.tier)

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -40,6 +40,18 @@ def _apple_silicon() -> bool:
     return platform.system() == "Darwin" and platform.machine() in ("arm64", "aarch64")
 
 
+_PLATFORM_MAP = {"Linux": "linux", "Windows": "windows", "Darwin": "macos"}
+
+
+def current_platform() -> str:
+    """This host's platform tag ('linux' | 'windows' | 'macos'), mapped from
+    platform.system(). The single source of truth for the catalog's per-deployment
+    `platforms` filter (D9); monkeypatched in tests to exercise the filter without
+    the host OS. An unmapped platform.system() falls through to its lowercased
+    name — harmless: no deployment lists it, so such a host resolves nothing."""
+    return _PLATFORM_MAP.get(platform.system(), platform.system().lower())
+
+
 def _dml_adapters() -> tuple[str, ...]:
     import onnxruntime
     return ("dml",) if "DmlExecutionProvider" in onnxruntime.get_available_providers() else ()
@@ -203,12 +215,26 @@ def _tier_available(tier: str, machine: Machine) -> bool:
     return False
 
 
+def _platform_ok(d, machine: Machine) -> bool:
+    """Whether deployment `d` is runnable on THIS host's OS (D9). A row is dropped
+    when this platform is not in its `platforms` set, or when it demands Apple
+    Silicon and the machine lacks it. Every shipped card defaults to all three
+    OSes + no AS requirement, so this is a no-op until platform-specific tiers
+    (windows-only gpu-dml, macOS/AS-only mlx) land in P5/P6."""
+    if current_platform() not in d.platforms:
+        return False
+    if d.requires_apple_silicon and not machine.apple_silicon:
+        return False
+    return True
+
+
 def resolve_deployments(model, machine: Machine, override: str = "auto", bench: dict | None = None) -> list[Plan]:
     """Ordered Plans for `model` on `machine`: filter to runnable, rank by tier
     (GPU/NPU >> CPU), then a non-'auto' override pins its tier to the front, then
     the bench cache demotes a proven-slow GPU plan. CPU floor always survives."""
     usable = [d for d in model.deployments
-              if d.backend in machine.installed and _tier_available(d.tier, machine)]
+              if d.backend in machine.installed and _tier_available(d.tier, machine)
+              and _platform_ok(d, machine)]
     usable.sort(key=lambda d: (TIER_RANK.get(d.tier, 0.0), d.rank), reverse=True)
     if override != "auto":
         # The renderer's device control is auto/cpu/GPU and sends 'cuda' for
@@ -361,6 +387,13 @@ def resolve_translate(model_id: str, override: str = "auto", machine: Machine | 
     # off the same reserved-VRAM figure — leaving this only in the auto branch
     # left the override path with a stale/zero reserved_bytes.
     llama_runtime.set_reserved_bytes(reserved_bytes)
+    # The `auto` branch below builds Plans via select_variant + a hand-picked cpu
+    # floor and never flows through resolve_deployments' choke point, so drop
+    # off-platform deployments up front here (all current translate cards are
+    # cross-platform → a no-op today). The override branch re-filters idempotently
+    # via resolve_deployments.
+    model = dataclasses.replace(
+        model, deployments=tuple(d for d in model.deployments if _platform_ok(d, machine)))
     if override == "auto":
         # Same STABLE basis as the download recommendation (_h_list_variants):
         # we always run exactly the file the user downloaded, so choose it the

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -49,7 +49,8 @@ def current_platform() -> str:
     `platforms` filter (D9); monkeypatched in tests to exercise the filter without
     the host OS. An unmapped platform.system() falls through to its lowercased
     name — harmless: no deployment lists it, so such a host resolves nothing."""
-    return _PLATFORM_MAP.get(platform.system(), platform.system().lower())
+    sysname = platform.system()
+    return _PLATFORM_MAP.get(sysname, sysname.lower())
 
 
 def _dml_adapters() -> tuple[str, ...]:

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -21,6 +21,8 @@ class Deployment:
     artifact: str       # backend.load() model_ref (repo id or "org/repo/file.gguf")
     rank: float         # tie-breaker within a tier (higher = preferred)
     est_bytes: int | None = None                     # footprint estimate; None → model_size(artifact)
+    platforms: tuple[str, ...] = ("linux", "windows", "macos")  # OSes this deployment runs on (D9)
+    requires_apple_silicon: bool = False             # gate: needs Apple Silicon (mlx / metal-only rows)
 
 
 @dataclass(frozen=True)

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -305,3 +305,21 @@ def test_sherpa_tts_rows_are_cpu_only():
         for d in m.deployments:
             if d.backend == "sherpa_tts":
                 assert d.tier == "cpu", m.id
+
+
+def test_deployment_platform_defaults():
+    # D9: every deployment is all-platforms + no Apple-Silicon requirement unless
+    # a card opts in. Positional construction (backend, tier, compute_type,
+    # artifact, rank) still works with the two new trailing fields.
+    d = catalog.Deployment("be", "cpu", "int8", "repo", 1.0)
+    assert d.platforms == ("linux", "windows", "macos")
+    assert d.requires_apple_silicon is False
+
+
+def test_deployment_platform_fields_are_settable():
+    d = catalog.Deployment("be", "gpu-dml", "fp32", "repo", 1.0,
+                           platforms=("windows",), requires_apple_silicon=False)
+    assert d.platforms == ("windows",)
+    mlx = catalog.Deployment("be", "gpu-metal", "fp16", "repo", 1.0,
+                             platforms=("macos",), requires_apple_silicon=True)
+    assert mlx.requires_apple_silicon is True

--- a/sidecar/tests/test_platform_filter.py
+++ b/sidecar/tests/test_platform_filter.py
@@ -63,8 +63,8 @@ def test_resolve_deployments_apple_silicon_gate(monkeypatch):
 def test_resolve_translate_auto_drops_off_platform(monkeypatch):
     # The translate `auto` branch builds Plans via select_variant and never flows
     # through resolve_deployments, so it needs the up-front filter. Without it the
-    # first cpu deployment (r-win) would be picked as the floor and the whole
-    # resolve would raise NoUsablePlan instead of falling back to r-all.
+    # first cpu deployment (r-win) would be picked as the floor and the resolve
+    # would return the off-platform ["r-win"] instead of falling back to r-all.
     monkeypatch.setattr(accel, "current_platform", lambda: "linux")
     model = catalog.TranslateModel("syn", "Syn", ("multi",), (
         catalog.Deployment("ct2_opus_translate", "cpu", "int8", "r-win", 1.0, platforms=("windows",)),

--- a/sidecar/tests/test_platform_filter.py
+++ b/sidecar/tests/test_platform_filter.py
@@ -84,3 +84,33 @@ def test_linux_real_card_resolution_unchanged(monkeypatch):
     m = _machine(gpus=_NV_GPUS, installed=frozenset({"transcribe_cpp"}))
     plans = accel.resolve("whisper-base", machine=m)
     assert [p.device for p in plans] == ["vulkan", "cpu"]
+
+
+def _dml_model():
+    # Synthetic card with a windows-only gpu-dml tier over a cross-platform cpu
+    # floor (the P5 shape). Same compute_type on both tiers, so the multi-quant
+    # variants block never triggers — the test isolates tier visibility.
+    return catalog.AsrModel("syn", "Syn", ("multi",), (
+        catalog.Deployment("moss_onnx", "gpu-dml", "q8_0", "r", 1.0, platforms=("windows",)),
+        catalog.Deployment("moss_onnx", "cpu", "q8_0", "r", 1.0),
+    ))
+
+
+def test_models_catalog_hides_off_platform_tier_on_linux(monkeypatch):
+    monkeypatch.setattr(accel, "current_platform", lambda: "linux")
+    monkeypatch.setattr(catalog, "asr_models", lambda: [_dml_model()])
+    monkeypatch.setattr(accel, "probe", lambda force=False: _machine(installed=frozenset({"moss_onnx"})))
+    reply, _ = asyncio.run(accel._h_models_catalog({}, {"type": "models_catalog", "id": 1}, None))
+    tiers = reply["models"][0]["tiers"]
+    assert [t["tier"] for t in tiers] == ["cpu"]  # windows-only gpu-dml tier hidden on linux
+
+
+def test_models_catalog_shows_on_platform_tier_with_availability(monkeypatch):
+    monkeypatch.setattr(accel, "current_platform", lambda: "windows")
+    monkeypatch.setattr(catalog, "asr_models", lambda: [_dml_model()])
+    monkeypatch.setattr(accel, "probe", lambda force=False: _machine(installed=frozenset({"moss_onnx"})))
+    reply, _ = asyncio.run(accel._h_models_catalog({}, {"type": "models_catalog", "id": 1}, None))
+    tiers = {t["tier"]: t for t in reply["models"][0]["tiers"]}
+    assert set(tiers) == {"gpu-dml", "cpu"}          # both tiers listed on windows
+    assert tiers["gpu-dml"]["available"] is False    # on-platform, but this machine has no DML adapter
+    assert tiers["cpu"]["available"] is True

--- a/sidecar/tests/test_platform_filter.py
+++ b/sidecar/tests/test_platform_filter.py
@@ -1,0 +1,86 @@
+import asyncio
+
+from sokuji_sidecar import accel, catalog
+
+
+# Machine shape mirrors tests/test_accel.py (post-P2): NVIDIA presence comes
+# from `gpus` device descriptions via accel.has_nvidia (the old `nvidia` field
+# and accel.Gpu class were removed in P2). `gpus` items are (kind, description,
+# mem_total) tuples; `tc_kinds` lists the accelerator kinds the probe reported.
+def _machine(*, apple=False, gpus=(), tc=(), installed=frozenset({"be"})):
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                         apple_silicon=apple, dml_adapters=(), installed=installed,
+                         fingerprint="pf-test", tc_kinds=tc, gpus=gpus)
+
+
+# An NVIDIA GPU as the tc probe reports it on the dev 4070 box; makes
+# has_nvidia() True → the gpu-vulkan tier is available.
+_NV_GPUS = (("vulkan", "NVIDIA GeForce RTX 4070 SUPER", 12 << 30),)
+
+
+def _asr(*deps):
+    return catalog.AsrModel("m", "M", ("multi",), deps)
+
+
+def test_current_platform_maps_system(monkeypatch):
+    for sysname, tag in (("Linux", "linux"), ("Windows", "windows"), ("Darwin", "macos")):
+        monkeypatch.setattr(accel.platform, "system", lambda s=sysname: s)
+        assert accel.current_platform() == tag
+
+
+def test_resolve_deployments_drops_off_platform_on_linux(monkeypatch):
+    monkeypatch.setattr(accel, "current_platform", lambda: "linux")
+    model = _asr(
+        catalog.Deployment("be", "cpu", "int8", "r-win", 1.0, platforms=("windows",)),
+        catalog.Deployment("be", "cpu", "int8", "r-all", 1.0),
+    )
+    plans = accel.resolve_deployments(model, _machine())
+    assert [p.artifact for p in plans] == ["r-all"]  # windows-only cpu row dropped on linux
+
+
+def test_resolve_deployments_keeps_row_on_its_own_platform(monkeypatch):
+    monkeypatch.setattr(accel, "current_platform", lambda: "windows")
+    model = _asr(
+        catalog.Deployment("be", "cpu", "int8", "r-win", 1.0, platforms=("windows",)),
+        catalog.Deployment("be", "cpu", "int8", "r-all", 1.0),
+    )
+    plans = accel.resolve_deployments(model, _machine())
+    assert {p.artifact for p in plans} == {"r-win", "r-all"}
+
+
+def test_resolve_deployments_apple_silicon_gate(monkeypatch):
+    monkeypatch.setattr(accel, "current_platform", lambda: "macos")
+    model = _asr(
+        catalog.Deployment("be", "cpu", "int8", "r-mlx", 1.0, requires_apple_silicon=True),
+        catalog.Deployment("be", "cpu", "int8", "r-all", 1.0),
+    )
+    # Intel mac (no Apple Silicon): the AS-only row is dropped.
+    assert [p.artifact for p in accel.resolve_deployments(model, _machine(apple=False))] == ["r-all"]
+    # Apple Silicon: the AS-only row survives.
+    assert {p.artifact for p in accel.resolve_deployments(model, _machine(apple=True))} == {"r-mlx", "r-all"}
+
+
+def test_resolve_translate_auto_drops_off_platform(monkeypatch):
+    # The translate `auto` branch builds Plans via select_variant and never flows
+    # through resolve_deployments, so it needs the up-front filter. Without it the
+    # first cpu deployment (r-win) would be picked as the floor and the whole
+    # resolve would raise NoUsablePlan instead of falling back to r-all.
+    monkeypatch.setattr(accel, "current_platform", lambda: "linux")
+    model = catalog.TranslateModel("syn", "Syn", ("multi",), (
+        catalog.Deployment("ct2_opus_translate", "cpu", "int8", "r-win", 1.0, platforms=("windows",)),
+        catalog.Deployment("ct2_opus_translate", "cpu", "int8", "r-all", 1.0),
+    ))
+    monkeypatch.setattr(catalog, "translate_model", lambda mid: model if mid == "syn" else None)
+    m = _machine(installed=frozenset({"ct2_opus_translate"}))
+    plans = accel.resolve_translate("syn", "auto", m)
+    assert [p.artifact for p in plans] == ["r-all"]
+
+
+def test_linux_real_card_resolution_unchanged(monkeypatch):
+    # Regression: a real all-platforms card resolves exactly as before on linux.
+    # whisper-base's tiers are (gpu-vulkan, gpu-metal, cpu); on an NVIDIA-Linux
+    # box gpu-vulkan is available (has_nvidia), gpu-metal is not → vulkan, cpu.
+    monkeypatch.setattr(accel, "current_platform", lambda: "linux")
+    m = _machine(gpus=_NV_GPUS, installed=frozenset({"transcribe_cpp"}))
+    plans = accel.resolve("whisper-base", machine=m)
+    assert [p.device for p in plans] == ["vulkan", "cpu"]


### PR DESCRIPTION
## P3 — Catalog `platforms` tags (D9)

Third workstream of the sidecar multi-platform hardware-acceleration refactor. Gives every catalog `Deployment` a `platforms` tag (default all three OSes) plus an Apple-Silicon-required marker, and makes the accel resolvers and the `models_catalog` handler **drop deployments the running host can't use**.

**This PR adds the filtering machinery only — it introduces no platform-restricted cards.** On Linux, resolution and `models_catalog` output for every shipped card are byte-identical to before; all platform behavior is exercised via a monkeypatched `current_platform`. It lays the "add-a-card-as-pure-data" foundation for P5 (Windows-only `gpu-dml`) and P6 (macOS/Apple-Silicon-only MLX).

### Changes
- **`Deployment` gains two defaulted fields** — `platforms: tuple[str, ...] = ("linux","windows","macos")` and `requires_apple_silicon: bool = False`. Keyword-defaulted, so every existing positional construction is unaffected.
- **`accel.current_platform()`** maps `platform.system()` → `"linux" | "windows" | "macos"` (monkeypatchable single source of truth); unmapped hosts fall through to a tag no card lists (resolve nothing, never crash).
- **`accel._platform_ok(d, machine)`** — the single filter predicate (drops a row when this platform isn't in `d.platforms`, or when it needs Apple Silicon and the machine lacks it). Referenced — never re-implemented — at three sites:
  - the resolver choke point `resolve_deployments` (ASR `resolve` and `resolve_tts` both flow through it via `_resolve_model`);
  - an up-front filter in `resolve_translate`'s `auto`-bypass (which builds Plans via `select_variant` and never hits the choke point);
  - the `_h_models_catalog` tier builder.
- **`models_catalog`**: off-platform tiers are hidden; on-platform-but-unavailable tiers still appear with `available: false`; wire shape (`tiers` = list of `{"tier","backend","available"}`) unchanged.

### Testing
- New `tests/test_platform_filter.py` (8 tests): OS-name mapping, resolver drop/keep on/off platform, the Apple-Silicon gate, the translate auto-path fallback, the NVIDIA-Linux regression, and the two `models_catalog` visibility cases. Each would fail if `_platform_ok` were constant-True.
- Full sidecar suite: **438 passed / 13 skipped**. The single failure (`test_qwen_tokenizer::test_golden_parity_with_transformers`) is a pre-existing dirty-dev-venv artifact (leftover `transformers` vs pinned `huggingface_hub`), unrelated to this branch.

### Review
Executed via subagent-driven development (fresh implementer + task reviewer per task; opus whole-branch review). Final verdict: **READY TO MERGE** — no Critical/Important findings.

Depends on: P1 (#280, merged), P2 (#281, merged). Unblocks: P5, P6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ee4BrrMH8msZQDJ1qoX7SE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Catalog deployments can now declare supported operating systems and whether they require Apple Silicon.
  * Automatic selection now detects your OS and uses these declarations to choose compatible deployments.

* **Bug Fixes**
  * Off-platform deployments are filtered out earlier, preventing unsupported options from appearing in automatic selection (including translate “auto” behavior).
  * The models catalog hides tiers that can’t run on the current platform while keeping accurate availability indications for other options.

* **Tests**
  * Added coverage for OS mapping, platform gating, Apple Silicon requirements, and translate “auto” fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->