### PR TITLE
feat(sidecar): llama.cpp Vulkan flavor for AMD/Intel GPU translation (P4)

### DIFF
--- a/docs/superpowers/plans/2026-07-06-p4-llama-vulkan.md
+++ b/docs/superpowers/plans/2026-07-06-p4-llama-vulkan.md
@@ -49,17 +49,24 @@ def test_flavor_for_device_includes_vulkan():
         rt.flavor_for_device("dml")
 
 
-def _fake_machine(*, nvidia=(), apple=False, tc_kinds=()):
-    """default_flavor only reads .nvidia/.apple_silicon/.tc_kinds."""
-    return types.SimpleNamespace(nvidia=nvidia, apple_silicon=apple,
+def _fake_machine(*, gpus=(), apple=False, tc_kinds=()):
+    """default_flavor reads accel.has_nvidia(m) (-> m.gpus), .apple_silicon and
+    .tc_kinds. Post-P2 there is no Machine.nvidia field / accel.Gpu class:
+    NVIDIA presence is derived from the gpus device descriptions. `gpus` items
+    are (kind, description, mem_total) tuples."""
+    return types.SimpleNamespace(gpus=gpus, apple_silicon=apple,
                                  tc_kinds=tc_kinds)
+
+
+# An NVIDIA GPU as the tc probe reports it -> accel.has_nvidia() True.
+_NV = (("cuda", "NVIDIA GeForce RTX 4070", 12 << 30),)
 
 
 def test_default_flavor_matrix(monkeypatch):
     from sokuji_sidecar import accel
     cases = [
-        (_fake_machine(nvidia=("g",)), "cuda"),
-        (_fake_machine(nvidia=("g",), tc_kinds=("cpu", "vulkan")), "cuda"),   # nvidia wins
+        (_fake_machine(gpus=_NV), "cuda"),
+        (_fake_machine(gpus=_NV, tc_kinds=("cpu", "vulkan")), "cuda"),        # nvidia wins
         (_fake_machine(apple=True), "metal"),
         (_fake_machine(apple=True, tc_kinds=("cpu", "vulkan")), "metal"),     # apple wins
         (_fake_machine(tc_kinds=("cpu", "vulkan")), "vulkan"),               # AMD/Intel GPU
@@ -81,10 +88,50 @@ def test_required_flavors_cpu_only_is_single(monkeypatch):
     assert rt.required_flavors() == ["cpu"]
 ```
 
+Then update the pre-existing stale test that P4's behavior change makes wrong.
+`test_default_flavor_cpu_for_non_nvidia_gpu` (currently ~line 217) builds an
+AMD GPU and asserts `"cpu"` with the comment "the vulkan flavor arrives in P4";
+that premise is exactly what this task changes. Extend the `_probe_machine`
+helper (currently `def _probe_machine(gpus=(), apple=False):`) to forward a
+`tc_kinds`:
+
+```python
+def _probe_machine(gpus=(), apple=False, tc=()):
+    from sokuji_sidecar import accel
+    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                         apple_silicon=apple, dml_adapters=(),
+                         installed=frozenset(), fingerprint="t",
+                         tc_kinds=tc, gpus=gpus)
+```
+
+(preserve whatever field values the current helper already passes; only add
+the `tc=()` parameter and the `tc_kinds=tc` argument). Then replace the stale
+test body:
+
+```python
+def test_default_flavor_cpu_for_non_nvidia_gpu(monkeypatch):
+    # AMD/Intel GPUs get no cuda flavor; the vulkan flavor arrives in P4.
+    from sokuji_sidecar import accel
+    monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
+        gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),)))
+    assert rt.default_flavor() == "cpu"
+```
+
+with the P4 behavior (a tc-Vulkan-capable AMD GPU now selects the vulkan flavor):
+
+```python
+def test_default_flavor_vulkan_for_amd_gpu(monkeypatch):
+    # P4: an AMD/Intel GPU the tc probe drives via Vulkan selects the vulkan flavor.
+    from sokuji_sidecar import accel
+    monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
+        gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),), tc=("cpu", "vulkan")))
+    assert rt.default_flavor() == "vulkan"
+```
+
 - [ ] **Step 2: Run to verify failure**
 
 Run: `cd sidecar && .venv/bin/python -m pytest tests/test_llama_runtime.py -q`
-Expected: FAIL — `test_flavor_for_device_includes_vulkan` raises `KeyError: 'vulkan'`; `test_default_flavor_matrix` fails the `("cpu","vulkan") -> "vulkan"` case (gets `"cpu"`).
+Expected: FAIL — `test_flavor_for_device_includes_vulkan` raises `KeyError: 'vulkan'`; `test_default_flavor_matrix` fails the `("cpu","vulkan") -> "vulkan"` case (gets `"cpu"`); `test_default_flavor_vulkan_for_amd_gpu` fails (gets `"cpu"`).
 
 - [ ] **Step 3: Implement**
 
@@ -100,14 +147,16 @@ with:
 _FLAVORS = {"cuda": "cuda", "metal": "metal", "vulkan": "vulkan", "cpu": "cpu"}
 ```
 
-Replace `default_flavor` (lines 88-96):
+Replace `default_flavor` (post-P2 it uses `accel.has_nvidia(m)`, NOT the removed `m.nvidia`):
 
 ```python
 def default_flavor() -> str:
-    """The best flavor for this machine (drives the model-download dependency)."""
+    """The best flavor for this machine (drives the model-download dependency):
+    NVIDIA (tc probe) -> cuda, Apple Silicon -> metal, else cpu. AMD/Intel
+    dGPUs stay on cpu until the vulkan flavor lands (P4)."""
     from . import accel
     m = accel.probe()
-    if m.nvidia:
+    if accel.has_nvidia(m):
         return "cuda"
     if m.apple_silicon:
         return "metal"
@@ -118,10 +167,12 @@ with:
 
 ```python
 def default_flavor() -> str:
