### PR TITLE
feat(native): enrich Logs-panel events for native sidecar pipeline

### DIFF
--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { LocalNativeClient } from './LocalNativeClient';
 import { useNativeModelStore } from '../../stores/nativeModelStore';
 
@@ -630,6 +630,9 @@ describe('LocalNativeClient enriched log fields', () => {
     asrResolved: null, translationResolved: null, ttsResolved: null,
     asrLoading: false, ttsLoading: false, catalog: {}, sizes: {},
   } as any));
+  // Restore module spies (nativeHardwareInfo) so they don't leak into later
+  // tests — the shared vitest setup doesn't enable restoreMocks.
+  afterEach(() => vi.restoreAllMocks());
 
   it('asr.end carries modelId + timing + rtf, and partials are logged', async () => {
     const m = mocks();
@@ -723,10 +726,41 @@ describe('LocalNativeClient enriched log fields', () => {
     c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event) });
     await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
       asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b' } as any);
+    await new Promise((r) => setTimeout(r, 0)); // hardware probe runs off the critical path
 
     const hw = events.find((e) => e.type === 'local.native.hardware');
     expect(hw.data).toMatchObject({ os: 'linux', arch: 'x64', cpuCores: 16, accelAvailable: true });
     expect(hw.data.gpus[0].name).toBe('RTX 4070');
     expect(hw.data.backendsInstalled).toContain('ort-cuda');
+  });
+
+  it('does not block session startup on a slow hardware probe', async () => {
+    // A hardware probe that never resolves must not hang connect() — the ASR/
+    // translation init is the critical path; hardware logging is diagnostic-only.
+    vi.spyOn(await import('../../stores/nativeModelStore'), 'nativeHardwareInfo')
+      .mockReturnValue(new Promise(() => { /* never resolves */ }));
+    const m = mocks();
+    const c = new LocalNativeClient(m);
+    c.setEventHandlers({});
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
+      asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b' } as any);
+    expect(m.asr.init).toHaveBeenCalled(); // reached here → connect resolved despite the stalled probe
+  });
+
+  it('translation failure emits a stage-tagged local.native.error', async () => {
+    const m = mocks();
+    m.translate.translate = vi.fn().mockRejectedValue(new Error('translate boom'));
+    const c = new LocalNativeClient(m);
+    const events: any[] = [];
+    c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event), onError() {} });
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
+      asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b' } as any);
+    await m.asr.onResult({ text: 'hola', durationMs: 1, recognitionTimeMs: 1 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const err = events.find((e) => e.type === 'local.native.error' && e.data.stage === 'translation');
+    expect(err).toBeDefined();
+    expect(err.data.modelId).toBe('qwen2.5-0.5b');
+    expect(err.data.error).toContain('translate boom');
   });
 });

--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -94,7 +94,7 @@ describe('LocalNativeClient', () => {
     await new Promise((r) => setTimeout(r, 0));
     expect(types).toContain('local.native.init.start');
     expect(types).toContain('local.native.init.ready');
-    expect(types).toContain('local.native.asr.result');
+    expect(types).toContain('local.native.asr.end');
     expect(types).toContain('local.native.translation.end');
   });
 
@@ -617,5 +617,116 @@ describe('LocalNativeClient voice selection', () => {
     await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'en', targetLanguage: 'en',
       asrModelId: 'sense-voice', ttsModelId: 'moss-tts-nano', ttsVoice: 'custom:8' } as any);
     expect(m.tts.setReferenceVoice).toHaveBeenCalledWith(expect.any(Float32Array), 16000, undefined);
