### PR TITLE
fix(linux): surface virtual audio device failures in the UI

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -84,6 +84,49 @@ app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 // Keep a global reference of the window object to prevent garbage collection
 let mainWindow;
 
+// Most recently computed virtual-audio-device status, forwarded to the
+// renderer over the 'audio-status' channel once it's ready to receive it.
+let lastAudioStatus = null;
+
+/**
+ * Figure out *why* virtual audio device setup failed so the renderer can show
+ * an actionable message instead of a generic failure.
+ * @returns {Promise<{ok: boolean, platform: string, reason: string, message: string}>}
+ */
+async function buildAudioStatus(devicesCreated) {
+  if (devicesCreated) {
+    return { ok: true, platform: process.platform, reason: null, message: null };
+  }
+
+  if (process.platform === 'linux') {
+    const { isPactlInstalled } = audioUtils;
+    const pactlInstalled = isPactlInstalled ? await isPactlInstalled() : true;
+    if (!pactlInstalled) {
+      return {
+        ok: false,
+        platform: 'linux',
+        reason: 'pactl-missing',
+        message: 'pactl (PulseAudio command-line tools) not found. Install it with: sudo apt install pulseaudio-utils'
+      };
+    }
+    return {
+      ok: false,
+      platform: 'linux',
+      reason: 'pulseaudio-unavailable',
+      message: 'Could not create virtual audio devices. Make sure PulseAudio or PipeWire is running.'
+    };
+  }
+
+  return { ok: false, platform: process.platform, reason: 'other', message: 'Failed to create virtual audio devices' };
+}
+
+function sendAudioStatus(status) {
+  lastAudioStatus = status;
+  if (mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.webContents.send('audio-status', status);
+  }
+}
+
 // Create application menu
 function createApplicationMenu() {
   const isMac = process.platform === 'darwin';
@@ -293,6 +336,12 @@ function createWindow() {
   mainWindow.webContents.on('did-finish-load', () => {
     const loadEndTime = Date.now();
     console.log(`[Sokuji] [Main] Page loaded in ${loadEndTime - loadStartTime}ms`);
+
+    // Forward the virtual-audio-device status computed during startup, now
+    // that the renderer is actually able to receive it.
+    if (lastAudioStatus) {
+      sendAudioStatus(lastAudioStatus);
+    }
   });
   
   mainWindow.webContents.on('dom-ready', () => {
@@ -363,6 +412,10 @@ app.whenReady().then(async () => {
   // Start virtual audio devices before creating the window
   try {
     const devicesCreated = await createVirtualAudioDevices();
+    lastAudioStatus = await buildAudioStatus(devicesCreated);
+    if (!devicesCreated) {
+      console.error('[Sokuji] [Main] Virtual audio device status:', lastAudioStatus.reason, '-', lastAudioStatus.message);
+    }
     if (devicesCreated) {
       console.log('[Sokuji] [Main] Virtual audio devices created successfully');
       
@@ -389,6 +442,7 @@ app.whenReady().then(async () => {
     }
   } catch (error) {
     console.error('[Sokuji] [Main] Error creating virtual audio devices:', error);
+    lastAudioStatus = { ok: false, platform: process.platform, reason: 'other', message: error.message || 'Failed to create virtual audio devices' };
   }
 
   // Create the application menu
@@ -471,6 +525,13 @@ app.on('will-quit', cleanupAndExit);
 
 // IPC handler for app version
 ipcMain.handle('get-app-version', () => app.getVersion());
+
+// IPC handler for the renderer to pull the current virtual-audio-device status.
+// The renderer's listener for the 'audio-status' push isn't guaranteed to be
+// registered yet when 'did-finish-load' fires (React mounts asynchronously),
+// so relying on the push alone can silently drop the event. The renderer
+// pulls this once right after it subscribes, to cover that race.
+ipcMain.handle('get-audio-status', () => lastAudioStatus);
 
 // ---- Window controls for the custom title bar ----
 ipcMain.handle('window:minimize', () => {
@@ -636,16 +697,19 @@ ipcMain.handle('open-external', async (event, url) => {
 
 
 
-// Handler to create virtual audio devices
+// Handler to create virtual audio devices (used for manual retry from the renderer)
 ipcMain.handle('create-virtual-speaker', async () => {
   try {
     const result = await createVirtualAudioDevices();
+    const status = await buildAudioStatus(result);
+    sendAudioStatus(status);
     return {
       success: result,
-      message: result ? 'Virtual audio devices created successfully' : 'Failed to create virtual audio devices'
+      message: result ? 'Virtual audio devices created successfully' : status.message
     };
   } catch (error) {
     console.error('[Sokuji] [Main] Error creating virtual audio devices:', error);
+    sendAudioStatus({ ok: false, platform: process.platform, reason: 'other', message: error.message || 'Failed to create virtual audio devices' });
     return {
       success: false,
       error: error.message || 'Failed to create virtual audio devices'

--- a/electron/main.js
+++ b/electron/main.js
@@ -91,7 +91,7 @@ let lastAudioStatus = null;
 /**
  * Figure out *why* virtual audio device setup failed so the renderer can show
  * an actionable message instead of a generic failure.
- * @returns {Promise<{ok: boolean, platform: string, reason: string, message: string}>}
+ * @returns {Promise<{ok: boolean, platform: string, reason: string | null, message: string | null}>}
  */
 async function buildAudioStatus(devicesCreated) {
   if (devicesCreated) {
@@ -442,7 +442,7 @@ app.whenReady().then(async () => {
     }
   } catch (error) {
     console.error('[Sokuji] [Main] Error creating virtual audio devices:', error);
-    lastAudioStatus = { ok: false, platform: process.platform, reason: 'other', message: error.message || 'Failed to create virtual audio devices' };
+    lastAudioStatus = { ok: false, platform: process.platform, reason: 'other', message: error?.message || 'Failed to create virtual audio devices' };
   }
 
   // Create the application menu
@@ -709,10 +709,10 @@ ipcMain.handle('create-virtual-speaker', async () => {
     };
   } catch (error) {
     console.error('[Sokuji] [Main] Error creating virtual audio devices:', error);
-    sendAudioStatus({ ok: false, platform: process.platform, reason: 'other', message: error.message || 'Failed to create virtual audio devices' });
+    sendAudioStatus({ ok: false, platform: process.platform, reason: 'other', message: error?.message || 'Failed to create virtual audio devices' });
     return {
       success: false,
-      error: error.message || 'Failed to create virtual audio devices'
+      error: error?.message || 'Failed to create virtual audio devices'
     };
   }
 });

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -131,6 +131,7 @@ contextBridge.exposeInMainWorld(
         'update-download',
         'update-install',
         'get-app-version',
+        'get-audio-status',
         // Window control IPC for custom title bar
         'window:minimize',
         'window:maximize-toggle',

--- a/electron/pulseaudio-utils.js
+++ b/electron/pulseaudio-utils.js
@@ -283,6 +283,22 @@ async function supportsSystemAudioCapture() { return true; }
 // ============================================================================
 
 /**
+ * Check if the `pactl` CLI binary is on PATH.
+ * On Linux, PipeWire/PulseAudio can be running fine while `pactl` itself
+ * (shipped in the separate `pulseaudio-utils` package) is missing, which is
+ * exactly the case that makes createVirtualAudioDevices() fail with ENOENT.
+ * @returns {Promise<boolean>}
+ */
+async function isPactlInstalled() {
+  try {
+    await execPromise('command -v pactl');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
  * Check if PulseAudio is available
  * @returns {Promise<boolean>}
  */
@@ -352,5 +368,6 @@ module.exports = {
   supportsSystemAudioCapture,
   // Utilities
   isPulseAudioAvailable,
+  isPactlInstalled,
   cleanupOrphanedDevices
 };

--- a/src/components/AudioSystemBanner/AudioSystemBanner.scss
+++ b/src/components/AudioSystemBanner/AudioSystemBanner.scss
@@ -1,0 +1,91 @@
+.audio-system-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: #fff;
+  background-color: #e67e22;
+  flex-shrink: 0;
+
+  .audio-system-banner-content {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+
+    svg {
+      flex-shrink: 0;
+    }
+  }
+
+  .audio-system-banner-text {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    min-width: 0;
+  }
+
+  .audio-system-banner-command {
+    font-family: monospace;
+    background: rgba(0, 0, 0, 0.25);
+    padding: 1px 6px;
+    border-radius: 3px;
+    user-select: all;
+  }
+
+  .audio-system-banner-actions {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+
+  .retry-button {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    background: rgba(255, 255, 255, 0.15);
+    border: none;
+    color: #fff;
+    font-size: 12px;
+    padding: 3px 8px;
+    border-radius: 3px;
+    cursor: pointer;
+
+    &:hover:not(:disabled) {
+      background: rgba(255, 255, 255, 0.25);
+    }
+
+    &:disabled {
+      cursor: default;
+      opacity: 0.7;
+    }
+
+    .spinning {
+      animation: audio-system-banner-spin 1s linear infinite;
+    }
+  }
+
+  .dismiss-button {
+    background: none;
+    border: none;
+    color: rgba(255, 255, 255, 0.7);
+    cursor: pointer;
+    padding: 2px;
+    display: flex;
+    align-items: center;
+
+    &:hover {
+      color: #fff;
+    }
+  }
+}
+
+@keyframes audio-system-banner-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}

--- a/src/components/AudioSystemBanner/AudioSystemBanner.tsx
+++ b/src/components/AudioSystemBanner/AudioSystemBanner.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { AlertTriangle, RefreshCw, X } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import {
+  useAudioSystemStatus,
+  useAudioSystemReason,
+  useAudioSystemMessage,
+  useAudioSystemDismissed,
+  useAudioSystemRetrying,
+  useAudioSystemRetry,
+  useAudioSystemDismiss,
+} from '../../stores/audioSystemStore';
+import './AudioSystemBanner.scss';
+
+const AudioSystemBanner: React.FC = () => {
+  const { t } = useTranslation();
+  const status = useAudioSystemStatus();
+  const reason = useAudioSystemReason();
+  const message = useAudioSystemMessage();
+  const dismissed = useAudioSystemDismissed();
+  const retrying = useAudioSystemRetrying();
+  const retry = useAudioSystemRetry();
+  const dismiss = useAudioSystemDismiss();
+
+  if (status !== 'unavailable' || dismissed) {
+    return null;
+  }
+
+  const isPactlMissing = reason === 'pactl-missing';
+
+  return (
+    <div className="audio-system-banner">
+      <div className="audio-system-banner-content">
+        <AlertTriangle size={14} />
+        <div className="audio-system-banner-text">
+          <span>
+            {isPactlMissing ? t('audioSystem.pactlMissingBody') : (message || t('audioSystem.unavailableBody'))}
+          </span>
+          {isPactlMissing && (
+            <code className="audio-system-banner-command">{t('audioSystem.installCommand')}</code>
+          )}
+        </div>
+      </div>
+      <div className="audio-system-banner-actions">
+        <button
+          className="retry-button"
+          onClick={() => retry()}
+          disabled={retrying}
+        >
+          <RefreshCw size={12} className={retrying ? 'spinning' : ''} />
+          {retrying ? t('audioSystem.retrying') : t('audioSystem.retry')}
+        </button>
+        <button className="dismiss-button" onClick={dismiss} aria-label="Dismiss">
+          <X size={12} />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AudioSystemBanner;

--- a/src/components/AudioSystemBanner/AudioSystemBanner.tsx
+++ b/src/components/AudioSystemBanner/AudioSystemBanner.tsx
@@ -4,7 +4,6 @@ import { useTranslation } from 'react-i18next';
 import {
   useAudioSystemStatus,
   useAudioSystemReason,
-  useAudioSystemMessage,
   useAudioSystemDismissed,
   useAudioSystemRetrying,
   useAudioSystemRetry,
@@ -16,7 +15,6 @@ const AudioSystemBanner: React.FC = () => {
   const { t } = useTranslation();
   const status = useAudioSystemStatus();
   const reason = useAudioSystemReason();
-  const message = useAudioSystemMessage();
   const dismissed = useAudioSystemDismissed();
   const retrying = useAudioSystemRetrying();
   const retry = useAudioSystemRetry();
@@ -34,7 +32,7 @@ const AudioSystemBanner: React.FC = () => {
         <AlertTriangle size={14} />
         <div className="audio-system-banner-text">
           <span>
-            {isPactlMissing ? t('audioSystem.pactlMissingBody') : (message || t('audioSystem.unavailableBody'))}
+            {isPactlMissing ? t('audioSystem.pactlMissingBody') : t('audioSystem.unavailableBody')}
           </span>
           {isPactlMissing && (
             <code className="audio-system-banner-command">{t('audioSystem.installCommand')}</code>

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -65,6 +65,8 @@ import { isExtension, isElectron, isLoopbackPlatform, getEnvironment } from '../
 import UpdateBanner from '../UpdateBanner/UpdateBanner';
 import UpdateDialog from '../UpdateDialog/UpdateDialog';
 import { useInitUpdateListeners, useCleanupUpdateListeners } from '../../stores/updateStore';
+import AudioSystemBanner from '../AudioSystemBanner/AudioSystemBanner';
+import { useInitAudioSystemListeners, useCleanupAudioSystemListeners } from '../../stores/audioSystemStore';
 import DisplayModeButton from './DisplayModeButton';
 import ConversationRow from './ConversationRow';
 import { shouldShowItem } from './conversationFilter';
@@ -689,6 +691,14 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     initUpdateListeners();
     return () => cleanupUpdateListeners();
   }, [initUpdateListeners, cleanupUpdateListeners]);
+
+  // Initialize virtual audio device status listeners (e.g. missing pactl on Linux)
+  const initAudioSystemListeners = useInitAudioSystemListeners();
+  const cleanupAudioSystemListeners = useCleanupAudioSystemListeners();
+  useEffect(() => {
+    initAudioSystemListeners();
+    return () => cleanupAudioSystemListeners();
+  }, [initAudioSystemListeners, cleanupAudioSystemListeners]);
 
   /**
    * Initialize the audio service and set up the virtual audio output
@@ -3047,6 +3057,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       } as React.CSSProperties}
     >
       <UpdateBanner />
+      <AudioSystemBanner />
       <UpdateDialog />
       <div className="main-panel">
         {/* Conversation toolbar */}

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -865,6 +865,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "لم يتم العثور على pactl (أدوات سطر أوامر PulseAudio)، لذا لم يتمكن Sokuji من إعداد الميكروفون/مكبر الصوت الافتراضي. قم بتثبيته ثم أعد المحاولة:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "لم يتمكن Sokuji من إعداد الميكروفون/مكبر الصوت الافتراضي. تأكد من تشغيل PulseAudio أو PipeWire.",
+    "retry": "إعادة المحاولة",
+    "retrying": "جارٍ إعادة المحاولة..."
+  },
   "subtitle": {
     "sessionEnded": "انتهت الجلسة",
     "backToMain": "العودة إلى النافذة الرئيسية",

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -871,6 +871,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio কমান্ড-লাইন টুলস) খুঁজে পাওয়া যায়নি, তাই Sokuji তার ভার্চুয়াল মাইক্রোফোন/স্পিকার সেট আপ করতে পারেনি। এটি ইনস্টল করুন, তারপর আবার চেষ্টা করুন:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji তার ভার্চুয়াল মাইক্রোফোন/স্পিকার সেট আপ করতে পারেনি। PulseAudio বা PipeWire চলছে কিনা তা নিশ্চিত করুন।",
+    "retry": "পুনরায় চেষ্টা করুন",
+    "retrying": "পুনরায় চেষ্টা করা হচ্ছে..."
+  },
   "subtitle": {
     "sessionEnded": "সেশন শেষ হয়েছে",
     "backToMain": "মূল উইন্ডোতে ফিরুন",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -864,6 +864,13 @@
     "linuxMigrateTitle": "Neue Version v{{version}} verfügbar",
     "linuxMigrateBody": "Automatische Updates sind mit AppImage verfügbar. Wähle ein Format, um v{{version}} herunterzuladen."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio-Kommandozeilenwerkzeuge) wurde nicht gefunden, daher konnte Sokuji sein virtuelles Mikrofon/virtuellen Lautsprecher nicht einrichten. Installiere es und versuche es erneut:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji konnte sein virtuelles Mikrofon/virtuellen Lautsprecher nicht einrichten. Stelle sicher, dass PulseAudio oder PipeWire läuft.",
+    "retry": "Wiederholen",
+    "retrying": "Wird wiederholt..."
+  },
   "subtitle": {
     "sessionEnded": "Sitzung beendet",
     "backToMain": "Zurück zum Hauptfenster",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -944,6 +944,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio command-line tools) was not found, so Sokuji couldn't set up its virtual microphone/speaker. Install it, then retry:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji couldn't set up its virtual microphone/speaker. Make sure PulseAudio or PipeWire is running.",
+    "retry": "Retry",
+    "retrying": "Retrying..."
+  },
   "subtitle": {
     "sessionEnded": "Session ended",
     "backToMain": "Return to main window",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -864,6 +864,13 @@
     "linuxMigrateTitle": "Nueva versión v{{version}} disponible",
     "linuxMigrateBody": "Las actualizaciones automáticas están disponibles con AppImage. Elige un formato para descargar v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "No se encontró pactl (herramientas de línea de comandos de PulseAudio), por lo que Sokuji no pudo configurar su micrófono/altavoz virtual. Instálalo y vuelve a intentarlo:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji no pudo configurar su micrófono/altavoz virtual. Asegúrate de que PulseAudio o PipeWire esté en ejecución.",
+    "retry": "Reintentar",
+    "retrying": "Reintentando..."
+  },
   "subtitle": {
     "sessionEnded": "Sesión finalizada",
     "backToMain": "Volver a la ventana principal",

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -871,6 +871,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (ابزارهای خط فرمان PulseAudio) یافت نشد، بنابراین Sokuji نتوانست میکروفون/بلندگوی مجازی خود را راه‌اندازی کند. آن را نصب کنید و سپس دوباره امتحان کنید:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji نتوانست میکروفون/بلندگوی مجازی خود را راه‌اندازی کند. مطمئن شوید PulseAudio یا PipeWire در حال اجراست.",
+    "retry": "تلاش دوباره",
+    "retrying": "در حال تلاش دوباره..."
+  },
   "subtitle": {
     "sessionEnded": "جلسه پایان یافت",
     "backToMain": "بازگشت به پنجره اصلی",

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -821,6 +821,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudion komentorivityökalut) ei löytynyt, joten Sokuji ei voinut määrittää virtuaalista mikrofonia/kaiutinta. Asenna se ja yritä sitten uudelleen:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji ei voinut määrittää virtuaalista mikrofonia/kaiutinta. Varmista, että PulseAudio tai PipeWire on käynnissä.",
+    "retry": "Yritä uudelleen",
+    "retrying": "Yritetään uudelleen..."
+  },
   "subtitle": {
     "sessionEnded": "Istunto päättyi",
     "backToMain": "Palaa pääikkunaan",

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -821,6 +821,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "Hindi nahanap ang pactl (mga command-line tool ng PulseAudio), kaya hindi ma-set up ng Sokuji ang virtual na mikropono/speaker nito. I-install ito, pagkatapos ay subukang muli:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Hindi ma-set up ng Sokuji ang virtual na mikropono/speaker nito. Tiyaking tumatakbo ang PulseAudio o PipeWire.",
+    "retry": "Subukang muli",
+    "retrying": "Sinusubukang muli..."
+  },
   "subtitle": {
     "sessionEnded": "Tapos na ang session",
     "backToMain": "Bumalik sa pangunahing window",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -864,6 +864,13 @@
     "linuxMigrateTitle": "Nouvelle version v{{version}} disponible",
     "linuxMigrateBody": "Les mises à jour automatiques sont disponibles avec AppImage. Choisissez un format pour télécharger v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (outils en ligne de commande PulseAudio) est introuvable, Sokuji n'a donc pas pu configurer son microphone/haut-parleur virtuel. Installez-le, puis réessayez :",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji n'a pas pu configurer son microphone/haut-parleur virtuel. Assurez-vous que PulseAudio ou PipeWire est en cours d'exécution.",
+    "retry": "Réessayer",
+    "retrying": "Nouvel essai..."
+  },
   "subtitle": {
     "sessionEnded": "Session terminée",
     "backToMain": "Retour à la fenêtre principale",

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -869,6 +869,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (כלי שורת הפקודה של PulseAudio) לא נמצא, ולכן Sokuji לא הצליח להגדיר את המיקרופון/הרמקול הווירטואליים שלו. התקן אותו ולאחר מכן נסה שוב:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji לא הצליח להגדיר את המיקרופון/הרמקול הווירטואליים שלו. ודא ש-PulseAudio או PipeWire פועלים.",
+    "retry": "נסה שוב",
+    "retrying": "מנסה שוב..."
+  },
   "subtitle": {
     "sessionEnded": "ההפעלה הסתיימה",
     "backToMain": "חזרה לחלון הראשי",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -815,6 +815,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio कमांड-लाइन टूल्स) नहीं मिला, इसलिए Sokuji अपना वर्चुअल माइक्रोफ़ोन/स्पीकर सेट अप नहीं कर सका। इसे इंस्टॉल करें, फिर पुनः प्रयास करें:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji अपना वर्चुअल माइक्रोफ़ोन/स्पीकर सेट अप नहीं कर सका। सुनिश्चित करें कि PulseAudio या PipeWire चल रहा है।",
+    "retry": "पुनः प्रयास करें",
+    "retrying": "पुनः प्रयास हो रहा है..."
+  },
   "subtitle": {
     "sessionEnded": "सत्र समाप्त हुआ",
     "backToMain": "मुख्य विंडो पर लौटें",

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -863,6 +863,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (alat baris perintah PulseAudio) tidak ditemukan, sehingga Sokuji tidak dapat menyiapkan mikrofon/speaker virtualnya. Instal, lalu coba lagi:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji tidak dapat menyiapkan mikrofon/speaker virtualnya. Pastikan PulseAudio atau PipeWire sedang berjalan.",
+    "retry": "Coba lagi",
+    "retrying": "Mencoba lagi..."
+  },
   "subtitle": {
     "sessionEnded": "Sesi berakhir",
     "backToMain": "Kembali ke jendela utama",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -863,6 +863,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (strumenti da riga di comando di PulseAudio) non è stato trovato, quindi Sokuji non è riuscito a configurare il microfono/altoparlante virtuale. Installalo, quindi riprova:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji non è riuscito a configurare il microfono/altoparlante virtuale. Assicurati che PulseAudio o PipeWire sia in esecuzione.",
+    "retry": "Riprova",
+    "retrying": "Nuovo tentativo..."
+  },
   "subtitle": {
     "sessionEnded": "Sessione terminata",
     "backToMain": "Torna alla finestra principale",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -875,6 +875,13 @@
     "linuxMigrateTitle": "新しいバージョン v{{version}} が利用できます",
     "linuxMigrateBody": "AppImage 形式なら自動更新を利用できます。v{{version}} をダウンロードする形式を選択してください。"
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl（PulseAudio のコマンドラインツール）が見つからなかったため、Sokuji は仮想マイク/スピーカーを設定できませんでした。インストールしてから再試行してください：",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji は仮想マイク/スピーカーを設定できませんでした。PulseAudio または PipeWire が実行されていることを確認してください。",
+    "retry": "再試行",
+    "retrying": "再試行中..."
+  },
   "subtitle": {
     "sessionEnded": "セッションが終了しました",
     "backToMain": "メイン画面に戻る",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -863,6 +863,13 @@
     "linuxMigrateTitle": "새 버전 v{{version}} 사용 가능",
     "linuxMigrateBody": "AppImage 형식에서 자동 업데이트가 지원됩니다. v{{version}} 다운로드 형식을 선택하세요."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl(PulseAudio 명령줄 도구)를 찾을 수 없어 Sokuji가 가상 마이크/스피커를 설정하지 못했습니다. 설치한 후 다시 시도하세요:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji가 가상 마이크/스피커를 설정하지 못했습니다. PulseAudio 또는 PipeWire가 실행 중인지 확인하세요.",
+    "retry": "다시 시도",
+    "retrying": "다시 시도하는 중..."
+  },
   "subtitle": {
     "sessionEnded": "세션이 종료되었습니다",
     "backToMain": "메인 창으로 돌아가기",

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -862,6 +862,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (alat baris arahan PulseAudio) tidak dijumpai, jadi Sokuji tidak dapat menyediakan mikrofon/pembesar suara maya. Pasang, kemudian cuba semula:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji tidak dapat menyediakan mikrofon/pembesar suara maya. Pastikan PulseAudio atau PipeWire sedang berjalan.",
+    "retry": "Cuba semula",
+    "retrying": "Mencuba semula..."
+  },
   "subtitle": {
     "sessionEnded": "Sesi berakhir",
     "backToMain": "Kembali ke tetingkap utama",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -863,6 +863,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio-opdrachtregelprogramma's) is niet gevonden, waardoor Sokuji de virtuele microfoon/luidspreker niet kon instellen. Installeer het en probeer het opnieuw:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji kon de virtuele microfoon/luidspreker niet instellen. Zorg dat PulseAudio of PipeWire actief is.",
+    "retry": "Opnieuw proberen",
+    "retrying": "Opnieuw proberen..."
+  },
   "subtitle": {
     "sessionEnded": "Sessie beëindigd",
     "backToMain": "Terug naar hoofdvenster",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -862,6 +862,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "Nie znaleziono pactl (narzędzi wiersza poleceń PulseAudio), więc Sokuji nie mógł skonfigurować wirtualnego mikrofonu/głośnika. Zainstaluj je, a następnie spróbuj ponownie:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji nie mógł skonfigurować wirtualnego mikrofonu/głośnika. Upewnij się, że PulseAudio lub PipeWire jest uruchomione.",
+    "retry": "Ponów",
+    "retrying": "Ponawianie..."
+  },
   "subtitle": {
     "sessionEnded": "Sesja zakończona",
     "backToMain": "Powrót do okna głównego",

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -863,6 +863,13 @@
     "linuxMigrateTitle": "Nova versão v{{version}} disponível",
     "linuxMigrateBody": "Atualizações automáticas estão disponíveis no AppImage. Escolha um formato para baixar v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (ferramentas de linha de comando do PulseAudio) não foi encontrado, então o Sokuji não conseguiu configurar seu microfone/alto-falante virtual. Instale-o e tente novamente:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "O Sokuji não conseguiu configurar seu microfone/alto-falante virtual. Verifique se o PulseAudio ou o PipeWire está em execução.",
+    "retry": "Tentar novamente",
+    "retrying": "Tentando novamente..."
+  },
   "subtitle": {
     "sessionEnded": "Sessão encerrada",
     "backToMain": "Voltar à janela principal",

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -866,6 +866,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "O pactl (ferramentas de linha de comandos do PulseAudio) não foi encontrado, pelo que o Sokuji não conseguiu configurar o microfone/altifalante virtual. Instale-o e tente novamente:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "O Sokuji não conseguiu configurar o microfone/altifalante virtual. Certifique-se de que o PulseAudio ou o PipeWire está em execução.",
+    "retry": "Tentar novamente",
+    "retrying": "A tentar novamente..."
+  },
   "subtitle": {
     "sessionEnded": "Sessão terminada",
     "backToMain": "Voltar à janela principal",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -870,6 +870,13 @@
     "linuxMigrateTitle": "Доступна новая версия v{{version}}",
     "linuxMigrateBody": "Автоматические обновления доступны в формате AppImage. Выберите формат для скачивания v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "Не найден pactl (инструменты командной строки PulseAudio), поэтому Sokuji не удалось настроить виртуальный микрофон/динамик. Установите его и повторите попытку:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji не удалось настроить виртуальный микрофон/динамик. Убедитесь, что PulseAudio или PipeWire запущены.",
+    "retry": "Повторить",
+    "retrying": "Повтор..."
+  },
   "subtitle": {
     "sessionEnded": "Сессия завершена",
     "backToMain": "Вернуться в главное окно",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -819,6 +819,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudios kommandoradsverktyg) hittades inte, så Sokuji kunde inte konfigurera sin virtuella mikrofon/högtalare. Installera det och försök igen:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji kunde inte konfigurera sin virtuella mikrofon/högtalare. Kontrollera att PulseAudio eller PipeWire körs.",
+    "retry": "Försök igen",
+    "retrying": "Försöker igen..."
+  },
   "subtitle": {
     "sessionEnded": "Sessionen avslutad",
     "backToMain": "Tillbaka till huvudfönstret",

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -796,6 +796,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio கட்டளை-வரி கருவிகள்) கிடைக்கவில்லை, எனவே Sokuji தனது மெய்நிகர் மைக்ரோஃபோன்/ஸ்பீக்கரை அமைக்க முடியவில்லை. அதை நிறுவிய பிறகு மீண்டும் முயற்சிக்கவும்:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji தனது மெய்நிகர் மைக்ரோஃபோன்/ஸ்பீக்கரை அமைக்க முடியவில்லை. PulseAudio அல்லது PipeWire இயங்குகிறதா என்பதை உறுதிப்படுத்தவும்.",
+    "retry": "மீண்டும் முயற்சி",
+    "retrying": "மீண்டும் முயற்சிக்கிறது..."
+  },
   "subtitle": {
     "sessionEnded": "அமர்வு முடிந்தது",
     "backToMain": "முதன்மை சாளரத்திற்குத் திரும்பு",

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -778,6 +778,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio కమాండ్-లైన్ సాధనాలు) కనుగొనబడలేదు, కాబట్టి Sokuji తన వర్చువల్ మైక్రోఫోన్/స్పీకర్‌ను సెటప్ చేయలేకపోయింది. దీన్ని ఇన్‌స్టాల్ చేసి, ఆపై మళ్లీ ప్రయత్నించండి:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji తన వర్చువల్ మైక్రోఫోన్/స్పీకర్‌ను సెటప్ చేయలేకపోయింది. PulseAudio లేదా PipeWire రన్ అవుతోందని నిర్ధారించుకోండి.",
+    "retry": "మళ్లీ ప్రయత్నించండి",
+    "retrying": "మళ్లీ ప్రయత్నిస్తోంది..."
+  },
   "subtitle": {
     "sessionEnded": "సెషన్ ముగిసింది",
     "backToMain": "ప్రధాన విండోకి తిరిగి వెళ్ళు",

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -785,6 +785,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "ไม่พบ pactl (เครื่องมือบรรทัดคำสั่งของ PulseAudio) ทำให้ Sokuji ไม่สามารถตั้งค่าไมโครโฟน/ลำโพงเสมือนได้ โปรดติดตั้งแล้วลองใหม่:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji ไม่สามารถตั้งค่าไมโครโฟน/ลำโพงเสมือนได้ โปรดตรวจสอบว่า PulseAudio หรือ PipeWire กำลังทำงานอยู่",
+    "retry": "ลองใหม่",
+    "retrying": "กำลังลองใหม่..."
+  },
   "subtitle": {
     "sessionEnded": "เซสชันสิ้นสุดแล้ว",
     "backToMain": "กลับสู่หน้าต่างหลัก",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -821,6 +821,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "pactl (PulseAudio komut satırı araçları) bulunamadığı için Sokuji sanal mikrofonunu/hoparlörünü kuramadı. Kurun ve ardından yeniden deneyin:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji sanal mikrofonunu/hoparlörünü kuramadı. PulseAudio veya PipeWire'ın çalıştığından emin olun.",
+    "retry": "Yeniden dene",
+    "retrying": "Yeniden deneniyor..."
+  },
   "subtitle": {
     "sessionEnded": "Oturum sona erdi",
     "backToMain": "Ana pencereye dön",

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -783,6 +783,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "Не знайдено pactl (інструменти командного рядка PulseAudio), тому Sokuji не вдалося налаштувати віртуальний мікрофон/динамік. Встановіть його та повторіть спробу:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji не вдалося налаштувати віртуальний мікрофон/динамік. Переконайтеся, що PulseAudio або PipeWire запущено.",
+    "retry": "Повторити",
+    "retrying": "Повторення..."
+  },
   "subtitle": {
     "sessionEnded": "Сеанс завершено",
     "backToMain": "Повернутися до головного вікна",

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -814,6 +814,13 @@
     "linuxMigrateTitle": "New version v{{version}} available",
     "linuxMigrateBody": "Auto-updates are available on AppImage. Pick a format to download v{{version}}."
   },
+  "audioSystem": {
+    "pactlMissingBody": "Không tìm thấy pactl (công cụ dòng lệnh của PulseAudio), vì vậy Sokuji không thể thiết lập micro/loa ảo. Hãy cài đặt rồi thử lại:",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji không thể thiết lập micro/loa ảo. Hãy đảm bảo PulseAudio hoặc PipeWire đang chạy.",
+    "retry": "Thử lại",
+    "retrying": "Đang thử lại..."
+  },
   "subtitle": {
     "sessionEnded": "Phiên đã kết thúc",
     "backToMain": "Quay lại cửa sổ chính",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -872,6 +872,13 @@
     "linuxMigrateTitle": "有新版本 v{{version}}",
     "linuxMigrateBody": "AppImage 格式支持自动更新。选择一种格式下载 v{{version}}。"
   },
+  "audioSystem": {
+    "pactlMissingBody": "未检测到 pactl（PulseAudio 命令行工具），Sokuji 无法创建虚拟麦克风/扬声器。请安装后重试：",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji 无法创建虚拟麦克风/扬声器，请确认 PulseAudio 或 PipeWire 正在运行。",
+    "retry": "重试",
+    "retrying": "重试中..."
+  },
   "connectionStatus": {
     "reconnecting": "重新连接中..."
   },

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -833,6 +833,13 @@
     "linuxMigrateTitle": "有新版本 v{{version}}",
     "linuxMigrateBody": "AppImage 格式支援自動更新。選擇一種格式下載 v{{version}}。"
   },
+  "audioSystem": {
+    "pactlMissingBody": "未偵測到 pactl（PulseAudio 命令列工具），Sokuji 無法建立虛擬麥克風/喇叭。請安裝後重試：",
+    "installCommand": "sudo apt install pulseaudio-utils",
+    "unavailableBody": "Sokuji 無法建立虛擬麥克風/喇叭，請確認 PulseAudio 或 PipeWire 正在執行。",
+    "retry": "重試",
+    "retrying": "重試中..."
+  },
   "subtitle": {
     "sessionEnded": "對話已結束",
     "backToMain": "返回主視窗",

--- a/src/stores/audioSystemStore.test.ts
+++ b/src/stores/audioSystemStore.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+vi.mock('../utils/environment', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/environment')>();
+  return {
+    ...actual,
+    isElectron: () => true,
+  };
+});
+
+// Import after mocking, following settingsStore.subtitle.test.ts's convention.
+const { default: useAudioSystemStore } = await import('./audioSystemStore');
+
+function mockElectron(overrides: Partial<Record<string, any>> = {}) {
+  const receivedHandlers: Record<string, (...args: any[]) => void> = {};
+  (window as any).electron = {
+    invoke: vi.fn(async (channel: string) => {
+      if (channel === 'get-audio-status') return null;
+      return { success: true };
+    }),
+    receive: vi.fn((channel: string, handler: (...args: any[]) => void) => {
+      receivedHandlers[channel] = handler;
+    }),
+    removeListener: vi.fn(),
+    removeAllListeners: vi.fn(),
+    send: vi.fn(),
+    ...overrides,
+  };
+  return { receivedHandlers, electron: (window as any).electron };
+}
+
+describe('audioSystemStore', () => {
+  beforeEach(() => {
+    useAudioSystemStore.setState({
+      status: 'unknown',
+      platform: null,
+      reason: null,
+      message: null,
+      dismissed: false,
+      retrying: false,
+    });
+    useAudioSystemStore.getState().cleanupListeners();
+  });
+
+  it('initListeners registers a push listener and pulls the current status once', () => {
+    const { electron } = mockElectron();
+    useAudioSystemStore.getState().initListeners();
+    expect(electron.receive).toHaveBeenCalledWith('audio-status', expect.any(Function));
+    expect(electron.invoke).toHaveBeenCalledWith('get-audio-status');
+  });
+
+  it('hydration pull (get-audio-status) applies status without un-dismissing an already-dismissed banner', async () => {
+    mockElectron({
+      invoke: vi.fn(async (channel: string) => {
+        if (channel === 'get-audio-status') {
+          return { ok: false, platform: 'linux', reason: 'pactl-missing', message: 'pactl not found' };
+        }
+        return { success: true };
+      }),
+    });
+    useAudioSystemStore.setState({ dismissed: true });
+
+    useAudioSystemStore.getState().initListeners();
+    // Let the pending invoke('get-audio-status') promise resolve.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    const s = useAudioSystemStore.getState();
+    expect(s.status).toBe('unavailable');
+    expect(s.reason).toBe('pactl-missing');
+    // Regression: hydrating the same still-unresolved failure must not
+    // silently re-open a banner the user already closed.
+    expect(s.dismissed).toBe(true);
+  });
+
+  it('a live audio-status push re-surfaces the banner even if previously dismissed', () => {
+    const { receivedHandlers } = mockElectron();
+    useAudioSystemStore.setState({ dismissed: true });
+
+    useAudioSystemStore.getState().initListeners();
+    receivedHandlers['audio-status']({ ok: false, platform: 'linux', reason: 'pactl-missing', message: 'pactl not found' });
+
+    const s = useAudioSystemStore.getState();
+    expect(s.status).toBe('unavailable');
+    expect(s.dismissed).toBe(false);
+  });
+
+  it('a live audio-status push reporting ok leaves dismissed untouched', () => {
+    const { receivedHandlers } = mockElectron();
+    useAudioSystemStore.setState({ dismissed: true });
+
+    useAudioSystemStore.getState().initListeners();
+    receivedHandlers['audio-status']({ ok: true, platform: 'linux' });
+
+    const s = useAudioSystemStore.getState();
+    expect(s.status).toBe('ok');
+    expect(s.dismissed).toBe(true);
+  });
+
+  it('dismiss() sets dismissed to true', () => {
+    mockElectron();
+    useAudioSystemStore.getState().dismiss();
+    expect(useAudioSystemStore.getState().dismissed).toBe(true);
+  });
+
+  it('retry() swallows a rejected create-virtual-speaker invoke instead of throwing', async () => {
+    mockElectron({
+      invoke: vi.fn(async (channel: string) => {
+        if (channel === 'create-virtual-speaker') throw new Error('IPC failed');
+        return null;
+      }),
+    });
+
+    await expect(useAudioSystemStore.getState().retry()).resolves.toBeUndefined();
+    expect(useAudioSystemStore.getState().retrying).toBe(false);
+  });
+
+  it('retry() is a no-op while already retrying', async () => {
+    const { electron } = mockElectron();
+    useAudioSystemStore.setState({ retrying: true });
+    await useAudioSystemStore.getState().retry();
+    expect(electron.invoke).not.toHaveBeenCalledWith('create-virtual-speaker');
+  });
+});

--- a/src/stores/audioSystemStore.ts
+++ b/src/stores/audioSystemStore.ts
@@ -1,0 +1,106 @@
+import { create } from 'zustand';
+import { isElectron } from '../utils/environment';
+
+export type AudioSystemStatus = 'unknown' | 'ok' | 'unavailable';
+export type AudioSystemReason = 'pactl-missing' | 'pulseaudio-unavailable' | 'other' | null;
+
+interface AudioSystemState {
+  status: AudioSystemStatus;
+  platform: string | null;
+  reason: AudioSystemReason;
+  message: string | null;
+  dismissed: boolean;
+  retrying: boolean;
+}
+
+interface AudioSystemActions {
+  retry: () => Promise<void>;
+  dismiss: () => void;
+  initListeners: () => void;
+  cleanupListeners: () => void;
+}
+
+type AudioSystemStore = AudioSystemState & AudioSystemActions;
+
+// Store handler reference for cleanup (mirrors updateStore.ts pattern)
+let statusHandler: ((...args: any[]) => void) | null = null;
+
+const useAudioSystemStore = create<AudioSystemStore>()((set, get) => ({
+  status: 'unknown',
+  platform: null,
+  reason: null,
+  message: null,
+  dismissed: false,
+  retrying: false,
+
+  retry: async () => {
+    if (!isElectron() || get().retrying) return;
+    set({ retrying: true });
+    try {
+      await (window as any).electron?.invoke('create-virtual-speaker');
+      // Result also arrives via the 'audio-status' push below; this just
+      // guards against a broken IPC round trip leaving the spinner stuck.
+    } finally {
+      set({ retrying: false });
+    }
+  },
+
+  dismiss: () => set({ dismissed: true }),
+
+  initListeners: () => {
+    if (!isElectron()) return;
+    const electron = (window as any).electron;
+    if (!electron) return;
+
+    if (statusHandler) {
+      electron.removeListener('audio-status', statusHandler);
+      statusHandler = null;
+    }
+
+    const applyStatus = (data: any) => {
+      if (!data) return;
+      set({
+        status: data.ok ? 'ok' : 'unavailable',
+        platform: data.platform ?? null,
+        reason: data.reason ?? null,
+        message: data.message ?? null,
+        // A fresh unavailable status (e.g. after retry) should re-surface the banner
+        dismissed: data.ok ? get().dismissed : false,
+      });
+    };
+
+    statusHandler = applyStatus;
+    electron.receive('audio-status', statusHandler);
+
+    // The main process may have already pushed 'audio-status' (on
+    // 'did-finish-load') before this listener was registered — React mounts
+    // asynchronously, so that push can easily be missed. Pull the current
+    // status once now to cover that race; future changes still arrive live
+    // via the push above.
+    electron.invoke('get-audio-status').then(applyStatus).catch(() => {});
+  },
+
+  cleanupListeners: () => {
+    if (!isElectron()) return;
+    const electron = (window as any).electron;
+    if (!electron) return;
+
+    if (statusHandler) {
+      electron.removeListener('audio-status', statusHandler);
+      statusHandler = null;
+    }
+  },
+}));
+
+export const useAudioSystemStatus = () => useAudioSystemStore(state => state.status);
+export const useAudioSystemPlatform = () => useAudioSystemStore(state => state.platform);
+export const useAudioSystemReason = () => useAudioSystemStore(state => state.reason);
+export const useAudioSystemMessage = () => useAudioSystemStore(state => state.message);
+export const useAudioSystemDismissed = () => useAudioSystemStore(state => state.dismissed);
+export const useAudioSystemRetrying = () => useAudioSystemStore(state => state.retrying);
+export const useAudioSystemRetry = () => useAudioSystemStore(state => state.retry);
+export const useAudioSystemDismiss = () => useAudioSystemStore(state => state.dismiss);
+export const useInitAudioSystemListeners = () => useAudioSystemStore(state => state.initListeners);
+export const useCleanupAudioSystemListeners = () => useAudioSystemStore(state => state.cleanupListeners);
+
+export default useAudioSystemStore;

--- a/src/stores/audioSystemStore.ts
+++ b/src/stores/audioSystemStore.ts
@@ -40,6 +40,8 @@ const useAudioSystemStore = create<AudioSystemStore>()((set, get) => ({
       await (window as any).electron?.invoke('create-virtual-speaker');
       // Result also arrives via the 'audio-status' push below; this just
       // guards against a broken IPC round trip leaving the spinner stuck.
+    } catch (error) {
+      console.error('[Sokuji] [AudioSystemStore] Failed to retry virtual speaker creation:', error);
     } finally {
       set({ retrying: false });
     }
@@ -57,19 +59,24 @@ const useAudioSystemStore = create<AudioSystemStore>()((set, get) => ({
       statusHandler = null;
     }
 
-    const applyStatus = (data: any) => {
+    // `isLiveUpdate` distinguishes a fresh push (a status change actually
+    // happened, e.g. after retry) from the one-time hydration pull below
+    // (just fetching whatever was last computed). Only a live update should
+    // re-surface a banner the user already dismissed — otherwise every
+    // remount of the listener (e.g. entering/exiting subtitle mode) would
+    // silently un-dismiss a still-unresolved, already-acknowledged failure.
+    const applyStatus = (data: any, isLiveUpdate: boolean) => {
       if (!data) return;
       set({
         status: data.ok ? 'ok' : 'unavailable',
         platform: data.platform ?? null,
         reason: data.reason ?? null,
         message: data.message ?? null,
-        // A fresh unavailable status (e.g. after retry) should re-surface the banner
-        dismissed: data.ok ? get().dismissed : false,
+        dismissed: (isLiveUpdate && !data.ok) ? false : get().dismissed,
       });
     };
 
-    statusHandler = applyStatus;
+    statusHandler = (data: any) => applyStatus(data, true);
     electron.receive('audio-status', statusHandler);
 
     // The main process may have already pushed 'audio-status' (on
@@ -77,7 +84,7 @@ const useAudioSystemStore = create<AudioSystemStore>()((set, get) => ({
     // asynchronously, so that push can easily be missed. Pull the current
     // status once now to cover that race; future changes still arrive live
     // via the push above.
-    electron.invoke('get-audio-status').then(applyStatus).catch(() => {});
+    electron.invoke('get-audio-status').then((data: any) => applyStatus(data, false)).catch(() => {});
   },
 
   cleanupListeners: () => {


### PR DESCRIPTION
## Summary
- On Linux, when `pactl` (from `pulseaudio-utils`) is missing, Sokuji's virtual mic/speaker setup failed silently — only visible in main-process console logs. Adds an actionable in-app banner (via the previously-defined-but-unwired `audio-status` IPC channel) that shows the specific failure reason and an install command, with a Retry button that re-attempts setup without an app restart.
- Fixes a race where the initial `audio-status` push from the main process could arrive before the renderer's listener was registered (React mounts asynchronously), silently dropping the event. The renderer now also pulls the current status once via a new `get-audio-status` handler right after subscribing.

## Test plan
- [x] `tsc --noEmit` passes for all new/changed files
- [x] `node --check` on `electron/main.js` and `electron/pulseaudio-utils.js`
- [x] Unit-verified `isPactlInstalled()` returns `true`/`false` correctly with/without `pactl` on `PATH`
- [x] Ran the app end-to-end with `pactl` genuinely missing; confirmed via screenshot that the banner renders with the correct message, install command, and working Retry/dismiss buttons
- [x] Ran the app with `pactl` present; confirmed no banner appears and virtual devices are created normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an audio system status banner that appears when virtual audio setup is unavailable, with Linux guidance for missing PulseAudio tooling and messaging when the audio service isn’t running.
  * Added retry and dismiss controls for the banner, with a spinning “retrying” state.
  * Added translations for the banner across multiple languages (including English and Chinese).
* **Bug Fixes**
  * Improved reliability of audio status updates by caching and hydrating the latest status earlier, reducing missed/late notifications during startup and retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->