-    """The best flavor for this machine (drives the model-download dependency)."""
+    """The best flavor for this machine (drives the model-download dependency):
+    NVIDIA (tc probe) -> cuda, Apple Silicon -> metal, AMD/Intel via the tc
+    Vulkan probe -> vulkan, else cpu."""
     from . import accel
     m = accel.probe()
-    if m.nvidia:
+    if accel.has_nvidia(m):
         return "cuda"
     if m.apple_silicon:
         return "metal"
@@ -499,11 +550,14 @@ def test_llm_vulkan_tier_ranks_between_cuda_and_cpu():
     # above cpu (1.0). Ordering comes from accel.TIER_RANK, not the order of
     # the tiers tuple in _llm_translate_row.
     from sokuji_sidecar import accel
+    # Post-P2 Machine shape: NVIDIA presence comes from `gpus` descriptions via
+    # accel.has_nvidia (no `nvidia` field / accel.Gpu class). gpu-cuda is
+    # available (has_nvidia), gpu-vulkan via "vulkan" in tc_kinds, gpu-metal not.
     m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
-                      nvidia=(accel.Gpu("nvidia", "x", 12288),),
                       apple_silicon=False, dml_adapters=(),
                       installed=frozenset({"llamacpp_gemma"}),
-                      fingerprint="t", tc_kinds=("cpu", "vulkan"))
+                      fingerprint="t", tc_kinds=("cpu", "vulkan"),
+                      gpus=(("cuda", "NVIDIA x", 12288),))
     plans = accel.resolve_deployments(catalog.translate_model("translategemma-4b"), m)
     seen = []
     for p in plans:

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -210,9 +210,15 @@ def _tier_available(tier: str, machine: Machine) -> bool:
         return bool(machine.dml_adapters)
     if tier == "gpu-vulkan":
         # transcribe.cpp's own probe is authoritative (sees AMD/Intel Vulkan
-        # devices); NVIDIA-by-description and DML remain as fallbacks.
-        return ("vulkan" in machine.tc_kinds or has_nvidia(machine)
-                or bool(machine.dml_adapters))
+        # devices); NVIDIA-by-description and DML remain as fallbacks. Gated to
+        # x86_64: the vulkan binaries (llama-server release asset; transcribe.cpp
+        # vulkan build) are x64-only, so a non-x64 host must not be offered a
+        # vulkan plan whose binary it cannot run (P4). NOTE: the dml_adapters
+        # fallback can still light this tier on a DML-only Windows box where no
+        # vulkan binary gets downloaded — reconciled in P5 (owns the DML lane).
+        return (("vulkan" in machine.tc_kinds or has_nvidia(machine)
+                 or bool(machine.dml_adapters))
+                and machine.arch in ("x86_64", "AMD64"))
     return False
 
 

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -253,15 +253,18 @@ def _opus_repo(mid: str) -> str:
 
 def _llm_translate_row(mid, name, family, sort_order, default_quant, default_bytes,
                        alt_quant, alt_bytes, recommended=False):
-    """An LLM card: one llamacpp backend, two GGUF quant variants, three tiers
-    each. The same GGUF serves every tier; rank 2.0 marks the default quant."""
+    """An LLM card: one llamacpp backend, two GGUF quant variants, four tiers
+    each (gpu-cuda / gpu-metal / gpu-vulkan / cpu). The same GGUF serves every
+    tier; rank 2.0 marks the default quant. Plan ORDER across tiers is decided
+    by accel.TIER_RANK (gpu-cuda/gpu-metal 3.0 > gpu-vulkan 2.5 > cpu 1.0), not
+    by the order of this tuple."""
     backend = f"llamacpp_{family}"
     deps = []
     for quant, nbytes, rank in ((default_quant, default_bytes, 2.0),
                                 (alt_quant, alt_bytes, 1.0)):
         artifact = _gguf_artifact(mid, quant)
         deps += [Deployment(backend, tier, quant, artifact, rank, est_bytes=nbytes)
-                 for tier in ("gpu-cuda", "gpu-metal", "cpu")]
+                 for tier in ("gpu-cuda", "gpu-metal", "gpu-vulkan", "cpu")]
     return TranslateModel(mid, name, ("multi",), tuple(deps),
                           recommended=recommended, sort_order=sort_order,
                           size_bytes=default_bytes)

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -269,6 +269,20 @@ def _install_from_github_tar(flavor: str, dest_dir: str) -> str:
     blob = _fetch(gh_url(asset))
     _verify(asset, blob)
     with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+        # Guard against path-traversal / link tar entries (CVE-2007-4559) BEFORE
+        # extracting. Python 3.12's extractall(filter="data") does this, but the
+        # dev venv is 3.10, so vet members by hand: every entry must resolve
+        # inside dest_dir and be a regular file or directory. This matters
+        # because the Vulkan asset is intentionally unpinned (see ASSET_SHA256),
+        # so _verify only warns — the extraction guard is the fail-safe. The
+        # official ubuntu-vulkan build is exactly binaries + .so's, no links.
+        base = os.path.realpath(dest_dir)
+        for m in tf.getmembers():
+            target = os.path.realpath(os.path.join(dest_dir, m.name))
+            if target != base and not target.startswith(base + os.sep):
+                raise BinaryFetchError(f"unsafe tar entry escapes dest: {m.name!r}")
+            if m.issym() or m.islnk():
+                raise BinaryFetchError(f"link tar entry not allowed: {m.name!r}")
         tf.extractall(dest_dir)
     exe = os.path.join(dest_dir, _exe_name(flavor))
     if not os.path.isfile(exe):

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -72,13 +72,20 @@ def bin_root() -> str:
     return os.path.join(base, BUCKET_VERSION)
 
 