+  });
+});
+
+// ── Enriched Logs-panel event payloads ───────────────────────────────────────
+// Native events must carry the same rich fields the WASM LocalInferenceClient
+// logs (modelId + timing + rtf per stage) and surface the sidecar's resolved
+// hardware plan (device/backend/computeType/memory) + fallback + machine info.
+
+describe('LocalNativeClient enriched log fields', () => {
+  beforeEach(() => useNativeModelStore.setState({
+    asrResolved: null, translationResolved: null, ttsResolved: null,
+    asrLoading: false, ttsLoading: false, catalog: {}, sizes: {},
+  } as any));
+
+  it('asr.end carries modelId + timing + rtf, and partials are logged', async () => {
+    const m = mocks();
+    const c = new LocalNativeClient(m);
+    const events: any[] = [];
+    c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event) });
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
+      asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b' } as any);
+    m.asr.onPartialResult('ho');
+    await m.asr.onResult({ text: 'hola', durationMs: 200, recognitionTimeMs: 10 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const partial = events.find((e) => e.type === 'local.native.asr.partial');
+    expect(partial?.data.text).toBe('ho');
+    const end = events.find((e) => e.type === 'local.native.asr.end');
+    expect(end.data).toMatchObject({ text: 'hola', modelId: 'sense-voice', durationMs: 200, recognitionTimeMs: 10, rtf: 0.05 });
+  });
+
+  it('translation.start/end carry sourceText, modelId, systemPrompt, wrapTranscript', async () => {
+    const m = mocks();
+    const c = new LocalNativeClient(m);
+    const events: any[] = [];
+    c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event) });
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
+      asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b', instructions: 'be terse', wrapTranscript: true } as any);
+    await m.asr.onResult({ text: 'hola', durationMs: 1, recognitionTimeMs: 1 });
+    await new Promise((r) => setTimeout(r, 0));
+
+    const start = events.find((e) => e.type === 'local.native.translation.start');
+    expect(start.data).toMatchObject({ sourceText: 'hola', modelId: 'qwen2.5-0.5b', systemPrompt: 'be terse', wrapTranscript: true });
+    const end = events.find((e) => e.type === 'local.native.translation.end');
+    expect(end.data).toMatchObject({ sourceText: 'hola', translatedText: 'hello', inferenceTimeMs: 2, modelId: 'qwen2.5-0.5b' });
+  });
+
+  it('tts.start carries text/sentenceCount/modelId/voice/speed and per-sentence events fire with generateMs', async () => {
+    const deps = fakeDeps(); // translate → 'Hello there. How are you?' (2 sentences); generate generationTimeMs:3
+    const c = new LocalNativeClient(deps as any);
+    const events: any[] = [];
+    c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event) });
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'en', targetLanguage: 'en',
+      asrModelId: 'sense-voice', translationModelId: 'q',
+      ttsModelId: 'csukuangfj/vits-piper-en_US-amy-low', ttsSpeed: 1.25, textOnly: false } as any);
+    await (c as any).runJob('hola');
+
+    const start = events.find((e) => e.type === 'local.native.tts.start');
+    expect(start.data).toMatchObject({ sentenceCount: 2, modelId: 'csukuangfj/vits-piper-en_US-amy-low', speed: 1.25 });
+    expect(start.data.text).toContain('Hello');
+    const sentEnds = events.filter((e) => e.type === 'local.native.tts.sentence.end');
+    expect(sentEnds.length).toBe(2);
+    expect(sentEnds[0].data).toMatchObject({ sentenceIndex: 0, sentenceCount: 2, generateMs: 3 });
+    expect(sentEnds[0].data.audioDurationMs).toBeGreaterThan(0);
+    const ttsEnd = events.find((e) => e.type === 'local.native.tts.end');
+    expect(ttsEnd.data).toMatchObject({ sentenceCount: 2 });
+    expect(ttsEnd.data.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('init.{engine}.ready carry device/backend/computeType/memory/loadTimeMs; fallback event emitted', async () => {
+    const asr = {
+      onResult: null as any, onError: null as any, onPartialResult: null as any,
+      init: async () => ({ loadTimeMs: 5, device: 'cuda', backend: 'ort', computeType: 'fp16', rtf: 0.02, memoryBytes: 8_000_000_000 }),
+      feedAudio() {}, flush: async () => {}, dispose() {},
+    };
+    const translate = {
+      onError: null as any,
+      init: async () => ({ loadTimeMs: 9, device: 'cpu', backend: 'llamacpp', computeType: 'q4', tokensPerSec: 12.5, memoryBytes: 4_000_000_000, fallbackReason: 'cuda skipped; using CPU' }),
+      translate: async () => ({ translatedText: 'x', inferenceTimeMs: 1 }), dispose() {},
+    };
+    const c = new LocalNativeClient({ asr, translate, tts: fakeTts() });
+    const events: any[] = [];
+    c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event) });
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'en', targetLanguage: 'ja',
+      asrModelId: 'granite', translationModelId: 'q', textOnly: true } as any);
+
+    const asrReady = events.find((e) => e.type === 'local.native.init.asr.ready');
+    expect(asrReady.data).toMatchObject({ model: 'granite', device: 'cuda', backend: 'ort', computeType: 'fp16', rtf: 0.02, memoryBytes: 8_000_000_000, loadTimeMs: 5 });
+    const trReady = events.find((e) => e.type === 'local.native.init.translation.ready');
+    expect(trReady.data).toMatchObject({ model: 'q', device: 'cpu', backend: 'llamacpp', tokensPerSec: 12.5, loadTimeMs: 9 });
+    const fb = events.find((e) => e.type === 'local.native.init.translation.fallback');
+    expect(fb.data).toMatchObject({ model: 'q', fallbackReason: 'cuda skipped; using CPU' });
+  });
+
+  it('emits local.native.hardware from nativeHardwareInfo', async () => {
+    vi.spyOn(await import('../../stores/nativeModelStore'), 'nativeHardwareInfo')
+      .mockResolvedValue({
+        type: 'hardware_info_result', id: 1, os: 'linux', arch: 'x64', cpuCores: 16,
+        gpus: [{ vendor: 'nvidia', name: 'RTX 4070', vramMb: 12000 }], backendsInstalled: ['ort-cuda'], accelAvailable: true,
+      } as any);
+    const m = mocks();
+    const c = new LocalNativeClient(m);
+    const events: any[] = [];
+    c.setEventHandlers({ onRealtimeEvent: (e: any) => events.push(e.event) });
+    await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'es', targetLanguage: 'en',
+      asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b' } as any);
+
+    const hw = events.find((e) => e.type === 'local.native.hardware');
+    expect(hw.data).toMatchObject({ os: 'linux', arch: 'x64', cpuCores: 16, accelAvailable: true });
+    expect(hw.data.gpus[0].name).toBe('RTX 4070');
+    expect(hw.data.backendsInstalled).toContain('ort-cuda');
   });
 });

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -60,15 +60,17 @@ export class LocalNativeClient implements IClient {
       sourceLanguage: config.sourceLanguage, targetLanguage: config.targetLanguage,
     });
     // Best-effort machine snapshot so the Logs panel shows which GPU/backends
