### PR TITLE
fix(sidecar): prevent Windows bundle promotion failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Windows Sidecar Installation**: Wait for extracted files to close before promoting a downloaded sidecar bundle, avoiding `EPERM` rename failures.
+
 ## [0.15.10] - 2026-03-16
 
 ### Fixed

--- a/electron/native-host-manager.js
+++ b/electron/native-host-manager.js
@@ -27,9 +27,10 @@ function resolvePython() {
 function resolveSidecarLaunch({ platform, envOverride, bundleRoot, requiredVersion, readVersion, devVenvPython, devCwd, existsSync }) {
   if (envOverride) return { python: envOverride, cwd: devCwd, source: 'env' };
   if (bundleRoot) {
+    const platformPath = platform === 'win32' ? path.win32 : path.posix;
     const bundlePython = platform === 'win32'
-      ? path.join(bundleRoot, 'python', 'python.exe')
-      : path.join(bundleRoot, 'python', 'bin', 'python3');
+      ? platformPath.join(bundleRoot, 'python', 'python.exe')
+      : platformPath.join(bundleRoot, 'python', 'bin', 'python3');
     if (existsSync(bundlePython)) {
       // Strict matching (spec S2): an installed bundle is only usable when its
       // version equals the app's sidecarVersion. A stale bundle falls through to
@@ -38,7 +39,7 @@ function resolveSidecarLaunch({ platform, envOverride, bundleRoot, requiredVersi
       // running an untested app x sidecar combination.
       const installed = readVersion ? readVersion(bundleRoot) : null;
       if (!requiredVersion || installed === requiredVersion) {
-        return { python: bundlePython, cwd: path.join(bundleRoot, 'app'), source: 'bundle' };
+        return { python: bundlePython, cwd: platformPath.join(bundleRoot, 'app'), source: 'bundle' };
       }
     }
   }

--- a/electron/native-host-manager.test.js
+++ b/electron/native-host-manager.test.js
@@ -192,7 +192,8 @@ describe('resolveSidecarLaunch launch order', () => {
       platform: 'win32', envOverride: undefined, bundleRoot: 'C:\\u\\sidecar\\directml',
       devVenvPython: devVenv, devCwd, existsSync: () => true,
     });
-    expect(l.python.endsWith(path.join('python', 'python.exe'))).toBe(true);
+    expect(l.python).toBe(path.win32.join('C:\\u\\sidecar\\directml', 'python', 'python.exe'));
+    expect(l.cwd).toBe(path.win32.join('C:\\u\\sidecar\\directml', 'app'));
     expect(l.source).toBe('bundle');
   });
 

--- a/electron/sidecar-bundle.js
+++ b/electron/sidecar-bundle.js
@@ -110,7 +110,14 @@ function extractTarZst(archivePath, destDir) {
     // through (traversal guard, corrupt zstd frame, disk error) left the tar
     // `extract` transform and/or the archive read stream open — a file descriptor
     // leak on every failed install attempt.
-    const fail = (err) => { try { rs.destroy(); } catch {} try { extract.destroy(); } catch {} reject(err); };
+    let failed = false;
+    const fail = (err) => {
+      if (failed) return;
+      failed = true;
+      try { rs.destroy(); } catch {}
+      try { extract.destroy(); } catch {}
+      reject(err);
+    };
 
     extract.on('entry', (header, stream, next) => {
       const target = path.resolve(destDir, header.name);
@@ -133,7 +140,9 @@ function extractTarZst(archivePath, destDir) {
       const ws = fs.createWriteStream(target, { mode: header.mode || 0o644 });
       stream.on('error', fail);
       ws.on('error', fail);
-      ws.on('finish', next);
+      ws.once('close', () => {
+        if (!failed) next();
+      });
       stream.pipe(ws);
     });
     extract.on('finish', resolve);

--- a/electron/sidecar-bundle.js
+++ b/electron/sidecar-bundle.js
@@ -111,11 +111,13 @@ function extractTarZst(archivePath, destDir) {
     // `extract` transform and/or the archive read stream open — a file descriptor
     // leak on every failed install attempt.
     let failed = false;
+    let activeWriteStream = null;
     const fail = (err) => {
       if (failed) return;
       failed = true;
       try { rs.destroy(); } catch {}
       try { extract.destroy(); } catch {}
+      try { activeWriteStream?.destroy(); } catch {}
       reject(err);
     };
 
@@ -138,9 +140,11 @@ function extractTarZst(archivePath, destDir) {
       }
       fs.mkdirSync(path.dirname(target), { recursive: true });
       const ws = fs.createWriteStream(target, { mode: header.mode || 0o644 });
+      activeWriteStream = ws;
       stream.on('error', fail);
       ws.on('error', fail);
       ws.once('close', () => {
+        if (activeWriteStream === ws) activeWriteStream = null;
         if (!failed) next();
       });
       stream.pipe(ws);

--- a/electron/sidecar-bundle.test.js
+++ b/electron/sidecar-bundle.test.js
@@ -69,6 +69,29 @@ describe('extractTarZst', () => {
     const fixture = path.join(__dirname, '__fixtures__', 'bundle-symlink.tar.zst');
     await expect(extractTarZst(fixture, out)).rejects.toThrow(/link member/);
   });
+
+  it('destroys the active output stream when extraction fails', async () => {
+    const fsMod = req('fs');
+    const realCreateWriteStream = fsMod.createWriteStream;
+    let destroySpy;
+
+    fsMod.createWriteStream = (file, options) => {
+      const ws = realCreateWriteStream(file, options);
+      destroySpy = vi.spyOn(ws, 'destroy');
+      queueMicrotask(() => ws.emit('error', new Error('simulated write failure')));
+      return ws;
+    };
+
+    try {
+      const out = mkdtempSync(path.join(tmpdir(), 'sb-write-error-'));
+      const fixture = path.join(__dirname, '__fixtures__', 'bundle-sample.tar.zst');
+      await expect(extractTarZst(fixture, out)).rejects.toThrow('simulated write failure');
+    } finally {
+      fsMod.createWriteStream = realCreateWriteStream;
+    }
+
+    expect(destroySpy).toHaveBeenCalled();
+  });
 });
 
 describe('installBundle rollback', () => {

--- a/electron/sidecar-bundle.test.js
+++ b/electron/sidecar-bundle.test.js
@@ -320,6 +320,51 @@ describe('installBundle v2 pipeline (spec S4-S9)', () => {
     expect(stagedBytes(u, 'mac', '9.9.9')).toBe(0);          // staging cleaned
   });
 
+  it('waits for extracted files to close before promoting the bundle', async () => {
+    const fsMod = req('fs');
+    const realCreateWriteStream = fsMod.createWriteStream;
+    const realRenameSync = fsMod.renameSync;
+    const u = mkdtempSync(path.join(tmpdir(), 'sb-inst-'));
+    const sku = 'mac';
+    const version = '9.9.9';
+    const name = archiveName(sku, version);
+    const dest = path.join(u, 'sidecar', sku);
+    const tmpDir = `${dest}.tmp`;
+    const manifest = manifestFor([{ name, size: fixture.length, sha256: sha(fixture) }]);
+    let openExtractedFiles = 0;
+
+    fsMod.createWriteStream = (file, options) => {
+      const ws = realCreateWriteStream(file, options);
+      if (path.resolve(file).startsWith(`${path.resolve(tmpDir)}${path.sep}`)) {
+        ws.once('finish', () => { openExtractedFiles += 1; });
+        ws.once('close', () => { openExtractedFiles -= 1; });
+      }
+      return ws;
+    };
+    fsMod.renameSync = (from, to) => {
+      if (path.resolve(from) === path.resolve(tmpDir) &&
+          path.resolve(to) === path.resolve(dest) && openExtractedFiles > 0) {
+        const error = new Error('simulated Windows EPERM: extracted file handle still open');
+        error.code = 'EPERM';
+        throw error;
+      }
+      return realRenameSync(from, to);
+    };
+
+    try {
+      await expect(installBundle({
+        sku, version, userDataDir: u,
+        fetchImpl: fetchFor(manifest, { [name]: fixture }),
+        statfs: bigStatfs, env: {},
+      })).resolves.toEqual({ version });
+    } finally {
+      fsMod.createWriteStream = realCreateWriteStream;
+      fsMod.renameSync = realRenameSync;
+    }
+
+    expect(readFileSync(path.join(dest, 'app', 'hi.txt'), 'utf8')).toBe('hi');
+  });
+
   it('multi part: reassembles, verifies the whole archive, installs', async () => {
     const u = mkdtempSync(path.join(tmpdir(), 'sb-inst-'));
     const name = archiveName('mac', '9.9.9');


### PR DESCRIPTION
## Summary

Fix Windows sidecar bundle promotion after extraction. The installer now waits for every extracted file stream to close before atomically renaming the temporary bundle directory.

Also make the sidecar-launch path resolver honor its injected platform, so its Linux and Windows bundle-path checks run correctly from any host OS.

## Root cause

Tar extraction advanced on the writable stream's `finish` event. That event occurs before the file descriptor closes, so Windows can reject the immediate temporary-directory rename with `EPERM`.

## Validation

- `npm test -- --run electron/sidecar-bundle.test.js` — 22 passed
- `npm test -- --run` — 993 passed
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows sidecar installation reliability by waiting for extracted files to fully close before promoting the installed bundle.
  * Prevented installation failures caused by rename (`EPERM`) issues during bundle promotion.
  * Improved cross-platform path handling when launching installed sidecar bundles on Windows and POSIX.
  * Strengthened extraction error handling to avoid inconsistent failure states.
* **Tests**
  * Added coverage for extraction stream error/ordering and Windows-style rename timing scenarios.
* **Documentation**
  * Updated the Unreleased changelog with the Windows sidecar installation fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->