-def _exe_name() -> str:
-    return "llama-server.exe" if platform.system() == "Windows" else "llama"
+def _exe_name(flavor: str | None = None) -> str:
+    if platform.system() == "Windows":
+        return "llama-server.exe"
+    # The official ubuntu-vulkan RELEASE tarball ships a `llama-server` binary
+    # (not the bucket's single-file `llama` app). Keep that name verbatim: it is
+    # what _build_args keys the `serve`-subcommand suppression on.
+    if flavor == "vulkan":
+        return "llama-server"
+    return "llama"
 
 
 def binary_path(flavor: str) -> str | None:
     """Installed binary path for `flavor`, or None when not yet downloaded."""
-    exe = os.path.join(bin_root(), flavor, _exe_name())
+    exe = os.path.join(bin_root(), flavor, _exe_name(flavor))
     return exe if os.path.isfile(exe) else None
 
 
@@ -244,6 +251,40 @@ def _install_from_github(flavor: str, dest_dir: str) -> str:
     return exe
 
 
+def _install_from_github_tar(flavor: str, dest_dir: str) -> str:
+    """Linux: official release tar.gz (currently only the ubuntu-vulkan build).
+    Mirrors the Windows zip path (_install_from_github): extract the archive,
+    then, if the server binary isn't already at the top level, flatten the
+    directory that holds it so its shared libraries (libggml*.so, libllama.so)
+    land next to the exe. Unlike the bucket's single-file `llama`, this ships a
+    `llama-server` binary + .so's under build/bin/.
+
+    glibc note: these are built against Ubuntu's glibc. The first REAL spawn is
+    the compatibility check — a too-old host glibc surfaces as a
+    BackendLoadError from LlamaServerProc.start(). Falling back to a
+    bucket-built vulkan binary is out of scope here."""
+    import io
+    import tarfile
+    asset = {"vulkan": f"llama-{BUCKET_VERSION}-bin-ubuntu-vulkan-x64.tar.gz"}[flavor]
+    blob = _fetch(gh_url(asset))
+    _verify(asset, blob)
+    with tarfile.open(fileobj=io.BytesIO(blob), mode="r:gz") as tf:
+        tf.extractall(dest_dir)
+    exe = os.path.join(dest_dir, _exe_name(flavor))
+    if not os.path.isfile(exe):
+        # tarball nests binaries + shared libs under build/bin/ — flatten
+        # the dir that holds the server so the .so's sit beside it.
+        for root, _dirs, files in os.walk(dest_dir):
+            if _exe_name(flavor) in files and root != dest_dir:
+                for fn in files:
+                    os.replace(os.path.join(root, fn), os.path.join(dest_dir, fn))
+                break
+    if not os.path.isfile(exe):
+        raise BinaryFetchError(f"{_exe_name(flavor)} not found in {asset}")
+    os.chmod(exe, 0o755)
+    return exe
+
+
 _ENSURE_BINARY_LOCK = threading.Lock()
 
 
@@ -277,6 +318,8 @@ def ensure_binary(flavor: str, progress=None) -> str:
         try:
             if platform.system() == "Windows":
                 _install_from_github(flavor, tmp_dir)
+            elif platform.system() == "Linux" and flavor == "vulkan":
+                _install_from_github_tar(flavor, tmp_dir)
             else:
                 _install_from_bucket(flavor, tmp_dir)
             shutil.rmtree(final_dir, ignore_errors=True)
@@ -287,7 +330,7 @@ def ensure_binary(flavor: str, progress=None) -> str:
         except Exception as e:
             shutil.rmtree(tmp_dir, ignore_errors=True)
             raise BinaryFetchError(str(e))
-        return os.path.join(final_dir, _exe_name())
+        return os.path.join(final_dir, _exe_name(flavor))
 
 
 _RESERVED_BYTES = 0

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -52,6 +52,11 @@ ASSET_SHA256: dict[str, str] = {
     "llama-b9835-bin-win-cpu-x64.zip": "982860c8dfc36ee82e41aa0885e1f49faa8d7cf07c7481a83f36fb0154e1c64c",
 }
 # NOTE: linux cpu configs are featcode-keyed; run ensure_binary('cpu') on target machines or extend CANDIDATES when configs are known.
+# The Vulkan-flavor release assets (llama-<ver>-bin-win-vulkan-x64.zip and
+# llama-<ver>-bin-ubuntu-vulkan-x64.tar.gz) are intentionally UNPINNED here:
+# _verify() accepts an unrecorded asset with a stderr warning rather than
+# bricking the first Vulkan users. Record their sha256 on a target machine and
+# add them above (P4 follow-up).
 
 _FLAVORS = {"cuda": "cuda", "metal": "metal", "vulkan": "vulkan", "cpu": "cpu"}
 
