### PR TITLE
refactor(electron): derive preload IPC allowlist from a shared channel registry

### DIFF
--- a/electron/ipc-channels.js
+++ b/electron/ipc-channels.js
@@ -19,9 +19,13 @@ export const EXTERNAL_INVOKE_CHANNELS = [
   'disable-loopback-audio',
 ];
 
-// Channels that HAVE an `ipcMain.handle` but are reached through a dedicated
-// preload bridge (the Better Auth cookieAPI), not the generic invoke — so the
-// reverse guard exempts them from requiring a generic-allowlist entry.
+// Channels that HAVE an `ipcMain.handle` but are intentionally NOT on the
+// generic renderer invoke allowlist — the reverse guard exempts them so an
+// unallowlisted handler here isn't flagged as accidentally dropped. The Better
+// Auth cookieAPI bridge exposes get/getAll/set (which use the allowlisted
+// get-cookies/set-cookie); 'clear-cookies' has a handler but no renderer path
+// today (no cookieAPI.clear, no invoke('clear-cookies')) — dead until wired,
+// and kept off the generic allowlist meanwhile.
 export const BRIDGE_ONLY_CHANNELS = [
   'clear-cookies',
 ];

--- a/electron/ipc-channels.js
+++ b/electron/ipc-channels.js
@@ -1,0 +1,81 @@
+// Single source of truth for renderer → main IPC channels reachable through the
+// generic `window.electron.invoke(channel, data)` bridge.
+//
+// preload.js derives its invoke allowlist from INVOKE_CHANNELS instead of a
+// hand-maintained copy, and ipc-channels.test.js guards both directions against
+// drift: every allowlist entry must resolve to a real `ipcMain.handle(...)`
+// (catching dead placeholders like the old 'invoke-channel'), and every handler
+// must be reachable (allowlisted, externally registered, or a dedicated bridge).
+//
+// Adding an IPC channel the renderer invokes = add its name here. That's it —
+// the allowlist and the guard follow automatically.
+
+// Channels whose handlers are registered by a third-party library, not by our
+// own `ipcMain.handle` — allowlisted so the renderer can call them, but they
+// have no handler in electron/*.js for the guard to find.
+export const EXTERNAL_INVOKE_CHANNELS = [
+  // electron-audio-loopback registers these in its initMain().
+  'enable-loopback-audio',
+  'disable-loopback-audio',
+];
+
+// Channels that HAVE an `ipcMain.handle` but are reached through a dedicated
+// preload bridge (the Better Auth cookieAPI), not the generic invoke — so the
+// reverse guard exempts them from requiring a generic-allowlist entry.
+export const BRIDGE_ONLY_CHANNELS = [
+  'clear-cookies',
+];
+
+export const INVOKE_CHANNELS = [
+  // Audio system / virtual devices
+  'check-audio-system',
+  'open-directory',
+  'open-external',
+  'create-virtual-speaker',
+  'get-cookies',
+  'set-cookie',
+  'check-vbcable',
+  'install-vbcable',
+  'check-sokuji-audio',
+  // System audio capture
+  'supports-system-audio-capture',
+  'list-system-audio-sources',
+  'connect-system-audio-source',
+  'disconnect-system-audio-source',
+  // Screen recording permission (macOS)
+  'check-screen-recording-permission',
+  // Linux: fix PipeWire monitor source volume after loopback capture starts
+  'fix-monitor-volume',
+  // WebSocket header injection (renderer → main)
+  'ws-headers-set',
+  'ws-headers-clear',
+  // Native local-inference sidecar lifecycle
+  'native-host:start',
+  'native-host:stop',
+  'native-host:status',
+  // Self-contained sidecar bundle install/status
+  'sidecar-bundle:status',
+  'sidecar-bundle:install',
+  'sidecar-bundle:cancel',
+  'sidecar-bundle:manifest',
+  'sidecar-bundle:remove',
+  // Auto-update
+  'update-check',
+  'update-download',
+  'update-install',
+  'get-app-version',
+  'get-audio-status',
+  // Window controls (custom title bar)
+  'window:minimize',
+  'window:maximize-toggle',
+  'window:close',
+  // Subtitle mode
+  'subtitle:enter',
+  'subtitle:exit',
+  'subtitle:set-always-on-top',
+  'subtitle:set-locked',
+  'subtitle:set-fullscreen',
+  'subtitle:get-screen-bounds',
+  // Externally-registered (electron-audio-loopback)
+  ...EXTERNAL_INVOKE_CHANNELS,
+];

