### PR TITLE
feat(native): tier-badge tooltip with inference framework + device details

### DIFF
--- a/docs/superpowers/plans/2026-07-08-native-model-backend-tooltip.md
+++ b/docs/superpowers/plans/2026-07-08-native-model-backend-tooltip.md
@@ -1,0 +1,474 @@
+# Native model tier-badge backend/device tooltip — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Hovering a native model card's tier badge shows an info tooltip listing the inference framework, device, acceleration API, and (when loaded) precision/speed/memory/fallback, plus model size and repo.
+
+**Architecture:** Pure formatting helpers in `nativeCatalog.ts` build an ordered list of `{key, value, warn?}` rows from the catalog `NativeModelInfo` (idle) and the store's per-stage resolved plan (active). `NativeModelManagementSection` renders those rows inside the existing `Tooltip` wrapping the existing tier badge. Runtime `backend`/`computeType` are already sent by the sidecar `ready` message and returned by the `Native*Client.init` methods; the only plumbing is to stop dropping them in `LocalNativeClient`/the store. No sidecar, protocol, or MainPanel changes.
+
+**Tech Stack:** React + TypeScript (strict), Zustand store, i18next (`t(key, defaultEnglish)`), vitest + @testing-library/react.
+
+## Global Constraints
+
+- English only in code/comments. Follow existing patterns: i18n via `t('models.<key>', 'English default')`; the `Tooltip` component (`content` accepts `ReactNode`, props `position`/`icon`/`trigger`); the existing formatters `formatMemMb(mb)`, `formatRtf(rtf)`, `formatTps(tps)`.
+- Frontend only re-labels/formats data that already comes from the sidecar (`models_catalog_result` + per-stage `ready`). No new sidecar messages, no protocol changes, no changes to MainPanel/ConnectionStatus.
+- Framework taxonomy is engine/library level, 7 labels: `transcribe.cpp`, `CTranslate2`, `llama.cpp`, `ONNXRuntime`, `sherpa-onnx`, `Supertonic`, `MLX`.
+- Tests run with `npx vitest run <file>`. TypeScript strict mode.
+
+## File Structure
+
+- `src/lib/local-inference/native/nativeCatalog.ts` — add `frameworkLabel`, `accelApiLabel`, `buildBackendTooltipRows` (pure, unit-tested). It already exports `tierLabel`, `resolvedTierState`, `formatMemMb`, `formatRtf`, `formatTps`.
+- `src/lib/local-inference/native/nativeCatalog.test.ts` — add tests for the new helpers (create file if absent).
+- `src/stores/nativeModelStore.ts` — widen the three `*Resolved` shapes + setters with `backend?`/`computeType?`.
+- `src/services/clients/LocalNativeClient.ts` — pass `backend`/`computeType` into the three `store.set*Resolved(...)` calls (the `Native*Client.init` results already carry them).
+- `src/components/Settings/sections/NativeModelManagementSection.tsx` — widen local `CardResolved`; build rows; wrap the tier badge in `Tooltip`.
+- `src/components/Settings/sections/TierIcon.tsx` — drop the native `title` (keep `aria-label`) so there is one tooltip on the badge.
+- `src/locales/{en,zh_CN,zh_TW}/translation.json` — add the eight `models.hw*` label keys.
+
+---
+
+### Task 1: Pure tooltip-content helpers in `nativeCatalog.ts`
+
+**Files:**
+- Modify: `src/lib/local-inference/native/nativeCatalog.ts`
+- Test: `src/lib/local-inference/native/nativeCatalog.test.ts`
+
+**Interfaces:**
+- Produces: `frameworkLabel(backendId: string): string`; `accelApiLabel(tier: string): string | null`; `type BackendTooltipRow = { key: string; value: string; warn?: boolean }`; `buildBackendTooltipRows(input: { tier: string; backendId?: string; resolved?: { computeType?: string; rtf?: number; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null; sizeMb?: number | null; repo?: string }): BackendTooltipRow[]`.
+- Consumes: existing `formatMemMb`, `formatRtf`, `formatTps` from the same file.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/lib/local-inference/native/nativeCatalog.test.ts` (create the file with the import header if it does not exist):
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { frameworkLabel, accelApiLabel, buildBackendTooltipRows } from './nativeCatalog';
+
+describe('frameworkLabel', () => {
+  it('maps every known backend id to its engine label', () => {
+    const cases: Record<string, string> = {
+      transcribe_cpp: 'transcribe.cpp',
+      transcribe_cpp_stream: 'transcribe.cpp',
+      ct2_opus_translate: 'CTranslate2',
+      llamacpp_qwen: 'llama.cpp',
+      llamacpp_hunyuan: 'llama.cpp',
+      llamacpp_gemma: 'llama.cpp',
+      moss_onnx: 'ONNXRuntime',
+      qwen3tts_onnx: 'ONNXRuntime',
+      sherpa_tts: 'sherpa-onnx',
+      supertonic: 'Supertonic',
+      mlx_audio_tts: 'MLX',
+    };
+    for (const [id, label] of Object.entries(cases)) expect(frameworkLabel(id)).toBe(label);
+  });
+  it('derives future ids by prefix, else echoes the raw id', () => {
+    expect(frameworkLabel('llamacpp_newmodel')).toBe('llama.cpp');
+    expect(frameworkLabel('foo_onnx')).toBe('ONNXRuntime');
+    expect(frameworkLabel('transcribe_cpp_x')).toBe('transcribe.cpp');
+    expect(frameworkLabel('brand_new_backend')).toBe('brand_new_backend');
+  });
+});
+
+describe('accelApiLabel', () => {
+  it('names the GPU API and returns null for cpu/unknown', () => {
+    expect(accelApiLabel('gpu-cuda')).toBe('CUDA');
+    expect(accelApiLabel('gpu-metal')).toBe('Metal');
+    expect(accelApiLabel('gpu-vulkan')).toBe('Vulkan');
+    expect(accelApiLabel('gpu-dml')).toBe('DirectML');
+    expect(accelApiLabel('cpu')).toBeNull();
+    expect(accelApiLabel('weird')).toBeNull();
+  });
+});
+
+describe('buildBackendTooltipRows', () => {
+  it('idle GPU tier: framework/device/api/size/repo, no runtime rows', () => {
+    const rows = buildBackendTooltipRows({
+      tier: 'gpu-vulkan', backendId: 'llamacpp_gemma', resolved: null, sizeMb: 1843, repo: 'org/model',
+    });
+    expect(rows.map((r) => r.key)).toEqual(['framework', 'device', 'api', 'size', 'repo']);
+    expect(rows[0]).toEqual({ key: 'framework', value: 'llama.cpp' });
+    expect(rows[1]).toEqual({ key: 'device', value: 'GPU' });
+    expect(rows[2]).toEqual({ key: 'api', value: 'Vulkan' });
+    expect(rows.find((r) => r.key === 'size')?.value).toBe('1.8 GB');
+  });
+  it('idle CPU tier: no api row, still has framework/device/size', () => {
+    const rows = buildBackendTooltipRows({ tier: 'cpu', backendId: 'ct2_opus_translate', resolved: null, sizeMb: 300 });
+    expect(rows.map((r) => r.key)).toEqual(['framework', 'device', 'size']);
+    expect(rows[1]).toEqual({ key: 'device', value: 'CPU' });
+    expect(rows[0].value).toBe('CTranslate2');
+  });
+  it('active tier adds precision/speed/memory from the resolved plan', () => {
+    const rows = buildBackendTooltipRows({
+      tier: 'gpu-cuda', backendId: 'moss_onnx',
+      resolved: { computeType: 'int8', rtf: 0.02, memoryBytes: 3_400_000_000 },
+      sizeMb: 100, repo: 'org/tts',
+    });
+    const byKey = Object.fromEntries(rows.map((r) => [r.key, r.value]));
+    expect(byKey.precision).toBe('INT8');
+    expect(byKey.speed).toBe('50× realtime');
+    expect(byKey.memory).toBe('3.2 GB');
+  });
+  it('translate speed uses tok/s; empty tps omits the speed row', () => {
+    const withTps = buildBackendTooltipRows({ tier: 'cpu', backendId: 'ct2_opus_translate', resolved: { tokensPerSec: 131 } });
+    expect(withTps.find((r) => r.key === 'speed')?.value).toBe('131 tok/s');
+    const zeroTps = buildBackendTooltipRows({ tier: 'cpu', backendId: 'ct2_opus_translate', resolved: { tokensPerSec: 0 } });
+    expect(zeroTps.find((r) => r.key === 'speed')).toBeUndefined();
+  });
+  it('fallbackReason becomes a trailing warn row', () => {
+    const rows = buildBackendTooltipRows({ tier: 'cpu', backendId: 'llamacpp_gemma', resolved: { fallbackReason: 'Low VRAM → CPU' } });
+    const last = rows[rows.length - 1];
+    expect(last).toEqual({ key: 'fallback', value: 'Low VRAM → CPU', warn: true });
+  });
+  it('omits the framework row when no backend id is known', () => {
+    const rows = buildBackendTooltipRows({ tier: 'cpu', resolved: null, sizeMb: 10 });
+    expect(rows.find((r) => r.key === 'framework')).toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: FAIL — `frameworkLabel`/`accelApiLabel`/`buildBackendTooltipRows` are not exported.
+
+- [ ] **Step 3: Implement the helpers**
+
+Add to `src/lib/local-inference/native/nativeCatalog.ts` (near `tierLabel`, after the `formatMemMb`/`formatRtf`/`formatTps` definitions so it can call them):
+
+```ts
+/** One row of the model-card backend/device tooltip. `key` selects the localized
+ *  label in the component; `warn` marks the degraded/fallback row. */
+export type BackendTooltipRow = { key: string; value: string; warn?: boolean };
+
+const FRAMEWORK_LABELS: Record<string, string> = {
+  transcribe_cpp: 'transcribe.cpp',
+  transcribe_cpp_stream: 'transcribe.cpp',
+  ct2_opus_translate: 'CTranslate2',
+  llamacpp_qwen: 'llama.cpp',
+  llamacpp_hunyuan: 'llama.cpp',
+  llamacpp_gemma: 'llama.cpp',
+  moss_onnx: 'ONNXRuntime',
+  qwen3tts_onnx: 'ONNXRuntime',
+  sherpa_tts: 'sherpa-onnx',
+  supertonic: 'Supertonic',
+  mlx_audio_tts: 'MLX',
+};
+
+/** Engine/library label for a sidecar backend id. Falls back by prefix so a new
+ *  llamacpp_*/*_onnx/transcribe_cpp* id still resolves, else echoes the raw id. */
+export function frameworkLabel(backendId: string): string {
+  if (FRAMEWORK_LABELS[backendId]) return FRAMEWORK_LABELS[backendId];
+  if (backendId.startsWith('llamacpp_')) return 'llama.cpp';
+  if (backendId.startsWith('transcribe_cpp')) return 'transcribe.cpp';
+  if (backendId.endsWith('_onnx')) return 'ONNXRuntime';
+  return backendId;
+}
+
+/** Hardware acceleration API for a GPU tier; null for cpu/unknown (no API row). */
+export function accelApiLabel(tier: string): string | null {
+  switch (tier) {
+    case 'gpu-cuda': return 'CUDA';
+    case 'gpu-metal': return 'Metal';
+    case 'gpu-vulkan': return 'Vulkan';
+    case 'gpu-dml': return 'DirectML';
+    default: return null;
+  }
+}
+
+/** Ordered rows for the tier-badge tooltip. `resolved` present = model loaded
+ *  (adds precision/speed/memory/fallback); null/undefined = idle catalog view. */
+export function buildBackendTooltipRows(input: {
+  tier: string;
+  backendId?: string;
+  resolved?: { computeType?: string; rtf?: number; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  sizeMb?: number | null;
+  repo?: string;
+}): BackendTooltipRow[] {
+  const { tier, backendId, resolved, sizeMb, repo } = input;
+  const rows: BackendTooltipRow[] = [];
+  if (backendId) rows.push({ key: 'framework', value: frameworkLabel(backendId) });
+  rows.push({ key: 'device', value: tier === 'cpu' ? 'CPU' : 'GPU' });
+  const api = accelApiLabel(tier);
+  if (api) rows.push({ key: 'api', value: api });
+  if (resolved?.computeType) rows.push({ key: 'precision', value: resolved.computeType.toUpperCase() });
+  if (resolved) {
+    if (resolved.rtf !== undefined) rows.push({ key: 'speed', value: formatRtf(resolved.rtf) });
+    else if (resolved.tokensPerSec !== undefined) {
+      const tps = formatTps(resolved.tokensPerSec);
+      if (tps) rows.push({ key: 'speed', value: tps });
+    }
+  }
+  if (resolved?.memoryBytes) rows.push({ key: 'memory', value: formatMemMb(Math.round(resolved.memoryBytes / 1_048_576)) });
+  if (sizeMb != null) rows.push({ key: 'size', value: formatMemMb(sizeMb) });
+  if (repo) rows.push({ key: 'repo', value: repo });
+  if (resolved?.fallbackReason) rows.push({ key: 'fallback', value: resolved.fallbackReason, warn: true });
+  return rows;
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts`
+Expected: PASS (all cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/native/nativeCatalog.ts src/lib/local-inference/native/nativeCatalog.test.ts
+git commit -m "feat(native): backend/device tooltip row helpers"
+```
+
+---
+
+### Task 2: Keep `backend`/`computeType` on the resolved plan
+
+**Files:**
+- Modify: `src/stores/nativeModelStore.ts` (three `*Resolved` shapes + setter signatures)
+- Modify: `src/services/clients/LocalNativeClient.ts` (three `set*Resolved` calls)
+- Test: `src/stores/nativeModelStore.test.ts`
+
+**Interfaces:**
+- Produces: `asrResolved`/`translationResolved`/`ttsResolved` now optionally carry `backend?: string; computeType?: string`. The `Native*Client.init` results already return `backend`/`computeType` (no change there).
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `src/stores/nativeModelStore.test.ts`:
+
+```ts
+it('resolved plans retain backend and computeType', () => {
+  const s = useNativeModelStore.getState();
+  s.setAsrResolved({ model: 'a', device: 'cuda', backend: 'moss_onnx', computeType: 'int8', rtf: 0.02 });
+  expect(useNativeModelStore.getState().asrResolved).toMatchObject({ backend: 'moss_onnx', computeType: 'int8' });
+  s.setTranslationResolved({ model: 't', device: 'cpu', backend: 'ct2_opus_translate', computeType: 'int8', tokensPerSec: 120 });
+  expect(useNativeModelStore.getState().translationResolved).toMatchObject({ backend: 'ct2_opus_translate', computeType: 'int8' });
+  s.setTtsResolved({ model: 'v', device: 'metal', backend: 'mlx_audio_tts', computeType: 'fp32' });
+  expect(useNativeModelStore.getState().ttsResolved).toMatchObject({ backend: 'mlx_audio_tts', computeType: 'fp32' });
+});
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `npx vitest run src/stores/nativeModelStore.test.ts`
+Expected: FAIL — TypeScript rejects `backend`/`computeType` on the resolved shapes (excess property), or the fields are dropped.
+
+- [ ] **Step 3: Widen the store shapes**
+
+In `src/stores/nativeModelStore.ts`, add `backend?: string; computeType?: string;` to each of the three resolved fields AND their setter parameter types. The three state fields (currently around lines 70/72/76) and the three setter signatures (currently around lines 78/79/81) become:
+
+```ts
+  asrResolved: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  translationResolved: { model: string; device: string; backend?: string; computeType?: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  ttsResolved: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  setAsrResolved: (r: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
+  setTranslationResolved: (r: { model: string; device: string; backend?: string; computeType?: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
+  setTtsResolved: (r: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
+```
+
+The setter bodies (`set({ asrResolved: r })` etc.) are unchanged — they already store the whole object.
+
+- [ ] **Step 4: Pass the fields through in LocalNativeClient**
+
+In `src/services/clients/LocalNativeClient.ts`, add `backend`/`computeType` to the three `store.set*Resolved({...})` calls (the `tr`/`res`/`r` results already contain them):
+
+```ts
+      store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu', backend: tr.backend, computeType: tr.computeType, tokensPerSec: tr.tokensPerSec, memoryBytes: tr.memoryBytes, fallbackReason: tr.fallbackReason });
+```
+```ts
+        store.setAsrResolved({ model: config.asrModelId, device: res.device ?? 'cpu', backend: res.backend, computeType: res.computeType, rtf: res.rtf, memoryBytes: res.memoryBytes, fallbackReason: res.fallbackReason });
+```
+```ts
+        store.setTtsResolved({ model: config.ttsModelId!, device: r.device ?? 'cpu', backend: r.backend, computeType: r.computeType, rtf: r.rtf, memoryBytes: r.memoryBytes, fallbackReason: r.fallbackReason });
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `npx vitest run src/stores/nativeModelStore.test.ts`
+Expected: PASS. Also run `npx vitest run src/services/clients/LocalNativeClient.test.ts` if it exists (should still pass).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/stores/nativeModelStore.ts src/services/clients/LocalNativeClient.ts src/stores/nativeModelStore.test.ts
+git commit -m "feat(native): retain resolved backend + computeType through the store"
+```
+
+---
+
+### Task 3: Render the tooltip on the tier badge + i18n + single tooltip
+
+**Files:**
+- Modify: `src/components/Settings/sections/NativeModelManagementSection.tsx`
+- Modify: `src/components/Settings/sections/TierIcon.tsx` (+ `TierIcon.test.tsx` if it asserts `title`)
+- Modify: `src/locales/en/translation.json`, `src/locales/zh_CN/translation.json`, `src/locales/zh_TW/translation.json`
+- Test: `src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+
+**Interfaces:**
+- Consumes: `frameworkLabel`, `buildBackendTooltipRows`, `BackendTooltipRow` from Task 1; the widened resolved shape from Task 2; the existing `Tooltip` component (already imported at the top of the section).
+
+- [ ] **Step 1: Add the i18n label keys**
+
+In each of `src/locales/en/translation.json`, `src/locales/zh_CN/translation.json`, `src/locales/zh_TW/translation.json`, add these sibling keys inside the existing top-level `models` object (keep the JSON valid — add a comma after the previous last key):
+
+en:
+```json
+"hwFramework": "Engine",
+"hwDevice": "Device",
+"hwApi": "Acceleration",
+"hwPrecision": "Precision",
+"hwSpeed": "Speed",
+"hwMemory": "Memory",
+"hwSize": "Size",
+"hwRepo": "Repo"
+```
+zh_CN:
+```json
+"hwFramework": "推理引擎",
+"hwDevice": "设备",
+"hwApi": "加速 API",
+"hwPrecision": "精度",
+"hwSpeed": "速度",
+"hwMemory": "内存",
+"hwSize": "模型大小",
+"hwRepo": "仓库"
+```
+zh_TW:
+```json
+"hwFramework": "推理引擎",
+"hwDevice": "裝置",
+"hwApi": "加速 API",
+"hwPrecision": "精度",
+"hwSpeed": "速度",
+"hwMemory": "記憶體",
+"hwSize": "模型大小",
+"hwRepo": "倉庫"
+```
+
+- [ ] **Step 2: Remove TierIcon's native title**
+
+In `src/components/Settings/sections/TierIcon.tsx`, drop `title={label}` from the wrapper span (keep `aria-label` for a11y):
+
+```tsx
+    <span role="img" aria-label={label} data-tier={tier} className="tier-icon">
+```
+
+Check `src/components/Settings/sections/TierIcon.test.tsx`: if any assertion reads the `title` attribute, change it to assert `aria-label` (same value). Run `npx vitest run src/components/Settings/sections/TierIcon.test.tsx` — expect PASS.
+
+- [ ] **Step 3: Write the failing section test**
+
+Add to `src/components/Settings/sections/NativeModelManagementSection.test.tsx` (follow the file's existing render/query idiom and imports). The test renders one card idle and one active and asserts the framework label text appears in the tooltip content. If the existing suite renders whole `NativeModelManagementSection`, mirror its setup; otherwise render the exported card. Assert on the tooltip content the component renders:
+
+```tsx
+it('tier badge tooltip lists the inference engine and device', async () => {
+  // Mirror the existing section test's store mock so an ASR card renders with a
+  // catalog entry whose available tier backend is a known engine id, then assert
+  // the tooltip content shows the mapped framework label.
+  renderSectionWithNativeCatalog({
+    asrCatalog: { id: 'sense', name: 'SenseVoice', tiers: [{ tier: 'gpu-vulkan', backend: 'llamacpp_gemma', available: true }], repo: 'org/sense', sizeBytes: 1_900_000_000, kind: 'asr' },
+  });
+  expect(await screen.findByText('llama.cpp')).toBeInTheDocument();
+  expect(screen.getByText('Vulkan')).toBeInTheDocument();
+});
+```
+
+> Note for the implementer: the exact helper (`renderSectionWithNativeCatalog`) and mock shape must match this test file's existing conventions — reuse whatever setup the current tests use to inject `useNativeCatalog`/store state. If the `Tooltip` renders its content only on hover in jsdom, either (a) query after a `userEvent.hover` on the badge, or (b) if that proves flaky, assert instead that the badge is wrapped by a tooltip trigger and rely on Task 1's row tests for content coverage. Pick the approach that the existing Tooltip tests in this repo use.
+
+Run: `npx vitest run src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+Expected: FAIL — no `llama.cpp`/`Vulkan` in the document yet.
+
+- [ ] **Step 4: Wire the tooltip into the badge**
+
+In `src/components/Settings/sections/NativeModelManagementSection.tsx`:
+
+(a) Add imports (extend the existing import from `nativeCatalog` and confirm `Tooltip` is imported — it is, at the top):
+```ts
+import { /* …existing… */ frameworkLabel, buildBackendTooltipRows } from '../../../lib/local-inference/native/nativeCatalog';
+```
+(Adjust the relative path to match the existing `nativeCatalog` import in this file.)
+
+(b) Widen the local `CardResolved` type to include the new fields:
+```ts
+type CardResolved = { model: string; device: string; backend?: string; computeType?: string; rtf?: number; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string };
+```
+
+(c) Add a label map near the top of the card component (module scope):
+```ts
+// [i18n key, English fallback] per tooltip row key.
+const TT_LABEL: Record<string, [string, string]> = {
+  framework: ['models.hwFramework', 'Engine'],
+  device: ['models.hwDevice', 'Device'],
+  api: ['models.hwApi', 'Acceleration'],
+  precision: ['models.hwPrecision', 'Precision'],
+  speed: ['models.hwSpeed', 'Speed'],
+  memory: ['models.hwMemory', 'Memory'],
+  size: ['models.hwSize', 'Size'],
+  repo: ['models.hwRepo', 'Repo'],
+};
+```
+
+(d) Inside the tier-badge IIFE (currently returning `<><span className={cls}>…</span>{degraded && …}</>`), after `cls` is computed, build the rows and wrap the badge span in `Tooltip`. Replace the returned `<span className={cls}>…</span>` (the first span only; leave the degraded warn span as-is) with:
+
+```tsx
+                const backendId = (showResolved && resolved?.backend) ? resolved.backend : activeTier?.backend;
+                const ttRows = buildBackendTooltipRows({
+                  tier,
+                  backendId,
+                  resolved: showResolved ? resolved : null,
+                  sizeMb,
+                  repo: chosenVariant?.repo ?? info?.repo,
+                });
+                return (
+                  <>
+                    <Tooltip
+                      position="top"
+                      icon="none"
+                      content={
+                        <div style={{ display: 'grid', gap: 2, textAlign: 'left', fontSize: 12, lineHeight: 1.35 }}>
+                          {ttRows.map((r) => r.key === 'fallback' ? (
+                            <div key={r.key} style={{ color: '#e74c3c' }}>⚠ {r.value}</div>
+                          ) : (
+                            <div key={r.key}>
+                              <span style={{ opacity: 0.6 }}>{t(TT_LABEL[r.key][0], TT_LABEL[r.key][1])}</span>{`: ${r.value}`}
+                            </div>
+                          ))}
+                        </div>
+                      }
+                    >
+                      <span className={cls}>
+                        <TierIcon tier={tier} size={10} />{tl.label}{metric}
+                      </span>
+                    </Tooltip>
+                    {view?.degraded && (
+                      <span className="model-card__lang-tag model-card__lang-tag--warn"
+                            title={resolved!.fallbackReason}>
+                        ⚠ Low VRAM → CPU
+                      </span>
+                    )}
+                  </>
+                );
+```
+
+`t`, `activeTier`, `info`, `sizeMb`, `chosenVariant`, `resolved`, `showResolved`, `view`, `tier`, `tl`, `metric`, `cls` are all already in scope at this point in the component.
+
+- [ ] **Step 5: Run the section + full front-end suites**
+
+Run: `npx vitest run src/components/Settings/sections/NativeModelManagementSection.test.tsx`
+Expected: PASS.
+Then run the touched suites together to confirm no regression:
+Run: `npx vitest run src/lib/local-inference/native/nativeCatalog.test.ts src/stores/nativeModelStore.test.ts src/components/Settings/sections/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/components/Settings/sections/NativeModelManagementSection.tsx src/components/Settings/sections/TierIcon.tsx src/components/Settings/sections/TierIcon.test.tsx src/components/Settings/sections/NativeModelManagementSection.test.tsx src/locales/en/translation.json src/locales/zh_CN/translation.json src/locales/zh_TW/translation.json
+git commit -m "feat(native): tier-badge tooltip with inference framework + device details"
+```
+
+---
+
+## Self-Review
+
+- **Spec coverage:** Framework label (7-engine taxonomy) ✓ Task 1; device/API ✓ Task 1; runtime precision/speed/memory/fallback ✓ Task 1 (data) + Task 2 (plumbing); model size + repo ✓ Task 1; tier-badge placement + single tooltip ✓ Task 3; i18n en/zh_CN/zh_TW ✓ Task 3; no sidecar/protocol/MainPanel changes ✓ (none touched). Framework-varies-by-tier is handled because the row builder takes the displayed `tier` + its `backendId`.
+- **Placeholders:** none — every step has concrete code or an exact command. The one soft spot (the section test's render helper) is explicitly delegated to the file's existing conventions with two concrete fallbacks, because the test-harness shape must match what's already there.
+- **Type consistency:** `BackendTooltipRow`, `frameworkLabel`, `accelApiLabel`, `buildBackendTooltipRows` signatures match between Task 1 (definition) and Task 3 (use). The resolved shape widening in Task 2 (`backend?`/`computeType?`) matches `CardResolved` in Task 3 and the `resolved` argument shape `buildBackendTooltipRows` expects.

--- a/docs/superpowers/specs/2026-07-08-native-model-backend-tooltip-design.md
+++ b/docs/superpowers/specs/2026-07-08-native-model-backend-tooltip-design.md
@@ -1,0 +1,79 @@
+# Native model tier-badge info tooltip — design
+
+**Goal:** Hovering the tier badge on a native (Electron local-inference) model card shows an info tooltip listing the inference **backend framework** (CTranslate2 / ONNXRuntime / llama.cpp / transcribe.cpp / sherpa-onnx / Supertonic / MLX), the **device**, the hardware **acceleration API**, and — when the model is loaded — runtime details (precision, speed, memory, fallback), plus static **model size** and **repo**.
+
+**Non-goals / out of scope:** No sidecar, protocol, or catalog-message changes. No changes to MainPanel / ConnectionStatus / the live-session panel. Presentation-only, in the Settings native-model cards.
+
+## Background — current state
+
+- The native model cards (`src/components/Settings/sections/NativeModelManagementSection.tsx`) already render a tier badge (`<span class="model-card__lang-tag">` = `TierIcon` + a label like `GPU · Vulkan`). Idle cards show the catalog capability tier; active cards show the resolved device via `resolvedTierState`/`tierLabel` (`CPU`, `GPU · CUDA`, `GPU · Metal`, `GPU · Vulkan`, `GPU · DirectML`), with a `⚠ Low VRAM → CPU` note when degraded. `TierIcon` carries a native `title="Vulkan"` browser tooltip.
+- The badge shows device + hardware API only. It does **not** show the inference **framework** (llama.cpp/CT2/ORT/...), and nothing about the framework is surfaced anywhere else.
+- The framework identity is already present in the renderer: `useNativeCatalog()[id].tiers[].backend` (`NativeTier.backend`), values like `llamacpp_gemma` / `ct2_opus_translate` / `transcribe_cpp` / `moss_onnx` / `sherpa_tts` / `supertonic` / `mlx_audio_tts`.
+
+## All data originates from the sidecar (two messages)
+
+Nothing is fabricated in the frontend; it only re-labels and formats.
+
+| Tooltip field | Sidecar source | Frontend transform |
+|---|---|---|
+| Framework (engine) | catalog `tiers[].backend` (idle) / `ready.backend` (active) | backend id → label (see map) |
+| Device (CPU/GPU) | catalog `tiers[].tier` (idle) / `ready.device` (active) | tier/device → `GPU`/`CPU` |
+| Acceleration API | same tier/device | → `CUDA`/`Vulkan`/`Metal`/`DirectML`; hidden on CPU |
+| Precision (computeType) | `ready.computeType` (active only) | verbatim (`int8`/`fp16`/`fp32`) |
+| Speed | `ready.rtf` (ASR/TTS) / `ready.tokensPerSec` (translate) | `RTF 0.03` / `128 tok/s` |
+| Memory | `ready.memoryBytes` (active only) | bytes → `3.2 GB` |
+| Fallback note | `ready.fallbackReason` (active only) | verbatim, warning style |
+| Model size | catalog `info.sizeBytes` (or selected variant `sizeBytes`) | bytes → GB |
+| Repo | catalog `info.repo` (or selected variant `repo`) | verbatim |
+
+The `models_catalog_result` message carries the static fields; the per-stage `ready` message carries the runtime fields (`asr_engine.py`/`translate_engine.py`/`tts_engine.py` ready handlers). **`ready.backend` and `ready.computeType` are already transmitted but currently dropped** by `LocalNativeClient`/`nativeModelStore` — the only "wiring" this feature adds is to stop dropping them.
+
+## Backend id → framework label (engine/library level, 7 labels)
+
+```
+transcribe_cpp         → transcribe.cpp
+transcribe_cpp_stream  → transcribe.cpp
+ct2_opus_translate     → CTranslate2
+llamacpp_qwen          → llama.cpp
+llamacpp_hunyuan       → llama.cpp
+llamacpp_gemma         → llama.cpp
+moss_onnx              → ONNXRuntime
+qwen3tts_onnx          → ONNXRuntime
+sherpa_tts             → sherpa-onnx
+supertonic             → Supertonic
+mlx_audio_tts          → MLX
+```
+
+Unknown/unmapped backend id → fall back to the raw id (so a future backend still renders something, not a blank).
+
+## Tooltip content (which tier it reflects)
+
+The tooltip describes the **tier currently shown in the badge**, not a per-model constant — framework can vary by tier (e.g. MOSS-TTS / Qwen3-TTS use `mlx_audio_tts` on `gpu-metal` but `*_onnx` on `cpu`/`gpu-cuda`/`gpu-dml`; so on a Mac the Metal badge → MLX, the CPU badge → ONNXRuntime).
+
+- **Idle** (model not loaded): the badge's `activeTier` (`tiers.find(t => t.available) ?? tiers[0]`). Rows: Framework, Device, Acceleration API (hidden on CPU), Model size, Repo.
+- **Active** (loaded): framework from `resolved.backend`, device from `resolved.device`, API derived from that device — all from the runtime `ready` values (no catalog-tier lookup needed). Size/repo come from the model info as in the idle case. Rows: Framework, Device, Acceleration API (hidden on CPU), Precision, Speed, Memory, Model size, Repo, and the Fallback note when `fallbackReason` is present. If `resolved.backend` is somehow absent, fall back to the idle `activeTier.backend`.
+- Any field whose data is absent → that row is omitted (no empty `Label: —` rows, except the API row which is simply hidden on CPU).
+
+Layout: a compact key/value list, one row per field (muted label + value), rendered inside the existing `src/components/Tooltip/Tooltip.tsx`. The `TierIcon` native `title` is removed so there is a single tooltip on the badge.
+
+## Files to change
+
+1. **`src/lib/local-inference/native/nativeCatalog.ts`** — add `frameworkLabel(backendId: string): string` (the 7-entry map + raw-id fallback) and a pure helper `buildBadgeTooltipRows(...)` that takes the model info, the displayed tier, and the resolved object (or null) and returns an ordered `{ label: string; value: string; warn?: boolean }[]` for the current state. Keeping the assembly in a pure function makes it unit-testable without rendering.
+2. **`src/services/clients/LocalNativeClient.ts`** — when parsing each `ready` message, keep `backend` and `computeType` (currently only `device`/`rtf`/`tokensPerSec`/`memoryBytes`/`fallbackReason` are read).
+3. **`src/stores/nativeModelStore.ts`** — widen the `asrResolved`/`translationResolved`/`ttsResolved` shapes (and their setters) to carry `backend?` and `computeType?`. No new selectors needed; the section already reads the resolved objects.
+4. **`src/components/Settings/sections/NativeModelManagementSection.tsx`** — wrap the tier badge in `<Tooltip content={<TooltipRows rows={...} />}>`, computing `rows` via `buildBadgeTooltipRows`; remove the native `title` from `TierIcon` usage. (If `TierIcon` sets its own `title` internally, drop it there.)
+5. **i18n (`src/locales/*/translation.json`)** — add label keys for the field prefixes: framework / device / accelerationApi / precision / speed / memory / modelSize / repo. Add English + Chinese now; other locales fall back to English (existing i18next behavior). Framework names, API names, `RTF`, `tok/s`, and repo strings are proper nouns / data — not translated.
+
+## Error handling / edge cases
+
+- Unknown backend id → raw id shown (never blank).
+- CPU tier → Acceleration API row omitted (CPU has no CUDA/Vulkan analog); all other rows still populate, so the CPU badge tooltip is still informative (framework, precision, speed, memory, size, repo).
+- `resolved.backend` absent on the ready message (older sidecar) → framework falls back to the idle `activeTier.backend`; other runtime fields still show.
+- Long repo strings wrap inside the tooltip; the tooltip has a sane max-width.
+- Multi-quant models: use the selected/recommended variant's `sizeBytes`/`repo` when available, else the model-level `info.sizeBytes`/`info.repo`.
+
+## Testing
+
+- **`nativeCatalog` unit tests**: `frameworkLabel` for all 11 backend ids → the 7 labels, plus an unknown id → raw fallback. `buildBadgeTooltipRows`: idle case (no runtime rows, API hidden on CPU tier, size/repo present), active GPU case (all rows incl. precision/speed/memory), active CPU case (API row absent), and the fallbackReason → warn row.
+- **`NativeModelManagementSection` render test**: idle card renders the tooltip trigger with framework+device+size+repo; active card additionally renders precision/speed/memory. Reuse the section's existing test setup (mock `nativeModelStore`).
+- Run the existing `vitest` suite to confirm no regression in the section and store tests.

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -195,9 +195,13 @@ vi.mock('react-i18next', () => ({
   useTranslation: () => ({ t: (_k: string, fallback?: string) => fallback ?? _k }),
 }));
 
-// Tooltip uses FloatingPortal which causes jsdom issues; replace with a passthrough.
+// Tooltip uses FloatingPortal which causes jsdom issues; replace with a passthrough
+// that also surfaces `content` inline (unconditionally, unlike the real hover-gated
+// tooltip) so tests can assert on tooltip content without simulating hover/floating-ui.
 vi.mock('../../Tooltip/Tooltip', () => ({
-  default: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  default: ({ children, content }: { children?: React.ReactNode; content?: React.ReactNode }) => (
+    <>{children}{content}</>
+  ),
 }));
 
 vi.mock('../../../stores/settingsStore', () => ({
@@ -502,6 +506,36 @@ describe('NativeModelManagementSection — store-driven voice wiring (Task 13)',
       expect((await screen.findAllByText('MyVoice')).length).toBeGreaterThan(0);
     } finally {
       mockSettings.ttsModel = prevTtsModel;
+    }
+  });
+});
+
+describe('NativeModelManagementSection — tier badge tooltip (Task 3)', () => {
+  // sense-voice is the selected ('sense-voice' === mockSettings.asrModel), ja-compatible
+  // ASR card already exercised elsewhere in this file. Give its available tier a known
+  // backend id so the tooltip's row builder resolves a real framework/API label pair.
+  it('tier badge tooltip lists the inference engine and device', async () => {
+    mockCatalogOverride = {
+      ...mockCatalog,
+      'sense-voice': {
+        ...mockCatalog['sense-voice'],
+        tiers: [{ tier: 'gpu-vulkan', backend: 'llamacpp_gemma', available: true }],
+      },
+    };
+    try {
+      render(<NativeModelManagementSection />);
+      const card = screen.getByTestId('model-card-sense-voice');
+
+      // The Tooltip mock (above) renders `content` inline unconditionally, so no
+      // hover/floating-ui simulation is needed in jsdom. Each tooltip row renders as
+      // "<label>: <value>" where only the ": <value>" half is the row's own direct
+      // text node (the label lives in a nested <span>) — match on that "colon +
+      // value" substring so this doesn't also match the tier badge itself, which
+      // separately renders "GPU · Vulkan" (a "·", not ":") from tierLabel().
+      expect(await within(card).findByText(/: llama\.cpp/)).toBeInTheDocument();
+      expect(within(card).getByText(/: Vulkan/)).toBeInTheDocument();
+    } finally {
+      mockCatalogOverride = null;
     }
   });
 });

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -332,7 +332,7 @@ const NativeModelCard: React.FC<{
                             <div key={r.key} style={{ color: '#e74c3c' }}>⚠ {r.value}</div>
                           ) : (
                             <div key={r.key}>
-                              <span style={{ opacity: 0.6 }}>{t(TT_LABEL[r.key][0], TT_LABEL[r.key][1])}</span>{`: ${r.value}`}
+                              <span style={{ opacity: 0.6 }}>{t(TT_LABEL[r.key]?.[0] ?? r.key, TT_LABEL[r.key]?.[1] ?? r.key)}</span>{`: ${r.value}`}
                             </div>
                           ))}
                         </div>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -19,6 +19,7 @@ import {
   resolvedTierState,
   formatMemMb,
   statusReposFor,
+  buildBackendTooltipRows,
   type NativeModelCardSpec,
   type NativeSelection,
 } from '../../../lib/local-inference/native/nativeCatalog';
@@ -43,11 +44,28 @@ import NativeVoiceSection from './NativeVoiceSection';
 // The resolved plan a card may display: device + one speed metric + optional memory
 // footprint and fallback reason. ASR carries rtf ("Nx realtime"), translation carries
 // tokensPerSec ("N tok/s"); never both. memoryBytes and fallbackReason come from the
-// native gate when it measured VRAM or moved the model off GPU.
-type CardResolved = { model: string; device: string; rtf?: number; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string };
+// native gate when it measured VRAM or moved the model off GPU. backend/computeType
+// identify the actual inference engine + precision that served the request, feeding
+// the tier-badge tooltip.
+type CardResolved = {
+  model: string; device: string; backend?: string; computeType?: string;
+  rtf?: number; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string;
+};
 import { ModelGroup, RecommendedOthers, ModelStorageFooter } from './ModelManagementControls';
 
 type Stage = 'asrModel' | 'translationModel' | 'ttsModel';
+
+// [i18n key, English fallback] per tooltip row key (see buildBackendTooltipRows).
+const TT_LABEL: Record<string, [string, string]> = {
+  framework: ['models.hwFramework', 'Engine'],
+  device: ['models.hwDevice', 'Device'],
+  api: ['models.hwApi', 'Acceleration'],
+  precision: ['models.hwPrecision', 'Precision'],
+  speed: ['models.hwSpeed', 'Speed'],
+  memory: ['models.hwMemory', 'Memory'],
+  size: ['models.hwSize', 'Size'],
+  repo: ['models.hwRepo', 'Repo'],
+};
 
 /** Props bundle for the optional variant chooser on multi-quant translation cards. */
 type VariantCardProps = {
@@ -289,11 +307,41 @@ const NativeModelCard: React.FC<{
                   + (view ? ' model-card__lang-tag--live' : '')
                   + (view && !view.degraded && tl.accel ? ' model-card__lang-tag--accel' : '')
                   + (view?.degraded ? ' model-card__lang-tag--warn' : '');
+                // Framework id for the tooltip: the loaded model's runtime backend
+                // when resolved, else the catalog's best-tier backend. The fallback
+                // assumes `ready.backend` is always present (sidecar + frontend ship
+                // together); a resolved plan that omitted it would show the idle-tier
+                // framework, which for a backend-varies-by-tier model could disagree
+                // with a degraded device — not reachable with the bundled sidecar.
+                const backendId = (showResolved && resolved?.backend) ? resolved.backend : activeTier?.backend;
+                const ttRows = buildBackendTooltipRows({
+                  tier,
+                  backendId,
+                  resolved: showResolved ? resolved : null,
+                  sizeMb,
+                  repo: chosenVariant?.repo ?? info?.repo,
+                });
                 return (
                   <>
-                    <span className={cls}>
-                      <TierIcon tier={tier} size={10} />{tl.label}{metric}
-                    </span>
+                    <Tooltip
+                      position="top"
+                      icon="none"
+                      content={
+                        <div style={{ display: 'grid', gap: 2, textAlign: 'left', fontSize: 12, lineHeight: 1.35 }}>
+                          {ttRows.map((r) => r.key === 'fallback' ? (
+                            <div key={r.key} style={{ color: '#e74c3c' }}>⚠ {r.value}</div>
+                          ) : (
+                            <div key={r.key}>
+                              <span style={{ opacity: 0.6 }}>{t(TT_LABEL[r.key][0], TT_LABEL[r.key][1])}</span>{`: ${r.value}`}
+                            </div>
+                          ))}
+                        </div>
+                      }
+                    >
+                      <span className={cls}>
+                        <TierIcon tier={tier} size={10} />{tl.label}{metric}
+                      </span>
+                    </Tooltip>
                     {view?.degraded && (
                       <span className="model-card__lang-tag model-card__lang-tag--warn"
                             title={resolved!.fallbackReason}>

--- a/src/components/Settings/sections/TierIcon.tsx
+++ b/src/components/Settings/sections/TierIcon.tsx
@@ -23,7 +23,7 @@ export function TierIcon({ tier, size = 10 }: { tier: string; size?: number }): 
   if (!entry) return null;
   const { Icon, label } = entry;
   return (
-    <span role="img" aria-label={label} title={label} data-tier={tier} className="tier-icon">
+    <span role="img" aria-label={label} data-tier={tier} className="tier-icon">
       <Icon size={size} aria-hidden={true} />
     </span>
   );

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { pickNativeTts, hasNativeTts, voiceCapability, nativeTtsModels, resolveNativeTts, resolveNativeTranslation, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, autoSelectNative, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps, estimateNativeMemoryByDevice, formatMemMb, actualNativeMemoryByDevice, resolvedTierState, statusReposFor, defaultTtsVoice, curatedBuiltinVoices, infoToCard } from './nativeCatalog';
+import { pickNativeTts, hasNativeTts, voiceCapability, nativeTtsModels, resolveNativeTts, resolveNativeTranslation, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, autoSelectNative, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps, estimateNativeMemoryByDevice, formatMemMb, actualNativeMemoryByDevice, resolvedTierState, statusReposFor, defaultTtsVoice, curatedBuiltinVoices, infoToCard, frameworkLabel, accelApiLabel, buildBackendTooltipRows } from './nativeCatalog';
 import type { NativeModelInfo, NativeVoiceInfo } from './nativeProtocol';
 
 const V = (name: string, language: string | undefined, curated: boolean, def = false): NativeVoiceInfo =>
@@ -511,5 +511,86 @@ describe('nativeCatalog', () => {
   it('passes variantIds through infoToCard', () => {
     const info = M('translategemma-4b', 'translate', ['multi'], 5, false, { variantIds: ['q4_k_m', 'q8_0'] });
     expect(infoToCard(info).variantIds).toEqual(['q4_k_m', 'q8_0']);
+  });
+});
+
+describe('frameworkLabel', () => {
+  it('maps every known backend id to its engine label', () => {
+    const cases: Record<string, string> = {
+      transcribe_cpp: 'transcribe.cpp',
+      transcribe_cpp_stream: 'transcribe.cpp',
+      ct2_opus_translate: 'CTranslate2',
+      llamacpp_qwen: 'llama.cpp',
+      llamacpp_hunyuan: 'llama.cpp',
+      llamacpp_gemma: 'llama.cpp',
+      moss_onnx: 'ONNXRuntime',
+      qwen3tts_onnx: 'ONNXRuntime',
+      sherpa_tts: 'sherpa-onnx',
+      supertonic: 'Supertonic',
+      mlx_audio_tts: 'MLX',
+    };
+    for (const [id, label] of Object.entries(cases)) expect(frameworkLabel(id)).toBe(label);
+  });
+  it('derives future ids by prefix, else echoes the raw id', () => {
+    expect(frameworkLabel('llamacpp_newmodel')).toBe('llama.cpp');
+    expect(frameworkLabel('foo_onnx')).toBe('ONNXRuntime');
+    expect(frameworkLabel('transcribe_cpp_x')).toBe('transcribe.cpp');
+    expect(frameworkLabel('brand_new_backend')).toBe('brand_new_backend');
+  });
+});
+
+describe('accelApiLabel', () => {
+  it('names the GPU API and returns null for cpu/unknown', () => {
+    expect(accelApiLabel('gpu-cuda')).toBe('CUDA');
+    expect(accelApiLabel('gpu-metal')).toBe('Metal');
+    expect(accelApiLabel('gpu-vulkan')).toBe('Vulkan');
+    expect(accelApiLabel('gpu-dml')).toBe('DirectML');
+    expect(accelApiLabel('cpu')).toBeNull();
+    expect(accelApiLabel('weird')).toBeNull();
+  });
+});
+
+describe('buildBackendTooltipRows', () => {
+  it('idle GPU tier: framework/device/api/size/repo, no runtime rows', () => {
+    const rows = buildBackendTooltipRows({
+      tier: 'gpu-vulkan', backendId: 'llamacpp_gemma', resolved: null, sizeMb: 1843, repo: 'org/model',
+    });
+    expect(rows.map((r) => r.key)).toEqual(['framework', 'device', 'api', 'size', 'repo']);
+    expect(rows[0]).toEqual({ key: 'framework', value: 'llama.cpp' });
+    expect(rows[1]).toEqual({ key: 'device', value: 'GPU' });
+    expect(rows[2]).toEqual({ key: 'api', value: 'Vulkan' });
+    expect(rows.find((r) => r.key === 'size')?.value).toBe('1.8 GB');
+  });
+  it('idle CPU tier: no api row, still has framework/device/size', () => {
+    const rows = buildBackendTooltipRows({ tier: 'cpu', backendId: 'ct2_opus_translate', resolved: null, sizeMb: 300 });
+    expect(rows.map((r) => r.key)).toEqual(['framework', 'device', 'size']);
+    expect(rows[1]).toEqual({ key: 'device', value: 'CPU' });
+    expect(rows[0].value).toBe('CTranslate2');
+  });
+  it('active tier adds precision/speed/memory from the resolved plan', () => {
+    const rows = buildBackendTooltipRows({
+      tier: 'gpu-cuda', backendId: 'moss_onnx',
+      resolved: { computeType: 'int8', rtf: 0.02, memoryBytes: 3_400_000_000 },
+      sizeMb: 100, repo: 'org/tts',
+    });
+    const byKey = Object.fromEntries(rows.map((r) => [r.key, r.value]));
+    expect(byKey.precision).toBe('INT8');
+    expect(byKey.speed).toBe('50× realtime');
+    expect(byKey.memory).toBe('3.2 GB');
+  });
+  it('translate speed uses tok/s; empty tps omits the speed row', () => {
+    const withTps = buildBackendTooltipRows({ tier: 'cpu', backendId: 'ct2_opus_translate', resolved: { tokensPerSec: 131 } });
+    expect(withTps.find((r) => r.key === 'speed')?.value).toBe('131 tok/s');
+    const zeroTps = buildBackendTooltipRows({ tier: 'cpu', backendId: 'ct2_opus_translate', resolved: { tokensPerSec: 0 } });
+    expect(zeroTps.find((r) => r.key === 'speed')).toBeUndefined();
+  });
+  it('fallbackReason becomes a trailing warn row', () => {
+    const rows = buildBackendTooltipRows({ tier: 'cpu', backendId: 'llamacpp_gemma', resolved: { fallbackReason: 'Low VRAM → CPU' } });
+    const last = rows[rows.length - 1];
+    expect(last).toEqual({ key: 'fallback', value: 'Low VRAM → CPU', warn: true });
+  });
+  it('omits the framework row when no backend id is known', () => {
+    const rows = buildBackendTooltipRows({ tier: 'cpu', resolved: null, sizeMb: 10 });
+    expect(rows.find((r) => r.key === 'framework')).toBeUndefined();
   });
 });

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -593,4 +593,15 @@ describe('buildBackendTooltipRows', () => {
     const rows = buildBackendTooltipRows({ tier: 'cpu', resolved: null, sizeMb: 10 });
     expect(rows.find((r) => r.key === 'framework')).toBeUndefined();
   });
+  it('omits the speed row for an unmeasured (zero) rtf, like zero tps', () => {
+    const rows = buildBackendTooltipRows({ tier: 'gpu-cuda', backendId: 'moss_onnx', resolved: { rtf: 0 } });
+    expect(rows.find((r) => r.key === 'speed')).toBeUndefined();
+  });
+  it('hides the repo row on MLX tiers (info.repo is the ONNX repo, would mislabel)', () => {
+    const mlx = buildBackendTooltipRows({ tier: 'gpu-metal', backendId: 'mlx_audio_tts', resolved: null, repo: 'org/onnx-assets' });
+    expect(mlx.find((r) => r.key === 'repo')).toBeUndefined();
+    // non-MLX still shows repo
+    const onnx = buildBackendTooltipRows({ tier: 'cpu', backendId: 'moss_onnx', resolved: null, repo: 'org/onnx-assets' });
+    expect(onnx.find((r) => r.key === 'repo')?.value).toBe('org/onnx-assets');
+  });
 });

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -285,6 +285,75 @@ export function formatTps(tps: number): string {
   return `${Math.round(tps)} tok/s`;
 }
 
+/** One row of the model-card backend/device tooltip. `key` selects the localized
+ *  label in the component; `warn` marks the degraded/fallback row. */
+export type BackendTooltipRow = { key: string; value: string; warn?: boolean };
+
+const FRAMEWORK_LABELS: Record<string, string> = {
+  transcribe_cpp: 'transcribe.cpp',
+  transcribe_cpp_stream: 'transcribe.cpp',
+  ct2_opus_translate: 'CTranslate2',
+  llamacpp_qwen: 'llama.cpp',
+  llamacpp_hunyuan: 'llama.cpp',
+  llamacpp_gemma: 'llama.cpp',
+  moss_onnx: 'ONNXRuntime',
+  qwen3tts_onnx: 'ONNXRuntime',
+  sherpa_tts: 'sherpa-onnx',
+  supertonic: 'Supertonic',
+  mlx_audio_tts: 'MLX',
+};
+
+/** Engine/library label for a sidecar backend id. Falls back by prefix so a new
+ *  llamacpp_X, X_onnx, or transcribe_cpp_X id still resolves, else echoes the raw id. */
+export function frameworkLabel(backendId: string): string {
+  if (FRAMEWORK_LABELS[backendId]) return FRAMEWORK_LABELS[backendId];
+  if (backendId.startsWith('llamacpp_')) return 'llama.cpp';
+  if (backendId.startsWith('transcribe_cpp')) return 'transcribe.cpp';
+  if (backendId.endsWith('_onnx')) return 'ONNXRuntime';
+  return backendId;
+}
+
+/** Hardware acceleration API for a GPU tier; null for cpu/unknown (no API row). */
+export function accelApiLabel(tier: string): string | null {
+  switch (tier) {
+    case 'gpu-cuda': return 'CUDA';
+    case 'gpu-metal': return 'Metal';
+    case 'gpu-vulkan': return 'Vulkan';
+    case 'gpu-dml': return 'DirectML';
+    default: return null;
+  }
+}
+
+/** Ordered rows for the tier-badge tooltip. `resolved` present = model loaded
+ *  (adds precision/speed/memory/fallback); null/undefined = idle catalog view. */
+export function buildBackendTooltipRows(input: {
+  tier: string;
+  backendId?: string;
+  resolved?: { computeType?: string; rtf?: number; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  sizeMb?: number | null;
+  repo?: string;
+}): BackendTooltipRow[] {
+  const { tier, backendId, resolved, sizeMb, repo } = input;
+  const rows: BackendTooltipRow[] = [];
+  if (backendId) rows.push({ key: 'framework', value: frameworkLabel(backendId) });
+  rows.push({ key: 'device', value: tier === 'cpu' ? 'CPU' : 'GPU' });
+  const api = accelApiLabel(tier);
+  if (api) rows.push({ key: 'api', value: api });
+  if (resolved?.computeType) rows.push({ key: 'precision', value: resolved.computeType.toUpperCase() });
+  if (resolved) {
+    if (resolved.rtf !== undefined) rows.push({ key: 'speed', value: formatRtf(resolved.rtf) });
+    else if (resolved.tokensPerSec !== undefined) {
+      const tps = formatTps(resolved.tokensPerSec);
+      if (tps) rows.push({ key: 'speed', value: tps });
+    }
+  }
+  if (resolved?.memoryBytes) rows.push({ key: 'memory', value: formatMemMb(Math.round(resolved.memoryBytes / 1_048_576)) });
+  if (sizeMb != null) rows.push({ key: 'size', value: formatMemMb(sizeMb) });
+  if (repo) rows.push({ key: 'repo', value: repo });
+  if (resolved?.fallbackReason) rows.push({ key: 'fallback', value: resolved.fallbackReason, warn: true });
+  return rows;
+}
+
 /** sid encoded as the suffix of a `sid:<n>` ttsVoice ('sid:5' → 5; anything else → 0). */
 export function sidFromTtsVoice(v: string): number {
   return v.startsWith('sid:') ? (Number(v.slice(4)) || 0) : 0;

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -341,7 +341,10 @@ export function buildBackendTooltipRows(input: {
   if (api) rows.push({ key: 'api', value: api });
   if (resolved?.computeType) rows.push({ key: 'precision', value: resolved.computeType.toUpperCase() });
   if (resolved) {
-    if (resolved.rtf !== undefined) rows.push({ key: 'speed', value: formatRtf(resolved.rtf) });
+    // Guard rtf like tokensPerSec: a zero/unmeasured rtf is omitted rather than
+    // shown as a degenerate "realtime" row (formatRtf already floors non-positive
+    // rtf to 'realtime', so this is symmetry, not a divide-by-zero fix).
+    if (resolved.rtf) rows.push({ key: 'speed', value: formatRtf(resolved.rtf) });
     else if (resolved.tokensPerSec !== undefined) {
       const tps = formatTps(resolved.tokensPerSec);
       if (tps) rows.push({ key: 'speed', value: tps });
@@ -349,7 +352,11 @@ export function buildBackendTooltipRows(input: {
   }
   if (resolved?.memoryBytes) rows.push({ key: 'memory', value: formatMemMb(Math.round(resolved.memoryBytes / 1_048_576)) });
   if (sizeMb != null) rows.push({ key: 'size', value: formatMemMb(sizeMb) });
-  if (repo) rows.push({ key: 'repo', value: repo });
+  // TODO(#287): the frontend catalog only exposes the model-level repo
+  // (info.repo = the ONNX/primary repo). MLX TTS tiers on Apple Silicon load a
+  // different per-tier artifact, so info.repo would mislabel them — hide the repo
+  // row for MLX until the sidecar sends a per-tier repo, then drop this guard.
+  if (repo && !(backendId && frameworkLabel(backendId) === 'MLX')) rows.push({ key: 'repo', value: repo });
   if (resolved?.fallbackReason) rows.push({ key: 'fallback', value: resolved.fallbackReason, warn: true });
   return rows;
 }

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -919,7 +919,15 @@
     "online": "Online",
     "variantWontFit": "Needs ~{{need}} of GPU memory — this machine has {{have}}",
     "variantWontFitNoMem": "Needs ~{{need}} of GPU memory",
-    "wontFit": "Won't fit on this machine"
+    "wontFit": "Won't fit on this machine",
+    "hwFramework": "Engine",
+    "hwDevice": "Device",
+    "hwApi": "Acceleration",
+    "hwPrecision": "Precision",
+    "hwSpeed": "Speed",
+    "hwMemory": "Memory",
+    "hwSize": "Size",
+    "hwRepo": "Repo"
   },
   "update": {
     "available": "New version v{{version}} available",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -855,7 +855,15 @@
     "online": "在线",
     "variantWontFit": "需要约 {{need}} 显存 — 本机为 {{have}}",
     "variantWontFitNoMem": "需要约 {{need}} 显存",
-    "wontFit": "本机无法运行"
+    "wontFit": "本机无法运行",
+    "hwFramework": "推理引擎",
+    "hwDevice": "设备",
+    "hwApi": "加速 API",
+    "hwPrecision": "精度",
+    "hwSpeed": "速度",
+    "hwMemory": "内存",
+    "hwSize": "模型大小",
+    "hwRepo": "仓库"
   },
   "update": {
     "available": "新版本 v{{version}} 可用",

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -816,7 +816,15 @@
     "online": "線上",
     "variantWontFit": "需要約 {{need}} 顯示記憶體 — 本機為 {{have}}",
     "variantWontFitNoMem": "需要約 {{need}} 顯示記憶體",
-    "wontFit": "本機無法執行"
+    "wontFit": "本機無法執行",
+    "hwFramework": "推理引擎",
+    "hwDevice": "裝置",
+    "hwApi": "加速 API",
+    "hwPrecision": "精度",
+    "hwSpeed": "速度",
+    "hwMemory": "記憶體",
+    "hwSize": "模型大小",
+    "hwRepo": "倉庫"
   },
   "update": {
     "available": "新版本 v{{version}} 可用",

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -66,7 +66,7 @@ export class LocalNativeClient implements IClient {
         config.sourceLanguage, config.targetLanguage, config.translationModelId, config.translationDevice,
         config.asrModelId, config.ttsModelId, config.translationVariant,
       );
-      store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu', tokensPerSec: tr.tokensPerSec, memoryBytes: tr.memoryBytes, fallbackReason: tr.fallbackReason });
+      store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu', backend: tr.backend, computeType: tr.computeType, tokensPerSec: tr.tokensPerSec, memoryBytes: tr.memoryBytes, fallbackReason: tr.fallbackReason });
     };
     const initAsr = async () => {
       store.setAsrLoading(true);
@@ -76,7 +76,7 @@ export class LocalNativeClient implements IClient {
           minSilence: config.vadMinSilenceDuration,
           minSpeech: config.vadMinSpeechDuration,
         }, config.asrDevice, config.asrVariant);
-        store.setAsrResolved({ model: config.asrModelId, device: res.device ?? 'cpu', rtf: res.rtf, memoryBytes: res.memoryBytes, fallbackReason: res.fallbackReason });
+        store.setAsrResolved({ model: config.asrModelId, device: res.device ?? 'cpu', backend: res.backend, computeType: res.computeType, rtf: res.rtf, memoryBytes: res.memoryBytes, fallbackReason: res.fallbackReason });
       } finally {
         store.setAsrLoading(false);
       }
@@ -101,7 +101,7 @@ export class LocalNativeClient implements IClient {
       try {
         const r = await this.tts.init(config.ttsModelId, config.ttsDevice);
         this.ttsStreaming = !!r.streaming;
-        store.setTtsResolved({ model: config.ttsModelId!, device: r.device ?? 'cpu',
+        store.setTtsResolved({ model: config.ttsModelId!, device: r.device ?? 'cpu', backend: r.backend, computeType: r.computeType,
           rtf: r.rtf, memoryBytes: r.memoryBytes, fallbackReason: r.fallbackReason });
         // Apply the selected voice (next-session semantics), driven by the
         // model's capability (built-in named/range and/or custom clip/style)

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -243,6 +243,18 @@ describe('nativeModelStore sidecar lifecycle', () => {
   });
 });
 
+describe('nativeModelStore resolved plans retain backend and computeType', () => {
+  it('resolved plans retain backend and computeType', () => {
+    const s = useNativeModelStore.getState();
+    s.setAsrResolved({ model: 'a', device: 'cuda', backend: 'moss_onnx', computeType: 'int8', rtf: 0.02 });
+    expect(useNativeModelStore.getState().asrResolved).toMatchObject({ backend: 'moss_onnx', computeType: 'int8' });
+    s.setTranslationResolved({ model: 't', device: 'cpu', backend: 'ct2_opus_translate', computeType: 'int8', tokensPerSec: 120 });
+    expect(useNativeModelStore.getState().translationResolved).toMatchObject({ backend: 'ct2_opus_translate', computeType: 'int8' });
+    s.setTtsResolved({ model: 'v', device: 'metal', backend: 'mlx_audio_tts', computeType: 'fp32' });
+    expect(useNativeModelStore.getState().ttsResolved).toMatchObject({ backend: 'mlx_audio_tts', computeType: 'fp32' });
+  });
+});
+
 describe('nativeModelStore bundle install (spec D10)', () => {
   it('refreshBundle reflects the installed status', async () => {
     (globalThis as any).window.electron = {

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -67,18 +67,18 @@ interface NativeModelStore {
   /** True while a native ASR session is loading its model (init→ready). */
   asrLoading: boolean;
   /** The resolved ASR plan from the last session `ready` (device + measured rtf + memory). */
-  asrResolved: { model: string; device: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  asrResolved: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null;
   /** The resolved translation plan from the last session `ready` (model + device + memory). */
-  translationResolved: { model: string; device: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  translationResolved: { model: string; device: string; backend?: string; computeType?: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null;
   /** True while a native TTS session is loading its model (init→ready). */
   ttsLoading: boolean;
   /** The resolved TTS plan from the last session `ready` (device + measured rtf + memory). */
-  ttsResolved: { model: string; device: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null;
+  ttsResolved: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null;
   setAsrLoading: (v: boolean) => void;
-  setAsrResolved: (r: { model: string; device: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
-  setTranslationResolved: (r: { model: string; device: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
+  setAsrResolved: (r: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
+  setTranslationResolved: (r: { model: string; device: string; backend?: string; computeType?: string; tokensPerSec?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
   setTtsLoading: (v: boolean) => void;
-  setTtsResolved: (r: { model: string; device: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
+  setTtsResolved: (r: { model: string; device: string; backend?: string; computeType?: string; rtf?: number; memoryBytes?: number; fallbackReason?: string } | null) => void;
 }
 
 // Singleton management connection (separate from session-stage clients).


### PR DESCRIPTION
## Native model tier-badge backend/device tooltip

Hovering a native (Electron local-inference) model card's **tier badge** now shows an info tooltip. The badge already displayed device + hardware API (e.g. `GPU · Vulkan`); the tooltip adds the missing dimension — the inference **framework** — plus the rest of the runtime picture.

**Tooltip content** (reflects the tier shown in the badge):
- **Idle** (model not loaded): Engine (framework), Device (CPU/GPU), Acceleration API (omitted on CPU), model Size, Repo.
- **Loaded**: also Precision (computeType), Speed (RTF / tok·s⁻¹), Memory, and a warn row for the fallback reason when the gate moved the model off GPU.

**Framework labels** (engine/library level): `transcribe.cpp`, `CTranslate2`, `llama.cpp`, `ONNXRuntime`, `sherpa-onnx`, `Supertonic`, `MLX`. Framework can vary by tier for a model (e.g. MOSS-TTS / Qwen3-TTS use MLX on `gpu-metal` but ONNXRuntime on cpu/cuda/dml), and the tooltip tracks the displayed tier.

**All data originates from the sidecar** — the `models_catalog_result` (static: tier/backend/repo/size) and per-stage `ready` (runtime: backend/device/computeType/rtf/tok-s/memory/fallback) messages. The frontend only re-labels and formats. `ready.backend` and `ready.computeType` were already transmitted but dropped by the store; the only "wiring" is to keep them. **No sidecar, protocol, or MainPanel changes.**

### Implementation (subagent-driven, 3 tasks + fresh review each + final whole-branch review)
- `nativeCatalog.ts`: `frameworkLabel` / `accelApiLabel` / `buildBackendTooltipRows` pure helpers.
- `nativeModelStore.ts` + `LocalNativeClient.ts`: retain `backend`/`computeType` on the resolved plans.
- `NativeModelManagementSection.tsx`: wrap the tier badge in the existing `Tooltip`; `TierIcon` native `title` removed (single tooltip).
- i18n: 8 `models.hw*` label keys in `en` / `zh_CN` / `zh_TW`.

### Tests
Full vitest suite **813/813**. New coverage: `buildBackendTooltipRows` idle/active/cpu/fallback cases, store backend/computeType retention, and a section render test asserting the tooltip surfaces the framework + API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer hover details for native model tier badges in Settings, showing backend/framework, device, speed, memory, size, and repository info when available.
  * Model badges now use a single tooltip presentation for clearer, more consistent hover behavior.

* **Bug Fixes**
  * Preserved more native model details so the Settings view can display accurate runtime information instead of dropping it.

* **Documentation**
  * Added design and implementation planning docs for the new native model tooltip behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->