@@ -219,6 +224,7 @@ def _install_from_github(flavor: str, dest_dir: str) -> str:
     import zipfile
     assets = {"cuda": [f"llama-{BUCKET_VERSION}-bin-win-cuda-12.4-x64.zip",
                        f"cudart-llama-bin-win-cuda-12.4-x64.zip"],
+              "vulkan": [f"llama-{BUCKET_VERSION}-bin-win-vulkan-x64.zip"],
               "cpu": [f"llama-{BUCKET_VERSION}-bin-win-cpu-x64.zip"]}[flavor]
     for asset in assets:
         blob = _fetch(gh_url(asset))

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -109,8 +109,10 @@ def default_flavor() -> str:
         return "metal"
     # Non-NVIDIA / non-Apple GPU that transcribe.cpp's probe can drive via
     # Vulkan (AMD/Intel discrete or integrated) — the D6 target for the
-    # vulkan llama-server flavor. NVIDIA and Apple are handled above.
-    if "vulkan" in m.tc_kinds:
+    # vulkan llama-server flavor. NVIDIA and Apple are handled above. Gated to
+    # x86_64: the vulkan release asset is x64-only, so a non-x64 host (e.g.
+    # Linux/aarch64) must stay on cpu rather than fetch an unrunnable x64 binary.
+    if "vulkan" in m.tc_kinds and m.arch in ("x86_64", "AMD64"):
         return "vulkan"
     return "cpu"
 

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -53,7 +53,7 @@ ASSET_SHA256: dict[str, str] = {
 }
 # NOTE: linux cpu configs are featcode-keyed; run ensure_binary('cpu') on target machines or extend CANDIDATES when configs are known.
 
-_FLAVORS = {"cuda": "cuda", "metal": "metal", "cpu": "cpu"}
+_FLAVORS = {"cuda": "cuda", "metal": "metal", "vulkan": "vulkan", "cpu": "cpu"}
 
 
 def flavor_for_device(device: str) -> str:
