### PR TITLE
refactor(local-inference): consolidate WASM model readiness into one predicate + store-owned seam

### DIFF
--- a/src/components/Settings/sections/ModelManagementSection.tsx
+++ b/src/components/Settings/sections/ModelManagementSection.tsx
@@ -735,7 +735,11 @@ export function ModelManagementSection({
                 isSelected={asrModel === entry.id}
                 isCompatible={false}
                 showRadio={true}
-                compatibilityHint={t('settings.langMismatch', 'language mismatch')}
+                compatibilityHint={
+                  !deviceReady(entry, webgpuAvailable)
+                    ? t('settings.webgpuNotSupported', 'Not available in current environment')
+                    : t('settings.langMismatch', 'language mismatch')
+                }
                 onSelect={() => {
                   updateLocalInference({ asrModel: entry.id });
                   useModelStore.getState().rememberModels(sourceLanguage, targetLanguage, entry.id, translationModel, ttsModel);

--- a/src/components/Settings/sections/ModelManagementSection.tsx
+++ b/src/components/Settings/sections/ModelManagementSection.tsx
@@ -19,6 +19,8 @@ import {
   getModelSizeMb,
   isTranslationModelCompatible,
   isAstCompatible,
+  modelUsable,
+  deviceReady,
   pickBestModel,
   selectVariant,
   getBaselineVariant,
@@ -330,48 +332,47 @@ export function ModelManagementSection({
   useEffect(() => {
     if (!initialized) return;
     const updates: Partial<LocalInferenceSettings> = {};
+    const ctx = { modelStatuses: statuses, webgpuAvailable };
 
-    // ASR: must support sourceLanguage and be downloaded (includes streaming models)
+    // ASR: must support sourceLanguage and be usable (includes streaming models)
     const allAsrModels = [...getManifestByType('asr'), ...getManifestByType('asr-stream')];
     const currentAsr = asrModel ? allAsrModels.find(m => m.id === asrModel) : null;
-    const asrOk = currentAsr && (currentAsr.multilingual || currentAsr.languages.includes(sourceLanguage)) && statuses[asrModel] === 'downloaded';
+    const asrOk = currentAsr && (currentAsr.multilingual || currentAsr.languages.includes(sourceLanguage)) && modelUsable(currentAsr, ctx);
     if (!asrOk) {
       const match = pickBestModel(allAsrModels.filter(m =>
-        (m.multilingual || m.languages.includes(sourceLanguage)) && statuses[m.id] === 'downloaded'
+        (m.multilingual || m.languages.includes(sourceLanguage)) && modelUsable(m, ctx)
       ));
       const newId = match?.id || '';
       if (newId !== asrModel) updates.asrModel = newId;
     }
 
-    // Translation: must be compatible with source→target pair, downloaded, and device-ready
+    // Translation: must be compatible with source→target pair and usable
     // AST short-circuit: if translation model === ASR model and it has astLanguages, it's valid
     const asrEntryForAst = translationModel && translationModel === asrModel
       ? getManifestEntry(translationModel) : null;
     const isAstValid = asrEntryForAst
       && isAstCompatible(asrEntryForAst, sourceLanguage, targetLanguage)
-      && statuses[translationModel] === 'downloaded';
+      && modelUsable(asrEntryForAst, ctx);
 
     const currentTrans = !isAstValid && translationModel ? getManifestByType('translation').find(m => m.id === translationModel) : null;
     const transOk = isAstValid || (currentTrans
       && isTranslationModelCompatible(currentTrans, sourceLanguage, targetLanguage)
-      && (currentTrans.isCloudModel || statuses[translationModel] === 'downloaded')
-      && !(currentTrans.requiredDevice === 'webgpu' && !webgpuAvailable));
+      && modelUsable(currentTrans, ctx));
     if (!transOk) {
       const match = pickBestModel(getManifestByType('translation').filter(m =>
         isTranslationModelCompatible(m, sourceLanguage, targetLanguage)
-        && (m.isCloudModel || statuses[m.id] === 'downloaded')
-        && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+        && modelUsable(m, ctx)
       ));
       const newId = match?.id || '';
       if (newId !== translationModel) updates.translationModel = newId;
     }
 
-    // TTS: must support targetLanguage and be downloaded (or be a cloud model)
+    // TTS: must support targetLanguage and be usable (or be a cloud model)
     const currentTts = ttsModel ? getManifestByType('tts').find(m => m.id === ttsModel) : null;
-    const ttsOk = currentTts && (currentTts.multilingual || currentTts.languages.includes(targetLanguage)) && (currentTts.isCloudModel || statuses[ttsModel] === 'downloaded');
+    const ttsOk = currentTts && (currentTts.multilingual || currentTts.languages.includes(targetLanguage)) && modelUsable(currentTts, ctx);
     if (!ttsOk) {
       const match = pickBestModel(getManifestByType('tts').filter(m =>
-        (m.multilingual || m.languages.includes(targetLanguage)) && (m.isCloudModel || statuses[m.id] === 'downloaded')
+        (m.multilingual || m.languages.includes(targetLanguage)) && modelUsable(m, ctx)
       ));
       const newId = match?.id || '';
       if (newId !== ttsModel) updates.ttsModel = newId;
@@ -417,7 +418,7 @@ export function ModelManagementSection({
   const compatibleTranslationModels = useMemo(
     () => translationModels.filter(m =>
       isTranslationModelCompatible(m, sourceLanguage, targetLanguage)
-      && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+      && deviceReady(m, webgpuAvailable)
     ),
     [translationModels, sourceLanguage, targetLanguage, webgpuAvailable],
   );
@@ -425,7 +426,7 @@ export function ModelManagementSection({
   const incompatibleTranslationModels = useMemo(
     () => translationModels.filter(m =>
       !isTranslationModelCompatible(m, sourceLanguage, targetLanguage)
-      || (m.requiredDevice === 'webgpu' && !webgpuAvailable)
+      || !deviceReady(m, webgpuAvailable)
     ),
     [translationModels, sourceLanguage, targetLanguage, webgpuAvailable],
   );
@@ -438,14 +439,14 @@ export function ModelManagementSection({
   const compatibleAsrModels = useMemo(
     () => asrModels.filter(m =>
       (m.multilingual || m.languages.includes(sourceLanguage))
-      && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+      && deviceReady(m, webgpuAvailable)
     ),
     [asrModels, sourceLanguage, webgpuAvailable],
   );
   const incompatibleAsrModels = useMemo(
     () => asrModels.filter(m =>
       (!m.multilingual && !m.languages.includes(sourceLanguage))
-      || (m.requiredDevice === 'webgpu' && !webgpuAvailable)
+      || !deviceReady(m, webgpuAvailable)
     ),
     [asrModels, sourceLanguage, webgpuAvailable],
   );
@@ -799,7 +800,7 @@ export function ModelManagementSection({
                 isCompatible={false}
                 showRadio={true}
                 compatibilityHint={
-                  entry.requiredDevice === 'webgpu' && !webgpuAvailable
+                  !deviceReady(entry, webgpuAvailable)
                     ? t('settings.webgpuNotSupported', 'Not available in current environment')
                     : t('settings.langMismatch', 'language mismatch')
                 }

--- a/src/lib/local-inference/modelManifest.modelUsable.test.ts
+++ b/src/lib/local-inference/modelManifest.modelUsable.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { modelUsable, deviceReady, type ModelManifestEntry, type ModelStatus } from './modelManifest';
+
+// Minimal entry factory — only the fields modelUsable reads.
+function entry(over: Partial<ModelManifestEntry>): ModelManifestEntry {
+  return { id: 'm', type: 'asr', name: 'M', languages: [], ...over } as ModelManifestEntry;
+}
+const ctx = (statuses: Record<string, ModelStatus>, webgpu: boolean) => ({
+  modelStatuses: statuses, webgpuAvailable: webgpu,
+});
+
+describe('modelUsable', () => {
+  it('is false for a missing entry', () => {
+    expect(modelUsable(undefined, ctx({}, true))).toBe(false);
+    expect(modelUsable(null, ctx({}, true))).toBe(false);
+  });
+
+  it('requires a downloaded status for non-cloud models', () => {
+    const e = entry({ id: 'a' });
+    expect(modelUsable(e, ctx({ a: 'downloaded' }, true))).toBe(true);
+    expect(modelUsable(e, ctx({ a: 'not_downloaded' }, true))).toBe(false);
+    expect(modelUsable(e, ctx({}, true))).toBe(false);
+  });
+
+  it('treats cloud models as usable regardless of download status', () => {
+    const e = entry({ id: 'c', isCloudModel: true });
+    expect(modelUsable(e, ctx({}, true))).toBe(true);
+    expect(modelUsable(e, ctx({ c: 'not_downloaded' }, false))).toBe(true);
+  });
+
+  it('rejects a webgpu-required model when webgpu is unavailable', () => {
+    const e = entry({ id: 'g', requiredDevice: 'webgpu' });
+    expect(modelUsable(e, ctx({ g: 'downloaded' }, true))).toBe(true);
+    expect(modelUsable(e, ctx({ g: 'downloaded' }, false))).toBe(false);
+  });
+
+  it('a cloud webgpu model still needs webgpu', () => {
+    const e = entry({ id: 'cg', isCloudModel: true, requiredDevice: 'webgpu' });
+    expect(modelUsable(e, ctx({}, false))).toBe(false);
+    expect(modelUsable(e, ctx({}, true))).toBe(true);
+  });
+});
+
+describe('deviceReady', () => {
+  it('is true for models with no device requirement, regardless of webgpu', () => {
+    expect(deviceReady(entry({}), false)).toBe(true);
+    expect(deviceReady(entry({}), true)).toBe(true);
+  });
+
+  it('gates webgpu-required models on webgpu availability', () => {
+    const g = entry({ requiredDevice: 'webgpu' });
+    expect(deviceReady(g, true)).toBe(true);
+    expect(deviceReady(g, false)).toBe(false);
+  });
+
+  it('treats a missing entry as device-ready (null-safe)', () => {
+    // A device-only filter never rejects on a null entry; readiness (modelUsable)
+    // is where a missing entry becomes unusable.
+    expect(deviceReady(null, false)).toBe(true);
+  });
+});

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -3275,6 +3275,38 @@ export function isAstCompatible(
     && entry.astLanguages.translate.includes(targetLang);
 }
 
+/**
+ * Whether a model's required device is available right now: a `webgpu` model
+ * needs WebGPU; everything else always qualifies. This is orthogonal to whether
+ * the model is downloaded — model *lists* (which offer not-yet-downloaded models
+ * for download) gate on this alone, while readiness code combines it with the
+ * download check via {@link modelUsable}.
+ */
+export function deviceReady(
+  entry: ModelManifestEntry | null | undefined,
+  webgpuAvailable: boolean,
+): boolean {
+  return !(entry?.requiredDevice === 'webgpu' && !webgpuAvailable);
+}
+
+/**
+ * Whether a model can run right now, independent of language: it must be
+ * downloaded (or a cloud model, which needs no download) AND its required
+ * device must be available. This is the "downloaded ∧ device-ready" check that
+ * readiness code (modelStore, ModelManagementSection) used to re-derive inline
+ * at ~18 sites. Language compatibility is orthogonal and stays with the per-type
+ * helpers (multilingual/languages.includes for ASR/TTS,
+ * isTranslationModelCompatible / isAstCompatible for translation).
+ */
+export function modelUsable(
+  entry: ModelManifestEntry | null | undefined,
+  ctx: { modelStatuses: Record<string, ModelStatus>; webgpuAvailable: boolean },
+): boolean {
+  if (!entry) return false;
+  const downloaded = entry.isCloudModel || ctx.modelStatuses[entry.id] === 'downloaded';
+  return Boolean(downloaded) && deviceReady(entry, ctx.webgpuAvailable);
+}
+
 /** Get TTS models that support a given language */
 export function getTtsModelsForLanguage(lang: string): ModelManifestEntry[] {
   return MODEL_MANIFEST.filter(m =>

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -6,15 +6,23 @@ const mockGetAsrModelsForLanguage = vi.fn();
 const mockGetTranslationModel = vi.fn();
 const mockGetManifestByType = vi.fn();
 
-vi.mock('../lib/local-inference/modelManifest', () => ({
-  MODEL_MANIFEST: [],
-  getManifestEntry: (...args: any[]) => mockGetManifestEntry(...args),
-  getManifestByType: (...args: any[]) => mockGetManifestByType(...args),
-  getAsrModelsForLanguage: (...args: any[]) => mockGetAsrModelsForLanguage(...args),
-  getTranslationModel: (...args: any[]) => mockGetTranslationModel(...args),
-  getTtsModelsForLanguage: vi.fn(() => []),
-  isTranslationModelCompatible: vi.fn(() => true),
-}));
+vi.mock('../lib/local-inference/modelManifest', async () => {
+  // Pull the pure readiness/compat predicates from the real module so the store
+  // exercises real logic; keep the data-lookup functions mocked.
+  const actual = await vi.importActual<any>('../lib/local-inference/modelManifest');
+  return {
+    MODEL_MANIFEST: [],
+    getManifestEntry: (...args: any[]) => mockGetManifestEntry(...args),
+    getManifestByType: (...args: any[]) => mockGetManifestByType(...args),
+    getAsrModelsForLanguage: (...args: any[]) => mockGetAsrModelsForLanguage(...args),
+    getTranslationModel: (...args: any[]) => mockGetTranslationModel(...args),
+    getTtsModelsForLanguage: vi.fn(() => []),
+    isTranslationModelCompatible: vi.fn(() => true),
+    modelUsable: actual.modelUsable,
+    isAstCompatible: actual.isAstCompatible,
+    pickBestModel: actual.pickBestModel,
+  };
+});
 
 const mockEstimateStorageUsedBytes = vi.fn();
 const mockGetMetadata = vi.fn();
@@ -130,6 +138,11 @@ describe('rememberModels / recallModels', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     useModelStore.setState({ modelPreferences: {} });
+    // Manifest entries persist even when a download is deleted, so recall's
+    // readiness check (modelUsable) can resolve every remembered id. These
+    // fixtures are plain local models (no cloud/webgpu), so usability reduces
+    // to the modelStatuses download state the individual tests drive.
+    mockGetManifestEntry.mockImplementation((id: string) => ({ id, type: 'asr', languages: [] }));
   });
 
   it('remembers and recalls models for a language pair', () => {
@@ -230,6 +243,48 @@ describe('rememberModels / recallModels', () => {
     expect(recalled!.asrModel).toBe('');
     expect(recalled!.translationModel).toBe('');
     expect(recalled!.ttsModel).toBe('');
+  });
+});
+
+describe('autoSelectModels device gating', () => {
+  // A downloaded webgpu ASR model must NOT be auto-selected when webgpu is
+  // unavailable — otherwise autoSelect hands the session a model isProviderReady
+  // then rejects (dead-end selection). This gate now flows through modelUsable,
+  // matching isProviderReady / getParticipantModelStatus.
+  const webgpuAsr = { id: 'voxtral-webgpu', type: 'asr', languages: ['en'], multilingual: true, requiredDevice: 'webgpu' };
+  const plainAsr = { id: 'sensevoice-int8', type: 'asr', languages: ['en'], multilingual: true };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useModelStore.setState({ modelPreferences: {}, webgpuAvailable: false });
+    mockGetManifestEntry.mockImplementation((id: string) =>
+      [webgpuAsr, plainAsr].find(m => m.id === id),
+    );
+    mockGetManifestByType.mockImplementation((type: string) =>
+      [webgpuAsr, plainAsr].filter(m => m.type === type),
+    );
+  });
+
+  it('skips a downloaded webgpu ASR model when webgpu is unavailable', () => {
+    useModelStore.setState({
+      modelStatuses: { 'voxtral-webgpu': 'downloaded', 'sensevoice-int8': 'downloaded' },
+    });
+
+    const updates = useModelStore.getState().autoSelectModels('en', 'ja', 'voxtral-webgpu', '', '');
+
+    expect(updates?.asrModel).toBe('sensevoice-int8');
+  });
+
+  it('keeps a webgpu ASR model when webgpu is available', () => {
+    useModelStore.setState({
+      webgpuAvailable: true,
+      modelStatuses: { 'voxtral-webgpu': 'downloaded', 'sensevoice-int8': 'downloaded' },
+    });
+
+    const updates = useModelStore.getState().autoSelectModels('en', 'ja', 'voxtral-webgpu', '', '');
+
+    // Current model is usable → no ASR correction emitted.
+    expect(updates?.asrModel).toBeUndefined();
   });
 });
 

--- a/src/stores/modelStore.test.ts
+++ b/src/stores/modelStore.test.ts
@@ -288,6 +288,51 @@ describe('autoSelectModels device gating', () => {
   });
 });
 
+describe('ensureSelectionReady', () => {
+  const sensevoice = { id: 'sensevoice-int8', type: 'asr', languages: ['ja', 'en'], multilingual: true };
+  const opusEnJa = { id: 'opus-mt-en-ja', type: 'translation', languages: ['en', 'ja'] };
+  const piperJa = { id: 'piper-ja', type: 'tts', languages: ['ja'], multilingual: false };
+  const piperEn = { id: 'piper-en', type: 'tts', languages: ['en'], multilingual: false };
+  const all = [sensevoice, opusEnJa, piperJa, piperEn];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Skip the IndexedDB scan — readiness logic is what we're exercising here.
+    useModelStore.setState({ initialized: true, modelPreferences: {}, webgpuAvailable: false });
+    mockGetManifestEntry.mockImplementation((id: string) => all.find(m => m.id === id));
+    mockGetManifestByType.mockImplementation((type: string) => all.filter(m => m.type === type));
+  });
+
+  it('reports ready with no corrections when the selection is already valid', async () => {
+    useModelStore.setState({
+      modelStatuses: { 'sensevoice-int8': 'downloaded', 'opus-mt-en-ja': 'downloaded', 'piper-ja': 'downloaded' },
+    });
+
+    const result = await useModelStore.getState().ensureSelectionReady({
+      sourceLanguage: 'en', targetLanguage: 'ja',
+      asrModel: 'sensevoice-int8', translationModel: 'opus-mt-en-ja', ttsModel: 'piper-ja',
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.corrections).toBeNull();
+  });
+
+  it('corrects a stale TTS selection and judges readiness against the correction', async () => {
+    useModelStore.setState({
+      // piper-en is downloaded but wrong language; piper-ja is the valid one.
+      modelStatuses: { 'sensevoice-int8': 'downloaded', 'opus-mt-en-ja': 'downloaded', 'piper-ja': 'downloaded', 'piper-en': 'downloaded' },
+    });
+
+    const result = await useModelStore.getState().ensureSelectionReady({
+      sourceLanguage: 'en', targetLanguage: 'ja',
+      asrModel: 'sensevoice-int8', translationModel: 'opus-mt-en-ja', ttsModel: 'piper-en',
+    });
+
+    expect(result.corrections?.ttsModel).toBe('piper-ja');
+    expect(result.ready).toBe(true);
+  });
+});
+
 describe('initialize resilience', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -42,6 +42,22 @@ export interface ParticipantModelStatus {
   translationModelId: string | null;
 }
 
+/**
+ * The subset of LOCAL_INFERENCE settings that determine session readiness:
+ * the language pair plus the three selected model IDs. Structurally matches
+ * `LocalInferenceSettings` so the settings slice can be passed directly.
+ */
+export interface LocalSelection {
+  sourceLanguage: string;
+  targetLanguage: string;
+  asrModel: string;
+  translationModel: string;
+  ttsModel: string;
+}
+
+/** Result of {@link ModelStoreState.autoSelectModels}: corrected model IDs, or null. */
+export type ModelCorrections = { asrModel?: string; translationModel?: string; ttsModel?: string } | null;
+
 interface ModelStoreState {
   /** Status of each model by ID */
   modelStatuses: Record<string, ModelStatus>;
@@ -104,7 +120,15 @@ interface ModelStoreState {
   autoSelectModels: (
     sourceLang: string, targetLang: string,
     currentAsrModel: string, currentTranslationModel: string, currentTtsModel: string,
-  ) => { asrModel?: string; translationModel?: string; ttsModel?: string } | null;
+  ) => ModelCorrections;
+  /**
+   * Full LOCAL_INFERENCE session-readiness check for a selection. Initializes
+   * the store if needed, auto-corrects stale selections, and reports readiness
+   * against the corrected selection — WITHOUT persisting. The caller applies the
+   * returned `corrections` to its own settings slice. This is the single
+   * readiness entry point for settingsStore.validateApiKey's LOCAL_INFERENCE arm.
+   */
+  ensureSelectionReady: (selection: LocalSelection) => Promise<{ ready: boolean; corrections: ModelCorrections }>;
   /** Save model selection for a language pair */
   rememberModels: (sourceLang: string, targetLang: string, asrModel: string, translationModel: string, ttsModel: string) => void;
   /** Recall saved model selection — per-field degradation if models deleted */
@@ -546,6 +570,32 @@ export const useModelStore = create<ModelStoreState>()(
         translationModel: isUsable(pref.translationModel) ? pref.translationModel : '',
         ttsModel: isUsable(pref.ttsModel) ? pref.ttsModel : '',
       };
+    },
+
+    ensureSelectionReady: async (selection) => {
+      // Scan IndexedDB for downloaded models before judging readiness.
+      if (!get().initialized) {
+        await get().initialize();
+      }
+      // Auto-correct stale selections (e.g. a TTS model for the wrong language
+      // after a language change); readiness is judged against the corrected
+      // selection so a valid setup isn't rejected for a stale stored ID.
+      const corrections = get().autoSelectModels(
+        selection.sourceLanguage,
+        selection.targetLanguage,
+        selection.asrModel,
+        selection.translationModel,
+        selection.ttsModel,
+      );
+      const effective = corrections ? { ...selection, ...corrections } : selection;
+      const ready = get().isProviderReady(
+        effective.sourceLanguage,
+        effective.targetLanguage,
+        effective.asrModel || undefined,
+        effective.translationModel || undefined,
+        effective.ttsModel || undefined,
+      );
+      return { ready, corrections };
     },
   })),
 );

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -352,7 +352,10 @@ export const useModelStore = create<ModelStoreState>()(
       if (selectedTtsModel) {
         const ttsEntry = getManifestEntry(selectedTtsModel);
         if (!modelUsable(ttsEntry, ctx)) return false;
-        if (ttsEntry && !ttsEntry.isCloudModel && !ttsEntry.multilingual && !ttsEntry.languages.includes(targetLang)) return false;
+        // Language compatibility is orthogonal to cloud/local (a cloud model
+        // still can't produce a language it doesn't support). The one current
+        // cloud TTS is multilingual, so this is behavior-identical today.
+        if (ttsEntry && !ttsEntry.multilingual && !ttsEntry.languages.includes(targetLang)) return false;
       } else {
         const hasTts = getTtsModelsForLanguage(targetLang).some(m => modelUsable(m, ctx));
         if (!hasTts) return false;

--- a/src/stores/modelStore.ts
+++ b/src/stores/modelStore.ts
@@ -17,6 +17,7 @@ import {
   getTtsModelsForLanguage,
   isTranslationModelCompatible,
   isAstCompatible,
+  modelUsable,
   pickBestModel,
   type ModelStatus,
 } from '../lib/local-inference/modelManifest';
@@ -295,19 +296,17 @@ export const useModelStore = create<ModelStoreState>()(
 
     isProviderReady: (sourceLang: string, targetLang: string, selectedAsrModel?: string, selectedTranslationModel?: string, selectedTtsModel?: string): boolean => {
       const { modelStatuses, webgpuAvailable } = get();
+      const ctx = { modelStatuses, webgpuAvailable };
 
-      // 1. ASR: if a specific model is selected, it must be downloaded;
-      //    otherwise at least 1 ASR model for sourceLang must be downloaded
+      // 1. ASR: if a specific model is selected, it must be usable (downloaded +
+      //    device-ready) and support sourceLang; otherwise at least 1 ASR model
+      //    for sourceLang must be usable.
       if (selectedAsrModel) {
-        if (modelStatuses[selectedAsrModel] !== 'downloaded') return false;
         const asrEntry = getManifestEntry(selectedAsrModel);
-        if (asrEntry?.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
+        if (!modelUsable(asrEntry, ctx)) return false;
         if (asrEntry && !asrEntry.multilingual && !asrEntry.languages.includes(sourceLang)) return false;
       } else {
-        const asrModels = getAsrModelsForLanguage(sourceLang);
-        const hasAsr = asrModels.some(
-          model => modelStatuses[model.id] === 'downloaded'
-        );
+        const hasAsr = getAsrModelsForLanguage(sourceLang).some(m => modelUsable(m, ctx));
         if (!hasAsr) return false;
       }
 
@@ -317,31 +316,21 @@ export const useModelStore = create<ModelStoreState>()(
         if (!asrEntry || !isAstCompatible(asrEntry, sourceLang, targetLang)) return false;
       } else if (selectedTranslationModel) {
         const entry = getManifestEntry(selectedTranslationModel);
-        if (!entry?.isCloudModel && modelStatuses[selectedTranslationModel] !== 'downloaded') return false;
-        if (entry?.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
+        if (!modelUsable(entry, ctx)) return false;
         if (entry && !isTranslationModelCompatible(entry, sourceLang, targetLang)) return false;
       } else {
         const translationEntry = getTranslationModel(sourceLang, targetLang);
-        if (!translationEntry) return false;
-        if (!translationEntry.isCloudModel && modelStatuses[translationEntry.id] !== 'downloaded') return false;
-        if (translationEntry.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
+        if (!modelUsable(translationEntry, ctx)) return false;
       }
 
-      // 3. TTS: if a specific model is selected, it must be downloaded (unless cloud);
-      //    otherwise at least 1 TTS model for targetLang must be downloaded
+      // 3. TTS: if a specific model is selected, it must be usable and support
+      //    targetLang; otherwise at least 1 TTS model for targetLang must be usable.
       if (selectedTtsModel) {
         const ttsEntry = getManifestEntry(selectedTtsModel);
-        if (ttsEntry?.isCloudModel) {
-          // Cloud models (e.g. Edge TTS) don't need download — always ready
-        } else {
-          if (modelStatuses[selectedTtsModel] !== 'downloaded') return false;
-          if (ttsEntry && !ttsEntry.multilingual && !ttsEntry.languages.includes(targetLang)) return false;
-        }
+        if (!modelUsable(ttsEntry, ctx)) return false;
+        if (ttsEntry && !ttsEntry.isCloudModel && !ttsEntry.multilingual && !ttsEntry.languages.includes(targetLang)) return false;
       } else {
-        const ttsModels = getTtsModelsForLanguage(targetLang);
-        const hasTts = ttsModels.some(
-          model => model.isCloudModel || modelStatuses[model.id] === 'downloaded'
-        );
+        const hasTts = getTtsModelsForLanguage(targetLang).some(m => modelUsable(m, ctx));
         if (!hasTts) return false;
       }
 
@@ -350,6 +339,7 @@ export const useModelStore = create<ModelStoreState>()(
 
     getParticipantModelStatus: (sourceLang: string, targetLang: string, currentAsrModelId: string, currentTranslationModelId?: string): ParticipantModelStatus => {
       const { modelStatuses, webgpuAvailable } = get();
+      const ctx = { modelStatuses, webgpuAvailable };
 
       // Participant reverses direction: participant source = user's target
       const participantSourceLang = targetLang;
@@ -369,8 +359,7 @@ export const useModelStore = create<ModelStoreState>()(
         const recalledAsr = allAsrModels.find(m => m.id === recalled.asrModel);
         if (recalledAsr
           && (recalledAsr.multilingual || recalledAsr.languages.includes(participantSourceLang))
-          && modelStatuses[recalled.asrModel] === 'downloaded'
-          && !(recalledAsr.requiredDevice === 'webgpu' && !webgpuAvailable)) {
+          && modelUsable(recalledAsr, ctx)) {
           asrModelId = recalled.asrModel;
           asrFallback = recalled.asrModel !== currentAsrModelId;
         }
@@ -381,16 +370,14 @@ export const useModelStore = create<ModelStoreState>()(
         const currentAsr = allAsrModels.find(m => m.id === currentAsrModelId);
         const currentAsrOk = currentAsr
           && (currentAsr.multilingual || currentAsr.languages.includes(participantSourceLang))
-          && modelStatuses[currentAsrModelId] === 'downloaded'
-          && !(currentAsr.requiredDevice === 'webgpu' && !webgpuAvailable);
+          && modelUsable(currentAsr, ctx);
 
         if (currentAsrOk) {
           asrModelId = currentAsrModelId;
         } else {
           const match = allAsrModels.find(m =>
             (m.multilingual || m.languages.includes(participantSourceLang))
-            && modelStatuses[m.id] === 'downloaded'
-            && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+            && modelUsable(m, ctx)
           );
           if (match) {
             asrModelId = match.id;
@@ -407,9 +394,7 @@ export const useModelStore = create<ModelStoreState>()(
       const isValidTranslation = (modelId: string, forAsrId: string | null) => {
         if (!modelId) return false;
         const entry = getManifestEntry(modelId);
-        if (!entry) return false;
-        if (!entry.isCloudModel && modelStatuses[modelId] !== 'downloaded') return false;
-        if (entry.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
+        if (!modelUsable(entry, ctx)) return false;
         // AST: translation model === ASR model with AST support
         if (modelId === forAsrId && isAstCompatible(entry, participantSourceLang, participantTargetLang)) return true;
         // Standard translation model
@@ -430,8 +415,7 @@ export const useModelStore = create<ModelStoreState>()(
       if (!translationModelId) {
         const match = getManifestByType('translation').find(m =>
           isTranslationModelCompatible(m, participantSourceLang, participantTargetLang)
-          && (m.isCloudModel || modelStatuses[m.id] === 'downloaded')
-          && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+          && modelUsable(m, ctx)
         );
         if (match) {
           translationModelId = match.id;
@@ -450,6 +434,7 @@ export const useModelStore = create<ModelStoreState>()(
 
     autoSelectModels: (sourceLang, targetLang, currentAsrModel, currentTranslationModel, currentTtsModel) => {
       const { modelStatuses, webgpuAvailable } = get();
+      const ctx = { modelStatuses, webgpuAvailable };
       const updates: { asrModel?: string; translationModel?: string; ttsModel?: string } = {};
 
       // Save original input to detect recall overrides later
@@ -476,10 +461,10 @@ export const useModelStore = create<ModelStoreState>()(
       const currentAsr = currentAsrModel ? allAsrModels.find(m => m.id === currentAsrModel) : null;
       const asrOk = currentAsr
         && (currentAsr.multilingual || currentAsr.languages.includes(sourceLang))
-        && modelStatuses[currentAsrModel] === 'downloaded';
+        && modelUsable(currentAsr, ctx);
       if (!asrOk) {
         const match = pickBestModel(allAsrModels.filter(m =>
-          (m.multilingual || m.languages.includes(sourceLang)) && modelStatuses[m.id] === 'downloaded'
+          (m.multilingual || m.languages.includes(sourceLang)) && modelUsable(m, ctx)
         ));
         const newId = match?.id || '';
         if (newId !== currentAsrModel) updates.asrModel = newId;
@@ -491,18 +476,16 @@ export const useModelStore = create<ModelStoreState>()(
         ? getManifestEntry(currentTranslationModel) : null;
       const isAstValid = asrEntryForAst
         && isAstCompatible(asrEntryForAst, sourceLang, targetLang)
-        && modelStatuses[currentTranslationModel] === 'downloaded';
+        && modelUsable(asrEntryForAst, ctx);
 
       const currentTrans = !isAstValid && currentTranslationModel ? getManifestByType('translation').find(m => m.id === currentTranslationModel) : null;
       const transOk = isAstValid || (currentTrans
         && isTranslationModelCompatible(currentTrans, sourceLang, targetLang)
-        && (currentTrans.isCloudModel || modelStatuses[currentTranslationModel] === 'downloaded')
-        && !(currentTrans.requiredDevice === 'webgpu' && !webgpuAvailable));
+        && modelUsable(currentTrans, ctx));
       if (!transOk) {
         const match = pickBestModel(getManifestByType('translation').filter(m =>
           isTranslationModelCompatible(m, sourceLang, targetLang)
-          && (m.isCloudModel || modelStatuses[m.id] === 'downloaded')
-          && !(m.requiredDevice === 'webgpu' && !webgpuAvailable)
+          && modelUsable(m, ctx)
         ));
         const newId = match?.id || '';
         if (newId !== currentTranslationModel) updates.translationModel = newId;
@@ -512,11 +495,11 @@ export const useModelStore = create<ModelStoreState>()(
       const currentTts = currentTtsModel ? getManifestByType('tts').find(m => m.id === currentTtsModel) : null;
       const ttsOk = currentTts
         && (currentTts.multilingual || currentTts.languages.includes(targetLang))
-        && (currentTts.isCloudModel || modelStatuses[currentTtsModel] === 'downloaded');
+        && modelUsable(currentTts, ctx);
       if (!ttsOk) {
         const match = pickBestModel(getManifestByType('tts').filter(m =>
           (m.multilingual || m.languages.includes(targetLang))
-          && (m.isCloudModel || modelStatuses[m.id] === 'downloaded')
+          && modelUsable(m, ctx)
         ));
         const newId = match?.id || '';
         if (newId !== currentTtsModel) updates.ttsModel = newId;
@@ -550,18 +533,13 @@ export const useModelStore = create<ModelStoreState>()(
 
     recallModels: (src, tgt) => {
       const { modelPreferences, modelStatuses, webgpuAvailable } = get();
+      const ctx = { modelStatuses, webgpuAvailable };
       const key = `${src}→${tgt}`;
       const pref = modelPreferences[key];
       if (!pref) return null;
 
       // Check downloaded + device compatibility (cloud models skip the download check)
-      const isUsable = (id: string) => {
-        if (!id) return false;
-        const entry = getManifestEntry(id);
-        if (!entry?.isCloudModel && modelStatuses[id] !== 'downloaded') return false;
-        if (entry?.requiredDevice === 'webgpu' && !webgpuAvailable) return false;
-        return true;
-      };
+      const isUsable = (id: string) => Boolean(id) && modelUsable(getManifestEntry(id), ctx);
 
       return {
         asrModel: isUsable(pref.asrModel) ? pref.asrModel : '',

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -941,62 +941,25 @@ const useSettingsStore = create<SettingsStore>()(
       if (provider === Provider.LOCAL_INFERENCE) {
         const localSettings = get().localInference;
         const { useModelStore } = await import('./modelStore');
-        const modelState = useModelStore.getState();
 
-        // Initialize model store if not yet done (scans IndexedDB for downloaded models)
-        if (!modelState.initialized) {
-          await modelState.initialize();
-        }
-
-        // Auto-correct stale model selections (e.g. TTS for wrong language after lang change).
-        // Without this, isProviderReady would reject a valid setup because the stored model
-        // IDs haven't been updated to match the current language pair.
-        const corrections = modelState.autoSelectModels(
-          localSettings.sourceLanguage,
-          localSettings.targetLanguage,
-          localSettings.asrModel,
-          localSettings.translationModel,
-          localSettings.ttsModel,
-        );
+        // modelStore owns readiness: it initializes, auto-corrects stale
+        // selections, and judges isProviderReady against the corrected IDs.
+        const { ready, corrections } = await useModelStore.getState().ensureSelectionReady(localSettings);
         if (corrections) {
           console.log('[SettingsStore] Auto-correcting stale model selections:', corrections);
           get().updateLocalInference(corrections);
-          // Re-read settings after correction
-          const updated = get().localInference;
-          const ready = modelState.isProviderReady(
-            updated.sourceLanguage,
-            updated.targetLanguage,
-            updated.asrModel || undefined,
-            updated.translationModel || undefined,
-            updated.ttsModel || undefined,
-          );
-          set({
-            isApiKeyValid: ready,
-            availableModels: ready
-              ? [{ id: 'local-asr-translate', type: 'realtime' as const, created: 0 }]
-              : [],
-            validationMessage: ready ? '' : i18n.t('settings.localInferenceModelsRequired'),
-            isValidating: false,
-          });
-          return { valid: ready, message: ready ? '' : i18n.t('settings.localInferenceModelsRequired'), validating: false };
         }
 
-        const ready = modelState.isProviderReady(
-          localSettings.sourceLanguage,
-          localSettings.targetLanguage,
-          localSettings.asrModel || undefined,
-          localSettings.translationModel || undefined,
-          localSettings.ttsModel || undefined,
-        );
+        const message = ready ? '' : i18n.t('settings.localInferenceModelsRequired');
         set({
           isApiKeyValid: ready,
           availableModels: ready
             ? [{ id: 'local-asr-translate', type: 'realtime' as const, created: 0 }]
             : [],
-          validationMessage: ready ? '' : i18n.t('settings.localInferenceModelsRequired'),
+          validationMessage: message,
           isValidating: false,
         });
-        return { valid: ready, message: ready ? '' : i18n.t('settings.localInferenceModelsRequired'), validating: false };
+        return { valid: ready, message, validating: false };
       }
 
       // For KizunaAI, ensure we have an API key first


### PR DESCRIPTION
## Candidate 7 of the architecture-review deepening series

Consolidates the WASM **Local Inference** model-readiness logic, which was re-derived inline at ~18 sites and had silently drifted between them.

Scope note: **WASM Local Inference only.** `nativeModelStore` (the peer *Local Native* provider) is deliberately untouched — the two are peer providers, not adapters of one seam.

### Part A — single readiness predicate (`c9e05c5a`)
- New in `modelManifest.ts`:
  - `modelUsable(entry, { modelStatuses, webgpuAvailable })` — the readiness check: downloaded-or-cloud ∧ device-ready.
  - `deviceReady(entry, webgpuAvailable)` — the WebGPU gate **alone**, for model *lists* that must still surface not-yet-downloaded models so the user can download them. `modelUsable` composes `deviceReady`.
- Routed ~18 hand-copied inline predicates through them across `modelStore` (isProviderReady, getParticipantModelStatus, autoSelectModels, recallModels) and `ModelManagementSection` (auto-select effect, list memos, hint).
- **Fixes a latent drift**: `autoSelectModels`' ASR/AST arms omitted the device gate the other readiness sites applied, so a downloaded WebGPU ASR model could be auto-selected on a machine without WebGPU — which `isProviderReady` would then reject (a dead-end selection). Now consistent, pinned by a regression test.

### Part B — modelStore owns readiness (`07458a13`)
- Extracted `modelStore.ensureSelectionReady(selection) → { ready, corrections }`: initialize → auto-correct stale selections → judge `isProviderReady` against the corrected IDs, **without persisting**.
- `settingsStore.validateApiKey`'s LOCAL_INFERENCE arm collapsed from ~60 lines across two drifting branches to ~20 lines of glue (apply corrections + set validation state).
- Added `LocalSelection` / `ModelCorrections` types so the seam is explicit.

### Verification
- 992/992 tests pass. New tests: `modelUsable`, `deviceReady`, `autoSelectModels` device gating, `ensureSelectionReady`.
- All substitutions are behavior-preserving in production except the documented `autoSelectModels` device-gate fix; `modelStatuses` is only populated for manifest entries, so the `modelUsable` null-entry edge is unreachable there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced automatic model selection with stricter device compatibility checks, including WebGPU availability.
  - Added a readiness utility that returns whether the current local selection is valid and provides suggested corrections when needed.
- **Bug Fixes**
  - Prevented auto-selection and compatibility filtering from including models that can’t run on the current device.
  - Improved readiness validation for cloud vs downloaded models and corrected stale/outdated selections.
  - Updated incompatible-model messaging to show the correct reason (WebGPU unsupported vs language mismatch).
- **Tests**
  - Added coverage for model/device readiness and selection readiness and gating behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->