### PR TITLE
fix(native): swap ASR/translate direction for participant mode

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -30,7 +30,7 @@ import {
   useSubtitleModeActive,
   useKeepReplayAudio,
 } from '../../stores/settingsStore';
-import useSettingsStore, { createParticipantLocalInferenceConfig } from '../../stores/settingsStore';
+import useSettingsStore, { createParticipantLocalInferenceConfig, createParticipantLocalNativeConfig } from '../../stores/settingsStore';
 import {
   useConversationDisplayFontSize,
   useSetConversationDisplayFontSize,
@@ -645,17 +645,29 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       const ast2 = config as VolcengineAST2SessionConfig;
       [ast2.sourceLanguage, ast2.targetLanguage] = [ast2.targetLanguage, ast2.sourceLanguage];
     } else if (config.provider === 'local_native') {
-      // Native ASR/translate carry direction in sourceLanguage/targetLanguage
-      // (the ASR model is language-conditioned; passing the speaker direction
-      // makes it decode the participant's speech in the wrong language). Swap
-      // them so the participant channel does "their speech → user's language".
-      // Both ASR and translation models are multilingual, so no reverse-direction
-      // model swap is needed (unlike local_inference's per-pair WASM models).
-      const nativeConfig = config as LocalNativeSessionConfig;
-      [nativeConfig.sourceLanguage, nativeConfig.targetLanguage] = [nativeConfig.targetLanguage, nativeConfig.sourceLanguage];
-      // Participant channel is text-only; drop the TTS model resolved for the
-      // original target language.
-      nativeConfig.ttsModelId = undefined;
+      // Native ASR/translate carry the translation direction in
+      // sourceLanguage/targetLanguage AND in the chosen model ids (a directional
+      // Opus model bakes the direction in; a source-specific ASR only handles one
+      // language). Reverse the direction and re-resolve both models for the
+      // reversed pair — see createParticipantLocalNativeConfig.
+      const result = createParticipantLocalNativeConfig(config as LocalNativeSessionConfig);
+
+      if (!result.success) {
+        addRealtimeEvent(
+          { type: 'participant.error', data: { message: result.detail } },
+          'client', 'participant.error'
+        );
+        return null;
+      }
+
+      if (!result.translationAvailable) {
+        addRealtimeEvent(
+          { type: 'participant.warning', data: { message: `No translation model for ${result.config.sourceLanguage} → ${result.config.targetLanguage} — transcription only` } },
+          'client', 'participant.warning'
+        );
+      }
+
+      return result.config;
     } else if (config.provider === 'volcengine_st') {
       const st = config as VolcengineSTSessionConfig;
       const oldSource = st.sourceLanguage;

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -48,7 +48,7 @@ import { useLogActions } from '../../stores/logStore';
 import { useNativeAsrLoading } from '../../stores/nativeModelStore';
 import type { RealtimeEvent } from '../../stores/logStore';
 import { IClient, ConversationItem, SessionConfig, ClientEventHandlers, ClientFactory, ResponseConfig } from '../../services/clients';
-import type { VolcengineAST2SessionConfig, VolcengineSTSessionConfig, LocalInferenceSessionConfig, OpenAITranslateSessionConfig, TranslateTargetLanguage } from '../../services/interfaces/IClient';
+import type { VolcengineAST2SessionConfig, VolcengineSTSessionConfig, LocalInferenceSessionConfig, LocalNativeSessionConfig, OpenAITranslateSessionConfig, TranslateTargetLanguage } from '../../services/interfaces/IClient';
 import { WavRenderer } from '../../utils/wav_renderer';
 import { ServiceFactory } from '../../services/ServiceFactory'; // Import the ServiceFactory
 import { IAudioService } from '../../services/interfaces/IAudioService';
@@ -602,7 +602,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
    * Helper to create session config for participant mode (swapped languages, text-only, semantic VAD)
    */
   const createParticipantSessionConfig = useCallback((): SessionConfig | null => {
-    const swappedSystemInstructions = provider === Provider.LOCAL_INFERENCE
+    const swappedSystemInstructions = (provider === Provider.LOCAL_INFERENCE || provider === Provider.LOCAL_NATIVE)
       ? getProcessedLocalPrompt(true)
       : getProcessedSystemInstructions(true);
     const baseConfig = createSessionConfig(swappedSystemInstructions);
@@ -644,6 +644,18 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     if (config.provider === 'volcengine_ast2') {
       const ast2 = config as VolcengineAST2SessionConfig;
       [ast2.sourceLanguage, ast2.targetLanguage] = [ast2.targetLanguage, ast2.sourceLanguage];
+    } else if (config.provider === 'local_native') {
+      // Native ASR/translate carry direction in sourceLanguage/targetLanguage
+      // (the ASR model is language-conditioned; passing the speaker direction
+      // makes it decode the participant's speech in the wrong language). Swap
+      // them so the participant channel does "their speech → user's language".
+      // Both ASR and translation models are multilingual, so no reverse-direction
+      // model swap is needed (unlike local_inference's per-pair WASM models).
+      const nativeConfig = config as LocalNativeSessionConfig;
+      [nativeConfig.sourceLanguage, nativeConfig.targetLanguage] = [nativeConfig.targetLanguage, nativeConfig.sourceLanguage];
+      // Participant channel is text-only; drop the TTS model resolved for the
+      // original target language.
+      nativeConfig.ttsModelId = undefined;
     } else if (config.provider === 'volcengine_st') {
       const st = config as VolcengineSTSessionConfig;
       const oldSource = st.sourceLanguage;

--- a/src/stores/settingsStore.participantNative.test.ts
+++ b/src/stores/settingsStore.participantNative.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createParticipantLocalNativeConfig } from './settingsStore';
+import { useNativeModelStore } from './nativeModelStore';
+import type { LocalNativeSessionConfig } from '../services/interfaces/IClient';
+import type { NativeModelInfo } from '../lib/local-inference/native/nativeProtocol';
+
+/** Minimal catalog-entry factory (mirrors nativeCatalog.test.ts). */
+const M = (id: string, kind: NativeModelInfo['kind'], languages: string[], order: number,
+           recommended = false): NativeModelInfo =>
+  ({ id, name: id, languages, recommended, tiers: [], order, repo: id, kind });
+
+const CATALOG: Record<string, NativeModelInfo> = {
+  // ASR
+  'whisper-base': M('whisper-base', 'asr', ['multi'], 3),
+  'sense-voice': M('sense-voice', 'asr', ['zh', 'en', 'ja', 'ko'], 1, true),
+  // Translation
+  'qwen2.5-0.5b': M('qwen2.5-0.5b', 'translate', ['multi'], 1, true),
+  'opus-mt-zh-en': M('opus-mt-zh-en', 'translate', ['zh', 'en'], 21),
+  'opus-mt-en-zh': M('opus-mt-en-zh', 'translate', ['en', 'zh'], 22),
+};
+
+/** Build a speaker-direction native session config (the base the participant helper reverses). */
+const baseConfig = (over: Partial<LocalNativeSessionConfig>): LocalNativeSessionConfig => ({
+  provider: 'local_native',
+  model: 'native-asr-translate',
+  instructions: '',
+  sourceLanguage: 'zh',
+  targetLanguage: 'en',
+  asrModelId: 'whisper-base',
+  translationModelId: 'qwen2.5-0.5b',
+  ttsModelId: 'some-tts',
+  ...over,
+});
+
+/** Seed the native model store with a catalog and a set of "ready" (downloaded) ids. */
+const seed = (readyIds: string[]) => {
+  useNativeModelStore.setState({
+    catalog: CATALOG,
+    statuses: Object.fromEntries(readyIds.map((id) => [id, 'ready' as const])),
+    modelPreferences: {},
+  });
+};
+
+describe('createParticipantLocalNativeConfig', () => {
+  beforeEach(() => {
+    seed([]);
+  });
+
+  it('reverses languages and reuses a multilingual model (no extra models loaded)', () => {
+    seed(['whisper-base', 'qwen2.5-0.5b']);
+    const result = createParticipantLocalNativeConfig(baseConfig({}));
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Direction reversed.
+    expect(result.config.sourceLanguage).toBe('en');
+    expect(result.config.targetLanguage).toBe('zh');
+    // Multilingual models handle both directions → same ids reused.
+    expect(result.config.asrModelId).toBe('whisper-base');
+    expect(result.config.translationModelId).toBe('qwen2.5-0.5b');
+    expect(result.translationAvailable).toBe(true);
+    // Participant channel is text-only.
+    expect(result.config.ttsModelId).toBeUndefined();
+  });
+
+  it('re-resolves a directional Opus model to the reverse-direction pair', () => {
+    // Speaker uses zh→en Opus; only the reverse en→zh Opus is downloaded.
+    seed(['whisper-base', 'opus-mt-en-zh']);
+    const result = createParticipantLocalNativeConfig(
+      baseConfig({ translationModelId: 'opus-mt-zh-en' }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    // Would have translated the WRONG direction if left as opus-mt-zh-en.
+    expect(result.config.translationModelId).toBe('opus-mt-en-zh');
+    expect(result.translationAvailable).toBe(true);
+  });
+
+  it('falls back to transcription-only when no reverse translation model is downloaded', () => {
+    // Only ASR downloaded; neither the reverse Opus nor any multilingual model is ready.
+    seed(['whisper-base']);
+    const result = createParticipantLocalNativeConfig(
+      baseConfig({ translationModelId: 'opus-mt-zh-en' }),
+    );
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.config.asrModelId).toBe('whisper-base');
+    expect(result.config.translationModelId).toBeUndefined();
+    expect(result.translationAvailable).toBe(false);
+  });
+
+  it('fails with no_asr when no ASR model can serve the reversed source language', () => {
+    // Speaker zh→de; reversed source is 'de'. sense-voice does not cover 'de' and no
+    // multilingual ASR is downloaded, so the participant channel cannot be built.
+    seed(['sense-voice']);
+    const result = createParticipantLocalNativeConfig(
+      baseConfig({ sourceLanguage: 'zh', targetLanguage: 'de', asrModelId: 'sense-voice', translationModelId: 'qwen2.5-0.5b' }),
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.reason).toBe('no_asr');
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -18,7 +18,7 @@ import {
 } from '../services/interfaces/IClient';
 import { getTtsModelsForLanguage, getManifestEntry, getTranslationModel, estimateModelMemoryByDevice } from '../lib/local-inference/modelManifest';
 import { buildDefaultLocalPrompt } from '../lib/local-inference/prompts';
-import { resolveNativeTts, resolveNativeTranslation, requiredNativeModels, supportsLanguage, statusReposFor, nativeTranslationCards, nativeAsrCards, nativeTtsCards } from '../lib/local-inference/native/nativeCatalog';
+import { resolveNativeTts, resolveNativeTranslation, requiredNativeModels, supportsLanguage, statusReposFor, nativeTranslationCards, nativeAsrCards, nativeTtsCards, autoSelectNative, hardwareGated, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
 import type { NativeModelInfo } from '../lib/local-inference/native/nativeProtocol';
 import { useNativeModelStore } from './nativeModelStore';
 import { isElectron } from '../utils/environment';
@@ -890,6 +890,79 @@ export function createParticipantLocalInferenceConfig(
       ttsModelId: undefined,
     },
     status,
+  };
+}
+
+export type ParticipantLocalNativeResult =
+  | { success: true; config: LocalNativeSessionConfig; translationAvailable: boolean }
+  | { success: false; reason: 'no_asr'; detail: string };
+
+/**
+ * Build a participant (other-speaker) session config for the native provider.
+ *
+ * The participant channel translates the OTHER speaker — who speaks the user's
+ * TARGET language — so the direction is reversed. Reversing must re-resolve the
+ * ASR and translation models, not just swap the language fields, because:
+ *   - the native ASR model is language-conditioned; a source-specific ASR can't
+ *     transcribe the reversed source language, and
+ *   - directional Opus-MT translation models bake the direction into the model
+ *     and ignore src/tgt (translate_backends.py), so the speaker-direction model
+ *     would translate the wrong way.
+ * Multilingual models (qwen*) handle both directions, so for them the
+ * re-resolution is a no-op and the same model is reused (no extra memory).
+ *
+ * Model re-resolution reuses `autoSelectNative` — the same download-/hardware-
+ * aware logic the settings UI uses — so an un-downloaded reverse model is never
+ * selected; it falls back to a downloaded multilingual model, else to
+ * transcription-only. TTS is dropped (participant channel is text-only).
+ *
+ * Returns `{ success: false, reason: 'no_asr' }` when no ASR model can serve the
+ * reversed source language, so the caller can skip the participant channel.
+ */
+export function createParticipantLocalNativeConfig(
+  baseConfig: LocalNativeSessionConfig
+): ParticipantLocalNativeResult {
+  const store = useNativeModelStore.getState();
+  const catalog = store.catalog;
+  const statuses = store.statuses;
+  const isDownloaded = (id: string | null) => id === null || statuses[id] === 'ready';
+  const isHardwareGated = (id: string | null) => id !== null && hardwareGated(catalog[id]);
+
+  // Reversed direction: the participant speaks the user's target language.
+  const revSrc = baseConfig.targetLanguage;
+  const revTgt = baseConfig.sourceLanguage;
+
+  const current: NativeSelection = {
+    asrModel: baseConfig.asrModelId,
+    translationModel: baseConfig.translationModelId ?? '',
+    ttsModel: '',
+  };
+  const updates = autoSelectNative(
+    revSrc, revTgt, current, isDownloaded, store.recallModels(revSrc, revTgt), isHardwareGated, catalog,
+  );
+  const asrModel = updates?.asrModel ?? current.asrModel;
+  const translationModel = updates?.translationModel ?? current.translationModel;
+
+  if (!asrModel) {
+    return { success: false, reason: 'no_asr', detail: `No ASR model available for ${revSrc}` };
+  }
+
+  return {
+    success: true,
+    translationAvailable: !!translationModel,
+    config: {
+      ...baseConfig,
+      sourceLanguage: revSrc,
+      targetLanguage: revTgt,
+      asrModelId: asrModel,
+      translationModelId: translationModel || undefined,
+      // Variant pins are keyed by model id: keep the pin only when the reversed
+      // direction reuses the same model, else let the sidecar auto-select.
+      asrVariant: asrModel === baseConfig.asrModelId ? baseConfig.asrVariant : undefined,
+      translationVariant: translationModel === (baseConfig.translationModelId ?? '')
+        ? baseConfig.translationVariant : undefined,
+      ttsModelId: undefined,
+    },
   };
 }
 


### PR DESCRIPTION
## Problem

In **participant mode** with the `local_native` provider, the user speaks their source language but ASR outputs gibberish in the wrong language.

Observed from a session log: init reports `sourceLanguage:"en", targetLanguage:"zh"` (speaker direction, **not** reversed) while the translation systemPrompt says "translate Chinese → English" (reversed). Chinese audio → `"AI show a mother, my dossier new, holding S"` — not a recognition error, the ASR was configured for the wrong language.

## Root cause

`createParticipantSessionConfig` in `src/components/MainPanel/MainPanel.tsx` reverses direction for participant channels, but its language-swap block had cases for `openai_translate`, `volcengine_ast2`, `volcengine_st`, and `local_inference` — **not** `local_native`. So the native config fell through with `sourceLanguage`/`targetLanguage` unchanged, while the prompt was reversed separately. The native ASR model is language-conditioned, so the wrong `sourceLanguage` makes it decode speech in the wrong language.

A secondary mismatch: the participant prompt-builder condition only checked `LOCAL_INFERENCE`, so `LOCAL_NATIVE` used the generic cloud interpreter prompt instead of the native prompt (the speaker path in `getSessionConfig` already handles both).

## Fix

- Add a `local_native` branch to the swap block that reverses `sourceLanguage`/`targetLanguage`. Both native ASR and translation models are multilingual, so no reverse-direction model swap is needed (unlike `local_inference`'s per-pair WASM models). Drop `ttsModelId` since the participant channel is text-only.
- Include `LOCAL_NATIVE` in the prompt-builder condition so it uses `getProcessedLocalPrompt`, mirroring the speaker path.

## Verification

- `LocalNativeClient`, `ClientFactory.localnative`, `settingsStore.nativeGate`, `ModePicker` suites: 52 passed.
- No new `tsc` errors introduced on the changed file (repo has ~113 pre-existing tsc errors; correctness gate is vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved participant session setup for local native translation flows.
  * Participant direction now uses the correct source and target languages.
  * Text-only sessions no longer attempt to use a voice model when one isn’t available.
  * System instructions are now applied more consistently for local native and local inference providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->