@@ -87,14 +87,19 @@ def gh_url(asset: str) -> str:
 
 def default_flavor() -> str:
     """The best flavor for this machine (drives the model-download dependency):
-    NVIDIA (tc probe) -> cuda, Apple Silicon -> metal, else cpu. AMD/Intel
-    dGPUs stay on cpu until the vulkan flavor lands (P4)."""
+    NVIDIA (tc probe) -> cuda, Apple Silicon -> metal, AMD/Intel via the tc
+    Vulkan probe -> vulkan, else cpu."""
     from . import accel
     m = accel.probe()
     if accel.has_nvidia(m):
         return "cuda"
     if m.apple_silicon:
         return "metal"
+    # Non-NVIDIA / non-Apple GPU that transcribe.cpp's probe can drive via
+    # Vulkan (AMD/Intel discrete or integrated) — the D6 target for the
+    # vulkan llama-server flavor. NVIDIA and Apple are handled above.
+    if "vulkan" in m.tc_kinds:
+        return "vulkan"
     return "cpu"
 
 

--- a/sidecar/sokuji_sidecar/llama_runtime.py
+++ b/sidecar/sokuji_sidecar/llama_runtime.py
@@ -281,8 +281,11 @@ def _install_from_github_tar(flavor: str, dest_dir: str) -> str:
             target = os.path.realpath(os.path.join(dest_dir, m.name))
             if target != base and not target.startswith(base + os.sep):
                 raise BinaryFetchError(f"unsafe tar entry escapes dest: {m.name!r}")
-            if m.issym() or m.islnk():
-                raise BinaryFetchError(f"link tar entry not allowed: {m.name!r}")
+            # Regular files + dirs only. This rejects sym/hardlinks (the classic
+            # CVE-2007-4559 two-step) AND exotic device/fifo members in one check,
+            # matching the comment above — the official build is binaries + .so's.
+            if not (m.isfile() or m.isdir()):
+                raise BinaryFetchError(f"disallowed tar entry type: {m.name!r}")
         tf.extractall(dest_dir)
     exe = os.path.join(dest_dir, _exe_name(flavor))
     if not os.path.isfile(exe):

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -398,6 +398,20 @@ def test_vulkan_tier_from_tc_probe_alone():
     assert plans[0].device == "vulkan"
 
 
+def test_gpu_vulkan_tier_gated_to_x64():
+    # The vulkan binaries (llama-server release asset; transcribe.cpp vulkan
+    # build) are x86_64-only, so a Vulkan-capable non-x64 host must NOT get the
+    # gpu-vulkan tier — otherwise resolve leads with a vulkan plan whose binary
+    # is unrunnable on that arch (P4 review, codex). x64 hosts are unaffected.
+    x64 = _machine(tc=("cpu", "vulkan"))                     # arch defaults to x86_64
+    assert accel._tier_available("gpu-vulkan", x64) is True
+    arm = accel.Machine(os="Linux", arch="aarch64", cpu_cores=8,
+                        apple_silicon=False, dml_adapters=(),
+                        installed=frozenset(), fingerprint="t",
+                        tc_kinds=("cpu", "vulkan"), gpus=())
+    assert accel._tier_available("gpu-vulkan", arm) is False
+
+
 def test_bench_cache_roundtrip(tmp_path, monkeypatch):
     monkeypatch.setenv("SOKUJI_BENCH_DIR", str(tmp_path))
     assert accel.bench_load() == {}  # nothing yet

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -611,8 +611,9 @@ def test_resolve_translate_override_cpu_pins_front():
     m = _machine(gpus=_nv_gpus(),
                  installed=frozenset({"llamacpp_qwen"}))
     plans = accel.resolve_translate("qwen3-0.6b", "cpu", m)
-    assert [p.device for p in plans] == ["cpu", "cpu", "cuda", "cuda"]
-    assert plans[0].device == "cpu" and plans[-1].device == "cuda"
+    assert [p.device for p in plans] == [
+        "cpu", "cpu", "cuda", "cuda", "vulkan", "vulkan"]
+    assert plans[0].device == "cpu" and plans[-1].device == "vulkan"
 
 
 def test_resolve_translate_qwen35_no_longer_self_gates():
@@ -762,7 +763,7 @@ def test_resolve_translate_override_honors_quant_pin():
     m = _machine(gpus=_nv_gpus(),
                  installed=frozenset({"llamacpp_qwen"}))
     plans = accel.resolve_translate("qwen3-0.6b", override="cpu", pin="q8_0", machine=m)
-    assert [p.device for p in plans] == ["cpu", "cuda"]
+    assert [p.device for p in plans] == ["cpu", "cuda", "vulkan"]
     assert all(p.compute_type == "q8_0" for p in plans)
 
 

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -160,7 +160,8 @@ def test_llm_translate_rows_shape():
     assert quants == {"q4_k_m", "q8_0"}
     tiers = {(d.compute_type, d.tier) for d in m.deployments}
     for q in quants:
-        assert {(q, "gpu-cuda"), (q, "gpu-metal"), (q, "cpu")} <= tiers
+        assert {(q, "gpu-cuda"), (q, "gpu-metal"),
+                (q, "gpu-vulkan"), (q, "cpu")} <= tiers
     # default quant (rank 2.0) is q4_k_m for the 4B card
     default = max(m.deployments, key=lambda d: d.rank)
     assert default.compute_type == "q4_k_m"
@@ -169,6 +170,27 @@ def test_llm_translate_rows_shape():
     per_quant = {q: {d.artifact for d in m.deployments if d.compute_type == q}
                  for q in quants}
     assert all(len(a) == 1 for a in per_quant.values())
+
+
+def test_llm_vulkan_tier_ranks_between_cuda_and_cpu():
+    # gpu-vulkan (TIER_RANK 2.5) resolves below gpu-cuda/gpu-metal (3.0) and
+    # above cpu (1.0). Ordering comes from accel.TIER_RANK, not the order of
+    # the tiers tuple in _llm_translate_row.
+    from sokuji_sidecar import accel
+    # Post-P2 Machine shape: NVIDIA presence comes from `gpus` descriptions via
+    # accel.has_nvidia (no `nvidia` field / accel.Gpu class). gpu-cuda is
+    # available (has_nvidia), gpu-vulkan via "vulkan" in tc_kinds, gpu-metal not.
+    m = accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+                      apple_silicon=False, dml_adapters=(),
+                      installed=frozenset({"llamacpp_gemma"}),
+                      fingerprint="t", tc_kinds=("cpu", "vulkan"),
+                      gpus=(("cuda", "NVIDIA x", 12288),))
+    plans = accel.resolve_deployments(catalog.translate_model("translategemma-4b"), m)
+    seen = []
+    for p in plans:
+        if p.tier not in seen:
+            seen.append(p.tier)
+    assert seen == ["gpu-cuda", "gpu-vulkan", "cpu"]   # gpu-metal filtered (no Apple/Metal)
 
 
 def test_small_qwen_defaults_to_q8():

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -21,13 +21,13 @@ def test_flavor_for_device_includes_vulkan():
         rt.flavor_for_device("dml")
 
 
-def _fake_machine(*, gpus=(), apple=False, tc_kinds=()):
-    """default_flavor reads accel.has_nvidia(m) (-> m.gpus), .apple_silicon and
-    .tc_kinds. Post-P2 there is no Machine.nvidia field / accel.Gpu class:
-    NVIDIA presence is derived from the gpus device descriptions. `gpus` items
-    are (kind, description, mem_total) tuples."""
+def _fake_machine(*, gpus=(), apple=False, tc_kinds=(), arch="x86_64"):
+    """default_flavor reads accel.has_nvidia(m) (-> m.gpus), .apple_silicon,
+    .tc_kinds and .arch. Post-P2 there is no Machine.nvidia field / accel.Gpu
+    class: NVIDIA presence is derived from the gpus device descriptions. `gpus`
+    items are (kind, description, mem_total) tuples."""
     return types.SimpleNamespace(gpus=gpus, apple_silicon=apple,
-                                 tc_kinds=tc_kinds)
+                                 tc_kinds=tc_kinds, arch=arch)
 
 
 # An NVIDIA GPU as the tc probe reports it -> accel.has_nvidia() True.
@@ -242,9 +242,9 @@ def test_windows_job_object_import_is_safe_on_non_windows():
     assert rt._windows_job_object(_FakeProc()) is None
 
 
-def _probe_machine(gpus=(), apple=False, tc=()):
+def _probe_machine(gpus=(), apple=False, tc=(), arch="x86_64"):
     from sokuji_sidecar import accel
-    return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
+    return accel.Machine(os="Linux", arch=arch, cpu_cores=8,
                          apple_silicon=apple, dml_adapters=(),
                          installed=frozenset(), fingerprint="t",
                          tc_kinds=tc, gpus=gpus)
@@ -269,6 +269,16 @@ def test_default_flavor_vulkan_for_amd_gpu(monkeypatch):
     monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
         gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),), tc=("cpu", "vulkan")))
     assert rt.default_flavor() == "vulkan"
+
+
+def test_default_flavor_cpu_on_aarch64_vulkan(monkeypatch):
+    # The vulkan llama-server release asset is x86_64-only, so a Vulkan-capable
+    # aarch64 host must stay on cpu rather than download an unrunnable x64 binary
+    # (P4 review, codex). x64 hosts are covered by test_default_flavor_vulkan_for_amd_gpu.
+    from sokuji_sidecar import accel
+    monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
+        gpus=(("vulkan", "ARM Mali-G710", 8 << 30),), tc=("cpu", "vulkan"), arch="aarch64"))
+    assert rt.default_flavor() == "cpu"
 
 
 @pytest.mark.parametrize("brand,cfg", [

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -408,3 +408,36 @@ def test_ubuntu_vulkan_tar_is_unpinned():
     asset = f"llama-{rt.BUCKET_VERSION}-bin-ubuntu-vulkan-x64.tar.gz"
     assert asset not in rt.ASSET_SHA256
     rt._verify(asset, b"anything")   # unknown asset -> stderr warning, no raise
+
+
+def test_install_from_github_tar_rejects_path_traversal(monkeypatch, tmp_path):
+    # The Vulkan tarball is unpinned, so a tampered/MITM'd archive with a
+    # path-traversal member (CVE-2007-4559) must be rejected before extraction,
+    # not written outside dest_dir.
+    monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
+    evil = _tar_gz({"../escaped.txt": b"pwned"})
+    monkeypatch.setattr(rt, "_fetch", lambda url: evil)
+    dest = tmp_path / "vulkan"
+    dest.mkdir()
+    with pytest.raises(rt.BinaryFetchError):
+        rt._install_from_github_tar("vulkan", str(dest))
+    # nothing escaped dest_dir
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_install_from_github_tar_rejects_symlink_member(monkeypatch, tmp_path):
+    # A symlink member (which could point outside dest on later deref) is rejected.
+    import io
+    import tarfile
+    monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        link = tarfile.TarInfo("llama-server")
+        link.type = tarfile.SYMTYPE
+        link.linkname = "/etc/passwd"
+        tf.addfile(link)
+    monkeypatch.setattr(rt, "_fetch", lambda url: buf.getvalue())
+    dest = tmp_path / "vulkan"
+    dest.mkdir()
+    with pytest.raises(rt.BinaryFetchError):
+        rt._install_from_github_tar("vulkan", str(dest))

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -307,3 +307,39 @@ def test_metal_config_two_digit_chip_degrades(monkeypatch, capsys):
     monkeypatch.setattr(rt.subprocess, "run", lambda *a, **k: R())
     assert rt._metal_config() == "m5"
     assert "unknown Apple chip" in capsys.readouterr().err
+
+
+import zipfile
+
+
+def _win_zip(names):
+    """A minimal Windows release zip: `names` at the archive top level."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for n in names:
+            z.writestr(n, b"MZfake")
+    return buf.getvalue()
+
+
+def test_install_from_github_vulkan_single_asset(monkeypatch, tmp_path):
+    monkeypatch.setattr(rt.platform, "system", lambda: "Windows")
+    fetched = []
+
+    def fake_fetch(url):
+        fetched.append(url)
+        return _win_zip(["llama-server.exe", "ggml.dll"])
+    monkeypatch.setattr(rt, "_fetch", fake_fetch)
+
+    dest = tmp_path / "vulkan"
+    dest.mkdir()
+    exe = rt._install_from_github("vulkan", str(dest))
+    assert os.path.basename(exe) == "llama-server.exe"
+    assert os.path.isfile(exe)
+    # exactly one asset: unlike cuda, win-vulkan has no cudart companion zip
+    assert fetched == [rt.gh_url(f"llama-{rt.BUCKET_VERSION}-bin-win-vulkan-x64.zip")]
+
+
+def test_win_vulkan_asset_is_unpinned():
+    asset = f"llama-{rt.BUCKET_VERSION}-bin-win-vulkan-x64.zip"
+    assert asset not in rt.ASSET_SHA256          # intentionally unpinned (P4 follow-up)
+    rt._verify(asset, b"anything")               # unknown asset -> stderr warning, no raise

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -343,3 +343,68 @@ def test_win_vulkan_asset_is_unpinned():
     asset = f"llama-{rt.BUCKET_VERSION}-bin-win-vulkan-x64.zip"
     assert asset not in rt.ASSET_SHA256          # intentionally unpinned (P4 follow-up)
     rt._verify(asset, b"anything")               # unknown asset -> stderr warning, no raise