-    // the session resolved against (helps diagnose "GPU wasn't used"). Null when
-    // the sidecar is unavailable — skip the line rather than fail the session.
-    const hw = await nativeHardwareInfo();
-    if (hw) {
-      this.emitEvent('local.native.hardware', 'client', {
-        os: hw.os, arch: hw.arch, cpuCores: hw.cpuCores,
-        gpus: hw.gpus, backendsInstalled: hw.backendsInstalled, accelAvailable: hw.accelAvailable,
-      });
-    }
+    // the session resolved against (helps diagnose "GPU wasn't used"). Fire-and-
+    // forget: this diagnostic probe must never delay ASR/translation init on the
+    // startup critical path. Null (sidecar unavailable) simply skips the line.
+    nativeHardwareInfo().then((hw) => {
+      if (hw) {
+        this.emitEvent('local.native.hardware', 'client', {
+          os: hw.os, arch: hw.arch, cpuCores: hw.cpuCores,
+          gpus: hw.gpus, backendsInstalled: hw.backendsInstalled, accelAvailable: hw.accelAvailable,
+        });
+      }
+    }).catch(() => { /* diagnostics only — ignore probe failures */ });
     this.ttsSpeed = config.ttsSpeed ?? 1.0;
     this.keepReplayAudio = config.keepReplayAudio ?? false;
     const store = useNativeModelStore.getState();
@@ -289,7 +291,18 @@ export class LocalNativeClient implements IClient {
       sourceText: text, modelId: this.cfg?.translationModelId,
       systemPrompt: this.cfg?.instructions ?? '', wrapTranscript: !!this.cfg?.wrapTranscript,
     });
