### PR TITLE
perf(sidecar): 2x realtime Qwen3-TTS on CUDA (issue #293)

### DIFF
--- a/scripts/convert-qwen3-tts-bf16.py
+++ b/scripts/convert-qwen3-tts-bf16.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """fp32 -> bf16 converter for code_predictor.onnx (Qwen3-TTS code predictor).
 
 Logic adapted from onnxruntime.transformers.float16.convert_float_to_float16 but

--- a/scripts/convert-qwen3-tts-bf16.py
+++ b/scripts/convert-qwen3-tts-bf16.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python
+"""fp32 -> bf16 converter for code_predictor.onnx (Qwen3-TTS code predictor).
+
+Logic adapted from onnxruntime.transformers.float16.convert_float_to_float16 but
+targeting BFLOAT16, simplified for a flat graph (no subgraphs/control flow):
+
+- float32 initializers -> BFLOAT16 raw uint16 (round-to-nearest-even via the
+  (u32 + 0x7FFF + lsb) >> 16 trick), unless consumed exclusively by blocked nodes.
+- keep_io_types style: graph inputs/outputs stay float32; Cast nodes are inserted
+  at the boundaries, so the runtime needs no dtype changes.
+- Cast(to=FLOAT) nodes on non-blocked paths are rewritten to Cast(to=BFLOAT16).
+- op_block_list / node_block_prefixes: blocked nodes keep fp32 compute; boundary
+  Casts are inserted on their float edges (with a peephole so blocked->blocked
+  edges stay fp32 without a bf16 round-trip).
+- --pre-optimize: run the ORT graph optimizer (CUDA EP, ORT_ENABLE_ALL) on the
+  fp32 model FIRST, so RMSNorm -> SimplifiedLayerNormalization / QuickGelu /
+  FusedMatMul / Split fusions fire in fp32, then convert the fused graph.
+  Without this, blocking ReduceMean breaks LayerNormFusion and the bf16 graph
+  ends up with ~170 extra dispatches per call (this workload is host-dispatch
+  bound, so that matters more than FLOPs).
+
+Empirically determined block set for ORT 1.24 CUDA EP on this graph:
+  - Cos/Sin: bfloat16 is not a legal input type per the ONNX schema at all.
+    The whole rotary angle path is kept fp32 (name prefixes /model/rotary_emb/
+    and the lone post-fusion "Transpose" feeding Cos/Sin): tiny tensors, and
+    angle precision does not survive bf16 for large positions.
+  - ReduceMean: no CUDA bf16 kernel in ORT 1.24 (fails placement). Only present
+    when converting the unoptimized graph; the pre-optimized graph fuses it away
+    into SimplifiedLayerNormalization (which stashes variance in fp32 anyway).
+Everything else used by these graphs (MatMul/FusedMatMul/Add/Mul/Div/Pow/Sqrt/
+Neg/Sigmoid/QuickGelu/Softmax/SimplifiedLayerNormalization/IsNaN/Where/Gather/
+Concat/Slice/Split/Reshape/Transpose/Expand/Squeeze/Unsqueeze/Shape/Cast) has
+bf16 CUDA kernels (probed with single-op models and
+session.disable_cpu_ep_fallback=1).
+"""
+import argparse
+import glob
+import os
+import tempfile
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+FLOAT = TensorProto.FLOAT
+BF16 = TensorProto.BFLOAT16
+BOOL = TensorProto.BOOL
+INT64 = TensorProto.INT64
+
+DEFAULT_OP_BLOCK_LIST = ["ReduceMean", "Cos", "Sin"]
+DEFAULT_NODE_BLOCK_PREFIXES = ["/model/rotary_emb/", "Transpose"]
+
+
+def f32_to_bf16_u16(a: np.ndarray) -> np.ndarray:
+    """Round-to-nearest-even fp32 -> bf16, returned as uint16."""
+    a = np.ascontiguousarray(a, dtype=np.float32)
+    u = a.view(np.uint32)
+    rounded = u + np.uint32(0x7FFF) + ((u >> np.uint32(16)) & np.uint32(1))
+    bf = (rounded >> np.uint32(16)).astype(np.uint16)
+    # keep NaNs NaN (the rounding trick can carry an sNaN mantissa into inf)
+    return np.where(np.isnan(a), np.uint16(0x7FC0), bf)
+
+
+def tensor_to_bf16(t: TensorProto) -> TensorProto:
+    arr = numpy_helper.to_array(t)
+    new = TensorProto()
+    new.name = t.name
+    new.dims.extend(t.dims)
+    new.data_type = BF16
+    new.raw_data = f32_to_bf16_u16(arr).tobytes()
+    return new
+
+
+BOOL_OPS = {"Equal", "Greater", "Less", "LessOrEqual", "GreaterOrEqual",
+            "IsNaN", "IsInf", "Not", "And", "Or", "Xor"}
+INT64_OPS = {"Shape", "Size", "NonZero", "ArgMax", "ArgMin"}
+
+
+def propagate_dtypes(graph):
+    """Forward element-type propagation. Unlike onnx.shape_inference this also
+    covers com.microsoft contrib ops (they are all type-preserving here)."""
+    dtype = {}
+    for t in graph.initializer:
+        dtype[t.name] = t.data_type
+    for gi in graph.input:
+        dtype[gi.name] = gi.type.tensor_type.elem_type
+    for n in graph.node:
+        if n.op_type == "Constant":
+            for a in n.attribute:
+                if a.type == onnx.AttributeProto.TENSOR:
+                    dtype[n.output[0]] = a.t.data_type
+                elif a.name in ("value_float", "value_floats"):
+                    dtype[n.output[0]] = FLOAT
+                elif a.name in ("value_int", "value_ints"):
+                    dtype[n.output[0]] = INT64
+            continue
+        if n.op_type == "Cast":
+            dtype[n.output[0]] = next(a.i for a in n.attribute if a.name == "to")
+        elif n.op_type == "ConstantOfShape":
+            val = [a for a in n.attribute if a.name == "value"]
+            dtype[n.output[0]] = val[0].t.data_type if val else FLOAT
+        elif n.op_type in BOOL_OPS:
+            dtype[n.output[0]] = BOOL
+        elif n.op_type in INT64_OPS:
+            dtype[n.output[0]] = INT64
+        elif n.op_type == "Where":
+            dtype[n.output[0]] = dtype.get(n.input[1], 0)
+        else:
+            dt = dtype.get(n.input[0], 0) if n.input else 0
+            for o in n.output:
+                dtype[o] = dt
+            if n.op_type in ("SimplifiedLayerNormalization", "LayerNormalization"):
+                for o in n.output[1:]:  # stash outputs are fp32 (stash_type=1)
+                    dtype[o] = FLOAT
+    return dtype
+
+
+def convert(model, op_block_list=None, node_block_prefixes=None):
+    op_block_list = set(DEFAULT_OP_BLOCK_LIST if op_block_list is None else op_block_list)
+    node_block_prefixes = list(DEFAULT_NODE_BLOCK_PREFIXES if node_block_prefixes is None else node_block_prefixes)
+    graph = model.graph
+    assert not any(a.type in (onnx.AttributeProto.GRAPH, onnx.AttributeProto.GRAPHS)
+                   for n in graph.node for a in n.attribute), "subgraphs not supported"
+
+    dtype = propagate_dtypes(graph)
+    is_float = lambda name: name and dtype.get(name) == FLOAT
+
+    def blocked(n):
+        return n.op_type in op_block_list or any(n.name.startswith(p) for p in node_block_prefixes)
+
+    consumers = {}
+    for n in graph.node:
+        for i in n.input:
+            consumers.setdefault(i, []).append(n)
+
+    # --- initializers ---------------------------------------------------
+    # domain[name] for float tensors: BF16 or FLOAT (dtype it carries post-conversion)
+    domain = {}
+    stats = {"init_bf16": 0, "init_fp32_kept": 0, "const_bf16": 0, "const_fp32_kept": 0,
+             "cast_retargeted": 0, "boundary_casts": 0, "blocked_nodes": 0}
+    new_inits = []
+    for t in graph.initializer:
+        if t.data_type == FLOAT:
+            cons = consumers.get(t.name, [])
+            if cons and all(blocked(c) for c in cons):
+                new_inits.append(t)  # only blocked consumers: keep fp32
+                domain[t.name] = FLOAT
+                stats["init_fp32_kept"] += 1
+            else:
+                new_inits.append(tensor_to_bf16(t))
+                domain[t.name] = BF16
+                stats["init_bf16"] += 1
+        else:
+            new_inits.append(t)
+    del graph.initializer[:]
+    graph.initializer.extend(new_inits)
+
+    # graph inputs stay fp32 (keep_io_types)
+    for gi in graph.input:
+        if gi.type.tensor_type.elem_type == FLOAT:
+            domain[gi.name] = FLOAT
+
+    # --- stream nodes, rewrite dtypes, insert boundary casts ------------
+    new_nodes = []
+    cast_cache = {}  # (tensor_name, target_dtype) -> casted name
+
+    def get_cast(name, target):
+        key = (name, target)
+        if key not in cast_cache:
+            suffix = "_bf16" if target == BF16 else "_fp32"
+            out = name + suffix
+            new_nodes.append(helper.make_node("Cast", [name], [out], name=f"bf16conv_Cast{len(cast_cache)}", to=target))
+            cast_cache[key] = out
+            stats["boundary_casts"] += 1
+        return cast_cache[key]
+
+    for n in graph.node:
+        nb = blocked(n)
+        want = FLOAT if nb else BF16
+        if nb:
+            stats["blocked_nodes"] += 1
+        # Constant nodes producing float tensors
+        if n.op_type == "Constant":
+            for a in n.attribute:
+                if a.type == onnx.AttributeProto.TENSOR and a.t.data_type == FLOAT:
+                    cons = consumers.get(n.output[0], [])
+                    if cons and all(blocked(c) for c in cons):
+                        domain[n.output[0]] = FLOAT
+                        stats["const_fp32_kept"] += 1
+                    else:
+                        a.t.CopyFrom(tensor_to_bf16(a.t))
+                        domain[n.output[0]] = BF16
+                        stats["const_bf16"] += 1
+            new_nodes.append(n)
+            continue
+        # retarget non-blocked Cast(to=FLOAT) -> Cast(to=BFLOAT16)
+        if n.op_type == "Cast" and not nb:
+            for a in n.attribute:
+                if a.name == "to" and a.i == FLOAT:
+                    a.i = BF16
+                    dtype[n.output[0]] = FLOAT  # logical dtype stays "float"
+                    stats["cast_retargeted"] += 1
+        # rewire float inputs whose current domain mismatches
+        for idx, i in enumerate(n.input):
+            if is_float(i) and domain.get(i, BF16) != want:
+                n.input[idx] = get_cast(i, want)
+        # record output domains
+        for o in n.output:
+            if is_float(o):
+                domain[o] = want
+        new_nodes.append(n)
+
+    # --- graph outputs stay fp32 ----------------------------------------
+    for go in graph.output:
+        if go.type.tensor_type.elem_type == FLOAT and domain.get(go.name) == BF16:
+            hidden = go.name + "_pre_out_bf16"
+            for n in new_nodes:  # rename producer + any internal consumers
+                for idx, o in enumerate(n.output):
+                    if o == go.name:
+                        n.output[idx] = hidden
+                for idx, i in enumerate(n.input):
+                    if i == go.name:
+                        n.input[idx] = hidden
+            new_nodes.append(helper.make_node("Cast", [hidden], [go.name], name=f"bf16conv_CastOut_{go.name}", to=FLOAT))
+            stats["boundary_casts"] += 1
+
+    del graph.node[:]
+    graph.node.extend(new_nodes)
+    del graph.value_info[:]  # let ORT re-infer; original infos are fp32-typed
+    return model, stats
+
+
+def ort_pre_optimize(src_path: str) -> str:
+    """Run the ORT graph optimizer (CUDA EP if available) on the fp32 model and
+    return the path of the optimized model (fusions fire in fp32)."""
+    import onnxruntime as ort
+    try:
+        ort.preload_dlls()
+    except Exception:
+        pass
+    out = os.path.join(tempfile.mkdtemp(prefix="bf16_opt_"), "opt_fp32.onnx")
+    so = ort.SessionOptions()
+    so.log_severity_level = 3
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
+    so.optimized_model_filepath = out
+    # >2GB models (the 1.7B talker) need external-data output from the optimizer
+    if os.path.getsize(src_path) + sum(
+            os.path.getsize(src_path + ext) for ext in (".data",)
+            if os.path.exists(src_path + ext)) > 1_900_000_000:
+        so.add_session_config_entry(
+            "session.optimized_model_external_initializers_file_name",
+            os.path.basename(out) + ".data")
+        so.add_session_config_entry(
+            "session.optimized_model_external_initializers_min_size_in_bytes", "1024")
+    providers = [p for p in ("CUDAExecutionProvider", "CPUExecutionProvider")
+                 if p in ort.get_available_providers()]
+    ort.InferenceSession(src_path, so, providers=providers)
+    return out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", required=True)
+    ap.add_argument("--dst", required=True)
+    ap.add_argument("--pre-optimize", action="store_true",
+                    help="run ORT fp32 graph optimizer (fusions) before bf16 conversion")
+    ap.add_argument("--op-block-list", nargs="*", default=None)
+    ap.add_argument("--node-block-prefixes", nargs="*", default=None)
+    args = ap.parse_args()
+
+    src = ort_pre_optimize(args.src) if args.pre_optimize else args.src
+    model = onnx.load(src)
+    model, stats = convert(model, args.op_block_list, args.node_block_prefixes)
+    try:
+        onnx.checker.check_model(model)
+    except onnx.checker.ValidationError as e:
+        # ORT-fused ops (e.g. SimplifiedLayerNormalization) are ORT-internal and
+        # unknown to the onnx checker; that is expected with --pre-optimize.
+        if "No Op registered" not in str(e):
+            raise
+        print(f"checker: skipped ORT-internal op ({str(e).splitlines()[0]})")
+    total = sum(len(t.raw_data) for t in model.graph.initializer)
+    if total > 1_900_000_000:
+        onnx.save(model, args.dst, save_as_external_data=True,
+                  all_tensors_to_one_file=True,
+                  location=os.path.basename(args.dst) + ".data")
+    else:
+        onnx.save(model, args.dst)
+    print("saved", args.dst)
+    print("stats", stats)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert-qwen3-tts-bf16.py
+++ b/scripts/convert-qwen3-tts-bf16.py
@@ -270,15 +270,18 @@ def main():
     src = ort_pre_optimize(args.src) if args.pre_optimize else args.src
     model = onnx.load(src)
     model, stats = convert(model, args.op_block_list, args.node_block_prefixes)
-    try:
-        onnx.checker.check_model(model)
-    except onnx.checker.ValidationError as e:
-        # ORT-fused ops (e.g. SimplifiedLayerNormalization) are ORT-internal and
-        # unknown to the onnx checker; that is expected with --pre-optimize.
-        if "No Op registered" not in str(e):
-            raise
-        print(f"checker: skipped ORT-internal op ({str(e).splitlines()[0]})")
     total = sum(len(t.raw_data) for t in model.graph.initializer)
+    if total > 1_900_000_000:
+        print("checker: skipped (>2GB proto cannot be serialized in memory)")
+    else:
+        try:
+            onnx.checker.check_model(model)
+        except onnx.checker.ValidationError as e:
+            # ORT-fused ops (e.g. SimplifiedLayerNormalization) are ORT-internal
+            # and unknown to the onnx checker; expected with --pre-optimize.
+            if "No Op registered" not in str(e):
+                raise
+            print(f"checker: skipped ORT-internal op ({str(e).splitlines()[0]})")
     if total > 1_900_000_000:
         onnx.save(model, args.dst, save_as_external_data=True,
                   all_tensors_to_one_file=True,

--- a/scripts/convert-qwen3-tts-fp16.py
+++ b/scripts/convert-qwen3-tts-fp16.py
@@ -38,12 +38,54 @@ REPOS = {"0.6b": "jiangzhuo9357/qwen3-tts-0.6b-onnx",
 EXTERNAL_DATA_THRESHOLD = 1_900_000_000
 
 
-def convert_one(src_path: str, dst_path: str) -> None:
+def trig_ancestor_block_list(src_path: str) -> list[str]:
+    """Node names that must stay fp32: every Sin/Cos node plus its ancestor
+    closure. Qwen3 uses rope_theta=1e6, so the RoPE inverse frequencies
+    (~1e-6) underflow fp16's 6e-5 normal range — converting the angle
+    computation garbles every position and the model degenerates to babble
+    with no EOS (observed on the first full-fp16 export). The closure is
+    shape/position math that runs once per step on tiny tensors; keeping it
+    fp32 costs nothing. Sin/Cos outputs are bounded [-1, 1] and are cast to
+    fp16 at the boundary by the converter."""
+    import onnx
+
+    model = onnx.load(src_path, load_external_data=False)
+    producers = {o: n for n in model.graph.node for o in n.output}
+    trig = [n for n in model.graph.node if n.op_type in ("Sin", "Cos")]
+    block = {n.name for n in trig}
+    seen: set[str] = set()
+    frontier = [i for n in trig for i in n.input]
+    while frontier:
+        tensor = frontier.pop()
+        if tensor in seen:
+            continue
+        seen.add(tensor)
+        node = producers.get(tensor)
+        if node is not None and node.name not in block:
+            block.add(node.name)
+            frontier.extend(node.input)
+    return sorted(block)
+
+
+def convert_one(src_path: str, dst_path: str) -> bool:
+    """Convert one graph to fp16; returns False (caller copies fp32) when the
+    trig-protection closure covers most of the graph — e.g. the codec vocoder,
+    whose harmonic-synthesis math IS a giant Sin/Cos chain: 'converting' it
+    would keep everything fp32 behind casts and only add overhead."""
     import onnx
     from onnxruntime.transformers.float16 import convert_float_to_float16
 
+    model_probe = onnx.load(src_path, load_external_data=False)
+    node_count = len(model_probe.graph.node)
+    block_list = trig_ancestor_block_list(src_path)
+    if node_count and len(block_list) > node_count // 3:
+        print(f"  {len(block_list)}/{node_count} nodes in Sin/Cos chains — keeping fp32", flush=True)
+        return False
+    if block_list:
+        print(f"  keeping {len(block_list)} Sin/Cos-chain nodes fp32", flush=True)
     # Path input → converter uses infer_shapes_path (safe for >2GB models).
-    model = convert_float_to_float16(src_path, keep_io_types=False)
+    model = convert_float_to_float16(src_path, keep_io_types=False,
+                                     node_block_list=block_list or None)
     fp16_bytes = sum(len(t.raw_data) for t in model.graph.initializer)
     if fp16_bytes > EXTERNAL_DATA_THRESHOLD:
         data_name = os.path.basename(dst_path) + ".data"
@@ -53,6 +95,7 @@ def convert_one(src_path: str, dst_path: str) -> None:
         onnx.save(model, dst_path)
     print(f"  {os.path.basename(src_path)}: {os.path.getsize(src_path):,} → "
           f"{os.path.getsize(dst_path):,} bytes", flush=True)
+    return True
 
 
 def main() -> None:
@@ -75,7 +118,10 @@ def main() -> None:
 
     for name in HOT_FP16 + ([] if args.keep_codec_fp32 else [CODEC_DECODE]):
         print(f"converting {name} → fp16", flush=True)
-        convert_one(os.path.join(src, "onnx", name), os.path.join(onnx_dir, name))
+        src_graph = os.path.join(src, "onnx", name)
+        dst_graph = os.path.join(onnx_dir, name)
+        if not convert_one(src_graph, dst_graph):
+            shutil.copyfile(os.path.realpath(src_graph), dst_graph)
 
     for name in COPY_FP32 + ([CODEC_DECODE] if args.keep_codec_fp32 else []):
         dst = os.path.join(onnx_dir, name)

--- a/scripts/convert-qwen3-tts-fp16.py
+++ b/scripts/convert-qwen3-tts-fp16.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Convert the Qwen3-TTS ONNX HOT graphs to fp16 for the CUDA lane.
+
+Reads a cached fp32 snapshot (jiangzhuo9357/qwen3-tts-{size}-onnx), converts
+the per-frame HOT graphs with onnxruntime's maintained float16 converter
+(onnxruntime.transformers.float16 — the fixed fork of onnxconverter-common),
+and stages a complete model dir (fp16 HOT graphs + fp32 COLD graphs + configs
++ voices) suitable for local testing or HF upload.
+
+fp16 halves the weight-read bandwidth that dominates the AR loop
+(talker_decode 1.78GB and code_predictor 0.44GB are re-read every frame) and
+halves the device-resident KV cache. COLD graphs (text_project,
+speaker_encoder, tokenizer12hz_encode) run once per utterance/voice on CPU
+where fp32 is faster — they stay fp32.
+
+Graphs >2GB after conversion (the 1.7B talker) are saved in external-data
+format; reading >2GB protos needs the pure-python protobuf impl, so run with
+PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION=python if the default C impl balks.
+
+Usage:
+  .venv/bin/python scripts/convert-qwen3-tts-fp16.py --size 0.6b --out /tmp/qwen3-fp16
+  (--keep-codec-fp32 leaves tokenizer12hz_decode at fp32 for quality A/B)
+"""
+import argparse
+import os
+import shutil
+
+HOT_FP16 = ["talker_decode.onnx", "code_predictor.onnx", "code_predictor_embed.onnx",
+            "codec_embed.onnx"]
+CODEC_DECODE = "tokenizer12hz_decode.onnx"
+COPY_FP32 = ["text_project.onnx", "speaker_encoder.onnx", "tokenizer12hz_encode.onnx"]
+ROOT_FILES = ["config.json", "vocab.json", "merges.txt", "tokenizer_config.json"]
+
+REPOS = {"0.6b": "jiangzhuo9357/qwen3-tts-0.6b-onnx",
+         "1.7b": "jiangzhuo9357/qwen3-tts-1.7b-onnx"}
+
+# protobuf hard limit is 2GB; leave headroom for the graph proto itself.
+EXTERNAL_DATA_THRESHOLD = 1_900_000_000
+
+
+def convert_one(src_path: str, dst_path: str) -> None:
+    import onnx
+    from onnxruntime.transformers.float16 import convert_float_to_float16
+
+    # Path input → converter uses infer_shapes_path (safe for >2GB models).
+    model = convert_float_to_float16(src_path, keep_io_types=False)
+    fp16_bytes = sum(len(t.raw_data) for t in model.graph.initializer)
+    if fp16_bytes > EXTERNAL_DATA_THRESHOLD:
+        data_name = os.path.basename(dst_path) + ".data"
+        onnx.save(model, dst_path, save_as_external_data=True,
+                  all_tensors_to_one_file=True, location=data_name)
+    else:
+        onnx.save(model, dst_path)
+    print(f"  {os.path.basename(src_path)}: {os.path.getsize(src_path):,} → "
+          f"{os.path.getsize(dst_path):,} bytes", flush=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--size", choices=("0.6b", "1.7b"), required=True)
+    ap.add_argument("--src", help="fp32 snapshot dir (default: cached HF snapshot)")
+    ap.add_argument("--out", required=True, help="staging root; model goes to <out>/<size>")
+    ap.add_argument("--keep-codec-fp32", action="store_true",
+                    help="leave tokenizer12hz_decode at fp32 (codec quality A/B)")
+    args = ap.parse_args()
+
+    src = args.src
+    if not src:
+        from huggingface_hub import snapshot_download
+        src = snapshot_download(REPOS[args.size], local_files_only=True)
+
+    root = os.path.join(args.out, args.size)
+    onnx_dir = os.path.join(root, "onnx")
+    os.makedirs(onnx_dir, exist_ok=True)
+
+    for name in HOT_FP16 + ([] if args.keep_codec_fp32 else [CODEC_DECODE]):
+        print(f"converting {name} → fp16", flush=True)
+        convert_one(os.path.join(src, "onnx", name), os.path.join(onnx_dir, name))
+
+    for name in COPY_FP32 + ([CODEC_DECODE] if args.keep_codec_fp32 else []):
+        dst = os.path.join(onnx_dir, name)
+        if not os.path.exists(dst):
+            shutil.copyfile(os.path.realpath(os.path.join(src, "onnx", name)), dst)
+
+    for name in ROOT_FILES:
+        shutil.copyfile(os.path.realpath(os.path.join(src, name)),
+                        os.path.join(root, name))
+    voices_src = os.path.join(src, "voices")
+    voices_dst = os.path.join(root, "voices")
+    if os.path.isdir(voices_src) and not os.path.isdir(voices_dst):
+        shutil.copytree(voices_src, voices_dst)
+
+    total = sum(os.path.getsize(os.path.join(dp, f))
+                for dp, _, fs in os.walk(root) for f in fs)
+    print(f"{args.size}: staged {total:,} bytes → {root}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/convert-qwen3-tts-fp16.py
+++ b/scripts/convert-qwen3-tts-fp16.py
@@ -67,6 +67,22 @@ def trig_ancestor_block_list(src_path: str) -> list[str]:
     return sorted(block)
 
 
+def swiglu_block_list(src_path: str) -> list[str]:
+    """MLP gate*up products and the down-projections that consume them must
+    stay fp32: Qwen3 hidden states carry outlier channels (|x| ~ 90 observed
+    at the talker output) whose SwiGLU products overflow fp16's 65504 — a
+    single inf then washes every downstream tensor to NaN (observed in
+    code_predictor layer 2 on real inputs; synthetic gaussians never trip it).
+    The down_proj must be blocked together with the Mul because casting the
+    fp32 product back to fp16 at its input would overflow identically."""
+    import onnx
+    import re
+
+    model = onnx.load(src_path, load_external_data=False)
+    pat = re.compile(r"/mlp/(Mul|down_proj/MatMul)$")
+    return sorted(n.name for n in model.graph.node if pat.search(n.name or ""))
+
+
 def convert_one(src_path: str, dst_path: str) -> bool:
     """Convert one graph to fp16; returns False (caller copies fp32) when the
     trig-protection closure covers most of the graph — e.g. the codec vocoder,
@@ -81,8 +97,11 @@ def convert_one(src_path: str, dst_path: str) -> bool:
     if node_count and len(block_list) > node_count // 3:
         print(f"  {len(block_list)}/{node_count} nodes in Sin/Cos chains — keeping fp32", flush=True)
         return False
-    if block_list:
-        print(f"  keeping {len(block_list)} Sin/Cos-chain nodes fp32", flush=True)
+    swiglu = swiglu_block_list(src_path)
+    if block_list or swiglu:
+        print(f"  keeping {len(block_list)} Sin/Cos-chain and {len(swiglu)} "
+              f"SwiGLU-product nodes fp32", flush=True)
+    block_list = sorted(set(block_list) | set(swiglu))
     # Path input → converter uses infer_shapes_path (safe for >2GB models).
     model = convert_float_to_float16(src_path, keep_io_types=False,
                                      node_block_list=block_list or None)

--- a/scripts/convert-qwen3-tts-fp16.py
+++ b/scripts/convert-qwen3-tts-fp16.py
@@ -135,17 +135,23 @@ def main() -> None:
     onnx_dir = os.path.join(root, "onnx")
     os.makedirs(onnx_dir, exist_ok=True)
 
+    def _copy_with_external_data(src_graph: str, dst_graph: str) -> None:
+        shutil.copyfile(os.path.realpath(src_graph), dst_graph)
+        data = src_graph + ".data"
+        if os.path.exists(data):  # >2GB graphs keep weights in a sidecar file
+            shutil.copyfile(os.path.realpath(data), dst_graph + ".data")
+
     for name in HOT_FP16 + ([] if args.keep_codec_fp32 else [CODEC_DECODE]):
         print(f"converting {name} → fp16", flush=True)
         src_graph = os.path.join(src, "onnx", name)
         dst_graph = os.path.join(onnx_dir, name)
         if not convert_one(src_graph, dst_graph):
-            shutil.copyfile(os.path.realpath(src_graph), dst_graph)
+            _copy_with_external_data(src_graph, dst_graph)
 
     for name in COPY_FP32 + ([CODEC_DECODE] if args.keep_codec_fp32 else []):
         dst = os.path.join(onnx_dir, name)
         if not os.path.exists(dst):
-            shutil.copyfile(os.path.realpath(os.path.join(src, "onnx", name)), dst)
+            _copy_with_external_data(os.path.join(src, "onnx", name), dst)
 
     for name in ROOT_FILES:
         shutil.copyfile(os.path.realpath(os.path.join(src, name)),

--- a/scripts/dynamize-qwen3-tts-codec.py
+++ b/scripts/dynamize-qwen3-tts-codec.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Dynamize the Qwen3-TTS 12.5Hz codec vocoder graph (tokenizer12hz_decode.onnx).
+
+WHY THIS EXISTS (the fixed-1024 export pathology)
+-------------------------------------------------
+The upstream ONNX export of the codec decoder bakes a fixed padded length of
+1024 codec frames (~82 s of 24 kHz audio) into the graph. Every causal conv /
+ConvNeXt block in the decoder is wrapped in an F.pad whose *target length* was
+traced as a Python int at export time and therefore froze into a scalar
+`Constant -> Sub(target, Gather(Shape(x), 2)) -> ... -> Pad` chain. The result:
+regardless of the actual input length, the graph zero-pads the sequence up to
+1024 frames right at `pre_conv`, runs the pre_transformer and the whole
+ConvTranspose upsampling stack (x1920 samples/frame) over the padded length,
+and emits a fixed [1, 1965525] waveform. A 5 s utterance decodes ~82 s worth
+of tensor work (~12x wasted compute, ~1.3 s wall on GB10 CUDA per call).
+
+WHAT THIS SCRIPT DOES
+---------------------
+There are exactly 29 such pad-target constants, one per padded conv:
+
+    stage                         const     = a*N + b  (N = 1024 at export)
+    pre_conv                      1024        1*N + 0
+    upsample.0.1 dwconv           2048        2*N + 0
+    upsample.1.1 dwconv           4096        4*N + 0
+    decoder.0                     4096        4*N + 0
+    decoder.1 block convs (x6)    32760      32*N - 8     = 8*(4N-1)
+    decoder.2 block convs (x6)    163795    160*N - 45    = 5*(32N-9)
+    decoder.3 block convs (x6)    655176    640*N - 184   = 4*(160N-46)
+    decoder.4 convs + decoder.6   1965525  1920*N - 555   = 3*(640N-185)
+
+Every target is *exactly affine* in the base padded frame count N because the
+whole decoder is a chain of length-affine ops (ConvTranspose:
+L_out = stride*(L_in - 1) + k, then edge trim). So instead of a frozen N=1024
+we compute N at runtime from the input:
+
+    L      = Shape(audio_codes)[1]                  # actual codec frames
+    N      = (floor(L / round) + 1) * round         # bucket, default round=64
+
+and replace each frozen constant with `a*N + b`, with (a, b) derived
+programmatically from the frozen value (a = ceil(V/1024), b = V - 1024*a; the
+offsets all lie in (-1024, 0]). The Subs then compute non-negative pad
+amounts, all downstream Slice ends clamp naturally, and compute scales with
+the actual input length. Note the strict bump to the *next* multiple of
+`round` (N >= L+1): the exported graph never trims its tail, so the final
+conv output must satisfy 1920*N - 555 >= 1920*L to keep all valid samples
+(the original export itself silently truncates the last 555 samples of a
+full 1024-frame input).
+
+The valid prefix `audio_values[:, :lengths[0]]` is bit-identical to the
+original graph's output because all padding is zeros on the right of a
+causal/masked pipeline, exactly as in the original -- only the amount of
+right-padding shrinks.
+
+Optionally `--static N` bakes a fixed bucket instead (fallback / bucketed
+deployments): same rewiring, but with constants folded to the given N.
+
+Usage:
+    python dynamize-qwen3-tts-codec.py \
+        --src ~/.config/Sokuji/hf-cache/.../snapshots/<rev>   # dir or .onnx \
+        --out /path/to/tokenizer12hz_decode_dyn.onnx \
+        [--round 64] [--static N]
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import numpy as np
+import onnx
+from onnx import TensorProto, helper, numpy_helper
+
+MODEL_BASENAME = "tokenizer12hz_decode.onnx"
+PREFIX = "dynpad"  # namespace for everything we add to the graph
+
+
+def resolve_src(src: str) -> str:
+    """Accept a model file, a snapshot dir, or a dir containing onnx/."""
+    if os.path.isfile(src):
+        return src
+    for cand in (
+        os.path.join(src, MODEL_BASENAME),
+        os.path.join(src, "onnx", MODEL_BASENAME),
+    ):
+        if os.path.isfile(cand):
+            return cand
+    hits = sorted(glob.glob(os.path.join(src, "**", MODEL_BASENAME), recursive=True))
+    if hits:
+        return hits[0]
+    raise FileNotFoundError(f"{MODEL_BASENAME} not found under {src}")
+
+
+def scalar_const_value(graph, prod, init_map, name):
+    """Return the numpy value of `name` if it is a 1-element Constant/initializer."""
+    tensor = None
+    if name in init_map:
+        tensor = init_map[name]
+    else:
+        node = prod.get(name)
+        if node is not None and node.op_type == "Constant":
+            for attr in node.attribute:
+                if attr.name == "value":
+                    tensor = attr.t
+    if tensor is None:
+        return None
+    try:
+        arr = numpy_helper.to_array(tensor)
+    except Exception:
+        return None
+    if arr.size != 1 or arr.dtype.kind not in "iu":
+        return None
+    return arr
+
+
+def find_pad_target_subs(graph, prod, init_map):
+    """Locate the frozen-length Sub nodes: Sub(scalar_const, Gather(Shape(x), 2)).
+
+    Returns (matches, base) where matches is [(sub_node, frozen_value)] and
+    base is the export-time padded frame count (the smallest frozen value,
+    1024 in the known export).
+    """
+    matches = []
+    for node in graph.node:
+        if node.op_type != "Sub" or len(node.input) != 2:
+            continue
+        val = scalar_const_value(graph, prod, init_map, node.input[0])
+        if val is None:
+            continue
+        gather = prod.get(node.input[1])
+        if gather is None or gather.op_type != "Gather":
+            continue
+        shape_node = prod.get(gather.input[0])
+        if shape_node is None or shape_node.op_type != "Shape":
+            continue
+        v = int(val.reshape(-1)[0])
+        # Excludes the F.pad plumbing Subs (const=6 = 2*rank of the pads
+        # array); every genuine length target is >= the base frame count.
+        if v < 512:
+            continue
+        matches.append((node, v))
+    if not matches:
+        raise RuntimeError("no frozen pad-target Sub(const, Gather(Shape)) nodes found")
+    base = min(v for _, v in matches)
+    return matches, base
+
+
+def affine_coeffs(value: int, base: int):
+    """Decompose a frozen stage target as a*base + b with b in (-base, 0]."""
+    a = -(-value // base)  # ceil division
+    b = value - base * a
+    assert -base < b <= 0, (value, base, a, b)
+    return a, b
+
+
+def int_scalar(name: str, value: int):
+    return numpy_helper.from_array(np.array(value, dtype=np.int64), name=name)
+
+
+def build_patch(model, round_to: int, static_n: int | None):
+    graph = model.graph
+    prod = {out: n for n in graph.node for out in n.output}
+    init_map = {i.name: i for i in graph.initializer}
+
+    matches, base = find_pad_target_subs(graph, prod, init_map)
+    input_name = graph.input[0].name  # audio_codes [batch, codes_length, 16]
+
+    new_nodes = []
+    new_inits = []
+
+    if static_n is None:
+        # N = (floor(L / round) + 1) * round, computed from Shape(audio_codes).
+        # Strictly greater than L so the untrimmed tail (555 samples) never
+        # eats into valid output.
+        new_inits += [
+            int_scalar(f"{PREFIX}_round", round_to),
+            int_scalar(f"{PREFIX}_one", 1),
+            int_scalar(f"{PREFIX}_axis1", 1),
+        ]
+        new_nodes += [
+            helper.make_node("Shape", [input_name], [f"{PREFIX}_shape"],
+                             name=f"{PREFIX}_Shape"),
+            helper.make_node("Gather", [f"{PREFIX}_shape", f"{PREFIX}_axis1"],
+                             [f"{PREFIX}_len"], name=f"{PREFIX}_Gather", axis=0),
+            helper.make_node("Div", [f"{PREFIX}_len", f"{PREFIX}_round"],
+                             [f"{PREFIX}_q"], name=f"{PREFIX}_Div"),
+            helper.make_node("Add", [f"{PREFIX}_q", f"{PREFIX}_one"],
+                             [f"{PREFIX}_q1"], name=f"{PREFIX}_Add"),
+            helper.make_node("Mul", [f"{PREFIX}_q1", f"{PREFIX}_round"],
+                             [f"{PREFIX}_N"], name=f"{PREFIX}_Mul"),
+        ]
+        n_name = f"{PREFIX}_N"
+
+    # One computed target per unique (a, b); every matched Sub is rewired to it.
+    made = {}
+    for sub_node, value in matches:
+        a, b = affine_coeffs(value, base)
+        key = (a, b)
+        if key not in made:
+            if static_n is not None:
+                target = f"{PREFIX}_target_{a}_{b}"
+                new_inits.append(int_scalar(target, a * static_n + b))
+            else:
+                mul_out = f"{PREFIX}_aN_{a}"
+                if a == 1:
+                    mul_out = n_name
+                elif not any(n.output[0] == mul_out for n in new_nodes):
+                    new_inits.append(int_scalar(f"{PREFIX}_a_{a}", a))
+                    new_nodes.append(helper.make_node(
+                        "Mul", [n_name, f"{PREFIX}_a_{a}"], [mul_out],
+                        name=f"{PREFIX}_Mul_a{a}"))
+                if b == 0:
+                    target = mul_out
+                else:
+                    target = f"{PREFIX}_target_{a}_{b}"
+                    new_inits.append(int_scalar(f"{PREFIX}_b_{a}_{b}", b))
+                    new_nodes.append(helper.make_node(
+                        "Add", [mul_out, f"{PREFIX}_b_{a}_{b}"], [target],
+                        name=f"{PREFIX}_Add_a{a}b{b}"))
+            made[key] = target
+        sub_node.input[0] = made[key]
+
+    # Prepend so the computed targets are defined before all consumers.
+    graph.initializer.extend(new_inits)
+    old_nodes = list(graph.node)
+    del graph.node[:]
+    graph.node.extend(new_nodes + old_nodes)
+
+    return sorted({(v, *affine_coeffs(v, base)) for _, v in matches}), base
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    ap.add_argument("--src", required=True,
+                    help="tokenizer12hz_decode.onnx, its dir, or a snapshot dir")
+    ap.add_argument("--out", required=True, help="output .onnx path")
+    ap.add_argument("--round", type=int, default=64, dest="round_to",
+                    help="pad bucket granularity in frames (default 64)")
+    ap.add_argument("--static", type=int, default=None, metavar="N",
+                    help="bake a fixed padded length N instead of a dynamic one "
+                         "(fallback for bucketed static deployments)")
+    args = ap.parse_args()
+
+    src = resolve_src(args.src)
+    print(f"loading {src}", file=sys.stderr)
+    model = onnx.load(src)  # self-contained fp32, <2GB
+
+    stages, base = build_patch(model, args.round_to, args.static)
+    mode = f"static N={args.static}" if args.static is not None else \
+           f"dynamic N=(floor(L/{args.round_to})+1)*{args.round_to}"
+    print(f"patched {len(stages)} unique stage targets (base={base}, {mode}):",
+          file=sys.stderr)
+    for value, a, b in stages:
+        print(f"  {value:>9} = {a}*N{b:+d}", file=sys.stderr)
+
+    onnx.checker.check_model(model, full_check=False)
+    os.makedirs(os.path.dirname(os.path.abspath(args.out)), exist_ok=True)
+    onnx.save(model, args.out)
+    print(f"wrote {args.out}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/quantize-qwen3-tts-nbits.py
+++ b/scripts/quantize-qwen3-tts-nbits.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Weight-only int4/int8 (MatMulNBits) quantization for Qwen3-TTS ONNX graphs.
+
+The AR loop is weight-bandwidth-bound (code_predictor's 440MB fp32 is re-read
+15x per generated frame; the talker's 1.78GB once per frame). fp16 halves the
+traffic but Qwen3's activation-outlier channels overflow fp16's range inside
+the residual stream (observed: code_predictor layer-2 down_proj output row
+>65504 on real inputs), so we quantize WEIGHTS only: MatMulNBits keeps all
+activations fp32 — no range hazard — while cutting weight reads 4-8x. The
+CUDA EP ships MatMulNBits kernels (the onnxruntime-genai LLM path).
+
+Usage:
+  .venv/bin/python scripts/quantize-qwen3-tts-nbits.py --size 0.6b \
+      --graphs code_predictor,talker_decode --bits 4 --out /tmp/stage
+Stages a complete model dir: quantized graphs + originals for the rest.
+"""
+import argparse
+import os
+import shutil
+
+GRAPHS_ALL = ["talker_decode.onnx", "code_predictor.onnx", "code_predictor_embed.onnx",
+              "codec_embed.onnx", "text_project.onnx", "speaker_encoder.onnx",
+              "tokenizer12hz_encode.onnx", "tokenizer12hz_decode.onnx"]
+ROOT_FILES = ["config.json", "vocab.json", "merges.txt", "tokenizer_config.json"]
+REPOS = {"0.6b": "jiangzhuo9357/qwen3-tts-0.6b-onnx",
+         "1.7b": "jiangzhuo9357/qwen3-tts-1.7b-onnx"}
+EXTERNAL_DATA_THRESHOLD = 1_900_000_000
+
+
+def quantize_one(src_path: str, dst_path: str, bits: int, block_size: int) -> None:
+    import onnx
+    from onnxruntime.quantization.matmul_nbits_quantizer import (
+        DefaultWeightOnlyQuantConfig,
+        MatMulNBitsQuantizer,
+    )
+
+    model = onnx.load(src_path)
+    cfg = DefaultWeightOnlyQuantConfig(block_size=block_size, is_symmetric=True, bits=bits)
+    quantizer = MatMulNBitsQuantizer(model, algo_config=cfg)
+    quantizer.process()
+    qmodel = quantizer.model.model if hasattr(quantizer.model, "model") else quantizer.model
+    total = sum(len(t.raw_data) for t in qmodel.graph.initializer)
+    if total > EXTERNAL_DATA_THRESHOLD:
+        onnx.save(qmodel, dst_path, save_as_external_data=True,
+                  all_tensors_to_one_file=True,
+                  location=os.path.basename(dst_path) + ".data")
+    else:
+        onnx.save(qmodel, dst_path)
+    print(f"  {os.path.basename(src_path)}: {os.path.getsize(src_path):,} → "
+          f"{os.path.getsize(dst_path):,} bytes (int{bits}, block {block_size})", flush=True)
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--size", choices=("0.6b", "1.7b"), required=True)
+    ap.add_argument("--graphs", default="code_predictor",
+                    help="comma list without .onnx, e.g. code_predictor,talker_decode")
+    ap.add_argument("--bits", type=int, choices=(4, 8), default=4)
+    ap.add_argument("--block-size", type=int, default=32)
+    ap.add_argument("--src", help="source snapshot dir (default: cached HF snapshot)")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    src = args.src
+    if not src:
+        from huggingface_hub import snapshot_download
+        src = snapshot_download(REPOS[args.size], local_files_only=True)
+
+    targets = {g.strip() + ".onnx" for g in args.graphs.split(",")}
+    root = os.path.join(args.out, args.size)
+    onnx_dir = os.path.join(root, "onnx")
+    os.makedirs(onnx_dir, exist_ok=True)
+
+    for name in GRAPHS_ALL:
+        src_graph = os.path.realpath(os.path.join(src, "onnx", name))
+        dst_graph = os.path.join(onnx_dir, name)
+        if os.path.exists(dst_graph):
+            continue
+        if name in targets:
+            print(f"quantizing {name} → int{args.bits}", flush=True)
+            quantize_one(src_graph, dst_graph, args.bits, args.block_size)
+            # external-data companions of the source must not be needed anymore
+        else:
+            try:
+                os.link(src_graph, dst_graph)
+            except OSError:
+                shutil.copyfile(src_graph, dst_graph)
+            data = src_graph + ".data"
+            if os.path.exists(data):
+                try:
+                    os.link(data, dst_graph + ".data")
+                except OSError:
+                    shutil.copyfile(data, dst_graph + ".data")
+
+    for name in ROOT_FILES:
+        dst = os.path.join(root, name)
+        if not os.path.exists(dst):
+            shutil.copyfile(os.path.realpath(os.path.join(src, name)), dst)
+    voices_dst = os.path.join(root, "voices")
+    if not os.path.isdir(voices_dst):
+        shutil.copytree(os.path.join(src, "voices"), voices_dst)
+
+    total = sum(os.path.getsize(os.path.join(dp, f))
+                for dp, _, fs in os.walk(root) for f in fs)
+    print(f"{args.size}: staged {total:,} bytes → {root}", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/sidecar/sokuji_sidecar/accel.py
+++ b/sidecar/sokuji_sidecar/accel.py
@@ -618,8 +618,10 @@ def load_measured(plans: list, stage: str | None = None):
 
 
 # Weight files dominate a model's GPU footprint; the rest (config/tokenizer) is
-# negligible. .gguf/.pt cover llama.cpp / raw-torch artifacts alongside HF safetensors.
-_WEIGHT_EXTS = (".safetensors", ".bin", ".pt", ".gguf", ".onnx")
+# negligible. .gguf/.pt cover llama.cpp / raw-torch artifacts alongside HF
+# safetensors; .onnx.data is the external-data payload of >2GB ONNX graphs
+# (e.g. the qwen3-tts 1.7B talker) — its .onnx proto alone is tiny.
+_WEIGHT_EXTS = (".safetensors", ".bin", ".pt", ".gguf", ".onnx", ".onnx.data")
 
 
 def _model_weight_bytes(artifact: str):
@@ -634,10 +636,21 @@ def _model_weight_bytes(artifact: str):
             from huggingface_hub import snapshot_download
             path = snapshot_download(artifact, local_files_only=True)
         total = 0
+        # Both callers estimate CUDA loads. A snapshot may ship CUDA-only
+        # graph rebuilds under onnx-bf16/ that are loaded INSTEAD of the
+        # same-named fp32 graphs in onnx/ (see Qwen3TtsOnnxBackend.load) —
+        # counting both copies would roughly double the estimate and wrongly
+        # demote GPUs that comfortably fit the actual load.
+        variant_root = os.path.join(path, "onnx-bf16")
+        has_variant = os.path.isdir(variant_root)
         for root, _dirs, files in os.walk(path):
             for fn in files:
-                if fn.endswith(_WEIGHT_EXTS):
-                    total += os.path.getsize(os.path.realpath(os.path.join(root, fn)))
+                if not fn.endswith(_WEIGHT_EXTS):
+                    continue
+                if (has_variant and os.path.basename(root) == "onnx"
+                        and os.path.exists(os.path.join(variant_root, fn))):
+                    continue
+                total += os.path.getsize(os.path.realpath(os.path.join(root, fn)))
         return total or None
     except Exception:
         return None

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -419,7 +419,7 @@ TTS_MODELS: list[TtsModel] = [
               Deployment("qwen3tts_onnx", "cpu", "fp32", _QWEN3_TTS_06B_REPO, 1.0)),
              repos=(_QWEN3_TTS_06B_REPO,), clones=True, streaming=False,
              transcript_required=True, named_voices=True, sample_rate=24000,
-             recommended=True, sort_order=2, size_bytes=4315672915),
+             recommended=True, sort_order=2, size_bytes=5426255909),
     TtsModel("qwen3-tts-1.7b", "Qwen3-TTS 1.7B",
              ("zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"),
              (Deployment("mlx_audio_tts", "gpu-metal", "fp32", _QWEN3_TTS_17B_MLX_REPO, 1.0,
@@ -430,7 +430,7 @@ TTS_MODELS: list[TtsModel] = [
               Deployment("qwen3tts_onnx", "cpu", "fp32", _QWEN3_TTS_17B_REPO, 1.0)),
              repos=(_QWEN3_TTS_17B_REPO,), clones=True, streaming=False,
              transcript_required=True, named_voices=True, sample_rate=24000,
-             recommended=False, sort_order=3, size_bytes=8372109691),
+             recommended=False, sort_order=3, size_bytes=11431098207),
     # piper / vits single-voice models (one repo = one model = one voice).
     _sherpa_tts_row("csukuangfj/vits-piper-en_US-amy-low", "Amy (US)", ("en",),
                     "csukuangfj/vits-piper-en_US-amy-low", 10, 16000, recommended=True,

--- a/sidecar/sokuji_sidecar/catalog.py
+++ b/sidecar/sokuji_sidecar/catalog.py
@@ -419,7 +419,7 @@ TTS_MODELS: list[TtsModel] = [
               Deployment("qwen3tts_onnx", "cpu", "fp32", _QWEN3_TTS_06B_REPO, 1.0)),
              repos=(_QWEN3_TTS_06B_REPO,), clones=True, streaming=False,
              transcript_required=True, named_voices=True, sample_rate=24000,
-             recommended=True, sort_order=2, size_bytes=5426255909),
+             recommended=True, sort_order=2, size_bytes=5426257741),
     TtsModel("qwen3-tts-1.7b", "Qwen3-TTS 1.7B",
              ("zh", "en", "ja", "ko", "de", "fr", "ru", "pt", "es", "it"),
              (Deployment("mlx_audio_tts", "gpu-metal", "fp32", _QWEN3_TTS_17B_MLX_REPO, 1.0,
@@ -430,7 +430,7 @@ TTS_MODELS: list[TtsModel] = [
               Deployment("qwen3tts_onnx", "cpu", "fp32", _QWEN3_TTS_17B_REPO, 1.0)),
              repos=(_QWEN3_TTS_17B_REPO,), clones=True, streaming=False,
              transcript_required=True, named_voices=True, sample_rate=24000,
-             recommended=False, sort_order=3, size_bytes=11431098207),
+             recommended=False, sort_order=3, size_bytes=11431100174),
     # piper / vits single-voice models (one repo = one model = one voice).
     _sherpa_tts_row("csukuangfj/vits-piper-en_US-amy-low", "Amy (US)", ("en",),
                     "csukuangfj/vits-piper-en_US-amy-low", 10, 16000, recommended=True,

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
@@ -311,7 +311,7 @@ class _SessionDecodeRunner:
             outputs = self._prefill.run({"inputs_embeds": self._inputs_np, "attention_mask": mask_np})
         else:
             feed = {"inputs_embeds": codec_sum, "attention_mask": mask_np}
-            for name, value in zip(self._past_names, self._past):
+            for name, value in zip(self._past_names, self._past, strict=True):
                 feed[name] = value
             outputs = self._decode.run(feed)
         self._past = list(outputs[2:]) if len(outputs) > 2 else None

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
@@ -206,7 +206,9 @@ class Embeddings:
         )
 
 
-def _zero_past_feeds(decode_session: Any, past_names: list[str], batch: int) -> dict[str, np.ndarray]:
+def _zero_past_feeds(
+    decode_session: Any, past_names: list[str], batch: int, dtype: Any = np.float32
+) -> dict[str, np.ndarray]:
     """Build zero-length past-KV feeds for `talker_decode`'s past inputs.
 
     Reads concrete (heads, head_dim) dims from the decode graph's declared
@@ -222,8 +224,18 @@ def _zero_past_feeds(decode_session: Any, past_names: list[str], batch: int) -> 
         head_dim = (
             shape[3] if shape is not None and len(shape) > 3 and isinstance(shape[3], int) else _DEFAULT_PAST_HEAD_DIM
         )
-        feeds[name] = np.zeros((batch, heads, 0, head_dim), dtype=np.float32)
+        feeds[name] = np.zeros((batch, heads, 0, head_dim), dtype=dtype)
     return feeds
+
+
+def _float_input_dtype(sess: Any) -> Any:
+    """The dtype of a session's first (float) input: fp16 for fp16-converted
+    graphs, else fp32. Test doubles without `.type` metadata default to fp32."""
+    try:
+        type_str = sess.get_inputs()[0].type
+    except Exception:
+        return np.float32
+    return np.float16 if type_str == "tensor(float16)" else np.float32
 
 
 def _is_binding_capable(sess: Any) -> bool:
@@ -412,9 +424,15 @@ def _ar_loop(
 
     finished = np.zeros((batch,), dtype=bool)
 
+    # fp16-converted graphs expose fp16 float I/O; sampling and host-side
+    # accumulation stay fp32 (np.asarray is a no-op for fp32 graphs/fakes).
+    cp_dtype = _float_input_dtype(code_predictor.session)
+
     logits, last_hidden = runner.prefill(inputs_np, mask_np)
 
     for step in range(max_new_tokens):
+        logits = np.asarray(logits, dtype=np.float32)
+        last_hidden = np.asarray(last_hidden, dtype=np.float32)
         step_logits = logits[:, -1, :]
         step_logits = apply_suppress_tokens(step_logits, suppress_tokens)
 
@@ -447,9 +465,10 @@ def _ar_loop(
             inputs_embed = np.concatenate(embed_seq, axis=1)
             gen_step = np.full((batch,), j, dtype=np.int64)
             sub_logits = code_predictor.run(
-                {"inputs_embeds": inputs_embed.astype(np.float32), "generation_step": gen_step},
+                {"inputs_embeds": inputs_embed.astype(cp_dtype), "generation_step": gen_step},
                 output_names=["logits"],
             )[0]
+            sub_logits = np.asarray(sub_logits, dtype=np.float32)
             sub_next = sample_next_token(
                 sub_logits,
                 rng=rng,

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
@@ -226,6 +226,68 @@ def _zero_past_feeds(decode_session: Any, past_names: list[str], batch: int) -> 
     return feeds
 
 
+def _is_binding_capable(sess: Any) -> bool:
+    """True when `sess` is a CUDA session exposing the IOBinding surface.
+
+    The AR-loop test fakes define no `get_providers`, so they (and any CPU
+    session) stay on the numpy reference path; DirectML sessions also return
+    False (no CUDA device strings for OrtValue binding)."""
+    get_providers = getattr(sess, "get_providers", None)
+    if not callable(get_providers) or "CUDAExecutionProvider" not in get_providers():
+        return False
+    return callable(getattr(sess, "io_binding", None)) and callable(
+        getattr(sess, "run_with_iobinding", None))
+
+
+class _SessionDecodeRunner:
+    """Reference decode runner: numpy feeds, KV cache round-trips through the
+    host every step. Preserves the original `generate_codes` semantics exactly,
+    including the prefill-session path and the no-KV re-prefill fallback (which
+    needs the prompt embeddings grown by one codec frame per step)."""
+
+    def __init__(self, sessions: dict[str, Any]) -> None:
+        decode_raw = sessions["talker_decode"]
+        self._decode_raw = decode_raw
+        self._decode = _Session(decode_raw)
+        self._past_names = self._decode.input_names[2:] if len(self._decode.input_names) > 2 else []
+        prefill_raw = sessions.get("talker_prefill")
+        self._prefill = _Session(prefill_raw) if prefill_raw is not None else None
+        self._past: list | None = None
+        self._inputs_np: np.ndarray | None = None
+
+    def prefill(self, inputs_np: np.ndarray, mask_np: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        self._inputs_np = inputs_np
+        if self._prefill is not None:
+            outputs = self._prefill.run({"inputs_embeds": inputs_np, "attention_mask": mask_np})
+            if len(outputs) < 2:
+                raise RuntimeError("talker_prefill session must output logits and last_hidden")
+        else:
+            zero_past = _zero_past_feeds(self._decode_raw, self._past_names, inputs_np.shape[0])
+            outputs = self._decode.run({"inputs_embeds": inputs_np, "attention_mask": mask_np, **zero_past})
+            if len(outputs) < 2:
+                raise RuntimeError("talker_decode session must output logits and last_hidden")
+        self._past = list(outputs[2:]) if len(outputs) > 2 else None
+        return outputs[0], outputs[1]
+
+    def step(self, codec_sum: np.ndarray, mask_np: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        self._inputs_np = np.concatenate([self._inputs_np, codec_sum], axis=1)
+        if self._past is None or len(self._past_names) == 0:
+            # Reference's no-KV re-prefill fallback. In zero-past mode there
+            # is no prefill session to fall back to, so a missing KV cache
+            # here means the decode graph doesn't thread state — a hard
+            # runtime error rather than a silent behavior change.
+            if self._prefill is None:
+                raise RuntimeError("talker_decode produced no KV cache and no talker_prefill is available")
+            outputs = self._prefill.run({"inputs_embeds": self._inputs_np, "attention_mask": mask_np})
+        else:
+            feed = {"inputs_embeds": codec_sum, "attention_mask": mask_np}
+            for name, value in zip(self._past_names, self._past):
+                feed[name] = value
+            outputs = self._decode.run(feed)
+        self._past = list(outputs[2:]) if len(outputs) > 2 else None
+        return outputs[0], outputs[1]
+
+
 def generate_codes(
     sessions: dict[str, Any],
     cfg_talker: Any,
@@ -270,6 +332,59 @@ def generate_codes(
         [effective_len, hidden] float32 hidden states, truncated at the
         first EOS frame (or the full length if no EOS was generated).
     """
+    if _is_binding_capable(sessions["talker_decode"]):
+        from . import runtime_cuda  # lazy: only real CUDA sessions reach this
+
+        runner: Any = runtime_cuda.BindingDecodeRunner(sessions["talker_decode"])
+        embeddings: Any = runtime_cuda.table_embeds_for(sessions, cfg_talker)
+    else:
+        runner = _SessionDecodeRunner(sessions)
+        embeddings = Embeddings(
+            codec_embed_session=sessions["codec_embed"],
+            code_predictor_embed_session=sessions["code_predictor_embed"],
+        )
+    return _ar_loop(
+        runner,
+        embeddings,
+        _Session(sessions["code_predictor"]),
+        cfg_talker,
+        inputs_embeds,
+        attention_mask,
+        trailing_text_hidden,
+        tts_pad_embed,
+        max_new_tokens=max_new_tokens,
+        sampling_params=sampling_params,
+        eos_token_id=eos_token_id,
+        suppress_tokens=suppress_tokens,
+        rng=rng,
+    )
+
+
+def _ar_loop(
+    runner: Any,
+    embeddings: Any,
+    code_predictor: _Session,
+    cfg_talker: Any,
+    inputs_embeds: np.ndarray,
+    attention_mask: np.ndarray,
+    trailing_text_hidden: np.ndarray,
+    tts_pad_embed: np.ndarray,
+    *,
+    max_new_tokens: int,
+    sampling_params: dict,
+    eos_token_id: int,
+    suppress_tokens: list | None,
+    rng: np.random.Generator,
+) -> tuple[list[np.ndarray], list[np.ndarray]]:
+    """Shared AR loop over a decode `runner` and an `embeddings` provider.
+
+    `runner` owns talker_decode invocation and KV-cache threading
+    (`_SessionDecodeRunner` for numpy feeds, `runtime_cuda.BindingDecodeRunner`
+    for the device-resident IOBinding path); `embeddings` provides
+    `codec_embed(ids)` / `code_predictor_embed(ids, step)` (per-step sessions
+    or pre-extracted tables). Everything else — sampling, EOS bookkeeping,
+    trailing-hidden switch, truncation — is identical for both paths.
+    """
     do_sample = sampling_params["do_sample"]
     top_k = sampling_params["top_k"]
     top_p = sampling_params["top_p"]
@@ -279,14 +394,6 @@ def generate_codes(
     subtalker_top_k = sampling_params["subtalker_top_k"]
     subtalker_top_p = sampling_params["subtalker_top_p"]
     subtalker_temperature = sampling_params["subtalker_temperature"]
-
-    decode_raw = sessions["talker_decode"]
-    decode = _Session(decode_raw)
-    code_predictor = _Session(sessions["code_predictor"])
-    embeddings = Embeddings(
-        codec_embed_session=sessions["codec_embed"],
-        code_predictor_embed_session=sessions["code_predictor_embed"],
-    )
 
     inputs_np = inputs_embeds.astype(np.float32)
     mask_np = attention_mask.astype(np.int64)
@@ -305,25 +412,7 @@ def generate_codes(
 
     finished = np.zeros((batch,), dtype=bool)
 
-    decode_past_names = decode.input_names[2:] if len(decode.input_names) > 2 else []
-
-    prefill_raw = sessions.get("talker_prefill")
-    if prefill_raw is not None:
-        prefill = _Session(prefill_raw)
-        prefill_outputs = prefill.run({"inputs_embeds": inputs_np, "attention_mask": mask_np})
-        if len(prefill_outputs) < 2:
-            raise RuntimeError("talker_prefill session must output logits and last_hidden")
-        logits, last_hidden = prefill_outputs[0], prefill_outputs[1]
-        past = prefill_outputs[2:] if len(prefill_outputs) > 2 else None
-    else:
-        prefill = None
-        zero_past = _zero_past_feeds(decode_raw, decode_past_names, batch)
-        init_feed = {"inputs_embeds": inputs_np, "attention_mask": mask_np, **zero_past}
-        init_outputs = decode.run(init_feed)
-        if len(init_outputs) < 2:
-            raise RuntimeError("talker_decode session must output logits and last_hidden")
-        logits, last_hidden = init_outputs[0], init_outputs[1]
-        past = init_outputs[2:] if len(init_outputs) > 2 else None
+    logits, last_hidden = runner.prefill(inputs_np, mask_np)
 
     for step in range(max_new_tokens):
         step_logits = logits[:, -1, :]
@@ -384,7 +473,6 @@ def generate_codes(
         else:
             codec_sum = codec_sum + tts_pad
 
-        inputs_np = np.concatenate([inputs_np, codec_sum.astype(np.float32)], axis=1)
         mask_np = np.concatenate([mask_np, np.ones((batch, 1), dtype=np.int64)], axis=1)
 
         step_codes = np.concatenate([next_ids[:, None], subcode_ids], axis=1)
@@ -394,23 +482,7 @@ def generate_codes(
         if finished.all():
             break
 
-        if past is None or len(decode_past_names) == 0:
-            # Reference's no-KV re-prefill fallback. In zero-past mode there
-            # is no prefill session to fall back to, so a missing KV cache
-            # here means the decode graph doesn't thread state — a hard
-            # runtime error rather than a silent behavior change.
-            if prefill is None:
-                raise RuntimeError("talker_decode produced no KV cache and no talker_prefill is available")
-            next_outputs = prefill.run({"inputs_embeds": inputs_np, "attention_mask": mask_np})
-            logits, last_hidden = next_outputs[0], next_outputs[1]
-            past = next_outputs[2:] if len(next_outputs) > 2 else None
-        else:
-            feed = {"inputs_embeds": codec_sum.astype(np.float32), "attention_mask": mask_np}
-            for name, value in zip(decode_past_names, past):
-                feed[name] = value
-            next_outputs = decode.run(feed)
-            logits, last_hidden = next_outputs[0], next_outputs[1]
-            past = next_outputs[2:]
+        logits, last_hidden = runner.step(codec_sum.astype(np.float32), mask_np)
 
     if not generated_steps:
         empty = [np.empty((0, num_code_groups), dtype=np.int64) for _ in range(batch)]

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
@@ -151,6 +151,10 @@ def build_sessions(onnx_dir: str | Path, device: str | None, threads: int) -> di
                     f"DmlExecutionProvider was requested but the HOT graph {name!r} was "
                     f"created without it (providers: {sess.get_providers()})")
 
+    # The CUDA fast path lazily builds extra sessions (CUDA-graph
+    # code_predictor) from the graph files, so remember where they live.
+    sessions["_onnx_dir"] = str(onnx_dir)
+
     return sessions
 
 
@@ -349,16 +353,19 @@ def generate_codes(
 
         runner: Any = runtime_cuda.BindingDecodeRunner(sessions["talker_decode"])
         embeddings: Any = runtime_cuda.table_embeds_for(sessions, cfg_talker)
+        code_predictor: Any = runtime_cuda.graphed_code_predictor_for(
+            sessions, cfg_talker, hidden=int(inputs_embeds.shape[-1]))
     else:
         runner = _SessionDecodeRunner(sessions)
         embeddings = Embeddings(
             codec_embed_session=sessions["codec_embed"],
             code_predictor_embed_session=sessions["code_predictor_embed"],
         )
+        code_predictor = _Session(sessions["code_predictor"])
     return _ar_loop(
         runner,
         embeddings,
-        _Session(sessions["code_predictor"]),
+        code_predictor,
         cfg_talker,
         inputs_embeds,
         attention_mask,

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime.py
@@ -86,7 +86,9 @@ def default_providers(device: str | None = None) -> list[str]:
     return providers
 
 
-def build_sessions(onnx_dir: str | Path, device: str | None, threads: int) -> dict[str, Any]:
+def build_sessions(
+    onnx_dir: str | Path, device: str | None, threads: int, variant_dir: str | None = None
+) -> dict[str, Any]:
     """Build the Qwen3-TTS talker ONNX sessions with per-graph device placement.
 
     COLD graphs (`speaker_encoder`, `tokenizer12hz_encode`, `text_project`)
@@ -95,12 +97,24 @@ def build_sessions(onnx_dir: str | Path, device: str | None, threads: int) -> di
     in try/except with a CPU-only retry, mirroring the reference
     `_make_session` pattern.
 
+    `variant_dir` (e.g. the snapshot's `onnx-bf16/`) overrides individual
+    graph files when present there — a repo ships one fp32 set plus a few
+    device-specific rebuilds, and the caller decides per device which variant
+    applies (bf16 graphs have no CPU/DML kernels).
+
     `talker_prefill` is included only if `talker_prefill.onnx` exists in
     `onnx_dir` — its absence puts `generate_codes` into zero-past mode.
     """
     import onnxruntime as ort  # local import: fake-session tests never touch ORT
 
     onnx_dir = Path(onnx_dir)
+
+    def _graph_path(filename: str) -> Path:
+        if variant_dir is not None:
+            candidate = Path(variant_dir) / filename
+            if candidate.exists():
+                return candidate
+        return onnx_dir / filename
 
     options = ort.SessionOptions()
     options.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_ALL
@@ -130,7 +144,7 @@ def build_sessions(onnx_dir: str | Path, device: str | None, threads: int) -> di
     sessions: dict[str, Any] = {}
     for name, filename in graph_files.items():
         providers = cold_providers if name in _COLD_GRAPH_NAMES else hot_providers
-        sessions[name] = _make_session(onnx_dir / filename, providers)
+        sessions[name] = _make_session(_graph_path(filename), providers)
 
     prefill_path = onnx_dir / "talker_prefill.onnx"
     if prefill_path.exists():
@@ -152,8 +166,8 @@ def build_sessions(onnx_dir: str | Path, device: str | None, threads: int) -> di
                     f"created without it (providers: {sess.get_providers()})")
 
     # The CUDA fast path lazily builds extra sessions (CUDA-graph
-    # code_predictor) from the graph files, so remember where they live.
-    sessions["_onnx_dir"] = str(onnx_dir)
+    # code_predictor) from the graph files, so remember where each one lives.
+    sessions["_graph_paths"] = {name: str(_graph_path(f)) for name, f in graph_files.items()}
 
     return sessions
 

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
@@ -20,7 +20,6 @@ and DirectML sessions (and the test fakes) never reach this module.
 
 from __future__ import annotations
 
-import os
 import weakref
 from typing import Any
 
@@ -227,15 +226,15 @@ def graphed_code_predictor_for(sessions: dict[str, Any], cfg_talker: Any, *, hid
     """The CUDA-graph code_predictor for this model, or the plain session
     wrapper when no graph dir is recorded or session creation fails."""
     plain = _Session(sessions["code_predictor"])
-    onnx_dir = sessions.get("_onnx_dir")
-    if not onnx_dir:
+    cp_path = (sessions.get("_graph_paths") or {}).get("code_predictor")
+    if not cp_path:
         return plain
     key = sessions["code_predictor"]
     cached = _GRAPHED_CP_CACHE.get(key)
     if cached is None:
         try:
             cached = GraphedCodePredictor(
-                os.path.join(onnx_dir, "code_predictor.onnx"),
+                cp_path,
                 hidden=hidden, sub_vocab=_sub_vocab(cfg_talker), fallback=plain)
         except Exception:
             cached = plain

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
@@ -87,7 +87,7 @@ class BindingDecodeRunner:
             for name, arr in cpu_past.items():
                 iob.bind_cpu_input(name, arr)
         if past_values is not None:
-            for name, value in zip(self._past_names, past_values):
+            for name, value in zip(self._past_names, past_values, strict=True):
                 iob.bind_ortvalue_input(name, value)
         for name in self._output_names[:2]:
             iob.bind_output(name, "cpu")

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
@@ -25,7 +25,7 @@ from typing import Any
 
 import numpy as np
 
-from .runtime import _Session, _zero_past_feeds
+from .runtime import _Session, _float_input_dtype, _zero_past_feeds
 
 
 class BindingDecodeRunner:
@@ -50,10 +50,11 @@ class BindingDecodeRunner:
         # step N+1 has produced replacements on the other binding.
         self._iobs = [decode_session.io_binding(), decode_session.io_binding()]
         self._turn = 0
+        self._dtype = _float_input_dtype(decode_session)
         self._present: list | None = None
 
     def prefill(self, inputs_np: np.ndarray, mask_np: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
-        zero_past = _zero_past_feeds(self._sess, self._past_names, inputs_np.shape[0])
+        zero_past = _zero_past_feeds(self._sess, self._past_names, inputs_np.shape[0], self._dtype)
         return self._run(inputs_np, mask_np, cpu_past=zero_past)
 
     def step(self, codec_sum: np.ndarray, mask_np: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
@@ -73,7 +74,7 @@ class BindingDecodeRunner:
         self._turn = 1 - self._turn
         iob.clear_binding_inputs()
         iob.clear_binding_outputs()
-        iob.bind_cpu_input(self._input_names[0], np.ascontiguousarray(embeds_np, dtype=np.float32))
+        iob.bind_cpu_input(self._input_names[0], np.ascontiguousarray(embeds_np, dtype=self._dtype))
         iob.bind_cpu_input(self._input_names[1], np.ascontiguousarray(mask_np, dtype=np.int64))
         if cpu_past is not None:
             for name, arr in cpu_past.items():

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
@@ -1,0 +1,151 @@
+"""CUDA fast path for the Qwen3-TTS AR loop.
+
+Two independent optimizations over the numpy reference path in `runtime.py`,
+both pure orchestration (bit-identical outputs given identical kernels):
+
+- `BindingDecodeRunner`: drives `talker_decode` through ORT IOBinding so the
+  KV cache never leaves the GPU. Present-KV OrtValues from step N are bound
+  back as past-KV inputs of step N+1 (the graph's past/present I/O is
+  positionally 1:1); only the tiny logits/last_hidden tensors are copied to
+  the host each step. This removes the ~2 x 28-layer KV round-trip
+  (hundreds of KiB per generated token of pure memcpy) per frame.
+- `table_embeds_for`: extracts the `codec_embed` / `code_predictor_embed`
+  Gather tables once per loaded model (one arange sweep per table) and serves
+  per-step lookups as host-side numpy indexing, removing 16 session.run
+  dispatches per generated frame.
+
+Selection happens in `runtime.generate_codes` via `_is_binding_capable`; CPU
+and DirectML sessions (and the test fakes) never reach this module.
+"""
+
+from __future__ import annotations
+
+import weakref
+from typing import Any
+
+import numpy as np
+
+from .runtime import _Session, _zero_past_feeds
+
+
+class BindingDecodeRunner:
+    """Decode runner that keeps the talker KV cache device-resident.
+
+    Always prefills through `talker_decode` with zero-length past feeds (the
+    snapshots ship no `talker_prefill` graph; zero-past decode was verified
+    bit-identical to prefill by the design spike). Host<->device traffic per
+    step: new-frame embedding + attention mask up, logits + last_hidden down.
+    """
+
+    def __init__(self, decode_session: Any) -> None:
+        self._sess = decode_session
+        self._input_names = [i.name for i in decode_session.get_inputs()]
+        self._output_names = [o.name for o in decode_session.get_outputs()]
+        self._past_names = self._input_names[2:] if len(self._input_names) > 2 else []
+        # Two bindings used alternately. OrtValues returned by get_outputs()
+        # REFERENCE the binding's internal storage: clearing (or re-running)
+        # the same binding invalidates them (observed on ORT 1.24 — garbage
+        # ranks, then segfault). Ping-ponging guarantees the binding holding
+        # the presents consumed by step N is only cleared at step N+2, after
+        # step N+1 has produced replacements on the other binding.
+        self._iobs = [decode_session.io_binding(), decode_session.io_binding()]
+        self._turn = 0
+        self._present: list | None = None
+
+    def prefill(self, inputs_np: np.ndarray, mask_np: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        zero_past = _zero_past_feeds(self._sess, self._past_names, inputs_np.shape[0])
+        return self._run(inputs_np, mask_np, cpu_past=zero_past)
+
+    def step(self, codec_sum: np.ndarray, mask_np: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+        if self._present is None or len(self._past_names) == 0:
+            raise RuntimeError("talker_decode produced no KV cache and no talker_prefill is available")
+        return self._run(codec_sum, mask_np, past_values=self._present)
+
+    def _run(
+        self,
+        embeds_np: np.ndarray,
+        mask_np: np.ndarray,
+        *,
+        cpu_past: dict[str, np.ndarray] | None = None,
+        past_values: list | None = None,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        iob = self._iobs[self._turn]
+        self._turn = 1 - self._turn
+        iob.clear_binding_inputs()
+        iob.clear_binding_outputs()
+        iob.bind_cpu_input(self._input_names[0], np.ascontiguousarray(embeds_np, dtype=np.float32))
+        iob.bind_cpu_input(self._input_names[1], np.ascontiguousarray(mask_np, dtype=np.int64))
+        if cpu_past is not None:
+            for name, arr in cpu_past.items():
+                iob.bind_cpu_input(name, arr)
+        if past_values is not None:
+            for name, value in zip(self._past_names, past_values):
+                iob.bind_ortvalue_input(name, value)
+        for name in self._output_names[:2]:
+            iob.bind_output(name, "cpu")
+        for name in self._output_names[2:]:
+            iob.bind_output(name, "cuda")
+        self._sess.run_with_iobinding(iob)
+        outputs = iob.get_outputs()
+        if len(outputs) < 2:
+            raise RuntimeError("talker_decode session must output logits and last_hidden")
+        logits = outputs[0].numpy()
+        last_hidden = outputs[1].numpy()
+        self._present = list(outputs[2:]) if len(outputs) > 2 else None
+        return logits, last_hidden
+
+
+class TableEmbeds:
+    """Embedding lookups served from tables extracted out of the ONNX graphs.
+
+    `codec_embed` and `code_predictor_embed` are pure Gather graphs; one
+    arange sweep per table recovers the full weight matrix, after which every
+    per-step lookup is a host-side fancy index instead of a session.run."""
+
+    def __init__(self, codec_table: np.ndarray, predictor_tables: list[np.ndarray]) -> None:
+        self._codec_table = codec_table
+        self._predictor_tables = predictor_tables
+
+    @classmethod
+    def extract(cls, sessions: dict[str, Any], cfg_talker: Any) -> "TableEmbeds":
+        codec_vocab = int(cfg_talker.vocab_size)
+        codec_sess = _Session(sessions["codec_embed"])
+        ids = np.arange(codec_vocab, dtype=np.int64)[None, :]
+        codec_table = np.asarray(codec_sess.run({"input_ids": ids})[0], dtype=np.float32)[0]
+
+        pred_cfg = getattr(cfg_talker, "code_predictor_config", None)
+        if isinstance(pred_cfg, dict):
+            sub_vocab = int(pred_cfg.get("vocab_size", 2048))
+        else:
+            sub_vocab = int(getattr(pred_cfg, "vocab_size", 2048))
+        pred_sess = _Session(sessions["code_predictor_embed"])
+        sub_ids = np.arange(sub_vocab, dtype=np.int64)[None, :]
+        tables = []
+        for j in range(int(cfg_talker.num_code_groups) - 1):
+            step = np.array([j], dtype=np.int64)
+            outputs = pred_sess.run({"input_ids": sub_ids, "generation_step": step})
+            tables.append(np.asarray(outputs[0], dtype=np.float32)[0])
+        return cls(codec_table, tables)
+
+    def codec_embed(self, input_ids: np.ndarray) -> np.ndarray:
+        return self._codec_table[np.asarray(input_ids, dtype=np.int64)]
+
+    def code_predictor_embed(self, input_ids: np.ndarray, generation_step: int) -> np.ndarray:
+        return self._predictor_tables[int(generation_step)][np.asarray(input_ids, dtype=np.int64)]
+
+
+# Extracted tables cached per loaded model, keyed on the codec_embed session
+# object (a new build_sessions() dict means new session objects → fresh cache).
+_TABLE_CACHE: "weakref.WeakKeyDictionary[Any, TableEmbeds]" = weakref.WeakKeyDictionary()
+
+
+def table_embeds_for(sessions: dict[str, Any], cfg_talker: Any) -> TableEmbeds:
+    key = sessions["codec_embed"]
+    cached = _TABLE_CACHE.get(key)
+    if cached is None:
+        cached = TableEmbeds.extract(sessions, cfg_talker)
+        _TABLE_CACHE[key] = cached
+    return cached
+
+
+__all__ = ["BindingDecodeRunner", "TableEmbeds", "table_embeds_for"]

--- a/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
+++ b/sidecar/sokuji_sidecar/qwen3_tts/runtime_cuda.py
@@ -20,12 +20,20 @@ and DirectML sessions (and the test fakes) never reach this module.
 
 from __future__ import annotations
 
+import os
 import weakref
 from typing import Any
 
 import numpy as np
 
 from .runtime import _Session, _float_input_dtype, _zero_past_feeds
+
+
+def _sub_vocab(cfg_talker: Any) -> int:
+    pred_cfg = getattr(cfg_talker, "code_predictor_config", None)
+    if isinstance(pred_cfg, dict):
+        return int(pred_cfg.get("vocab_size", 2048))
+    return int(getattr(pred_cfg, "vocab_size", 2048))
 
 
 class BindingDecodeRunner:
@@ -114,11 +122,7 @@ class TableEmbeds:
         ids = np.arange(codec_vocab, dtype=np.int64)[None, :]
         codec_table = np.asarray(codec_sess.run({"input_ids": ids})[0], dtype=np.float32)[0]
 
-        pred_cfg = getattr(cfg_talker, "code_predictor_config", None)
-        if isinstance(pred_cfg, dict):
-            sub_vocab = int(pred_cfg.get("vocab_size", 2048))
-        else:
-            sub_vocab = int(getattr(pred_cfg, "vocab_size", 2048))
+        sub_vocab = _sub_vocab(cfg_talker)
         pred_sess = _Session(sessions["code_predictor_embed"])
         sub_ids = np.arange(sub_vocab, dtype=np.int64)[None, :]
         tables = []
@@ -135,6 +139,72 @@ class TableEmbeds:
         return self._predictor_tables[int(generation_step)][np.asarray(input_ids, dtype=np.int64)]
 
 
+class GraphedCodePredictor:
+    """code_predictor driven through CUDA Graph replays, one graph per input
+    length (the 15 substep lengths 2..16 are the only shapes that occur).
+
+    Requires a dedicated session created with `enable_cuda_graph`; per
+    `gpu_graph_id` the bound device addresses must stay fixed between the
+    capture run and every replay, so each length gets one IOBinding with
+    pre-allocated CUDA OrtValues refreshed via `update_inplace`. Replays were
+    verified bit-identical to plain session runs on GB10; the win is the
+    per-call launch overhead of the ~565-node optimized graph (~0.5ms of the
+    ~2.5ms call). Any failure (capture refused, kernel error) permanently
+    drops to `fallback` — the plain numpy-feed session."""
+
+    def __init__(self, onnx_path: str, *, hidden: int, sub_vocab: int, fallback: Any) -> None:
+        import onnxruntime as ort  # lazy: fakes inject a module double
+
+        options = ort.SessionOptions()
+        options.log_severity_level = 3
+        self.session = ort.InferenceSession(
+            str(onnx_path), sess_options=options,
+            providers=[("CUDAExecutionProvider", {"enable_cuda_graph": "1"}),
+                       "CPUExecutionProvider"])
+        self._ort = ort
+        self._hidden = int(hidden)
+        self._sub_vocab = int(sub_vocab)
+        self._fallback = fallback
+        self._bindings: dict[int, tuple] = {}
+        self._broken = False
+
+    def _binding_for(self, length: int, dtype: Any):
+        cached = self._bindings.get(length)
+        if cached is not None:
+            return cached
+        ort = self._ort
+        x_val = ort.OrtValue.ortvalue_from_shape_and_type(
+            (1, length, self._hidden), dtype, "cuda", 0)
+        g_val = ort.OrtValue.ortvalue_from_shape_and_type((1,), np.int64, "cuda", 0)
+        out_val = ort.OrtValue.ortvalue_from_shape_and_type(
+            (1, self._sub_vocab), dtype, "cuda", 0)
+        iob = self.session.io_binding()
+        iob.bind_ortvalue_input("inputs_embeds", x_val)
+        iob.bind_ortvalue_input("generation_step", g_val)
+        iob.bind_ortvalue_output("logits", out_val)
+        run_options = ort.RunOptions()
+        run_options.add_run_config_entry("gpu_graph_id", str(length))
+        entry = (iob, x_val, g_val, out_val, run_options)
+        self._bindings[length] = entry
+        return entry
+
+    def run(self, feeds: dict, output_names: list[str] | None = None) -> list:
+        x = feeds["inputs_embeds"]
+        if self._broken or x.shape[0] != 1:
+            return self._fallback.run(feeds, output_names)
+        try:
+            iob, x_val, g_val, out_val, run_options = self._binding_for(
+                int(x.shape[1]), x.dtype)
+            x_val.update_inplace(np.ascontiguousarray(x))
+            g_val.update_inplace(
+                np.ascontiguousarray(feeds["generation_step"], dtype=np.int64))
+            self.session.run_with_iobinding(iob, run_options)
+            return [out_val.numpy()]
+        except Exception:
+            self._broken = True
+            return self._fallback.run(feeds, output_names)
+
+
 # Extracted tables cached per loaded model, keyed on the codec_embed session
 # object (a new build_sessions() dict means new session objects → fresh cache).
 _TABLE_CACHE: "weakref.WeakKeyDictionary[Any, TableEmbeds]" = weakref.WeakKeyDictionary()
@@ -149,4 +219,34 @@ def table_embeds_for(sessions: dict[str, Any], cfg_talker: Any) -> TableEmbeds:
     return cached
 
 
-__all__ = ["BindingDecodeRunner", "TableEmbeds", "table_embeds_for"]
+# Graphed code_predictor cached per loaded model, keyed on the plain session.
+_GRAPHED_CP_CACHE: "weakref.WeakKeyDictionary[Any, Any]" = weakref.WeakKeyDictionary()
+
+
+def graphed_code_predictor_for(sessions: dict[str, Any], cfg_talker: Any, *, hidden: int) -> Any:
+    """The CUDA-graph code_predictor for this model, or the plain session
+    wrapper when no graph dir is recorded or session creation fails."""
+    plain = _Session(sessions["code_predictor"])
+    onnx_dir = sessions.get("_onnx_dir")
+    if not onnx_dir:
+        return plain
+    key = sessions["code_predictor"]
+    cached = _GRAPHED_CP_CACHE.get(key)
+    if cached is None:
+        try:
+            cached = GraphedCodePredictor(
+                os.path.join(onnx_dir, "code_predictor.onnx"),
+                hidden=hidden, sub_vocab=_sub_vocab(cfg_talker), fallback=plain)
+        except Exception:
+            cached = plain
+        _GRAPHED_CP_CACHE[key] = cached
+    return cached
+
+
+__all__ = [
+    "BindingDecodeRunner",
+    "GraphedCodePredictor",
+    "TableEmbeds",
+    "graphed_code_predictor_for",
+    "table_embeds_for",
+]

--- a/sidecar/sokuji_sidecar/tts_backends.py
+++ b/sidecar/sokuji_sidecar/tts_backends.py
@@ -599,6 +599,13 @@ class Qwen3TtsOnnxBackend:
 
         ref_code = self._voice_prompt["ref_code"][0] if self._voice_prompt else None
         if ref_code is not None:
+            # The ref prefix exists only to warm up the vocoder's receptive
+            # field before the generated frames; decoding all ~100 frames of
+            # the reference clip costs more codec time than the utterance
+            # itself. This cap keeps just the tail as context.
+            max_ref = int(os.environ.get("SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES", "-1"))
+            if 0 <= max_ref < int(ref_code.shape[0]):
+                ref_code = ref_code[int(ref_code.shape[0]) - max_ref:]
             codes_for_decode = np.concatenate([ref_code, codes], axis=0)
         else:
             codes_for_decode = codes

--- a/sidecar/sokuji_sidecar/tts_backends.py
+++ b/sidecar/sokuji_sidecar/tts_backends.py
@@ -601,9 +601,10 @@ class Qwen3TtsOnnxBackend:
         if ref_code is not None:
             # The ref prefix exists only to warm up the vocoder's receptive
             # field before the generated frames; decoding all ~100 frames of
-            # the reference clip costs more codec time than the utterance
-            # itself. This cap keeps just the tail as context.
-            max_ref = int(os.environ.get("SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES", "-1"))
+            # the reference clip costs more codec time than a short utterance
+            # itself. Keep a ~1s tail as context (ASR-loopback verified);
+            # SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES=-1 restores the full prefix.
+            max_ref = int(os.environ.get("SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES", "12"))
             if 0 <= max_ref < int(ref_code.shape[0]):
                 ref_code = ref_code[int(ref_code.shape[0]) - max_ref:]
             codes_for_decode = np.concatenate([ref_code, codes], axis=0)

--- a/sidecar/sokuji_sidecar/tts_backends.py
+++ b/sidecar/sokuji_sidecar/tts_backends.py
@@ -581,12 +581,20 @@ class Qwen3TtsOnnxBackend:
         suppress_tokens = [i for i in range(vocab_size - 1024, vocab_size) if i != eos_token_id]
         max_new_tokens = int(os.environ.get("SOKUJI_QWEN3_TTS_MAX_FRAMES", "600"))
 
+        # Verification hooks: a fixed seed and/or greedy decoding make runs
+        # reproducible so optimized code paths can be A/B-compared numerically.
+        seed = os.environ.get("SOKUJI_QWEN3_TTS_SEED")
+        rng = np.random.default_rng(int(seed)) if seed else np.random.default_rng()
+        sampling_params = _QWEN3_TTS_SAMPLING_PARAMS
+        if os.environ.get("SOKUJI_QWEN3_TTS_GREEDY"):
+            sampling_params = dict(sampling_params, do_sample=False, subtalker_dosample=False)
+
         codes_list, _hidden_list = _q3_runtime.generate_codes(
             self._sessions, self._cfg.talker,
             talker_embed, attention_mask, trailing_text_hidden, tts_pad_embed,
-            max_new_tokens=max_new_tokens, sampling_params=_QWEN3_TTS_SAMPLING_PARAMS,
+            max_new_tokens=max_new_tokens, sampling_params=sampling_params,
             eos_token_id=eos_token_id, suppress_tokens=suppress_tokens,
-            rng=np.random.default_rng())
+            rng=rng)
         codes = codes_list[0]
 
         ref_code = self._voice_prompt["ref_code"][0] if self._voice_prompt else None

--- a/sidecar/sokuji_sidecar/tts_backends.py
+++ b/sidecar/sokuji_sidecar/tts_backends.py
@@ -499,7 +499,14 @@ class Qwen3TtsOnnxBackend:
             from .qwen_tokenizer import load_qwen2_tokenizer
             d = snapshot_download(repo_id=model_ref, local_files_only=True)
             threads = int(os.environ.get("SOKUJI_TTS_THREADS", "4"))
-            sessions = _q3_runtime.build_sessions(f"{d}/onnx", device, threads)
+            # The snapshot may ship CUDA-only graph rebuilds (bf16 talker /
+            # code_predictor) alongside the fp32 set; bf16 has no CPU or DML
+            # kernels, so only the cuda device picks them up.
+            variant_dir = None
+            if str(device).lower() == "cuda" and os.path.isdir(f"{d}/onnx-bf16"):
+                variant_dir = f"{d}/onnx-bf16"
+            sessions = _q3_runtime.build_sessions(f"{d}/onnx", device, threads,
+                                                  variant_dir=variant_dir)
             self._cfg = _q3_config.load_model_config(d)
             self._tok = load_qwen2_tokenizer(d)
             self._emb = _q3_runtime.Embeddings.from_sessions(sessions)

--- a/sidecar/tests/test_accel.py
+++ b/sidecar/tests/test_accel.py
@@ -1809,3 +1809,30 @@ def test_gpu_metal_tier_available_via_tc_metal_kind():
                       apple_silicon=False, dml_adapters=(), installed=frozenset(),
                       fingerprint="intel-mac", tc_kinds=("cpu", "metal"))
     assert accel._tier_available("gpu-metal", m) is True
+
+
+def test_model_weight_bytes_counts_variant_shadowing_and_external_data(tmp_path):
+    # A qwen3-tts-style snapshot: fp32 graphs under onnx/, CUDA-only bf16
+    # rebuilds under onnx-bf16/. The estimator serves CUDA-plan gating, and
+    # CUDA loads the bf16 rebuild INSTEAD of the same-named fp32 graph — the
+    # shadowed fp32 file must not be double-counted. External weight payloads
+    # (<name>.onnx.data) count toward their graph.
+    onnx_dir = tmp_path / "onnx"
+    bf16_dir = tmp_path / "onnx-bf16"
+    onnx_dir.mkdir()
+    bf16_dir.mkdir()
+    (onnx_dir / "talker.onnx").write_bytes(b"x" * 100)      # shadowed by bf16
+    (onnx_dir / "codec.onnx").write_bytes(b"x" * 20)
+    (onnx_dir / "codec.onnx.data").write_bytes(b"x" * 30)   # external payload
+    (bf16_dir / "talker.onnx").write_bytes(b"x" * 40)
+    from sokuji_sidecar import accel
+    assert accel._model_weight_bytes(str(tmp_path)) == 40 + 20 + 30
+
+
+def test_model_weight_bytes_without_variant_dir_counts_everything(tmp_path):
+    onnx_dir = tmp_path / "onnx"
+    onnx_dir.mkdir()
+    (onnx_dir / "talker.onnx").write_bytes(b"x" * 100)
+    (onnx_dir / "talker.onnx.data").write_bytes(b"x" * 50)
+    from sokuji_sidecar import accel
+    assert accel._model_weight_bytes(str(tmp_path)) == 150

--- a/sidecar/tests/test_qwen3_backend.py
+++ b/sidecar/tests/test_qwen3_backend.py
@@ -105,3 +105,62 @@ def test_tts_backends_no_librosa_or_transformers_import():
                 for n in ast.walk(tree) if isinstance(n, (ast.Import, ast.ImportFrom))
                 for a in n.names}
     assert not any((x or "").split(".")[0] in ("librosa", "transformers") for x in imported)
+
+
+def _generate_with_stubs(monkeypatch, env=None):
+    """Run backend.generate() with template/runtime stubbed out; return the
+    kwargs generate_codes was called with."""
+    from types import SimpleNamespace
+
+    captured = {}
+    b = Qwen3TtsOnnxBackend()
+    b._sessions = {}
+    b._cfg = SimpleNamespace(talker=SimpleNamespace(
+        codec_eos_token_id=2150, vocab_size=3072, num_code_groups=16))
+    b._tokenize = lambda text: np.arange(4, dtype=np.int64)[None, :]
+    b._codec = type("C", (), {"decode": staticmethod(
+        lambda codes: np.zeros(1920, np.float32))})()
+
+    monkeypatch.setattr(
+        "sokuji_sidecar.tts_backends._q3_template.build_talker_inputs",
+        lambda *a, **k: (np.zeros((1, 3, 8), np.float32), np.ones((1, 3), np.int64),
+                         np.zeros((1, 1, 8), np.float32), np.zeros((1, 1, 8), np.float32)))
+
+    def fake_generate_codes(sessions, cfg_talker, *args, **kwargs):
+        captured.update(kwargs)
+        return [np.zeros((2, 16), np.int64)], [np.zeros((2, 8), np.float32)]
+
+    monkeypatch.setattr(
+        "sokuji_sidecar.tts_backends._q3_runtime.generate_codes", fake_generate_codes)
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    b.generate("hi")
+    return captured
+
+
+def test_generate_seed_env_makes_rng_deterministic(monkeypatch):
+    env = {"SOKUJI_QWEN3_TTS_SEED": "123"}
+    r1 = _generate_with_stubs(monkeypatch, env)["rng"].random(4)
+    r2 = _generate_with_stubs(monkeypatch, env)["rng"].random(4)
+    assert np.array_equal(r1, r2)
+
+
+def test_generate_rng_unseeded_by_default(monkeypatch):
+    r1 = _generate_with_stubs(monkeypatch)["rng"].random(4)
+    r2 = _generate_with_stubs(monkeypatch)["rng"].random(4)
+    assert not np.array_equal(r1, r2)
+
+
+def test_generate_greedy_env_disables_sampling(monkeypatch):
+    params = _generate_with_stubs(
+        monkeypatch, {"SOKUJI_QWEN3_TTS_GREEDY": "1"})["sampling_params"]
+    assert params["do_sample"] is False and params["subtalker_dosample"] is False
+
+
+def test_generate_default_sampling_params_unchanged(monkeypatch):
+    from sokuji_sidecar.tts_backends import _QWEN3_TTS_SAMPLING_PARAMS
+    params = _generate_with_stubs(monkeypatch)["sampling_params"]
+    assert params["do_sample"] is True and params["subtalker_dosample"] is True
+    # greedy runs must never mutate the module-level constant
+    _generate_with_stubs(monkeypatch, {"SOKUJI_QWEN3_TTS_GREEDY": "1"})
+    assert _QWEN3_TTS_SAMPLING_PARAMS["do_sample"] is True

--- a/sidecar/tests/test_qwen3_backend.py
+++ b/sidecar/tests/test_qwen3_backend.py
@@ -202,10 +202,23 @@ def _generate_with_ref(monkeypatch, ref_frames=10, env=None):
     return seen["frames"], len(wav), 5
 
 
-def test_generate_decodes_full_ref_prefix_by_default(monkeypatch):
+def test_generate_defaults_to_twelve_ref_decode_frames(monkeypatch):
+    frames, wav_len, gen = _generate_with_ref(monkeypatch, ref_frames=90)
+    assert frames == 12 + gen             # default: 12-frame vocoder warm-up tail
+    assert wav_len == gen * 1920
+
+
+def test_generate_short_ref_decoded_fully_by_default(monkeypatch):
     frames, wav_len, gen = _generate_with_ref(monkeypatch, ref_frames=10)
-    assert frames == 10 + gen
-    assert wav_len == gen * 1920          # proportional ref cut removes the prefix
+    assert frames == 10 + gen             # refs shorter than the cap are untouched
+    assert wav_len == gen * 1920
+
+
+def test_generate_ref_decode_frames_env_disables_cap(monkeypatch):
+    frames, wav_len, gen = _generate_with_ref(
+        monkeypatch, ref_frames=90, env={"SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES": "-1"})
+    assert frames == 90 + gen
+    assert wav_len == gen * 1920
 
 
 def test_generate_ref_decode_frames_env_limits_prefix(monkeypatch):

--- a/sidecar/tests/test_qwen3_backend.py
+++ b/sidecar/tests/test_qwen3_backend.py
@@ -164,3 +164,59 @@ def test_generate_default_sampling_params_unchanged(monkeypatch):
     # greedy runs must never mutate the module-level constant
     _generate_with_stubs(monkeypatch, {"SOKUJI_QWEN3_TTS_GREEDY": "1"})
     assert _QWEN3_TTS_SAMPLING_PARAMS["do_sample"] is True
+
+
+def _generate_with_ref(monkeypatch, ref_frames=10, env=None):
+    """Run generate() with an ICL voice prompt and a decode-capturing codec.
+    Returns (decode_input_frames, wav_len, gen_frames)."""
+    from types import SimpleNamespace
+
+    seen = {}
+    b = Qwen3TtsOnnxBackend()
+    b._sessions = {}
+    b._cfg = SimpleNamespace(talker=SimpleNamespace(
+        codec_eos_token_id=2150, vocab_size=3072, num_code_groups=16))
+    b._tokenize = lambda text: np.arange(4, dtype=np.int64)[None, :]
+    b._voice_prompt = {
+        "ref_code": [np.ones((ref_frames, 16), np.int64)],
+        "ref_spk_embedding": [np.zeros(8, np.float32)],
+        "x_vector_only_mode": [False], "icl_mode": [True],
+    }
+
+    def fake_decode(codes):
+        seen["frames"] = int(codes.shape[0])
+        return np.zeros(int(codes.shape[0]) * 1920, np.float32)
+
+    b._codec = type("C", (), {"decode": staticmethod(fake_decode)})()
+
+    monkeypatch.setattr(
+        "sokuji_sidecar.tts_backends._q3_template.build_talker_inputs",
+        lambda *a, **k: (np.zeros((1, 3, 8), np.float32), np.ones((1, 3), np.int64),
+                         np.zeros((1, 1, 8), np.float32), np.zeros((1, 1, 8), np.float32)))
+    monkeypatch.setattr(
+        "sokuji_sidecar.tts_backends._q3_runtime.generate_codes",
+        lambda *a, **k: ([np.zeros((5, 16), np.int64)], [np.zeros((5, 8), np.float32)]))
+    for k, v in (env or {}).items():
+        monkeypatch.setenv(k, v)
+    wav, _ = b.generate("hi")
+    return seen["frames"], len(wav), 5
+
+
+def test_generate_decodes_full_ref_prefix_by_default(monkeypatch):
+    frames, wav_len, gen = _generate_with_ref(monkeypatch, ref_frames=10)
+    assert frames == 10 + gen
+    assert wav_len == gen * 1920          # proportional ref cut removes the prefix
+
+
+def test_generate_ref_decode_frames_env_limits_prefix(monkeypatch):
+    frames, wav_len, gen = _generate_with_ref(
+        monkeypatch, ref_frames=10, env={"SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES": "4"})
+    assert frames == 4 + gen              # only a 4-frame vocoder warm-up tail
+    assert wav_len == gen * 1920          # cut must use the truncated ref length
+
+
+def test_generate_ref_decode_frames_env_larger_than_ref_is_noop(monkeypatch):
+    frames, wav_len, gen = _generate_with_ref(
+        monkeypatch, ref_frames=10, env={"SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES": "64"})
+    assert frames == 10 + gen
+    assert wav_len == gen * 1920

--- a/sidecar/tests/test_qwen3_runtime_cuda.py
+++ b/sidecar/tests/test_qwen3_runtime_cuda.py
@@ -1,0 +1,307 @@
+"""CUDA fast-path (IOBinding) tests for the Qwen3-TTS AR loop.
+
+No GPU needed: fakes model the io_binding()/run_with_iobinding()/OrtValue
+surface, delegating to the same scripted compute as the numpy-path fakes so
+the two paths can be compared value-for-value.
+"""
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+from sokuji_sidecar.qwen3_tts import runtime
+
+H, GROUPS, VOCAB, SUBVOCAB, EOS = 8, 4, 32, 16, 30
+
+
+class _IO:
+    def __init__(self, name):
+        self.name = name
+
+
+class _ScriptedDecode:
+    """Value-bearing talker_decode fake. First-code script: 5, 9, EOS.
+    last_hidden varies by call so downstream values depend on the step."""
+
+    def __init__(self):
+        self.calls = 0
+        self.direct_run_calls = 0
+
+    def get_inputs(self):
+        return [_IO("inputs_embeds"), _IO("attention_mask"),
+                _IO("past_key_0"), _IO("past_value_0")]
+
+    def get_outputs(self):
+        return [_IO("logits"), _IO("last_hidden"),
+                _IO("present_key_0"), _IO("present_value_0")]
+
+    def _compute(self, feeds):
+        t = feeds["inputs_embeds"].shape[1]
+        past_len = feeds["past_key_0"].shape[2]
+        if self.calls == 0:
+            assert past_len == 0            # zero-past initial pass
+        assert feeds["attention_mask"].shape[1] == past_len + t
+        logits = np.full((1, t, VOCAB), -5.0, np.float32)
+        script = [5, 9, EOS]
+        logits[0, -1, script[min(self.calls, 2)]] = 5.0
+        last_hidden = np.full((1, 1, H), float(self.calls + 1), np.float32)
+        present = np.full((1, 2, past_len + t, 4), float(self.calls), np.float32)
+        self.calls += 1
+        return [logits, last_hidden, present, present.copy()]
+
+    def run(self, names, feeds):
+        self.direct_run_calls += 1
+        return self._compute(feeds)
+
+
+class _FakeOrtValue:
+    def __init__(self, arr):
+        self.arr = arr
+        self.numpy_calls = 0
+        self.valid = True
+
+    def numpy(self):
+        assert self.valid, "use-after-free: OrtValue read after clear_binding_outputs"
+        self.numpy_calls += 1
+        return self.arr
+
+
+class _FakeIoBinding:
+    """Models the real pybind ownership rule observed on ORT 1.24: OrtValues
+    returned by get_outputs() reference the binding's internal storage and are
+    INVALIDATED by clear_binding_outputs() on the same binding object."""
+
+    def __init__(self, sess):
+        self._sess = sess
+        self.cpu_inputs = {}
+        self.ortvalue_inputs = {}
+        self.bound_outputs = []
+        self.outputs = None
+        self._handed_out = []
+
+    def bind_cpu_input(self, name, arr):
+        self.cpu_inputs[name] = arr
+
+    def bind_ortvalue_input(self, name, val):
+        self.ortvalue_inputs[name] = val
+
+    def bind_output(self, name, device_type="cpu", device_id=0):
+        self.bound_outputs.append((name, device_type))
+
+    def clear_binding_inputs(self):
+        self.cpu_inputs = {}
+        self.ortvalue_inputs = {}
+
+    def clear_binding_outputs(self):
+        self.bound_outputs = []
+        for val in self._handed_out:
+            val.valid = False
+
+    def set_run_outputs(self, vals):
+        # a new run also invalidates the previous run's output references
+        for val in self._handed_out:
+            val.valid = False
+        self.outputs = vals
+        self._handed_out = list(vals)
+
+    def get_outputs(self):
+        return self.outputs
+
+
+class _CudaScriptedDecode(_ScriptedDecode):
+    """Same scripted compute, exposed through the CUDA/IOBinding surface."""
+
+    def __init__(self):
+        super().__init__()
+        self.presents = []          # every present OrtValue handed out
+        self.past_ortvalues_seen = []  # per call: dict of bound past OrtValues
+        self.first_call_cpu_past = None
+
+    def get_providers(self):
+        return ["CUDAExecutionProvider", "CPUExecutionProvider"]
+
+    def io_binding(self):
+        return _FakeIoBinding(self)
+
+    def run_with_iobinding(self, iob, run_options=None):
+        for name, val in iob.ortvalue_inputs.items():
+            assert val.valid, f"use-after-free: {name} was invalidated before this run"
+        feeds = dict(iob.cpu_inputs)
+        for name, val in iob.ortvalue_inputs.items():
+            feeds[name] = val.arr
+        if self.calls == 0:
+            self.first_call_cpu_past = {
+                k: v for k, v in iob.cpu_inputs.items() if k.startswith("past_")}
+        self.past_ortvalues_seen.append(dict(iob.ortvalue_inputs))
+        outs = self._compute(feeds)
+        vals = [_FakeOrtValue(o) for o in outs]
+        self.presents.extend(vals[2:])
+        iob.set_run_outputs(vals)
+
+
+class _ValueCodecEmbed:
+    """codec_embed fake whose row value equals the token id."""
+
+    def __init__(self):
+        self.calls = 0
+        self.ids_seen = []
+
+    def get_outputs(self):
+        return [_IO("embeds")]
+
+    def run(self, names, feeds):
+        self.calls += 1
+        ids = feeds["input_ids"]
+        self.ids_seen.append(np.asarray(ids).copy())
+        out = np.repeat(ids[..., None].astype(np.float32), H, axis=-1)
+        return [out]
+
+
+class _ValuePredEmbed:
+    """code_predictor_embed fake: row value = id * 100 + generation_step."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get_outputs(self):
+        return [_IO("embeds")]
+
+    def run(self, names, feeds):
+        self.calls += 1
+        ids = feeds["input_ids"]
+        j = int(np.asarray(feeds["generation_step"]).reshape(-1)[0])
+        out = ids[..., None].astype(np.float32) * 100.0 + float(j)
+        out = np.repeat(out, H, axis=-1)
+        return [out]
+
+
+class _ValueCodePred:
+    """code_predictor fake whose argmax depends on the embed values it sees,
+    so embed-table gathers must match per-step embed session runs exactly."""
+
+    def get_outputs(self):
+        return [_IO("logits")]
+
+    def run(self, names, feeds):
+        s = float(np.abs(feeds["inputs_embeds"]).sum())
+        j = int(np.asarray(feeds["generation_step"]).reshape(-1)[0])
+        out = np.full((1, SUBVOCAB), -5.0, np.float32)
+        out[0, (int(s) + j) % SUBVOCAB] = 5.0
+        return [out]
+
+
+def _cfg():
+    return SimpleNamespace(num_code_groups=GROUPS, vocab_size=VOCAB,
+                           code_predictor_config={"vocab_size": SUBVOCAB})
+
+
+def _numpy_sessions():
+    return {"talker_decode": _ScriptedDecode(), "code_predictor": _ValueCodePred(),
+            "codec_embed": _ValueCodecEmbed(), "code_predictor_embed": _ValuePredEmbed()}
+
+
+def _cuda_sessions():
+    return {"talker_decode": _CudaScriptedDecode(), "code_predictor": _ValueCodePred(),
+            "codec_embed": _ValueCodecEmbed(), "code_predictor_embed": _ValuePredEmbed()}
+
+
+def _gen(sessions, *, do_sample=False, rng=None):
+    return runtime.generate_codes(
+        sessions, _cfg(),
+        inputs_embeds=np.zeros((1, 3, H), np.float32),
+        attention_mask=np.ones((1, 3), np.int64),
+        trailing_text_hidden=np.full((1, 2, H), 0.5, np.float32),
+        tts_pad_embed=np.full((1, 1, H), 0.25, np.float32),
+        max_new_tokens=10, sampling_params=dict(
+            do_sample=do_sample, top_k=3, top_p=1.0, temperature=1.0,
+            repetition_penalty=1.05, subtalker_dosample=do_sample,
+            subtalker_top_k=3, subtalker_top_p=1.0, subtalker_temperature=1.0),
+        eos_token_id=EOS, suppress_tokens=None,
+        rng=rng or np.random.default_rng(0))
+
+
+def test_binding_path_matches_numpy_path_greedy():
+    codes_np, hidden_np = _gen(_numpy_sessions())
+    codes_cu, hidden_cu = _gen(_cuda_sessions())
+    assert np.array_equal(codes_np[0], codes_cu[0])
+    assert np.array_equal(hidden_np[0], hidden_cu[0])
+    assert codes_np[0].shape == (2, GROUPS)   # scripted EOS at step 3
+
+
+def test_binding_path_matches_numpy_path_sampled():
+    codes_np, _ = _gen(_numpy_sessions(), do_sample=True, rng=np.random.default_rng(42))
+    codes_cu, _ = _gen(_cuda_sessions(), do_sample=True, rng=np.random.default_rng(42))
+    assert np.array_equal(codes_np[0], codes_cu[0])
+
+
+def test_binding_path_keeps_kv_on_device():
+    sessions = _cuda_sessions()
+    dec = sessions["talker_decode"]
+    _gen(sessions)
+    assert dec.direct_run_calls == 0            # decode went through iobinding only
+    assert dec.calls >= 2
+    for val in dec.presents:
+        assert val.numpy_calls == 0             # present KV never pulled to host
+    # step 2 got step 1's present OrtValues bound back as past, by identity
+    step2_past = dec.past_ortvalues_seen[1]
+    assert set(step2_past.keys()) == {"past_key_0", "past_value_0"}
+    assert all(any(v is p for p in dec.presents) for v in step2_past.values())
+
+
+def test_binding_path_zero_past_first_step_binds_cpu_zeros():
+    sessions = _cuda_sessions()
+    dec = sessions["talker_decode"]
+    _gen(sessions)
+    assert dec.past_ortvalues_seen[0] == {}     # no device past on the first call
+    shapes = {k: v.shape for k, v in dec.first_call_cpu_past.items()}
+    assert shapes == {"past_key_0": (1, 8, 0, 128), "past_value_0": (1, 8, 0, 128)}
+
+
+def test_binding_path_extracts_embed_tables_once():
+    sessions = _cuda_sessions()
+    ce, pe = sessions["codec_embed"], sessions["code_predictor_embed"]
+    _gen(sessions)
+    assert ce.calls == 1                         # one arange sweep, not one per frame
+    assert ce.ids_seen[0].shape == (1, VOCAB)
+    assert pe.calls == GROUPS - 1                # one sweep per code group table
+    _gen(sessions)                               # second utterance reuses the cache
+    assert ce.calls == 1 and pe.calls == GROUPS - 1
+
+
+def test_numpy_path_still_runs_embeds_per_step():
+    sessions = _numpy_sessions()
+    ce = sessions["codec_embed"]
+    _gen(sessions)
+    assert ce.calls >= 2                         # per-frame session runs preserved
+
+
+def test_non_cuda_providers_stay_on_numpy_path():
+    class _DmlDecode(_CudaScriptedDecode):
+        def get_providers(self):
+            return ["DmlExecutionProvider", "CPUExecutionProvider"]
+
+    sessions = _cuda_sessions()
+    sessions["talker_decode"] = _DmlDecode()
+    dec = sessions["talker_decode"]
+    _gen(sessions)
+    assert dec.direct_run_calls >= 2             # plain session.run path
+
+
+def test_binding_path_without_kv_outputs_raises():
+    class _NoKvDecode(_CudaScriptedDecode):
+        def get_inputs(self):
+            return [_IO("inputs_embeds"), _IO("attention_mask")]
+
+        def get_outputs(self):
+            return [_IO("logits"), _IO("last_hidden")]
+
+        def _compute(self, feeds):
+            t = feeds["inputs_embeds"].shape[1]
+            logits = np.full((1, t, VOCAB), -5.0, np.float32)
+            logits[0, -1, 5] = 5.0               # never EOS → needs a second step
+            self.calls += 1
+            return [logits, np.zeros((1, 1, H), np.float32)]
+
+    sessions = _cuda_sessions()
+    sessions["talker_decode"] = _NoKvDecode()
+    with pytest.raises(RuntimeError, match="no KV cache"):
+        _gen(sessions)

--- a/sidecar/tests/test_qwen3_runtime_cuda.py
+++ b/sidecar/tests/test_qwen3_runtime_cuda.py
@@ -357,3 +357,201 @@ def test_binding_path_fp16_feeds_and_fp32_results():
     # the fp16 pipeline must reproduce the fp32 reference codes bit-for-bit
     codes_ref, _ = _gen(_numpy_sessions())
     assert np.array_equal(codes[0], codes_ref[0])
+
+
+class _FakeGraphOrtValue:
+    """OrtValue with a fixed device buffer updated in place (CUDA-graph style)."""
+
+    def __init__(self, arr):
+        self.arr = np.array(arr)
+        self.update_calls = 0
+
+    def update_inplace(self, arr):
+        assert arr.shape == self.arr.shape and arr.dtype == self.arr.dtype, \
+            f"CUDA-graph buffers are fixed: {arr.shape}/{arr.dtype} vs {self.arr.shape}/{self.arr.dtype}"
+        self.arr = np.array(arr)
+        self.update_calls += 1
+
+    def numpy(self):
+        return self.arr
+
+
+class _FakeRunOptions:
+    def __init__(self):
+        self.entries = {}
+
+    def add_run_config_entry(self, k, v):
+        self.entries[k] = v
+
+
+class _FakeGraphedCpSession:
+    """Session double with enable_cuda_graph semantics: per gpu_graph_id the
+    bound addresses must never change after the capture run."""
+
+    def __init__(self, compute):
+        self._compute = compute
+        self.captured = {}          # graph_id -> iob identity
+        self.io_binding_calls = 0
+
+    def get_inputs(self):
+        return [_IO("inputs_embeds"), _IO("generation_step")]
+
+    def get_outputs(self):
+        return [_IO("logits")]
+
+    def io_binding(self):
+        self.io_binding_calls += 1
+        return _FakeIoBinding(self)
+
+    def run_with_iobinding(self, iob, run_options=None):
+        gid = run_options.entries.get("gpu_graph_id") if run_options else None
+        assert gid is not None, "graphed session must be run with a gpu_graph_id"
+        if gid in self.captured:
+            assert self.captured[gid] is iob, \
+                "replay must reuse the captured binding object (fixed addresses)"
+        else:
+            self.captured[gid] = iob
+        feeds = {k: v.arr for k, v in iob.ortvalue_inputs.items()}
+        logits = self._compute(feeds)
+        out_name, out_val = next(iter(iob.ortvalue_outputs.items()))
+        out_val.arr = logits
+
+
+def _graphed_env(monkeypatch):
+    """Fake onnxruntime module exposing what GraphedCodePredictor needs."""
+    import sys
+    import types
+
+    compute = _ValueCodePred()
+
+    def fake_infer_session(path, sess_options=None, providers=None):
+        assert any(isinstance(p, tuple) and p[1].get("enable_cuda_graph") == "1"
+                   for p in providers), "graphed session must enable cuda graphs"
+        return _FakeGraphedCpSession(lambda feeds: compute.run(["logits"], feeds)[0])
+
+    def fake_from_shape_and_type(shape, dtype, device, device_id=0):
+        return _FakeGraphOrtValue(np.zeros(shape, dtype))
+
+    fake_ort = types.SimpleNamespace(
+        InferenceSession=fake_infer_session,
+        SessionOptions=lambda: types.SimpleNamespace(
+            log_severity_level=0, add_session_config_entry=lambda *a: None),
+        RunOptions=_FakeRunOptions,
+        OrtValue=types.SimpleNamespace(
+            ortvalue_from_shape_and_type=fake_from_shape_and_type),
+    )
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake_ort)
+
+
+def _bind_ortvalue_output_shim():
+    # extend the fake binding with ortvalue outputs for the graphed path
+    if not hasattr(_FakeIoBinding, "bind_ortvalue_output"):
+        def bind_ortvalue_output(self, name, val):
+            if not hasattr(self, "ortvalue_outputs"):
+                self.ortvalue_outputs = {}
+            self.ortvalue_outputs[name] = val
+        _FakeIoBinding.bind_ortvalue_output = bind_ortvalue_output
+
+
+def test_graphed_code_predictor_matches_plain(monkeypatch, tmp_path):
+    from sokuji_sidecar.qwen3_tts import runtime_cuda
+
+    _bind_ortvalue_output_shim()
+    _graphed_env(monkeypatch)
+    gcp = runtime_cuda.GraphedCodePredictor(
+        str(tmp_path / "code_predictor.onnx"), hidden=H, sub_vocab=SUBVOCAB,
+        fallback=None)
+    plain = _ValueCodePred()
+    rng = np.random.default_rng(3)
+    for j, L in enumerate((2, 5, 16, 5, 2)):
+        x = rng.standard_normal((1, L, H)).astype(np.float32)
+        g = np.full((1,), j % 15, np.int64)
+        got = gcp.run({"inputs_embeds": x, "generation_step": g},
+                      output_names=["logits"])[0]
+        want = plain.run(["logits"], {"inputs_embeds": x, "generation_step": g})[0]
+        assert np.array_equal(got, want)
+
+
+def test_graphed_code_predictor_reuses_bindings_per_length(monkeypatch, tmp_path):
+    from sokuji_sidecar.qwen3_tts import runtime_cuda
+
+    _bind_ortvalue_output_shim()
+    _graphed_env(monkeypatch)
+    gcp = runtime_cuda.GraphedCodePredictor(
+        str(tmp_path / "code_predictor.onnx"), hidden=H, sub_vocab=SUBVOCAB,
+        fallback=None)
+    rng = np.random.default_rng(4)
+    for _ in range(3):
+        for L in (2, 9):
+            x = rng.standard_normal((1, L, H)).astype(np.float32)
+            gcp.run({"inputs_embeds": x, "generation_step": np.zeros((1,), np.int64)},
+                    output_names=["logits"])
+    sess = gcp.session
+    assert sess.io_binding_calls == 2            # one binding per distinct length
+    assert set(sess.captured.keys()) == {"2", "9"}
+
+
+def test_graphed_code_predictor_falls_back_on_run_error(monkeypatch, tmp_path):
+    from sokuji_sidecar.qwen3_tts import runtime_cuda
+
+    _bind_ortvalue_output_shim()
+    _graphed_env(monkeypatch)
+    gcp = runtime_cuda.GraphedCodePredictor(
+        str(tmp_path / "code_predictor.onnx"), hidden=H, sub_vocab=SUBVOCAB,
+        fallback=runtime.  _Session(_ValueCodePred()))
+
+    def boom(iob, run_options=None):
+        raise RuntimeError("capture failed")
+
+    gcp.session.run_with_iobinding = boom
+    x = np.zeros((1, 2, H), np.float32)
+    out = gcp.run({"inputs_embeds": x, "generation_step": np.zeros((1,), np.int64)},
+                  output_names=["logits"])[0]
+    plain = _ValueCodePred().run(["logits"], {"inputs_embeds": x,
+                                              "generation_step": np.zeros((1,), np.int64)})[0]
+    assert np.array_equal(out, plain)
+
+
+def test_build_sessions_records_onnx_dir(monkeypatch, tmp_path):
+    import sys
+    import types
+
+    class _Sess:
+        def __init__(self, path, sess_options=None, providers=None):
+            pass
+
+        def get_providers(self):
+            return ["CPUExecutionProvider"]
+
+    fake = types.SimpleNamespace(
+        get_available_providers=lambda: ["CPUExecutionProvider"],
+        InferenceSession=_Sess,
+        SessionOptions=lambda: types.SimpleNamespace(
+            graph_optimization_level=0, log_severity_level=0, intra_op_num_threads=0),
+        GraphOptimizationLevel=types.SimpleNamespace(ORT_ENABLE_ALL=1))
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake)
+    sessions = runtime.build_sessions(tmp_path, "cpu", 1)
+    assert sessions["_onnx_dir"] == str(tmp_path)
+
+
+def test_binding_path_uses_graphed_code_predictor_and_caches_it(monkeypatch, tmp_path):
+    _bind_ortvalue_output_shim()
+    _graphed_env(monkeypatch)
+    import sys
+    created = []
+    real_infer = sys.modules["onnxruntime"].InferenceSession
+
+    def counting_infer(*a, **k):
+        created.append(a)
+        return real_infer(*a, **k)
+
+    sys.modules["onnxruntime"].InferenceSession = counting_infer
+
+    sessions = _cuda_sessions()
+    sessions["_onnx_dir"] = str(tmp_path)
+    codes_graphed, _ = _gen(sessions)
+    codes_plain, _ = _gen(_numpy_sessions())
+    assert np.array_equal(codes_graphed[0], codes_plain[0])
+    assert len(created) == 1                     # graphed session built once...
+    _gen(sessions)
+    assert len(created) == 1                     # ...and cached across utterances

--- a/sidecar/tests/test_qwen3_runtime_cuda.py
+++ b/sidecar/tests/test_qwen3_runtime_cuda.py
@@ -512,7 +512,7 @@ def test_graphed_code_predictor_falls_back_on_run_error(monkeypatch, tmp_path):
     assert np.array_equal(out, plain)
 
 
-def test_build_sessions_records_onnx_dir(monkeypatch, tmp_path):
+def test_build_sessions_records_graph_paths(monkeypatch, tmp_path):
     import sys
     import types
 
@@ -531,7 +531,7 @@ def test_build_sessions_records_onnx_dir(monkeypatch, tmp_path):
         GraphOptimizationLevel=types.SimpleNamespace(ORT_ENABLE_ALL=1))
     monkeypatch.setitem(sys.modules, "onnxruntime", fake)
     sessions = runtime.build_sessions(tmp_path, "cpu", 1)
-    assert sessions["_onnx_dir"] == str(tmp_path)
+    assert sessions["_graph_paths"]["code_predictor"] == str(tmp_path / "code_predictor.onnx")
 
 
 def test_binding_path_uses_graphed_code_predictor_and_caches_it(monkeypatch, tmp_path):
@@ -548,10 +548,74 @@ def test_binding_path_uses_graphed_code_predictor_and_caches_it(monkeypatch, tmp
     sys.modules["onnxruntime"].InferenceSession = counting_infer
 
     sessions = _cuda_sessions()
-    sessions["_onnx_dir"] = str(tmp_path)
+    sessions["_graph_paths"] = {"code_predictor": str(tmp_path / "code_predictor.onnx")}
     codes_graphed, _ = _gen(sessions)
     codes_plain, _ = _gen(_numpy_sessions())
     assert np.array_equal(codes_graphed[0], codes_plain[0])
     assert len(created) == 1                     # graphed session built once...
     _gen(sessions)
     assert len(created) == 1                     # ...and cached across utterances
+
+
+def test_build_sessions_variant_dir_overrides_graphs(monkeypatch, tmp_path):
+    import sys
+    import types
+
+    base = tmp_path / "onnx"
+    variant = tmp_path / "onnx-bf16"
+    base.mkdir()
+    variant.mkdir()
+    (variant / "code_predictor.onnx").write_bytes(b"x")   # only cp has a bf16 build
+
+    paths_seen = {}
+
+    class _Sess:
+        def __init__(self, path, sess_options=None, providers=None):
+            paths_seen.setdefault(str(path), 0)
+            paths_seen[str(path)] += 1
+
+        def get_providers(self):
+            return ["CPUExecutionProvider"]
+
+    fake = types.SimpleNamespace(
+        get_available_providers=lambda: ["CPUExecutionProvider"],
+        InferenceSession=_Sess,
+        SessionOptions=lambda: types.SimpleNamespace(
+            graph_optimization_level=0, log_severity_level=0, intra_op_num_threads=0),
+        GraphOptimizationLevel=types.SimpleNamespace(ORT_ENABLE_ALL=1))
+    monkeypatch.setitem(sys.modules, "onnxruntime", fake)
+
+    sessions = runtime.build_sessions(base, "cpu", 1, variant_dir=str(variant))
+    assert str(variant / "code_predictor.onnx") in paths_seen
+    assert sessions["_graph_paths"]["code_predictor"] == str(variant / "code_predictor.onnx")
+    assert sessions["_graph_paths"]["talker_decode"] == str(base / "talker_decode.onnx")
+
+
+def test_backend_load_prefers_bf16_dir_on_cuda(monkeypatch, tmp_path):
+    from sokuji_sidecar.tts_backends import Qwen3TtsOnnxBackend
+
+    (tmp_path / "onnx").mkdir()
+    (tmp_path / "onnx-bf16").mkdir()
+    seen = {}
+
+    import huggingface_hub
+    monkeypatch.setattr(huggingface_hub, "snapshot_download",
+                        lambda repo_id, local_files_only=True: str(tmp_path))
+    monkeypatch.setattr("sokuji_sidecar.tts_backends._q3_runtime.build_sessions",
+                        lambda d, device, threads, variant_dir=None:
+                        seen.update(dir=d, variant=variant_dir) or
+                        {"tokenizer12hz_encode": None, "tokenizer12hz_decode": None})
+    monkeypatch.setattr("sokuji_sidecar.tts_backends._q3_config.load_model_config",
+                        lambda d: object())
+    monkeypatch.setattr("sokuji_sidecar.qwen_tokenizer.load_qwen2_tokenizer",
+                        lambda d: object())
+    monkeypatch.setattr("sokuji_sidecar.tts_backends._q3_codec.Codec12Hz",
+                        lambda sessions: object())
+
+    b = Qwen3TtsOnnxBackend()
+    b.load("some/repo", "cuda", "fp32")
+    assert seen["variant"] == str(tmp_path / "onnx-bf16")
+
+    b2 = Qwen3TtsOnnxBackend()
+    b2.load("some/repo", "cpu", "fp32")
+    assert seen["variant"] is None                # CPU lane must stay on fp32

--- a/sidecar/tests/test_qwen3_runtime_cuda.py
+++ b/sidecar/tests/test_qwen3_runtime_cuda.py
@@ -305,3 +305,55 @@ def test_binding_path_without_kv_outputs_raises():
     sessions["talker_decode"] = _NoKvDecode()
     with pytest.raises(RuntimeError, match="no KV cache"):
         _gen(sessions)
+
+
+class _IO16:
+    def __init__(self, name):
+        self.name = name
+        self.type = "tensor(float16)"
+
+
+class _Fp16CudaDecode(_CudaScriptedDecode):
+    """fp16-exported talker_decode: float inputs/outputs are all fp16."""
+
+    def get_inputs(self):
+        return [_IO16("inputs_embeds"), _IO("attention_mask"),
+                _IO16("past_key_0"), _IO16("past_value_0")]
+
+    def _compute(self, feeds):
+        assert feeds["inputs_embeds"].dtype == np.float16
+        assert feeds["past_key_0"].dtype == np.float16
+        outs = super()._compute({k: np.asarray(v, np.float32) for k, v in feeds.items()})
+        return [o.astype(np.float16) for o in outs]
+
+
+class _Fp16CodePred(_ValueCodePred):
+    def get_inputs(self):
+        return [_IO16("inputs_embeds"), _IO("generation_step")]
+
+    def run(self, names, feeds):
+        assert feeds["inputs_embeds"].dtype == np.float16
+        outs = super().run(names, {k: np.asarray(v, np.float32) for k, v in feeds.items()})
+        return [o.astype(np.float16) for o in outs]
+
+
+class _Fp16Embed(_ValueCodecEmbed):
+    def run(self, names, feeds):
+        return [o.astype(np.float16) for o in super().run(names, feeds)]
+
+
+class _Fp16PredEmbed(_ValuePredEmbed):
+    def run(self, names, feeds):
+        return [o.astype(np.float16) for o in super().run(names, feeds)]
+
+
+def test_binding_path_fp16_feeds_and_fp32_results():
+    sessions = {"talker_decode": _Fp16CudaDecode(), "code_predictor": _Fp16CodePred(),
+                "codec_embed": _Fp16Embed(), "code_predictor_embed": _Fp16PredEmbed()}
+    codes, hidden = _gen(sessions)
+    assert codes[0].shape == (2, GROUPS)
+    assert hidden[0].dtype == np.float32          # public contract stays fp32
+    # fp16 rounding of the value-fakes is exact for these small integers, so
+    # the fp16 pipeline must reproduce the fp32 reference codes bit-for-bit
+    codes_ref, _ = _gen(_numpy_sessions())
+    assert np.array_equal(codes[0], codes_ref[0])

--- a/sidecar/tests/test_qwen3_runtime_cuda.py
+++ b/sidecar/tests/test_qwen3_runtime_cuda.py
@@ -498,7 +498,7 @@ def test_graphed_code_predictor_falls_back_on_run_error(monkeypatch, tmp_path):
     _graphed_env(monkeypatch)
     gcp = runtime_cuda.GraphedCodePredictor(
         str(tmp_path / "code_predictor.onnx"), hidden=H, sub_vocab=SUBVOCAB,
-        fallback=runtime.  _Session(_ValueCodePred()))
+        fallback=runtime._Session(_ValueCodePred()))
 
     def boom(iob, run_options=None):
         raise RuntimeError("capture failed")


### PR DESCRIPTION
Closes #293 for the primary target: **0.6B reaches 2.17x realtime on GB10 CUDA** (baseline 0.94x); **1.7B reaches 1.71x** (baseline 0.48-0.76x). All changes are covered by fake-session unit tests (590 passing), and every optimization was verified on hardware — orchestration changes bit-identically against the reference path (seeded A/B), numerics-changing changes via sense-voice ASR loopback (19/20 and 9/10; every failure is the pre-existing temp-0.9 leading-word sampling variance that the fp32 baseline also exhibits).

## Runtime changes (work with existing fp32 snapshots too)
- **Device-resident KV cache** via ORT IOBinding: present-KV OrtValues rebound as next-step past-KV without leaving the GPU. Uses two alternating IOBindings — on ORT 1.24, `get_outputs()` returns references into the binding's internal storage that `clear_binding_outputs()` invalidates (observed as garbage tensor ranks, then a segfault).
- **Embedding-table extraction**: `codec_embed` / `code_predictor_embed` are pure Gathers; one arange sweep per table at load turns 16 session dispatches per frame into host-side numpy indexing.
- **CUDA-graph code_predictor**: the 15 per-frame substeps only ever see lengths 2..16, so a dedicated `enable_cuda_graph` session captures one graph per length (`gpu_graph_id`), replays measured bit-identical.
- **Ref-prefix decode cap (default 12 frames)**: the ICL reference prefix is decoded on every utterance purely as vocoder warm-up context and then trimmed away; a ~1s tail suffices (ASR-verified). `SOKUJI_QWEN3_TTS_REF_DECODE_FRAMES=-1` restores the old behavior.
- **bf16 variant pickup**: snapshots may ship `onnx-bf16/` rebuilds of talker/code_predictor; only `device=cuda` loads them (bf16 has no CPU/DML kernels).
- **Reproducibility hooks**: `SOKUJI_QWEN3_TTS_SEED` / `SOKUJI_QWEN3_TTS_GREEDY` for numeric A/B verification.

## Model-asset tooling (scripts/) — assets already uploaded to both HF repos
- `dynamize-qwen3-tts-codec.py`: the exported codec decoder pads **every** input to a fixed 1024 frames (82s) and decodes all of it — 1.3s per call regardless of utterance length, the dominant cost for short sentences. Rewires the 29 frozen affine pad-target constants to a Shape-derived value rounded up to a multiple of 64. 16x faster at 32 frames, max|diff| ~1e-5.
- `convert-qwen3-tts-bf16.py`: fp32→bf16 with ORT fusions applied **first** (the fused contrib ops all have bf16 CUDA kernels), fp32 graph I/O, rotary chain kept fp32. bf16 keeps fp32's exponent range, which sidesteps the Qwen3 activation-outlier overflow that makes fp16 unusable (residual-stream values exceed 65504 by layer 3 — measured, not theoretical).
- `convert-qwen3-tts-fp16.py`, `quantize-qwen3-tts-nbits.py`: kept as tooling with their measured findings (fp16 numerically dead for code_predictor; int4 slower than fp32 on GB10 at these GEMV shapes).

## Notes for reviewers
- The accel bench cache persists rtf per (machine, model, backend, device, compute) — stale entries will keep reporting the old rtf until cleared.
- Remaining known headroom: talker_decode (~20ms/frame) is dispatch-bound (16k-node export); TensorRT EP is the credible next step and needs a TensorRT 10 sbsa install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added BF16, FP16, and weight-only INT4/INT8 model conversion tools.
  * Added dynamic codec padding support for improved variable-length audio handling.
  * Added CUDA-optimized inference with persistent KV caching and CUDA Graph acceleration.
  * CUDA deployments can automatically use BF16 model variants when available.
  * Added configurable random seeds, greedy decoding, and reference-audio frame limits.

* **Bug Fixes**
  * Improved compatibility with models lacking prefill support.
  * Maintained stable FP32 sampling and output behavior across reduced-precision inference.

* **Tests**
  * Added comprehensive coverage for deterministic decoding, precision handling, CUDA execution, caching, and model variant selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->