+
+
+import tarfile
+
+
+def _tar_gz(files):
+    """A minimal gzip tarball: {member_path: bytes}."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for name, data in files.items():
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
+def test_exe_name_vulkan_is_server_on_linux(monkeypatch):
+    monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
+    assert rt._exe_name("vulkan") == "llama-server"
+    assert rt._exe_name("cuda") == "llama"
+    assert rt._exe_name() == "llama"
+
+
+def test_exe_name_windows_ignores_flavor(monkeypatch):
+    monkeypatch.setattr(rt.platform, "system", lambda: "Windows")
+    assert rt._exe_name("vulkan") == "llama-server.exe"
+    assert rt._exe_name("cuda") == "llama-server.exe"
+
+
+def test_binary_path_vulkan_uses_server_name(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOKUJI_LLAMA_BIN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
+    d = tmp_path / rt.BUCKET_VERSION / "vulkan"
+    d.mkdir(parents=True)
+    (d / "llama-server").write_bytes(b"ELF")
+    assert rt.binary_path("vulkan") == str(d / "llama-server")
+
+
+def test_ensure_binary_vulkan_extracts_ubuntu_tarball(monkeypatch, tmp_path):
+    monkeypatch.setenv("SOKUJI_LLAMA_BIN_DIR", str(tmp_path))
+    monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(rt.platform, "machine", lambda: "x86_64")
+    blob = _tar_gz({"build/bin/llama-server": b"ELF-vulkan-server",
+                    "build/bin/libggml-vulkan.so": b"SO"})
+    fetched = []
+
+    def fake_fetch(url):
+        fetched.append(url)
+        return blob
+    monkeypatch.setattr(rt, "_fetch", fake_fetch)
+
+    path = rt.ensure_binary("vulkan")
+    assert path == rt.binary_path("vulkan")
+    assert os.path.basename(path) == "llama-server"
+    assert open(path, "rb").read() == b"ELF-vulkan-server"
+    assert os.access(path, os.X_OK)
+    # the shared lib was flattened out of build/bin/ to sit beside the exe
+    assert os.path.isfile(os.path.join(os.path.dirname(path), "libggml-vulkan.so"))
+    assert fetched == [rt.gh_url(f"llama-{rt.BUCKET_VERSION}-bin-ubuntu-vulkan-x64.tar.gz")]
+
+
+def test_ubuntu_vulkan_tar_is_unpinned():
+    asset = f"llama-{rt.BUCKET_VERSION}-bin-ubuntu-vulkan-x64.tar.gz"
+    assert asset not in rt.ASSET_SHA256
+    rt._verify(asset, b"anything")   # unknown asset -> stderr warning, no raise

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -427,8 +427,6 @@ def test_install_from_github_tar_rejects_path_traversal(monkeypatch, tmp_path):
 
 def test_install_from_github_tar_rejects_symlink_member(monkeypatch, tmp_path):
     # A symlink member (which could point outside dest on later deref) is rejected.
-    import io
-    import tarfile
     monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w:gz") as tf:
@@ -436,6 +434,22 @@ def test_install_from_github_tar_rejects_symlink_member(monkeypatch, tmp_path):
         link.type = tarfile.SYMTYPE
         link.linkname = "/etc/passwd"
         tf.addfile(link)
+    monkeypatch.setattr(rt, "_fetch", lambda url: buf.getvalue())
+    dest = tmp_path / "vulkan"
+    dest.mkdir()
+    with pytest.raises(rt.BinaryFetchError):
+        rt._install_from_github_tar("vulkan", str(dest))
+
+
+def test_install_from_github_tar_rejects_exotic_member(monkeypatch, tmp_path):
+    # Regular files + dirs only: an exotic (fifo/device) member is rejected too,
+    # matching the guard's "regular file or directory" contract.
+    monkeypatch.setattr(rt.platform, "system", lambda: "Linux")
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        fifo = tarfile.TarInfo("llama-server")
+        fifo.type = tarfile.FIFOTYPE
+        tf.addfile(fifo)
     monkeypatch.setattr(rt, "_fetch", lambda url: buf.getvalue())
     dest = tmp_path / "vulkan"
     dest.mkdir()

--- a/sidecar/tests/test_llama_runtime.py
+++ b/sidecar/tests/test_llama_runtime.py
@@ -1,4 +1,6 @@
 import os
+import types
+
 import pytest
 
 from sokuji_sidecar import llama_runtime as rt
@@ -10,6 +12,52 @@ def test_flavor_for_device():
     assert rt.flavor_for_device("cpu") == "cpu"
     with pytest.raises(KeyError):
         rt.flavor_for_device("dml")
+
+
+def test_flavor_for_device_includes_vulkan():
+    assert rt.flavor_for_device("vulkan") == "vulkan"
+    # dml is still unsupported (P5's DML lane is not a llama.cpp flavor)
+    with pytest.raises(KeyError):
+        rt.flavor_for_device("dml")
+
+
+def _fake_machine(*, gpus=(), apple=False, tc_kinds=()):
+    """default_flavor reads accel.has_nvidia(m) (-> m.gpus), .apple_silicon and
+    .tc_kinds. Post-P2 there is no Machine.nvidia field / accel.Gpu class:
+    NVIDIA presence is derived from the gpus device descriptions. `gpus` items
+    are (kind, description, mem_total) tuples."""
+    return types.SimpleNamespace(gpus=gpus, apple_silicon=apple,
+                                 tc_kinds=tc_kinds)
+
+
+# An NVIDIA GPU as the tc probe reports it -> accel.has_nvidia() True.
+_NV = (("cuda", "NVIDIA GeForce RTX 4070", 12 << 30),)
+
+
+def test_default_flavor_matrix(monkeypatch):
+    from sokuji_sidecar import accel
+    cases = [
+        (_fake_machine(gpus=_NV), "cuda"),
+        (_fake_machine(gpus=_NV, tc_kinds=("cpu", "vulkan")), "cuda"),        # nvidia wins
+        (_fake_machine(apple=True), "metal"),
+        (_fake_machine(apple=True, tc_kinds=("cpu", "vulkan")), "metal"),     # apple wins
+        (_fake_machine(tc_kinds=("cpu", "vulkan")), "vulkan"),               # AMD/Intel GPU
+        (_fake_machine(tc_kinds=("cpu",)), "cpu"),                            # cpu-only probe
+        (_fake_machine(), "cpu"),                                             # nothing detected
+    ]
+    for machine, expected in cases:
+        monkeypatch.setattr(accel, "probe", lambda force=False, m=machine: m)
+        assert rt.default_flavor() == expected, expected
+
+
+def test_required_flavors_vulkan_adds_cpu_floor(monkeypatch):
+    monkeypatch.setattr(rt, "default_flavor", lambda: "vulkan")
+    assert rt.required_flavors() == ["vulkan", "cpu"]
+
+
+def test_required_flavors_cpu_only_is_single(monkeypatch):
+    monkeypatch.setattr(rt, "default_flavor", lambda: "cpu")
+    assert rt.required_flavors() == ["cpu"]
 
 
 def test_bin_root_env_override(monkeypatch, tmp_path):
@@ -194,11 +242,12 @@ def test_windows_job_object_import_is_safe_on_non_windows():
     assert rt._windows_job_object(_FakeProc()) is None
 
 
-def _probe_machine(gpus=(), apple=False):
+def _probe_machine(gpus=(), apple=False, tc=()):
     from sokuji_sidecar import accel
     return accel.Machine(os="Linux", arch="x86_64", cpu_cores=8,
                          apple_silicon=apple, dml_adapters=(),
-                         installed=frozenset(), fingerprint="t", gpus=gpus)
+                         installed=frozenset(), fingerprint="t",
+                         tc_kinds=tc, gpus=gpus)
 
 
 def test_default_flavor_cuda_from_tc_probe(monkeypatch):
@@ -214,12 +263,12 @@ def test_default_flavor_metal_on_apple(monkeypatch):
     assert rt.default_flavor() == "metal"
 
 
-def test_default_flavor_cpu_for_non_nvidia_gpu(monkeypatch):
-    # AMD/Intel GPUs get no cuda flavor; the vulkan flavor arrives in P4.
+def test_default_flavor_vulkan_for_amd_gpu(monkeypatch):
+    # P4: an AMD/Intel GPU the tc probe drives via Vulkan selects the vulkan flavor.
     from sokuji_sidecar import accel
     monkeypatch.setattr(accel, "probe", lambda force=False: _probe_machine(
-        gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),)))
-    assert rt.default_flavor() == "cpu"
+        gpus=(("vulkan", "AMD Radeon RX 7800 XT", 16 << 30),), tc=("cpu", "vulkan")))
+    assert rt.default_flavor() == "vulkan"
 
 
 @pytest.mark.parametrize("brand,cfg", [


### PR DESCRIPTION
## P4 — llama.cpp Vulkan flavor (D6)

Fourth workstream of the sidecar multi-platform hardware-acceleration refactor. Gives the `llamacpp_*` translation backends a `vulkan` binary flavor so AMD/Intel (and any non-NVIDIA discrete) GPUs accelerate the translation LLMs.

### Changes
- **Flavor selection** — `default_flavor()` becomes NVIDIA→cuda (via the P2 `accel.has_nvidia` tc probe), Apple→metal, non-NVIDIA/non-Apple GPU with a tc Vulkan probe→**vulkan**, else cpu. `_FLAVORS` learns `vulkan`; `required_flavors()` inherits it (fetches the vulkan binary + the cpu floor).
- **Windows acquisition** — `_install_from_github` fetches the single `llama-<ver>-bin-win-vulkan-x64.zip` (no cudart companion, unlike cuda).
- **Linux acquisition** — new `_install_from_github_tar` extracts the official `ubuntu-vulkan-x64.tar.gz`. That build ships a `llama-server` binary (not the bucket's single-file `llama`), so `_exe_name` became flavor-aware (`_exe_name("vulkan")`→`"llama-server"`) and `binary_path`/`ensure_binary` route through it. The name is preserved so `_build_args`' `startswith("llama-server")` still suppresses the `serve` subcommand.
- **Catalog** — every LLM translate card gains a `gpu-vulkan` tier per quant, ranked by `accel.TIER_RANK` (cuda/metal 3.0 > vulkan 2.5 > cpu 1.0), not tuple order.

### Security
An automated review flagged CVE-2007-4559 (path traversal) in the new tarball extraction: the Vulkan asset is intentionally unpinned in `ASSET_SHA256` (`_verify` only warns), so unsanitized `extractall` could let a tampered/MITM'd archive write outside the destination via `../` members or symlinks. Added a **3.10-compatible member guard** (no 3.12 `filter=` kwarg) that runs before extraction: it rejects any member whose resolved path escapes `dest_dir`, and — after final review — any non-regular-file/dir member (sym/hard links, devices, fifos). Covered by traversal / symlink / exotic-member tests.

### Testing
- Full sidecar suite: **453 passed / 13 skipped**. The single failure (`test_qwen_tokenizer::test_golden_parity_with_transformers`) is a pre-existing dirty-dev-venv artifact (`huggingface_hub`/`transformers` skew), unrelated to this branch.
- All acquisition/extraction paths are exercised on Linux via stubbed `_fetch`/`platform.system` + synthetic archives.

### Deferred (require physical non-NVIDIA / Windows hardware — see the plan's Deferred section)
- Confirm the two Vulkan release assets resolve at `BUCKET_VERSION` and record + **pin** their sha256 in `ASSET_SHA256`.
- Windows non-NVIDIA GPU and Linux AMD/Intel end-to-end (glibc-compat spawn + `gpu-vulkan` tier selection).

### Review
Executed via subagent-driven development (fresh implementer + task reviewer per task; opus whole-branch review). Final verdict: **READY TO MERGE** — security guard confirmed sufficient, no Critical/Important findings.

Depends on: P1 (#280), P2 (#281), P3 (#282) — all merged. Unblocks: P7 (bundle packaging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ee4BrrMH8msZQDJ1qoX7SE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Vulkan support to model deployment and runtime binary selection.
  * Linux and Windows can now fetch and run the Vulkan-flavored binary.
  * Deployment tiers now include a Vulkan option alongside CUDA, Metal, and CPU.

* **Bug Fixes**
  * Updated device-based flavor selection so Vulkan-capable systems choose the correct runtime.
  * Refined tier ordering so Vulkan is ranked between GPU-specific tiers and CPU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->