### PR TITLE
fix(audio): stop auto-selecting virtual devices as the default microphone

### DIFF
--- a/src/components/Settings/shared/hooks.ts
+++ b/src/components/Settings/shared/hooks.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react';
+import { isVirtualDevice, isVirtualMic, isVirtualSpeaker } from '../../../utils/audioDevices';
 
 /**
  * Shared types for audio devices
@@ -9,38 +10,10 @@ export interface AudioDevice {
   isDefault?: boolean;
 }
 
-/**
- * Check if a device is a virtual device that should be filtered or warned about
- */
-export const isVirtualDevice = (device: AudioDevice): boolean => {
-  const label = device.label.toLowerCase();
-  return label.includes('sokuji_virtual_mic') ||
-         label.includes('sokuji_virtual_speaker') ||
-         label.includes('sokuji virtual output') || // Windows display name
-         label.includes('sokujivirtualaudio') || // Mac virtual device
-         label.includes('cable');
-};
-
-/**
- * Check if a device is a virtual microphone
- */
-export const isVirtualMic = (device: AudioDevice): boolean => {
-  const label = device.label.toLowerCase();
-  return label.includes('sokuji_virtual_mic') ||
-         label.includes('sokujivirtualaudio') ||
-         label.includes('cable');
-};
-
-/**
- * Check if a device is a virtual speaker
- */
-export const isVirtualSpeaker = (device: AudioDevice): boolean => {
-  const label = device.label.toLowerCase();
-  return label.includes('sokuji_virtual_speaker') ||
-         label.includes('sokuji virtual output') || // Windows display name
-         label.includes('sokujivirtualaudio') ||
-         label.includes('cable');
-};
+// Re-exported for backward compatibility — the actual (React-free) predicates
+// now live in utils/audioDevices.ts so non-UI modules (e.g.
+// ModernBrowserAudioService) can use them without pulling in React.
+export { isVirtualDevice, isVirtualMic, isVirtualSpeaker };
 
 /**
  * Hook to filter virtual devices from a device list

--- a/src/lib/modern-audio/ModernBrowserAudioService.ts
+++ b/src/lib/modern-audio/ModernBrowserAudioService.ts
@@ -7,7 +7,7 @@ import { IParticipantAudioRecorder } from './IParticipantAudioRecorder';
 import { ServiceFactory } from '../../services/ServiceFactory';
 import { AudioDevice } from '../../stores/audioStore';
 import { isExtension } from '../../utils/environment';
-import { isVirtualMic, isVirtualSpeaker } from '../../components/Settings/shared/hooks';
+import { isVirtualMic, isVirtualSpeaker } from '../../utils/audioDevices';
 
 // Declare chrome namespace for extension messaging
 declare const chrome: any;

--- a/src/lib/modern-audio/ModernBrowserAudioService.ts
+++ b/src/lib/modern-audio/ModernBrowserAudioService.ts
@@ -7,6 +7,7 @@ import { IParticipantAudioRecorder } from './IParticipantAudioRecorder';
 import { ServiceFactory } from '../../services/ServiceFactory';
 import { AudioDevice } from '../../stores/audioStore';
 import { isExtension } from '../../utils/environment';
+import { isVirtualMic, isVirtualSpeaker } from '../../components/Settings/shared/hooks';
 
 // Declare chrome namespace for extension messaging
 declare const chrome: any;
@@ -129,7 +130,12 @@ export class ModernBrowserAudioService implements IAudioService {
         .map(device => ({
           deviceId: device.deviceId,
           label: device.label || `Microphone ${device.deviceId.substring(0, 5)}...`,
-          isVirtual: device.label ? device.label.includes('CABLE') : false
+          // Use the same detector as the Settings device pickers (hooks.ts) so a
+          // device flagged virtual there is also excluded from default-selection
+          // fallbacks here — e.g. Sokuji's own "Sokuji_Virtual_Mic" (the monitor of
+          // its own virtual speaker, meant for other apps to consume, not for
+          // Sokuji to listen to itself).
+          isVirtual: device.label ? isVirtualMic(device) : false
         }));
 
       const outputs = devices
@@ -139,7 +145,7 @@ export class ModernBrowserAudioService implements IAudioService {
         .map(device => ({
           deviceId: device.deviceId,
           label: device.label || `Speaker ${device.deviceId.substring(0, 5)}...`,
-          isVirtual: device.label ? device.label.includes('CABLE') : false
+          isVirtual: device.label ? isVirtualSpeaker(device) : false
         }));
       
       return { inputs, outputs };

--- a/src/stores/audioStore.test.ts
+++ b/src/stores/audioStore.test.ts
@@ -1,6 +1,34 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import useAudioStore from './audioStore';
-import type { AudioMode } from './audioStore';
+import useAudioStore, { pickDefaultInputDevice } from './audioStore';
+import type { AudioMode, AudioDevice } from './audioStore';
+
+// Regression test: on a machine with no physical microphone, the only
+// enumerated "audioinput" device can be a virtual/loopback one — notably
+// Sokuji's own "Sokuji_Virtual_Mic", the monitor of Sokuji's own virtual
+// speaker (electron/pulseaudio-utils.js). Auto-selecting it as the mic feeds
+// Sokuji's own TTS output back into ASR as "user speech", producing an
+// infinite transcribe -> translate -> speak loop. The fallback must never
+// pick a virtual device, even when it's the only one available.
+describe('pickDefaultInputDevice', () => {
+  it('picks the first non-virtual device when a real mic is present', () => {
+    const inputs: AudioDevice[] = [
+      { deviceId: 'virtual-1', label: 'Sokuji_Virtual_Mic', isVirtual: true },
+      { deviceId: 'real-1', label: 'Built-in Microphone', isVirtual: false },
+    ];
+    expect(pickDefaultInputDevice(inputs)?.deviceId).toBe('real-1');
+  });
+
+  it('returns null when every available input is virtual (no physical mic)', () => {
+    const inputs: AudioDevice[] = [
+      { deviceId: 'virtual-1', label: 'Sokuji_Virtual_Mic', isVirtual: true },
+    ];
+    expect(pickDefaultInputDevice(inputs)).toBeNull();
+  });
+
+  it('returns null for an empty device list', () => {
+    expect(pickDefaultInputDevice([])).toBeNull();
+  });
+});
 
 describe('audioStore — mode + mute flags', () => {
   beforeEach(() => {

--- a/src/stores/audioStore.test.ts
+++ b/src/stores/audioStore.test.ts
@@ -103,6 +103,57 @@ describe('audioStore — refreshDevices with no real microphone', () => {
     expect(s.selectedInputDevice?.deviceId).toBe('real-1');
     expect(s.isMicMuted).toBe(false);
   });
+
+  // Regression for code review finding: canStartSession (MainPanel.tsx) gates
+  // purely on !!selectedInputDevice and "mute state does not block start" by
+  // design, so a stale device object left in place after it's unplugged would
+  // still satisfy the start gate — and unmuting mid-session would reconnect
+  // straight to it.
+  it('clears a stale selectedInputDevice (now disconnected) when no real mic remains', async () => {
+    useAudioStore.setState({
+      selectedInputDevice: { deviceId: 'unplugged-real-mic', label: 'USB Microphone', isVirtual: false },
+      isMicMuted: false,
+      audioService: {
+        initialize: async () => {},
+        getDevices: async () => ({
+          inputs: [{ deviceId: 'virtual-1', label: 'Sokuji_Virtual_Mic', isVirtual: true }],
+          outputs: [],
+        }),
+        setMonitorVolume: () => {},
+      },
+    } as any);
+
+    await useAudioStore.getState().refreshDevices();
+
+    const s = useAudioStore.getState();
+    expect(s.selectedInputDevice).toBeNull();
+    expect(s.isMicMuted).toBe(true);
+  });
+
+  // Regression for code review finding: a user who hit the original bug may
+  // already have SELECTED_INPUT_DEVICE_ID persisted as the virtual mic's id.
+  // The saved-device restore path must reject it rather than blindly trusting
+  // whatever's on disk — otherwise the fix does nothing for exactly the users
+  // it's meant to protect.
+  it('does not restore a persisted device id that resolves to a virtual device', async () => {
+    localStorage.setItem('audio.selectedInputDeviceId', 'virtual-1');
+    useAudioStore.setState({
+      audioService: {
+        initialize: async () => {},
+        getDevices: async () => ({
+          inputs: [{ deviceId: 'virtual-1', label: 'Sokuji_Virtual_Mic', isVirtual: true }],
+          outputs: [],
+        }),
+        setMonitorVolume: () => {},
+      },
+    } as any);
+
+    await useAudioStore.getState().refreshDevices();
+
+    const s = useAudioStore.getState();
+    expect(s.selectedInputDevice).toBeNull();
+    expect(s.isMicMuted).toBe(true);
+  });
 });
 
 describe('audioStore — mode + mute flags', () => {

--- a/src/stores/audioStore.test.ts
+++ b/src/stores/audioStore.test.ts
@@ -30,6 +30,81 @@ describe('pickDefaultInputDevice', () => {
   });
 });
 
+// Integration-level regression test for the actual UI-visible fix: when
+// refreshDevices() finds no real microphone, it must turn the mic off
+// (isMicMuted: true), not just leave selectedInputDevice unset. The device
+// picker's "Off" option (DeviceList.tsx) only renders as selected when
+// isMicMuted is true — an unset device with isMicMuted still false shows
+// nothing selected at all, which is what prompted this follow-up.
+describe('audioStore — refreshDevices with no real microphone', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    useAudioStore.setState({
+      selectedInputDevice: null,
+      selectedMonitorDevice: null,
+      isMicMuted: false,
+      mode: 'speaker' as AudioMode,
+    } as any);
+  });
+
+  it('turns the mic off when only virtual/loopback input devices are enumerated', async () => {
+    useAudioStore.setState({
+      audioService: {
+        initialize: async () => {},
+        getDevices: async () => ({
+          inputs: [{ deviceId: 'virtual-1', label: 'Sokuji_Virtual_Mic', isVirtual: true }],
+          outputs: [],
+        }),
+        setMonitorVolume: () => {},
+      },
+    } as any);
+
+    await useAudioStore.getState().refreshDevices();
+
+    const s = useAudioStore.getState();
+    expect(s.selectedInputDevice).toBeNull();
+    expect(s.isMicMuted).toBe(true);
+  });
+
+  it('turns the mic off when no input devices are enumerated at all', async () => {
+    useAudioStore.setState({
+      audioService: {
+        initialize: async () => {},
+        getDevices: async () => ({ inputs: [], outputs: [] }),
+        setMonitorVolume: () => {},
+      },
+    } as any);
+
+    await useAudioStore.getState().refreshDevices();
+
+    const s = useAudioStore.getState();
+    expect(s.selectedInputDevice).toBeNull();
+    expect(s.isMicMuted).toBe(true);
+  });
+
+  it('still auto-selects a real microphone when one is present', async () => {
+    useAudioStore.setState({
+      audioService: {
+        initialize: async () => {},
+        getDevices: async () => ({
+          inputs: [
+            { deviceId: 'virtual-1', label: 'Sokuji_Virtual_Mic', isVirtual: true },
+            { deviceId: 'real-1', label: 'Built-in Microphone', isVirtual: false },
+          ],
+          outputs: [],
+        }),
+        setMonitorVolume: () => {},
+      },
+    } as any);
+
+    await useAudioStore.getState().refreshDevices();
+
+    const s = useAudioStore.getState();
+    expect(s.selectedInputDevice?.deviceId).toBe('real-1');
+    expect(s.isMicMuted).toBe(false);
+  });
+});
+
 describe('audioStore — mode + mute flags', () => {
   beforeEach(() => {
     useAudioStore.setState({

--- a/src/stores/audioStore.ts
+++ b/src/stores/audioStore.ts
@@ -395,28 +395,32 @@ const useAudioStore = create<AudioStore>()(
         // Try to restore saved input device, or select default
         const currentInputDevice = get().selectedInputDevice;
         if (!currentInputDevice || !devices.inputs.some(d => d.deviceId === currentInputDevice?.deviceId)) {
-          if (savedInputDeviceId) {
-            // Try to restore saved input device
-            const savedInputDevice = devices.inputs.find(d => d.deviceId === savedInputDeviceId);
-            if (savedInputDevice) {
-              console.info('[Sokuji] [AudioStore] Restored saved input device:', savedInputDevice.label);
-              set({ selectedInputDevice: savedInputDevice });
-            } else if (devices.inputs.length > 0) {
-              // Saved device not found, fall back to the first real (non-virtual) input.
-              const fallback = pickDefaultInputDevice(devices.inputs);
-              if (fallback) {
-                set({ selectedInputDevice: fallback });
-              } else {
-                console.warn('[Sokuji] [AudioStore] No real microphone found — only virtual/loopback input devices are available. Leaving mic unselected to avoid capturing Sokuji\'s own audio output.');
-              }
-            }
-          } else if (devices.inputs.length > 0) {
-            // No saved preference, select the first real (non-virtual) input.
+          const savedInputDevice = savedInputDeviceId
+            ? devices.inputs.find(d => d.deviceId === savedInputDeviceId)
+            : undefined;
+
+          if (savedInputDevice) {
+            console.info('[Sokuji] [AudioStore] Restored saved input device:', savedInputDevice.label);
+            set({ selectedInputDevice: savedInputDevice });
+          } else {
+            // No saved device (or it's gone) — fall back to the first real
+            // (non-virtual) input.
             const fallback = pickDefaultInputDevice(devices.inputs);
             if (fallback) {
               set({ selectedInputDevice: fallback });
             } else {
-              console.warn('[Sokuji] [AudioStore] No real microphone found — only virtual/loopback input devices are available. Leaving mic unselected to avoid capturing Sokuji\'s own audio output.');
+              // No real microphone available — either no input devices were
+              // enumerated at all, or the only ones present are virtual/loopback
+              // (e.g. Sokuji's own "Sokuji_Virtual_Mic"). Turn the mic off
+              // explicitly instead of leaving selectedInputDevice unset with
+              // isMicMuted still false: the device picker's "Off" option (see
+              // DeviceList.tsx) only renders as selected when isMicMuted is
+              // true, so an unset device + unmuted mic shows nothing selected
+              // at all rather than a clear "Off" state.
+              console.warn('[Sokuji] [AudioStore] No real microphone found — turning mic off.');
+              set({ isMicMuted: true });
+              settingsService.setSetting(STORAGE_KEYS.IS_MIC_MUTED, true)
+                .catch(error => console.error('[Sokuji] [AudioStore] Failed to persist auto-muted mic state:', error));
             }
           }
         }

--- a/src/stores/audioStore.ts
+++ b/src/stores/audioStore.ts
@@ -32,6 +32,21 @@ export interface AudioDevice {
   isVirtual?: boolean;
 }
 
+/**
+ * Pick a default microphone from an enumerated input list, excluding virtual
+ * ones (e.g. Sokuji's own "Sokuji_Virtual_Mic" — the monitor of Sokuji's own
+ * virtual speaker, meant for other apps to consume, not for Sokuji to listen
+ * to itself). Returns null when only virtual/loopback devices are available
+ * rather than falling back to one — auto-selecting a loopback device as the
+ * mic would feed Sokuji's own TTS output back into ASR as "user speech",
+ * creating a self-sustaining transcription loop (observed on machines with
+ * no physical microphone, where a virtual device is the only input listed).
+ */
+export function pickDefaultInputDevice(inputs: AudioDevice[]): AudioDevice | null {
+  const nonVirtualInputs = inputs.filter(device => !device.isVirtual);
+  return nonVirtualInputs[0] ?? null;
+}
+
 interface AudioStore {
   // State
   audioInputDevices: AudioDevice[];
@@ -387,21 +402,21 @@ const useAudioStore = create<AudioStore>()(
               console.info('[Sokuji] [AudioStore] Restored saved input device:', savedInputDevice.label);
               set({ selectedInputDevice: savedInputDevice });
             } else if (devices.inputs.length > 0) {
-              // Saved device not found, fall back to first non-virtual input device
-              const nonVirtualInputs = devices.inputs.filter(device => !device.isVirtual);
-              if (nonVirtualInputs.length > 0) {
-                set({ selectedInputDevice: nonVirtualInputs[0] });
+              // Saved device not found, fall back to the first real (non-virtual) input.
+              const fallback = pickDefaultInputDevice(devices.inputs);
+              if (fallback) {
+                set({ selectedInputDevice: fallback });
               } else {
-                set({ selectedInputDevice: devices.inputs[0] });
+                console.warn('[Sokuji] [AudioStore] No real microphone found — only virtual/loopback input devices are available. Leaving mic unselected to avoid capturing Sokuji\'s own audio output.');
               }
             }
           } else if (devices.inputs.length > 0) {
-            // No saved preference, select first non-virtual input device
-            const nonVirtualInputs = devices.inputs.filter(device => !device.isVirtual);
-            if (nonVirtualInputs.length > 0) {
-              set({ selectedInputDevice: nonVirtualInputs[0] });
+            // No saved preference, select the first real (non-virtual) input.
+            const fallback = pickDefaultInputDevice(devices.inputs);
+            if (fallback) {
+              set({ selectedInputDevice: fallback });
             } else {
-              set({ selectedInputDevice: devices.inputs[0] });
+              console.warn('[Sokuji] [AudioStore] No real microphone found — only virtual/loopback input devices are available. Leaving mic unselected to avoid capturing Sokuji\'s own audio output.');
             }
           }
         }

--- a/src/stores/audioStore.ts
+++ b/src/stores/audioStore.ts
@@ -395,32 +395,40 @@ const useAudioStore = create<AudioStore>()(
         // Try to restore saved input device, or select default
         const currentInputDevice = get().selectedInputDevice;
         if (!currentInputDevice || !devices.inputs.some(d => d.deviceId === currentInputDevice?.deviceId)) {
+          // Reject a persisted device if it's virtual: a user who hit the old
+          // auto-select bug may have SELECTED_INPUT_DEVICE_ID pointing at
+          // Sokuji's own virtual mic. Restoring it here would silently
+          // reintroduce the feedback loop for exactly the users this fix is
+          // meant to protect, since it'd never reach pickDefaultInputDevice.
           const savedInputDevice = savedInputDeviceId
-            ? devices.inputs.find(d => d.deviceId === savedInputDeviceId)
+            ? devices.inputs.find(d => d.deviceId === savedInputDeviceId && !d.isVirtual)
             : undefined;
 
           if (savedInputDevice) {
             console.info('[Sokuji] [AudioStore] Restored saved input device:', savedInputDevice.label);
             set({ selectedInputDevice: savedInputDevice });
           } else {
-            // No saved device (or it's gone) — fall back to the first real
-            // (non-virtual) input.
+            // No saved device (or it's gone, or it was virtual) — fall back
+            // to the first real (non-virtual) input.
             const fallback = pickDefaultInputDevice(devices.inputs);
             if (fallback) {
               set({ selectedInputDevice: fallback });
             } else {
               // No real microphone available — either no input devices were
               // enumerated at all, or the only ones present are virtual/loopback
-              // (e.g. Sokuji's own "Sokuji_Virtual_Mic"). Turn the mic off
-              // explicitly instead of leaving selectedInputDevice unset with
-              // isMicMuted still false: the device picker's "Off" option (see
-              // DeviceList.tsx) only renders as selected when isMicMuted is
-              // true, so an unset device + unmuted mic shows nothing selected
-              // at all rather than a clear "Off" state.
-              console.warn('[Sokuji] [AudioStore] No real microphone found — turning mic off.');
-              set({ isMicMuted: true });
-              settingsService.setSetting(STORAGE_KEYS.IS_MIC_MUTED, true)
-                .catch(error => console.error('[Sokuji] [AudioStore] Failed to persist auto-muted mic state:', error));
+              // (e.g. Sokuji's own "Sokuji_Virtual_Mic"). Clear the selection
+              // AND mute: canStartSession (MainPanel.tsx) gates purely on
+              // !!selectedInputDevice — by design "mute state does not block
+              // start" — so leaving a stale device object in place would let
+              // a session start (and later unmute) against a device that's
+              // no longer connected or was never meant to be listened to.
+              const currentlyMuted = get().isMicMuted;
+              set({ selectedInputDevice: null, isMicMuted: true });
+              if (!currentlyMuted) {
+                console.warn('[Sokuji] [AudioStore] No real microphone found — clearing selection and turning mic off.');
+                settingsService.setSetting(STORAGE_KEYS.IS_MIC_MUTED, true)
+                  .catch(error => console.error('[Sokuji] [AudioStore] Failed to persist auto-muted mic state:', error));
+              }
             }
           }
         }

--- a/src/utils/audioDevices.ts
+++ b/src/utils/audioDevices.ts
@@ -1,0 +1,45 @@
+/**
+ * Pure label-based virtual/loopback audio device detection.
+ *
+ * Deliberately has no dependency on React or any UI layer — it's used both by
+ * Settings device pickers (a React component tree) and by
+ * ModernBrowserAudioService (a low-level service that should stay usable and
+ * testable outside the React bundle).
+ */
+
+interface LabeledDevice {
+  label: string;
+}
+
+/**
+ * Check if a device is a virtual device that should be filtered or warned about
+ */
+export const isVirtualDevice = (device: LabeledDevice): boolean => {
+  const label = device.label.toLowerCase();
+  return label.includes('sokuji_virtual_mic') ||
+         label.includes('sokuji_virtual_speaker') ||
+         label.includes('sokuji virtual output') || // Windows display name
+         label.includes('sokujivirtualaudio') || // Mac virtual device
+         label.includes('cable');
+};
+
+/**
+ * Check if a device is a virtual microphone
+ */
+export const isVirtualMic = (device: LabeledDevice): boolean => {
+  const label = device.label.toLowerCase();
+  return label.includes('sokuji_virtual_mic') ||
+         label.includes('sokujivirtualaudio') ||
+         label.includes('cable');
+};
+
+/**
+ * Check if a device is a virtual speaker
+ */
+export const isVirtualSpeaker = (device: LabeledDevice): boolean => {
+  const label = device.label.toLowerCase();
+  return label.includes('sokuji_virtual_speaker') ||
+         label.includes('sokuji virtual output') || // Windows display name
+         label.includes('sokujivirtualaudio') ||
+         label.includes('cable');
+};


### PR DESCRIPTION
## Summary
- On machines with no physical microphone, the mic auto-select fallback (`audioStore.ts`) picked the first enumerated `audioinput` device even when it was virtual/loopback.
- `ModernBrowserAudioService.getDevices()` only flagged a device virtual if its label contained `CABLE`, missing Sokuji's own `Sokuji_Virtual_Mic` (the monitor of Sokuji's own virtual speaker, created in `electron/pulseaudio-utils.js` so *other apps* can consume translated audio — never meant for Sokuji to listen to itself).
- With no real mic present, this loopback device got auto-selected as "the microphone", so Sokuji's own TTS output was captured as new user speech, producing an infinite transcribe → translate → speak → re-capture loop (reported: user typed "我饿了", TTS said "I am hungry", and the app then heard and re-spoke "I am hungry" forever).
- Fix: reuse the existing `isVirtualMic`/`isVirtualSpeaker` detectors already used by the Settings device pickers (`components/Settings/shared/hooks.ts`) when building the device list, and stop the `audioStore` fallback from ever auto-selecting a virtual device.
- Follow-up (from manual testing): when no real mic exists, explicitly turn the mic off (`isMicMuted: true`) instead of just leaving `selectedInputDevice` unset. The device picker's "Off" row (`DeviceList.tsx`) only renders as selected when `isMicMuted` is true — leaving it unset-but-unmuted showed nothing selected at all in Settings.

## Test plan
- [x] `npx vitest run src/stores/audioStore.test.ts` — regression tests for `pickDefaultInputDevice` and an integration-level test driving `refreshDevices()` end-to-end (virtual-only devices, zero devices, and real-mic-present cases)
- [x] `npx vitest run` — full suite (585 tests) passes
- [ ] Manual verification on a Linux machine with no physical mic: confirm the mic picker shows "Off" selected instead of silently capturing `Sokuji_Virtual_Mic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved audio device handling to better recognize virtual microphones and speakers.
  * When no real microphone is available, the app now clears the selected input and mutes the mic automatically.
* **Bug Fixes**
  * Prevents virtual audio devices from being restored as the active microphone.
  * Default microphone selection now prefers a real device instead of a virtual one.
* **Tests**
  * Added regression coverage for device selection, mute behavior, and virtual-device handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->