-    const tr = await this.translate.translate(text, this.cfg?.instructions ?? '', !!this.cfg?.wrapTranscript);
+    // Stage-local catch so a translation failure surfaces in the Logs panel with
+    // translation-stage context (which model/text), rather than only through the
+    // generic queue catch. Aborts this job — no assistant item is produced.
+    let tr: { sourceText?: string; translatedText: string; inferenceTimeMs?: number };
+    try {
+      tr = await this.translate.translate(text, this.cfg?.instructions ?? '', !!this.cfg?.wrapTranscript);
+    } catch (e) {
+      const error = e instanceof Error ? e.message : String(e);
+      this.emitEvent('local.native.error', 'client', { stage: 'translation', modelId: this.cfg?.translationModelId, sourceText: text, error });
+      this.handlers.onError?.(error);
+      return;
+    }
     this.emitEvent('local.native.translation.end', 'server', {
       sourceText: tr.sourceText ?? text, translatedText: tr.translatedText,
       inferenceTimeMs: tr.inferenceTimeMs, modelId: this.cfg?.translationModelId,

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -11,7 +11,7 @@ import { sidFromTtsVoice, voiceCapability } from '../../lib/local-inference/nati
 import { voiceStoreFor } from '../../lib/local-inference/native/nativeVoiceStores';
 import type { NativeModelInfo } from '../../lib/local-inference/native/nativeProtocol';
 import { splitSentences } from '../../utils/splitSentences';
-import { useNativeModelStore, nativeListTtsVoices } from '../../stores/nativeModelStore';
+import { useNativeModelStore, nativeListTtsVoices, nativeHardwareInfo } from '../../stores/nativeModelStore';
 
 interface Deps {
   asr?: NativeAsrClient | any;
@@ -37,6 +37,7 @@ export class LocalNativeClient implements IClient {
   private ttsEnabled = false;
   private ttsStreaming = false;
   private ttsSpeed = 1.0;
+  private ttsVoiceLabel = '';
   private keepReplayAudio: boolean = false;
   private queue: Promise<void> = Promise.resolve();
   private partialUserItem: ConversationItem | null = null;
@@ -58,6 +59,16 @@ export class LocalNativeClient implements IClient {
       asr: config.asrModelId, translation: config.translationModelId, tts: config.ttsModelId,
       sourceLanguage: config.sourceLanguage, targetLanguage: config.targetLanguage,
     });
+    // Best-effort machine snapshot so the Logs panel shows which GPU/backends
+    // the session resolved against (helps diagnose "GPU wasn't used"). Null when
+    // the sidecar is unavailable — skip the line rather than fail the session.
+    const hw = await nativeHardwareInfo();
+    if (hw) {
+      this.emitEvent('local.native.hardware', 'client', {
+        os: hw.os, arch: hw.arch, cpuCores: hw.cpuCores,
+        gpus: hw.gpus, backendsInstalled: hw.backendsInstalled, accelAvailable: hw.accelAvailable,
+      });
+    }
     this.ttsSpeed = config.ttsSpeed ?? 1.0;
     this.keepReplayAudio = config.keepReplayAudio ?? false;
     const store = useNativeModelStore.getState();
@@ -67,6 +78,7 @@ export class LocalNativeClient implements IClient {
         config.asrModelId, config.ttsModelId, config.translationVariant,
       );
       store.setTranslationResolved({ model: config.translationModelId ?? '', device: tr.device ?? 'cpu', backend: tr.backend, computeType: tr.computeType, tokensPerSec: tr.tokensPerSec, memoryBytes: tr.memoryBytes, fallbackReason: tr.fallbackReason });
+      this.emitInitReady('translation', config.translationModelId ?? '', tr);
     };
     const initAsr = async () => {
       store.setAsrLoading(true);
@@ -77,6 +89,7 @@ export class LocalNativeClient implements IClient {
           minSpeech: config.vadMinSpeechDuration,
         }, config.asrDevice, config.asrVariant);
         store.setAsrResolved({ model: config.asrModelId, device: res.device ?? 'cpu', backend: res.backend, computeType: res.computeType, rtf: res.rtf, memoryBytes: res.memoryBytes, fallbackReason: res.fallbackReason });
+        this.emitInitReady('asr', config.asrModelId ?? '', res);
       } finally {
         store.setAsrLoading(false);
       }
@@ -103,6 +116,7 @@ export class LocalNativeClient implements IClient {
         this.ttsStreaming = !!r.streaming;
         store.setTtsResolved({ model: config.ttsModelId!, device: r.device ?? 'cpu', backend: r.backend, computeType: r.computeType,
           rtf: r.rtf, memoryBytes: r.memoryBytes, fallbackReason: r.fallbackReason });
+        this.emitInitReady('tts', config.ttsModelId!, r);
         // Apply the selected voice (next-session semantics), driven by the
         // model's capability (built-in named/range and/or custom clip/style)
         // rather than a MOSS-specific "clones" flag, so any current or future
@@ -125,6 +139,7 @@ export class LocalNativeClient implements IClient {
         }
         const voiceList = cap.builtin === 'named' ? await nativeListTtsVoices(config.ttsModelId) : [];
         const voice = reconcileTtsVoice(config.ttsVoice ?? '', customIds, config.targetLanguage, voiceList, cap.custom !== 'none');
+        this.ttsVoiceLabel = voice;   // e.g. builtin:Bella | custom:7 | sid:3 — logged on tts.start
         if (voice.startsWith('builtin:')) {
           await this.tts.setVoice?.(voice.slice('builtin:'.length));
         } else if (voice.startsWith('custom:') && voiceStore) {
@@ -184,6 +199,26 @@ export class LocalNativeClient implements IClient {
   }
 
   /**
+   * Surface the sidecar's resolved plan for one stage into the Logs panel:
+   * which device/backend/quant it landed on, its load time and RTF/tokens, and
+   * — critically — a distinct `.fallback` line when the stage was moved off the
+   * requested device (e.g. GPU→CPU), which was previously silent. Only defined
+   * metrics are attached so CPU-only stages don't log empty `rtf`/`memoryBytes`.
+   */
+  private emitInitReady(engine: 'asr' | 'translation' | 'tts', modelId: string, r: any): void {
+    this.emitEvent(`local.native.init.${engine}.ready`, 'client', {
+      model: modelId, device: r.device ?? 'cpu', backend: r.backend, computeType: r.computeType,
+      ...(r.rtf !== undefined && { rtf: r.rtf }),
+      ...(r.tokensPerSec !== undefined && { tokensPerSec: r.tokensPerSec }),
+      ...(r.memoryBytes !== undefined && { memoryBytes: r.memoryBytes }),
+      loadTimeMs: r.loadTimeMs,
+    });
+    if (r.fallbackReason) {
+      this.emitEvent(`local.native.init.${engine}.fallback`, 'client', { model: modelId, fallbackReason: r.fallbackReason });
+    }
+  }
+
+  /**
    * Accumulate a TTS audio chunk onto the item so the inline replay button has
    * a complete buffer. Gated on `keepReplayAudio`; real-time playback (via the
    * audio delta) is unaffected when this is skipped.
@@ -203,6 +238,7 @@ export class LocalNativeClient implements IClient {
 
   private onAsrPartial(text: string): void {
     if (!text) return;
+    this.emitEvent('local.native.asr.partial', 'server', { text });
     if (!this.partialUserItem) {
       this.partialUserItem = {
         id: this.nextId('user'), role: 'user', type: 'message', status: 'in_progress',
@@ -216,9 +252,18 @@ export class LocalNativeClient implements IClient {
     }
   }
 
-  private onAsrResult(r: { text: string }): void {
+  private onAsrResult(r: { text: string; durationMs?: number; recognitionTimeMs?: number; startSample?: number }): void {
     if (!r.text?.trim()) return;
-    this.emitEvent('local.native.asr.result', 'server', { text: r.text });
+    // rtf = compute time / audio duration — the single "can it keep up with
+    // real time" number. Only derived when the sidecar sent both timings.
+    const rtf = r.durationMs && r.recognitionTimeMs !== undefined
+      ? Math.round((r.recognitionTimeMs / r.durationMs) * 1000) / 1000 : undefined;
+    this.emitEvent('local.native.asr.end', 'server', {
+      text: r.text, modelId: this.cfg?.asrModelId,
+      ...(r.durationMs !== undefined && { durationMs: r.durationMs }),
+      ...(r.recognitionTimeMs !== undefined && { recognitionTimeMs: r.recognitionTimeMs }),
+      ...(rtf !== undefined && { rtf }),
+    });
     let userItem = this.partialUserItem;
     if (userItem) {
       userItem.status = 'completed';
@@ -240,9 +285,15 @@ export class LocalNativeClient implements IClient {
   }
 
   private async runJob(text: string): Promise<void> {
-    this.emitEvent('local.native.translation.start', 'client', { text });
+    this.emitEvent('local.native.translation.start', 'client', {
+      sourceText: text, modelId: this.cfg?.translationModelId,
+      systemPrompt: this.cfg?.instructions ?? '', wrapTranscript: !!this.cfg?.wrapTranscript,
+    });
     const tr = await this.translate.translate(text, this.cfg?.instructions ?? '', !!this.cfg?.wrapTranscript);
-    this.emitEvent('local.native.translation.end', 'server', { translatedText: tr.translatedText, inferenceTimeMs: tr.inferenceTimeMs });
+    this.emitEvent('local.native.translation.end', 'server', {
+      sourceText: tr.sourceText ?? text, translatedText: tr.translatedText,
+      inferenceTimeMs: tr.inferenceTimeMs, modelId: this.cfg?.translationModelId,
+    });
     const item: ConversationItem = {
       id: this.nextId('asst'), role: 'assistant', type: 'message', status: 'in_progress',
       createdAt: Date.now(), formatted: { transcript: tr.translatedText },
@@ -250,32 +301,47 @@ export class LocalNativeClient implements IClient {
     this.items.push(item);
     this.emit(item);
     if (this.ttsEnabled) {
-      this.emitEvent('local.native.tts.start', 'client', {});
       const displayText = tr.translatedText;
-      const sentences = splitSentences(displayText, this.cfg?.targetLanguage);
+      // Iterate the non-empty sentences so sentenceIndex/sentenceCount are clean
+      // and consistent with the per-sentence events emitted below.
+      const sentences = splitSentences(displayText, this.cfg?.targetLanguage).filter((s) => s.trim());
+      const sentenceCount = sentences.length;
+      this.emitEvent('local.native.tts.start', 'client', {
+        text: displayText, sentenceCount, modelId: this.cfg?.ttsModelId,
+        voice: this.ttsVoiceLabel, speed: this.ttsSpeed,
+      });
+      const ttsStartTime = performance.now();
       item.formatted!.audioSegments = [];
       let searchFrom = 0;
       let cumulativeAudioDuration = 0;
 
-      for (const sentence of sentences) {
-        if (!sentence.trim()) continue;
-
+      for (let i = 0; i < sentences.length; i++) {
+        const sentence = sentences[i];
         const pos = displayText.indexOf(sentence, searchFrom);
         const textEnd = pos >= 0 ? pos + sentence.length : searchFrom + sentence.length;
         searchFrom = textEnd;
 
+        this.emitEvent('local.native.tts.sentence.start', 'client', {
+          sentenceIndex: i, sentenceCount, text: sentence,
+        });
+        const sentenceStart = performance.now();
+
         try {
+          let sentenceSamples: number;
+          let generateMs: number | undefined;
           if (this.ttsStreaming) {
             // Pre-set audioTextEnd so every chunk delta already carries current karaoke
             // metadata — mirrors LocalInferenceClient streaming path (LIC line 647).
             item.formatted!.audioTextEnd = textEnd;
             let chunkSampleCount = 0;
-            await this.tts.generate(sentence, this.ttsSpeed, (pcm: Float32Array) => {
+            const done = await this.tts.generate(sentence, this.ttsSpeed, (pcm: Float32Array) => {
               const int16 = float32ToInt16(resampleFloat32(pcm, 24000, 24000));
               chunkSampleCount += int16.length;
               if (this.keepReplayAudio) this.appendItemAudio(item, int16);
               this.emit(item, { audio: int16 });
             });
+            sentenceSamples = chunkSampleCount;
+            generateMs = done?.generationTimeMs;
             cumulativeAudioDuration += chunkSampleCount / 24000;
             item.formatted!.audioSegments.push({ textEnd, audioEnd: cumulativeAudioDuration });
             // Bare emit (no delta) publishes finalized segment metadata to the renderer
@@ -287,24 +353,39 @@ export class LocalNativeClient implements IClient {
             item.formatted!.audioTextEnd = textEnd;
             const res = await this.tts.generate(sentence, this.ttsSpeed);
             const int16 = float32ToInt16(resampleFloat32(res.samples as Float32Array, res.sampleRate, 24000));
+            sentenceSamples = int16.length;
+            generateMs = res.generationTimeMs;
             cumulativeAudioDuration += int16.length / 24000;
             item.formatted!.audioSegments.push({ textEnd, audioEnd: cumulativeAudioDuration });
             if (this.keepReplayAudio) this.appendItemAudio(item, int16);
             this.emit(item, { audio: int16 });
           }
+
+          const audioDurationMs = Math.round((sentenceSamples / 24000) * 1000);
+          // Prefer the sidecar's reported synth time; fall back to wall time when
+          // it isn't provided so the log always carries a generateMs.
+          const gm = generateMs ?? Math.round(performance.now() - sentenceStart);
+          const rtf = audioDurationMs > 0 ? Math.round((gm / audioDurationMs) * 1000) / 1000 : undefined;
+          this.emitEvent('local.native.tts.sentence.end', 'server', {
+            sentenceIndex: i, sentenceCount, text: sentence,
+            generateMs: gm, audioDurationMs, ...(rtf !== undefined && { rtf }),
+          });
         } catch (ttsError) {
           // Mirror LocalInferenceClient lines 751-757: log + skip failed sentence,
           // loop continues so the item still reaches status='completed'.
           console.warn('[LocalNative] TTS failed for sentence, skipping:', ttsError);
-          this.emitEvent('local.native.tts.error', 'client', {
+          this.emitEvent('local.native.tts.error', 'server', {
             error: ttsError instanceof Error ? ttsError.message : String(ttsError),
+            sentenceIndex: i,
           });
         }
       }
 
       // Ensure trailing whitespace is covered
       item.formatted!.audioTextEnd = displayText.length;
-      this.emitEvent('local.native.tts.end', 'server', { samples: Math.round(cumulativeAudioDuration * 24000) });
+      this.emitEvent('local.native.tts.end', 'server', {
+        sentenceCount, durationMs: Math.round(performance.now() - ttsStartTime),
+      });
     }
     item.status = 'completed';
     this.emit(item);

--- a/src/stores/logStore.ts
+++ b/src/stores/logStore.ts
@@ -112,7 +112,29 @@ export interface EventData {
     | 'local.init.translation.error'
     | 'local.init.tts.start'
     | 'local.init.tts.ready'
-    | 'local.init.tts.error';
+    | 'local.init.tts.error'
+    // LocalNative (Electron sidecar) pipeline event types
+    | 'local.native.session.closed'
+    | 'local.native.hardware'
+    | 'local.native.error'
+    | 'local.native.asr.partial'
+    | 'local.native.asr.end'
+    | 'local.native.translation.start'
+    | 'local.native.translation.end'
+    | 'local.native.tts.start'
+    | 'local.native.tts.sentence.start'
+    | 'local.native.tts.sentence.end'
+    | 'local.native.tts.end'
+    | 'local.native.tts.error'
+    // LocalNative init progress event types
+    | 'local.native.init.start'
+    | 'local.native.init.ready'
+    | 'local.native.init.asr.ready'
+    | 'local.native.init.asr.fallback'
+    | 'local.native.init.translation.ready'
+    | 'local.native.init.translation.fallback'
+    | 'local.native.init.tts.ready'
+    | 'local.native.init.tts.fallback';
   data: any;
   // Support additional properties for flexible event handling (e.g., OpenAI properties)
   [key: string]: any;

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { NativeModelClient } from '../lib/local-inference/native/NativeModelClient';
-import type { NativeModelState, NativeModelInfo, NativeVoiceInfo, VariantInfo } from '../lib/local-inference/native/nativeProtocol';
+import type { NativeModelState, NativeModelInfo, NativeVoiceInfo, VariantInfo, HardwareInfoResultMsg } from '../lib/local-inference/native/nativeProtocol';
 import { autoSelectNative, hardwareGated, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
 import { isElectron } from '../utils/environment';
 
@@ -343,6 +343,18 @@ export async function nativeListTtsVoices(model?: string): Promise<NativeVoiceIn
     return await client.listTtsVoices(model);
   } catch {
     return [];
+  }
+}
+
+/** Best-effort detected hardware (CPU/GPU + installed backends) for the Logs
+ *  panel. Returns null when the sidecar is unavailable (e.g. not running in
+ *  Electron) so callers can skip the log line rather than crash. Exported at
+ *  this module boundary so the renderer can mock it in tests. */
+export async function nativeHardwareInfo(): Promise<HardwareInfoResultMsg | null> {
+  try {
+    return await client.hardwareInfo();
+  } catch {
+    return null;
   }
 }
 


### PR DESCRIPTION
## Why

The native (Electron sidecar) client dropped almost every metric the sidecar already sends — only translation `inferenceTimeMs` reached the Logs panel. ASR/TTS timing, per-sentence progress, and the resolved device/backend/quant/memory plan were received on the renderer but never logged (the device plan went only to `nativeModelStore`, feeding UI badges). This brings native log events to parity with the WASM `LocalInferenceClient`.

## What changed

| Event | Fields added / change |
|---|---|
| `local.native.hardware` (**new**, once per session) | `os, arch, cpuCores, gpus[], backendsInstalled, accelAvailable` |
| `local.native.init.{asr,translation,tts}.ready` (**new**) | `model, device, backend, computeType, rtf`/`tokensPerSec`, `memoryBytes, loadTimeMs` |
| `local.native.init.{engine}.fallback` (**new**) | `model, fallbackReason` — a previously **silent** GPU→CPU downgrade now shows up |
| `local.native.asr.partial` (**new**) / `asr.end` (renamed from `asr.result`) | `text` / `+modelId, durationMs, recognitionTimeMs, rtf` |
| `local.native.translation.start/end` | `+sourceText, modelId, systemPrompt, wrapTranscript` |
| `local.native.tts.start` | `text, sentenceCount, modelId, voice, speed` (was `{}`) |
| `local.native.tts.sentence.start/end` (**new**) | `sentenceIndex, sentenceCount, text, generateMs, audioDurationMs, rtf` |
| `local.native.tts.end` | `sentenceCount, durationMs` (was `samples`) |

Most fields were **already present on the callback/init objects** and simply not logged (e.g. `onAsrResult`'s arg was type-narrowed to `{ text }`). `rtf` is derived (compute time ÷ audio duration). A new best-effort `nativeHardwareInfo()` store helper fetches the machine snapshot; it returns `null` (skips the log line) when the sidecar isn't available.

### Structural
- All `local.native.*` types are now declared in `logStore`'s `EventData` union (previously cast through `as any`).
- `asr.result` split conceptually into `asr.partial` + `asr.end`; TTS gains per-sentence events — both aligning native key names with the WASM path so `LogsPanel` can format one set of events.

## Testing
- TDD: 6 tests written first (RED, failing for the right reasons) → implemented → GREEN.
- `LocalNativeClient.test.ts`: 32/32 ✅
- Full suite: **820/820 ✅**
- No new `tsc` errors in the 3 changed non-test files (the 2 remaining `logStore` errors are pre-existing zustand `subscribeWithSelector` typing quirks).

## Notes / follow-ups
- `fallbackReason` is surfaced as a **distinct event** but still `info` level, since `addRealtimeEvent` hardcodes `type:'info'`. Rendering it as a visual warning in `LogsPanel` is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer native runtime and hardware logging events, including device, backend, memory, and OS details.
  * Expanded realtime event coverage for speech, translation, and text-to-speech with more complete timing and model information.

* **Bug Fixes**
  * Improved native speech and translation event reporting so final, partial, and fallback states are captured more consistently.
  * Enhanced text-to-speech event payloads to include sentence-level progress and completion details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->