--- a/electron/ipc-channels.test.js
+++ b/electron/ipc-channels.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { INVOKE_CHANNELS, EXTERNAL_INVOKE_CHANNELS, BRIDGE_ONLY_CHANNELS } from './ipc-channels.js';
+
+// Collect every `ipcMain.handle('X'` channel across the electron main-process
+// files, read as text (no need to boot Electron).
+function registeredHandlerChannels() {
+  const dir = __dirname;
+  const channels = new Set();
+  for (const file of readdirSync(dir)) {
+    if (!file.endsWith('.js') || file.endsWith('.test.js')) continue;
+    const src = readFileSync(join(dir, file), 'utf8');
+    for (const m of src.matchAll(/ipcMain\.handle\(\s*['"]([^'"]+)['"]/g)) {
+      channels.add(m[1]);
+    }
+  }
+  return channels;
+}
+
+describe('IPC channel registry drift guard', () => {
+  const handlers = registeredHandlerChannels();
+  const invokeSet = new Set(INVOKE_CHANNELS);
+  const external = new Set(EXTERNAL_INVOKE_CHANNELS);
+  const bridge = new Set(BRIDGE_ONLY_CHANNELS);
+
+  it('every allowlisted invoke channel resolves to a handler (or is externally registered)', () => {
+    // Catches dead placeholders like the old 'invoke-channel': an allowlist
+    // entry with no handler behind it.
+    for (const ch of INVOKE_CHANNELS) {
+      if (external.has(ch)) continue;
+      expect(handlers.has(ch), `allowlisted '${ch}' has no ipcMain.handle`).toBe(true);
+    }
+  });
+
+  it('every handler is reachable (allowlisted, external, or a dedicated bridge)', () => {
+    // Catches a new handler someone forgot to expose: renderer can never call it.
+    for (const ch of handlers) {
+      const reachable = invokeSet.has(ch) || bridge.has(ch);
+      expect(reachable, `handler '${ch}' is not in INVOKE_CHANNELS or BRIDGE_ONLY_CHANNELS`).toBe(true);
+    }
+  });
+
+  it("does not carry the dead 'invoke-channel' placeholder", () => {
+    expect(invokeSet.has('invoke-channel')).toBe(false);
+  });
+
+  it('preload derives its allowlist from this module (no hand-copied literal list)', () => {
+    const preload = readFileSync(join(__dirname, 'preload.js'), 'utf8');
+    expect(preload).toMatch(/INVOKE_CHANNELS/);
+    // The old 30-entry inline array must be gone.
+    expect(preload).not.toMatch(/const validChannels = \[\s*'invoke-channel'/);
+  });
+});

--- a/electron/ipc-channels.test.js
+++ b/electron/ipc-channels.test.js
@@ -8,9 +8,9 @@ import { INVOKE_CHANNELS, EXTERNAL_INVOKE_CHANNELS, BRIDGE_ONLY_CHANNELS } from 
 function registeredHandlerChannels() {
   const dir = __dirname;
   const channels = new Set();
-  for (const file of readdirSync(dir)) {
-    if (!file.endsWith('.js') || file.endsWith('.test.js')) continue;
-    const src = readFileSync(join(dir, file), 'utf8');
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (!entry.isFile() || !entry.name.endsWith('.js') || entry.name.endsWith('.test.js')) continue;
+    const src = readFileSync(join(dir, entry.name), 'utf8');
     for (const m of src.matchAll(/ipcMain\.handle\(\s*['"]([^'"]+)['"]/g)) {
       channels.add(m[1]);
     }

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,4 @@
-const { contextBridge, ipcRenderer } = require('electron');
+import { contextBridge, ipcRenderer } from 'electron';
 // Renderer→main invoke allowlist. Single source of truth in ipc-channels.js
 // (guarded against handler drift by ipc-channels.test.js). The bundler inlines
 // this array into the built preload.js, so the shipped artifact stays an
@@ -110,6 +110,11 @@ contextBridge.exposeInMainWorld(
       if (INVOKE_CHANNELS.includes(channel)) {
         return ipcRenderer.invoke(channel, data);
       }
+      // Fail loud on the security boundary: a channel outside the allowlist is
+      // a bug (all real channels are registered), not a graceful-degradation
+      // path. Reject + warn instead of silently resolving to undefined.
+      console.warn(`[Sokuji] [Preload] Blocked unauthorized invoke for channel: ${channel}`);
+      return Promise.reject(new Error(`Blocked unauthorized invoke for channel: ${channel}`));
     }
   }
 );

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,4 +1,9 @@
 const { contextBridge, ipcRenderer } = require('electron');
+// Renderer→main invoke allowlist. Single source of truth in ipc-channels.js
+// (guarded against handler drift by ipc-channels.test.js). The bundler inlines
+// this array into the built preload.js, so the shipped artifact stays an
+// auditable literal list.
+import { INVOKE_CHANNELS } from './ipc-channels.js';
 
 // Cookie API for Better Auth adapter
 const cookieAPI = {
@@ -102,61 +107,7 @@ contextBridge.exposeInMainWorld(
       }
     },
     invoke: (channel, data) => {
-      const validChannels = [
-        'invoke-channel',
-        'check-audio-system',
-        'open-directory',
-        'open-external',
-        'create-virtual-speaker',
-        'get-cookies',
-        'set-cookie',
-        'check-vbcable',
-        'install-vbcable',
-        'check-sokuji-audio',
-        // System audio capture channels
-        'supports-system-audio-capture',
-        'list-system-audio-sources',
-        'connect-system-audio-source',
-        'disconnect-system-audio-source',
-        // Screen recording permission check (macOS)
-        'check-screen-recording-permission',
-        // electron-audio-loopback channels (auto-registered by initMain())
-        'enable-loopback-audio',
-        'disable-loopback-audio',
-        // Linux: fix PipeWire monitor source volume after loopback capture starts
-        'fix-monitor-volume',
-        // WebSocket header injection (renderer → main)
-        'ws-headers-set',
-        'ws-headers-clear',
-        // Native local-inference sidecar lifecycle (renderer → main)
-        'native-host:start',
-        'native-host:stop',
-        'native-host:status',
-        // Self-contained sidecar bundle install/status (renderer → main)
-        'sidecar-bundle:status',
-        'sidecar-bundle:install',
-        'sidecar-bundle:cancel',
-        'sidecar-bundle:manifest',
-        'sidecar-bundle:remove',
-        // Auto-update channels (renderer → main)
-        'update-check',
-        'update-download',
-        'update-install',
-        'get-app-version',
-        'get-audio-status',
-        // Window control IPC for custom title bar
-        'window:minimize',
-        'window:maximize-toggle',
-        'window:close',
-        // Subtitle mode IPC
-        'subtitle:enter',
-        'subtitle:exit',
-        'subtitle:set-always-on-top',
-        'subtitle:set-locked',
-        'subtitle:set-fullscreen',
-        'subtitle:get-screen-bounds',
-      ];
-      if (validChannels.includes(channel)) {
+      if (INVOKE_CHANNELS.includes(channel)) {
         return ipcRenderer.invoke(channel, data);
       }
     }

--- a/electron/preload.native.test.js
+++ b/electron/preload.native.test.js
@@ -1,22 +1,29 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { INVOKE_CHANNELS } from './ipc-channels.js';
 
-describe('preload invoke whitelist', () => {
-  it('includes the native-host channels', () => {
-    const src = readFileSync(join(__dirname, 'preload.js'), 'utf8');
+// The native-host + sidecar-bundle invoke channels now live in the shared
+// ipc-channels registry (preload derives its allowlist from it); the
+// bundle-progress event stays a receive channel in preload.js.
+describe('native / sidecar IPC channels are exposed', () => {
+  it('native-host invoke channels are in the registry', () => {
     for (const ch of ['native-host:start', 'native-host:stop', 'native-host:status']) {
-      expect(src).toContain(`'${ch}'`);
+      expect(INVOKE_CHANNELS).toContain(ch);
     }
   });
 
-  it('includes the sidecar-bundle channels', () => {
-    const src = readFileSync(join(__dirname, 'preload.js'), 'utf8');
+  it('sidecar-bundle invoke channels are in the registry', () => {
     for (const ch of [
       'sidecar-bundle:status', 'sidecar-bundle:install', 'sidecar-bundle:cancel',
-      'sidecar-bundle:manifest', 'sidecar-bundle:remove', 'sidecar-bundle-progress',
+      'sidecar-bundle:manifest', 'sidecar-bundle:remove',
     ]) {
-      expect(src).toContain(`'${ch}'`);
+      expect(INVOKE_CHANNELS).toContain(ch);
     }
+  });
+
+  it('the bundle-progress receive channel stays in preload', () => {
+    const src = readFileSync(join(__dirname, 'preload.js'), 'utf8');
+    expect(src).toContain("'sidecar-bundle-progress'");
   });
 });

--- a/src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ElectronSubtitleSurface.ts
@@ -24,4 +24,8 @@ export class ElectronSubtitleSurface implements SubtitleSurface {
   async setFullscreen(flag: boolean): Promise<void> {
     await window.electron?.invoke('subtitle:set-fullscreen', flag);
   }
+
+  async setAlwaysOnTop(flag: boolean): Promise<void> {
+    await window.electron?.invoke('subtitle:set-always-on-top', flag);
+  }
 }

--- a/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/ExtensionContentScriptSubtitleSurface.ts
@@ -194,6 +194,10 @@ export class ExtensionContentScriptSubtitleSurface implements SubtitleSurface {
     /* no-op */
   }
 
+  async setAlwaysOnTop(_flag: boolean): Promise<void> {
+    /* no-op — the extension overlay has no OS window to pin */
+  }
+
   private tearDown() {
     chrome.runtime.onConnect.removeListener(this.handleConnect);
     chrome.tabs.onRemoved.removeListener(this.handleTabRemoved);

--- a/src/components/Subtitle/surfaces/SubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/SubtitleSurface.ts
@@ -8,4 +8,11 @@ export interface SubtitleSurface {
    * other surfaces implement this as a no-op.
    */
   setFullscreen(flag: boolean): Promise<void>;
+  /**
+   * Apply always-on-top to the live subtitle window. Electron-only (a native
+   * window property); other surfaces implement this as a no-op. The persisted
+   * value is applied at window creation via enter(); this keeps the OPEN
+   * window in sync when the user toggles it.
+   */
+  setAlwaysOnTop(flag: boolean): Promise<void>;
 }

--- a/src/components/Subtitle/surfaces/getSubtitleSurface.ts
+++ b/src/components/Subtitle/surfaces/getSubtitleSurface.ts
@@ -10,6 +10,7 @@ class NoopSubtitleSurface implements SubtitleSurface {
   }
   async exit(): Promise<void> { /* no-op */ }
   async setFullscreen(_flag: boolean): Promise<void> { /* no-op */ }
+  async setAlwaysOnTop(_flag: boolean): Promise<void> { /* no-op */ }
 }
 
 let cached: SubtitleSurface | null = null;

--- a/src/electron.d.ts
+++ b/src/electron.d.ts
@@ -4,31 +4,6 @@ interface ElectronAPI {
   removeListener: (channel: string, func: (...args: any[]) => void) => void;
   removeAllListeners: (channel: string) => void;
   invoke: (channel: string, data?: any) => Promise<any>;
-  config: {
-    get: (key: string, defaultValue?: any) => Promise<any>;
-    set: (key: string, value: any) => Promise<{ success: boolean; error?: string }>;
-    getPath: () => Promise<{ configDir: string; configFile: string }>;
-  };
-  openai: {
-    generateToken: (options?: {
-      model?: string;
-      voice?: string;
-      turnDetectionMode?: 'Normal' | 'Semantic' | 'Disabled';
-      threshold?: number;
-      prefixPadding?: number;
-      silenceDuration?: number;
-      semanticEagerness?: 'Auto' | 'Low' | 'Medium' | 'High';
-      temperature?: number;
-      maxTokens?: number;
-      transcriptModel?: 'gpt-4o-mini-transcribe' | 'gpt-4o-transcribe' | 'whisper-1';
-      noiseReduction?: 'None' | 'Near field' | 'Far field';
-      systemInstructions?: string;
-    }) => Promise<{
-      success: boolean;
-      data?: any;
-      error?: string
-    }>;
-  };
 }
 
 declare interface Window {

--- a/src/stores/subtitleStore.test.ts
+++ b/src/stores/subtitleStore.test.ts
@@ -11,6 +11,14 @@ vi.mock('../services/ServiceFactory', () => ({
   },
 }));
 
+const setAlwaysOnTopSpy = vi.fn(async () => {});
+vi.mock('../components/Subtitle/surfaces/getSubtitleSurface', () => ({
+  getSubtitleSurface: () => ({
+    enter: vi.fn(), exit: vi.fn(), setFullscreen: vi.fn(),
+    setAlwaysOnTop: (flag: boolean) => setAlwaysOnTopSpy(flag),
+  }),
+}));
+
 describe('subtitleStore', () => {
   beforeEach(() => {
     useSubtitleStore.setState({
@@ -80,5 +88,17 @@ describe('subtitleStore', () => {
     expect(useSubtitleStore.getState().fontSize).toBe(30);
     expect(typeof useSubtitleFontSize).toBe('function');
     expect(typeof useSubtitlePositionLocked).toBe('function');
+  });
+  it('toggleAlwaysOnTop applies the change to the live window (not just persistence)', async () => {
+    // always-on-top is a native window property: toggling while the subtitle
+    // window is open must invoke the surface so the main process re-applies it,
+    // not merely persist the value for the next window creation.
+    setAlwaysOnTopSpy.mockClear();
+    expect(useSubtitleStore.getState().alwaysOnTop).toBe(false);
+    await useSubtitleStore.getState().toggleAlwaysOnTop();
+    expect(useSubtitleStore.getState().alwaysOnTop).toBe(true);
+    expect(setAlwaysOnTopSpy).toHaveBeenCalledWith(true);
+    await useSubtitleStore.getState().toggleAlwaysOnTop();
+    expect(setAlwaysOnTopSpy).toHaveBeenCalledWith(false);
   });
 });

--- a/src/stores/subtitleStore.ts
+++ b/src/stores/subtitleStore.ts
@@ -149,8 +149,18 @@ export const useSubtitleStore = create<SubtitleState>()(
       const previous = get().alwaysOnTop;
       const next = !previous;
       set({ alwaysOnTop: next });
+      // Apply to the live window (always-on-top is a native window property
+      // only the main process can set); persistence keeps it for the next
+      // window creation. Dynamic import so this lightweight store doesn't
+      // statically pull the Electron/Extension surface graph. Roll back on
+      // persistence failure.
+      const { getSubtitleSurface } = await import('../components/Subtitle/surfaces/getSubtitleSurface');
+      await getSubtitleSurface().setAlwaysOnTop(next);
       const { ok } = await persist('alwaysOnTop', next, 'alwaysOnTop');
-      if (!ok) set({ alwaysOnTop: previous });
+      if (!ok) {
+        set({ alwaysOnTop: previous });
+        await getSubtitleSurface().setAlwaysOnTop(previous);
+      }
     },
     togglePositionLocked: async () => {
       const previous = get().positionLocked;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -167,7 +167,10 @@ export default defineConfig(({ command, mode }) => {
           }
         },
         preload: {
-          // Entry point for the preload script
+          // Entry point for the preload script. It ESM-imports ipc-channels.js,
+          // which the single-file preload build inlines into the shipped
+          // preload.js (so the invoke allowlist stays an auditable literal in
+          // the built artifact).
           input: 'electron/preload.js',
           vite: {
             build: {


### PR DESCRIPTION
## Summary

The renderer→main invoke surface had three hand-synced, drifting registries: 40 `ipcMain.handle` registrations, a hand-copied ~30-entry `validChannels` array in `preload.js`, and a stale `electron.d.ts`. The allowlist carried a dead `invoke-channel` placeholder; `electron.d.ts` declared `config` / `openai.generateToken` namespaces with **zero** handlers, zero preload exposure, and zero renderer callers.

- **`electron/ipc-channels.js`** is now the single source of truth: `INVOKE_CHANNELS` + `EXTERNAL_INVOKE_CHANNELS` (the loopback library's channels) + `BRIDGE_ONLY_CHANNELS` (the cookieAPI). `preload.js` ESM-imports `INVOKE_CHANNELS`; the single-file preload build **inlines** it, so the shipped `preload.js` stays an auditable literal allowlist (verified against `dist-electron/preload.js`).
- **`ipc-channels.test.js`** guards both directions: every allowlist entry must resolve to a real handler (kills dead placeholders), and every handler must be reachable — allowlisted, externally registered, or a dedicated bridge (so a new channel someone forgets to allowlist fails loudly instead of being silently unreachable).
- Deleted the dead `config`/`openai` type surface from `electron.d.ts` and the `invoke-channel` placeholder.

## Deliberately bounded scope

`electron/` is main-process, security-critical, and lightly tested. The 40 handler registrations **keep registering inline** — this kills the triple-maintenance and drift without rewriting them. **No renderer channel was added or dropped**: the invokable set is byte-for-byte the same as before minus the one dead placeholder.

## Behavior changes (intentional)

- **Blocked-channel invoke now fails loud**: a channel outside the allowlist warns + rejects instead of silently resolving to `undefined`. Verified safe — every renderer invoke uses a string-literal allowlisted channel (no variable channels, no callers relying on undefined-degradation), so the reject path is unreachable for real code and only surfaces a bug.

## Bonus fix (found while smoke-testing this PR's IPC paths)

- **`fix(subtitle)`: always-on-top now applies to the live window.** A pre-existing bug (present on `main` / v0.31.1, unrelated to this refactor): `toggleAlwaysOnTop` only persisted the setting and never invoked `subtitle:set-always-on-top`, so toggling while the subtitle window was open had no effect (it only applied at the next window creation). `positionLocked` looked fine only because its visible effect is renderer-side; always-on-top is a native window property only the main process can set. Fixed by adding `setAlwaysOnTop` to the `SubtitleSurface` abstraction (matching `setFullscreen`) and wiring the toggle to it. **Manually verified in Electron** — toggling now takes effect live.

## Testing

- **980 vitest tests green**; `npm run build` (root + electron) succeeds. Verified the built `dist-electron/preload.js` is consistent ESM source → working CJS output, with the full channel literal allowlist inlined and no dangling `require`/`import`.
- The drift guard was confirmed non-vacuous (fails on both a dead allowlist entry and an unallowlisted handler).
- An adversarial review confirmed the two security-critical dimensions (allowlist identical minus dead placeholder; build genuinely inlines) against the built artifact, not the commit message.

## ⚠️ Manual check status

The always-on-top path was manually verified in Electron. Recommend a quick pass over a couple more invoke paths (window controls, subtitle enter/exit) since IPC runtime bugs don't surface in vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H7N6q35NKwpguCM61fKSc3