### PR TITLE
refactor(local-inference): shared WASM worker env harness (candidate 6, PR 1)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-wasm-worker-harness-pr1.md
+++ b/docs/superpowers/plans/2026-07-13-wasm-worker-harness-pr1.md
@@ -1,0 +1,629 @@
+# WASM Worker Harness (PR 1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the two blocks of transformers.js worker boilerplate — the `createBlobUrlCache` bridge and the `env` setup — into two shared, unit-tested `_shared/` helpers, and rewire all 10 transformers workers through them.
+
+**Architecture:** Two new pure modules under `src/lib/local-inference/workers/_shared/`: `blob-url-cache.ts` (`createBlobUrlCache`) and `transformers-env.ts` (`initTransformersEnv`, which calls `createBlobUrlCache` internally). Each worker imports only `initTransformersEnv`, deletes its local `createBlobUrlCache` and its inline `env` block, and calls the helper inside `handleInit`. Behavior-preserving.
+
+**Tech Stack:** TypeScript, Vitest, `@huggingface/transformers` (transformers.js), Web Workers, Vite worker bundling.
+
+## Global Constraints
+
+- **WASM side only.** Do not touch `nativeModelStore`, the Python sidecar, or any `engine/` file. This PR is workers + `_shared/` only.
+- **No wire-protocol change.** Message shapes, `postMessage` payloads, and `self.onmessage` dispatch stay exactly as they are.
+- **`transformers-all.ts` and `onnxruntime-all.ts` are NOT modified.** They are build-time chunk-dedup shims, orthogonal to this source-dedup.
+- **Each worker imports only `initTransformersEnv`** (from `./_shared/transformers-env`). It does NOT import `createBlobUrlCache` — that is now an internal detail of `transformers-env.ts`.
+- **ASR workers keep their `ortEnv.wasm.wasmPaths`** assignment in its original spot (before `initVad`). The helper handles the transformers `env` only, never `ortEnv`. Both worker families already guard `wasmPaths` on `msg.ortWasmBaseUrl`.
+- **whisper:** `initTransformersEnv` must be called *after* `patchWhisperConfigs(...)` (it already sits after it in the flow).
+- English-only comments. Conventional-commit messages. Commit after every task.
+- Verification per rewire task = full `npm run test` stays green + a completeness grep. Workers cannot be unit-tested (they need the real Worker/WASM runtime); a `npm run build` at the end is the integration check.
+
+The 10 transformers workers, by family:
+- **Translation (5):** `translation.worker.ts`, `qwen-translation.worker.ts`, `qwen35-translation.worker.ts`, `hy-mt-translation.worker.ts`, `translategemma-translation.worker.ts` — transformers `env` only; do NOT import `ortEnv`.
+- **ASR/WebGPU (5):** `whisper-webgpu.worker.ts`, `cohere-transcribe-webgpu.worker.ts`, `voxtral-3b-webgpu.worker.ts`, `voxtral-webgpu.worker.ts`, `granite-speech-webgpu.worker.ts` — also set `ortEnv.wasm.wasmPaths` (imported as `env as ortEnv` from `./_shared/onnxruntime-all`).
+
+---
+
+### Task 1: `createBlobUrlCache` shared helper
+
+**Files:**
+- Create: `src/lib/local-inference/workers/_shared/blob-url-cache.ts`
+- Test: `src/lib/local-inference/workers/_shared/blob-url-cache.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (pure; calls global `fetch`).
+- Produces: `export function createBlobUrlCache(fileUrls: Record<string, string>): { match(request: string | Request | undefined): Promise<Response | undefined>; put(request: string | Request, response: Response): Promise<void> }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/local-inference/workers/_shared/blob-url-cache.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createBlobUrlCache } from './blob-url-cache';
+
+describe('createBlobUrlCache', () => {
+  const fileUrls = { 'config.json': 'blob:abc', 'onnx/model.onnx': 'blob:def' };
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true }) as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('resolves an HF /resolve/main/ URL to a fetch of the mapped blob URL', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await cache.match('https://huggingface.co/org/model/resolve/main/config.json');
+    expect(fetchMock).toHaveBeenCalledWith('blob:abc');
+  });
+
+  it('resolves nested paths after /resolve/main/', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await cache.match('https://huggingface.co/org/model/resolve/main/onnx/model.onnx');
+    expect(fetchMock).toHaveBeenCalledWith('blob:def');
+  });
+
+  it('returns undefined for a file not in the map (no fetch)', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    expect(await cache.match('https://huggingface.co/org/model/resolve/main/missing.bin')).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a non-HF URL (no /resolve/main/)', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    expect(await cache.match('https://example.com/config.json')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty request', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    expect(await cache.match(undefined)).toBeUndefined();
+  });
+
+  it('reads .url from a Request-like object', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await cache.match({ url: 'https://huggingface.co/o/m/resolve/main/config.json' } as unknown as Request);
+    expect(fetchMock).toHaveBeenCalledWith('blob:abc');
+  });
+
+  it('put is a no-op that resolves to undefined', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await expect(cache.put('x', {} as Response)).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run src/lib/local-inference/workers/_shared/blob-url-cache.test.ts`
+Expected: FAIL — `Failed to resolve import "./blob-url-cache"` (module does not exist yet).
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/local-inference/workers/_shared/blob-url-cache.ts`:
+
+```ts
+/**
+ * customCache bridge for Transformers.js: resolves the HuggingFace Hub
+ * ".../resolve/main/<path>" URLs it requests to the pre-downloaded IndexedDB
+ * blob URLs passed in `fileUrls`, so no network request leaves the worker.
+ * `put` is a no-op — the files already live in IndexedDB.
+ *
+ * This is the single behavioural definition of the bridge; the 10 transformers.js
+ * workers each used to carry a byte-identical copy.
+ */
+export function createBlobUrlCache(fileUrls: Record<string, string>) {
+  return {
+    async match(request: string | Request | undefined): Promise<Response | undefined> {
+      if (!request) return undefined;
+      const url = typeof request === 'string' ? request : request.url;
+      const marker = '/resolve/main/';
+      const idx = url.indexOf(marker);
+      if (idx === -1) return undefined;
+      const filename = url.slice(idx + marker.length);
+      const blobUrl = fileUrls[filename];
+      if (!blobUrl) return undefined;
+      return fetch(blobUrl);
+    },
+    async put(_request: string | Request, _response: Response): Promise<void> {},
+  };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run src/lib/local-inference/workers/_shared/blob-url-cache.test.ts`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/workers/_shared/blob-url-cache.ts src/lib/local-inference/workers/_shared/blob-url-cache.test.ts
+git commit -m "feat(local-inference): shared createBlobUrlCache helper for WASM workers"
+```
+
+---
+
+### Task 2: `initTransformersEnv` shared helper
+
+**Files:**
+- Create: `src/lib/local-inference/workers/_shared/transformers-env.ts`
+- Test: `src/lib/local-inference/workers/_shared/transformers-env.test.ts`
+
+**Interfaces:**
+- Consumes: `createBlobUrlCache` from Task 1 (`./blob-url-cache`).
+- Produces:
+  - `export interface TransformersEnvInit { fileUrls: Record<string, string>; ortWasmBaseUrl?: string }`
+  - `export function initTransformersEnv(env: TransformersEnvLike, msg: TransformersEnvInit): void` — sets `proxy=false` + `wasmPaths` (guarded) on `env.backends.onnx.wasm`, sets the four `env` flags, and installs `env.customCache = createBlobUrlCache(msg.fileUrls)`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/local-inference/workers/_shared/transformers-env.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initTransformersEnv } from './transformers-env';
+
+function fakeEnv(withWasm = true) {
+  return {
+    backends: withWasm ? { onnx: { wasm: {} as Record<string, unknown> } } : {},
+    allowRemoteModels: undefined as unknown,
+    allowLocalModels: undefined as unknown,
+    useBrowserCache: undefined as unknown,
+    useCustomCache: undefined as unknown,
+    customCache: undefined as unknown,
+  };
+}
+
+describe('initTransformersEnv', () => {
+  beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sets the four transformers.js flags and a customCache bridge', () => {
+    const env = fakeEnv();
+    initTransformersEnv(env, { fileUrls: { 'config.json': 'blob:x' } });
+    expect(env.allowRemoteModels).toBe(false);
+    expect(env.allowLocalModels).toBe(true);
+    expect(env.useBrowserCache).toBe(false);
+    expect(env.useCustomCache).toBe(true);
+    expect(typeof (env.customCache as { match?: unknown }).match).toBe('function');
+  });
+
+  it('disables the wasm proxy when the backend exists', () => {
+    const env = fakeEnv();
+    initTransformersEnv(env, { fileUrls: {} });
+    expect((env.backends as { onnx: { wasm: { proxy?: boolean } } }).onnx.wasm.proxy).toBe(false);
+  });
+
+  it('sets wasmPaths only when ortWasmBaseUrl is provided', () => {
+    const a = fakeEnv();
+    initTransformersEnv(a, { fileUrls: {}, ortWasmBaseUrl: 'https://host/wasm/ort/' });
+    expect((a.backends as { onnx: { wasm: { wasmPaths?: string } } }).onnx.wasm.wasmPaths).toBe('https://host/wasm/ort/');
+
+    const b = fakeEnv();
+    initTransformersEnv(b, { fileUrls: {} });
+    expect((b.backends as { onnx: { wasm: { wasmPaths?: string } } }).onnx.wasm.wasmPaths).toBeUndefined();
+  });
+
+  it('does not throw when the wasm backend is absent, still sets flags', () => {
+    const env = fakeEnv(false);
+    expect(() => initTransformersEnv(env, { fileUrls: {}, ortWasmBaseUrl: 'x' })).not.toThrow();
+    expect(env.useCustomCache).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run src/lib/local-inference/workers/_shared/transformers-env.test.ts`
+Expected: FAIL — `Failed to resolve import "./transformers-env"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/local-inference/workers/_shared/transformers-env.ts`:
+
+```ts
+import { createBlobUrlCache } from './blob-url-cache';
+
+/**
+ * Configure the Transformers.js `env` for offline, IndexedDB-backed inference:
+ * disable the WASM proxy and remote/browser caching, point ONNX at the
+ * app-served WASM binaries, and install the blob-URL customCache bridge.
+ *
+ * `env` is passed in (not imported) so this helper stays decoupled from the
+ * `transformers-all` chunk-dedup shim. It configures the transformers `env`
+ * ONLY — ASR workers set their separate onnxruntime-web `ortEnv.wasm.wasmPaths`
+ * themselves, before their VAD InferenceSession is created.
+ *
+ * Folds in the module-top `proxy=false` that every worker also duplicated.
+ */
+export interface TransformersEnvInit {
+  fileUrls: Record<string, string>;
+  ortWasmBaseUrl?: string;
+}
+
+export interface TransformersEnvLike {
+  backends?: { onnx?: { wasm?: { proxy?: boolean; wasmPaths?: string } } };
+  allowRemoteModels?: unknown;
+  allowLocalModels?: unknown;
+  useBrowserCache?: unknown;
+  useCustomCache?: unknown;
+  customCache?: unknown;
+}
+
+export function initTransformersEnv(env: TransformersEnvLike, msg: TransformersEnvInit): void {
+  if (env.backends?.onnx?.wasm) {
+    env.backends.onnx.wasm.proxy = false;
+    if (msg.ortWasmBaseUrl) env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+  }
+  env.allowRemoteModels = false;
+  env.allowLocalModels = true;
+  env.useBrowserCache = false;
+  env.useCustomCache = true;
+  env.customCache = createBlobUrlCache(msg.fileUrls);
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run src/lib/local-inference/workers/_shared/transformers-env.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/workers/_shared/transformers-env.ts src/lib/local-inference/workers/_shared/transformers-env.test.ts
+git commit -m "feat(local-inference): shared initTransformersEnv helper for WASM workers"
+```
+
+---
+
+### Task 3: Rewire the 5 translation workers
+
+**Files (all Modify):**
+- `src/lib/local-inference/workers/translation.worker.ts`
+- `src/lib/local-inference/workers/qwen-translation.worker.ts`
+- `src/lib/local-inference/workers/qwen35-translation.worker.ts`
+- `src/lib/local-inference/workers/hy-mt-translation.worker.ts`
+- `src/lib/local-inference/workers/translategemma-translation.worker.ts`
+
+**Interfaces:**
+- Consumes: `initTransformersEnv` from Task 2.
+- Produces: nothing new (behavior-preserving rewire).
+
+Apply this exact 4-part edit to **each** of the 5 files (read the file first — line numbers vary per file; match on the code shown):
+
+**(a) Add the import** immediately after the `... from './_shared/transformers-all';` import line:
+
+```ts
+import { initTransformersEnv } from './_shared/transformers-env';
+```
+
+**(b) Delete the module-top proxy block.** It looks like this (a comment line may precede it):
+
+```ts
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.proxy = false;
+}
+```
+
+**(c) Delete the local `createBlobUrlCache` function** in its entirety — the whole `function createBlobUrlCache(fileUrls: Record<string, string>) { ... }` block (and its preceding doc-comment).
+
+**(d) Delete the transformers-env `wasmPaths` block.** Note: in these workers the `wasmPaths` block and the flag block are usually **NOT adjacent** (only `translation.worker.ts` has them together) — do (d) and (e) as two separate find-and-replace edits. Delete this block entirely (the helper sets `wasmPaths` for you; a `// Set ORT WASM paths ...` comment may precede it — delete that too):
+
+```ts
+    if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {
+      env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+    }
+```
+
+**(e) Replace the inline flag block** (appears separately, under a `// Configure Transformers.js ...` comment) with the single call:
+
+Find:
+```ts
+    env.allowRemoteModels = false;
+    env.allowLocalModels = true;
+    env.useBrowserCache = false;
+    env.useCustomCache = true;
+    env.customCache = createBlobUrlCache(msg.fileUrls);
+```
+Replace with:
+```ts
+    initTransformersEnv(env, msg);
+```
+
+(`msg` already carries `fileUrls` and `ortWasmBaseUrl`. A worker-local comment near either block may differ; keep only the call.)
+
+- [ ] **Step 1: Apply edits (a)–(e) to all 5 translation workers.**
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm run test -- --run`
+Expected: PASS — same total as before plus the 2 new helper suites; no failures.
+
+- [ ] **Step 3: Completeness grep**
+
+Run:
+```bash
+cd src/lib/local-inference/workers
+grep -L "initTransformersEnv" translation.worker.ts qwen-translation.worker.ts qwen35-translation.worker.ts hy-mt-translation.worker.ts translategemma-translation.worker.ts
+grep -l "function createBlobUrlCache" translation.worker.ts qwen-translation.worker.ts qwen35-translation.worker.ts hy-mt-translation.worker.ts translategemma-translation.worker.ts
+```
+Expected: BOTH commands print nothing (every file imports/uses `initTransformersEnv`; no file still defines `createBlobUrlCache`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/local-inference/workers/translation.worker.ts \
+        src/lib/local-inference/workers/qwen-translation.worker.ts \
+        src/lib/local-inference/workers/qwen35-translation.worker.ts \
+        src/lib/local-inference/workers/hy-mt-translation.worker.ts \
+        src/lib/local-inference/workers/translategemma-translation.worker.ts
+git commit -m "refactor(local-inference): route translation workers through shared env harness"
+```
+
+---
+
+### Task 4: Rewire the 4 non-whisper ASR workers
+
+**Files (all Modify):**
+- `src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts`
+- `src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts`
+- `src/lib/local-inference/workers/voxtral-webgpu.worker.ts`
+- `src/lib/local-inference/workers/granite-speech-webgpu.worker.ts`
+
+**Interfaces:**
+- Consumes: `initTransformersEnv` from Task 2.
+- Produces: nothing new (behavior-preserving rewire).
+
+These differ from Task 3 in one way: they also set `ortEnv.wasm.wasmPaths`, which **must stay before `initVad`**. Apply this exact edit to **each** of the 4 files (read the file first; match on the code shown):
+
+**(a) Add the import** after the `... from './_shared/onnxruntime-all';` import line:
+
+```ts
+import { initTransformersEnv } from './_shared/transformers-env';
+```
+
+**(b) Delete the module-top proxy block:**
+
+```ts
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.proxy = false;
+}
+```
+
+**(c) Delete the local `createBlobUrlCache` function** in its entirety (and its doc-comment).
+
+**(d) Trim the wasmPaths block to keep only the `ortEnv` half.** Find this block (a `// Set ORT WASM paths` comment precedes it):
+
+```ts
+    if (msg.ortWasmBaseUrl) {
+      if (env.backends?.onnx?.wasm) {
+        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+      if (ortEnv?.wasm) {
+        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+    }
+```
+
+Replace it with (drops the transformers-`env` half — the helper sets that later; keeps the `ortEnv` half in place before `initVad`):
+
+```ts
+    // ortEnv wasmPaths must be set before initVad's InferenceSession; the
+    // transformers env is configured later via initTransformersEnv.
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
+    }
+```
+
+**(e) Replace the inline transformers env block** (it appears later, after `initVad`, under a `// ... Configure Transformers.js ...` comment):
+
+```ts
+    env.allowRemoteModels = false;
+    env.allowLocalModels = true;
+    env.useBrowserCache = false;
+    env.useCustomCache = true;
+    env.customCache = createBlobUrlCache(msg.fileUrls);
+```
+
+Replace with:
+
+```ts
+    initTransformersEnv(env, msg);
+```
+
+- [ ] **Step 1: Apply edits (a)–(e) to all 4 ASR workers.**
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `npm run test -- --run`
+Expected: PASS — no failures.
+
+- [ ] **Step 3: Completeness grep**
+
+Run:
+```bash
+cd src/lib/local-inference/workers
+grep -L "initTransformersEnv" cohere-transcribe-webgpu.worker.ts voxtral-3b-webgpu.worker.ts voxtral-webgpu.worker.ts granite-speech-webgpu.worker.ts
+grep -l "function createBlobUrlCache" cohere-transcribe-webgpu.worker.ts voxtral-3b-webgpu.worker.ts voxtral-webgpu.worker.ts granite-speech-webgpu.worker.ts
+grep -c "ortEnv.wasm.wasmPaths" cohere-transcribe-webgpu.worker.ts voxtral-3b-webgpu.worker.ts voxtral-webgpu.worker.ts granite-speech-webgpu.worker.ts
+```
+Expected: first two print nothing; the third prints `...:1` for each file (the `ortEnv` assignment is retained exactly once per worker).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts \
+        src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts \
+        src/lib/local-inference/workers/voxtral-webgpu.worker.ts \
+        src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+git commit -m "refactor(local-inference): route ASR workers through shared env harness (keep ortEnv wasmPaths)"
+```
+
+---
+
+### Task 5: Rewire the whisper worker
+
+**Files:**
+- Modify: `src/lib/local-inference/workers/whisper-webgpu.worker.ts`
+
+**Interfaces:**
+- Consumes: `initTransformersEnv` from Task 2.
+- Produces: nothing new.
+
+Whisper is identical to Task 4 with one ordering note: its transformers env block sits **after** `await patchWhisperConfigs(msg.fileUrls, msg.language);`. The `initTransformersEnv(env, msg)` call must land in that same spot (after the patch), so the cache is built over the already-mutated `fileUrls`.
+
+Apply the same 5-part edit as Task 4:
+
+**(a)** Add `import { initTransformersEnv } from './_shared/transformers-env';` after the `... from './_shared/onnxruntime-all';` import.
+
+**(b)** Delete the module-top proxy block:
+```ts
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.proxy = false;
+}
+```
+
+**(c)** Delete the local `function createBlobUrlCache(...) { ... }` (and its doc-comment).
+
+**(d)** Trim the wasmPaths block (has a 3-line `// Set ORT WASM paths ...` comment preceding it):
+```ts
+    if (msg.ortWasmBaseUrl) {
+      if (env.backends?.onnx?.wasm) {
+        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+      if (ortEnv?.wasm) {
+        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
+      }
+    }
+```
+Replace with:
+```ts
+    // ortEnv wasmPaths must be set before the VAD/whisper InferenceSession; the
+    // transformers env is configured later (after patchWhisperConfigs).
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
+    }
+```
+
+**(e)** Replace the transformers env block that follows `await patchWhisperConfigs(...)`:
+```ts
+    env.allowRemoteModels = false;
+    env.allowLocalModels = true;
+    env.useBrowserCache = false;
+    env.useCustomCache = true;
+    env.customCache = createBlobUrlCache(msg.fileUrls);
+```
+with:
+```ts
+    initTransformersEnv(env, msg);
+```
+
+- [ ] **Step 1: Apply edits (a)–(e) to whisper-webgpu.worker.ts.**
+
+- [ ] **Step 2: Verify the ordering is preserved**
+
+Run:
+```bash
+cd src/lib/local-inference/workers
+grep -n "patchWhisperConfigs\|initTransformersEnv" whisper-webgpu.worker.ts
+```
+Expected: the `await patchWhisperConfigs(...)` call line number is **less than** the `initTransformersEnv(env, msg)` line number (patch runs first).
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npm run test -- --run`
+Expected: PASS.
+
+- [ ] **Step 4: Completeness grep**
+
+Run:
+```bash
+cd src/lib/local-inference/workers
+grep -c "function createBlobUrlCache" whisper-webgpu.worker.ts
+grep -c "ortEnv.wasm.wasmPaths" whisper-webgpu.worker.ts
+```
+Expected: `0` and `1`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/workers/whisper-webgpu.worker.ts
+git commit -m "refactor(local-inference): route whisper worker through shared env harness (after config patch)"
+```
+
+---
+
+### Task 6: Consolidation guard test + integration verification
+
+**Files:**
+- Create: `src/lib/local-inference/workers/_shared/harness-consolidation.test.ts`
+
+**Interfaces:**
+- Consumes: nothing (reads worker source files from disk).
+- Produces: a source-scan guard preventing re-inlining of the harness in any of the 10 workers.
+
+- [ ] **Step 1: Write the guard test (it should pass immediately after Tasks 3–5)**
+
+Create `src/lib/local-inference/workers/_shared/harness-consolidation.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Every transformers.js worker must route through the shared harness — no
+// re-inlined createBlobUrlCache, no hand-written env block. Guards against drift.
+const TRANSFORMERS_WORKERS = [
+  'translation.worker.ts',
+  'qwen-translation.worker.ts',
+  'qwen35-translation.worker.ts',
+  'hy-mt-translation.worker.ts',
+  'translategemma-translation.worker.ts',
+  'whisper-webgpu.worker.ts',
+  'cohere-transcribe-webgpu.worker.ts',
+  'voxtral-3b-webgpu.worker.ts',
+  'voxtral-webgpu.worker.ts',
+  'granite-speech-webgpu.worker.ts',
+];
+
+function read(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`../${name}`, import.meta.url)), 'utf8');
+}
+
+describe('worker harness consolidation', () => {
+  it.each(TRANSFORMERS_WORKERS)('%s routes through the shared harness', (name) => {
+    const src = read(name);
+    expect(src, `${name} still defines a local createBlobUrlCache`).not.toMatch(/function\s+createBlobUrlCache/);
+    expect(src, `${name} still hand-sets env.customCache`).not.toMatch(/env\.customCache\s*=\s*createBlobUrlCache/);
+    expect(src, `${name} does not import initTransformersEnv`).toContain("from './_shared/transformers-env'");
+    expect(src, `${name} does not call initTransformersEnv`).toMatch(/initTransformersEnv\(/);
+  });
+});
+```
+
+- [ ] **Step 2: Run the guard test**
+
+Run: `npm run test -- --run src/lib/local-inference/workers/_shared/harness-consolidation.test.ts`
+Expected: PASS (10 cases). If any fails, a worker from Tasks 3–5 was missed — fix that worker, do not weaken the test.
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm run test -- --run`
+Expected: PASS, no failures.
+
+- [ ] **Step 4: Integration build check**
+
+Run: `npm run build`
+Expected: build succeeds. This bundles every worker via Vite; a broken import or missing symbol in any rewired worker fails here (the real integration gate, since workers have no unit tests).
+
+> **Coverage note:** the build catches import/symbol breakage but does not *run* the workers, so it cannot prove runtime behavior. Because this PR is a mechanical, line-for-line extraction (the helper bodies are byte-identical to the deleted code, plus the folded-in `proxy=false`), automated green here is strong evidence. A brief manual smoke — one local-inference ASR→translation→TTS session — before merge is the behavioral backstop and is recommended, not required for task completion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+git commit -m "test(local-inference): guard WASM workers against re-inlining the shared harness"
+```

--- a/docs/superpowers/specs/2026-07-13-wasm-worker-session-design.md
+++ b/docs/superpowers/specs/2026-07-13-wasm-worker-session-design.md
@@ -1,0 +1,212 @@
+# WASM WorkerSession + worker harness consolidation (Design)
+
+**Date**: 2026-07-13
+**Branch**: `refactor/wasm-worker-session`
+**Status**: Design / proposal — approved forks, no implementation yet
+
+## Summary
+
+The WASM Local-Inference layer duplicates worker plumbing at two levels:
+
+- **Worker side** (runs in the worker): `createBlobUrlCache` is copied into 10 transformers.js workers (all semantically identical), and the transformers `env` setup block — `allowRemoteModels=false … useCustomCache=true … customCache=createBlobUrlCache(msg.fileUrls)` plus the ORT `wasmPaths` wiring and a module-top `proxy=false` — is copied into all 10 as well.
+- **Engine side** (main thread): the 4 engines (`AsrEngine`, `StreamingAsrEngine`, `TranslationEngine`, `TtsEngine`) copy the same Worker lifecycle verbatim — the init handshake (create worker → await `ready`/`error` → revoke blob URLs), the `onerror` path, and the `dispose()` core (`postMessage({type:'dispose'})` → `terminate()`). The two request/response engines additionally each hand-roll an id-keyed `pendingRequests` map.
+
+None of this is under test. The only existing engine test (`TtsEngine.supertonic.test.ts`) works by monkeypatching `globalThis.Worker`.
+
+This design extracts the shared plumbing into small, independently-testable units — **behavior-preserving**, **WASM side only** — landed as two PRs. It is a peer of, and shares nothing with, the Local Native (sidecar) path.
+
+## Goals
+
+- Collapse the 10× `createBlobUrlCache` + 10× transformers `env` setup into two shared `_shared/` helpers.
+- Extract the engine Worker lifecycle into a composed `WorkerSession`, and the id-correlation into a `RequestRegistry`, so all 4 engines share one tested lifecycle instead of four hand-copied ones.
+- Bring this 0-test area under characterization tests that pin current observable behavior before any extraction, and unit tests on the new shared units after.
+
+## Non-goals
+
+- **No wire-protocol change.** The message shapes stay exactly as they are today, including the known drift between families: ASR workers use the shared `types.ts` union (`ready{loadTimeMs}`, `status{message}`); translation workers declare types locally and emit `ready{modelId, loadTimeMs, device}` / `status{status:'loading', modelId}`. Unifying that is a separate, riskier change and is explicitly out of scope.
+- **Local Native / sidecar untouched.** `nativeModelStore`, the Python sidecar, and its engines are a peer provider with separate repos, runtimes, and readiness stores. No shared abstraction is introduced across the WASM/native boundary.
+- **The 3 non-transformers workers stay as-is.** `bing-translation` (HTTP client), `supertonic-tts` (raw `InferenceSession`), and `zoom-vad` (raw `InferenceSession`) do not use `createBlobUrlCache` or the transformers `env` bridge and legitimately differ; they are not folded into the harness.
+- No `types.ts` init-message dedup (a separate duplication axis, deferred).
+
+## Background — the duplication, with evidence
+
+### Worker side
+
+`createBlobUrlCache` — 10 copies, all semantically identical, two cosmetic families plus one drifted ancestor:
+
+- Family A (`marker` var, dense): `whisper-webgpu:210`, `cohere-transcribe-webgpu:158`, `voxtral-webgpu:413`, `voxtral-3b-webgpu:174`, `granite-speech-webgpu:179` (granite differs only in a `put` brace).
+- Family B (`resolveMainMarker` var, blank lines): `qwen-translation:51`, `translategemma-translation:51`, `hy-mt-translation:70`, `qwen35-translation:56`.
+- Drifted ancestor: `translation.worker.ts:67` (splits the `return fetch(...)` into two statements; semantically identical).
+
+The transformers `env` setup, identical in all 10 (line refs from `translation.worker.ts`):
+
+```ts
+// module top-level (runs at worker load)
+if (env.backends?.onnx?.wasm) {
+  env.backends.onnx.wasm.proxy = false;      // :14-15
+}
+
+// inside handleInit(msg)
+if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {   // :100-102
+  env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+}
+env.allowRemoteModels = false;   // :105
+env.allowLocalModels = true;     // :106
+env.useBrowserCache = false;     // :107
+env.useCustomCache = true;       // :108
+env.customCache = createBlobUrlCache(msg.fileUrls);  // :109
+```
+
+**Per-family difference in the `wasmPaths` wiring** (both families are `msg.ortWasmBaseUrl`-guarded — there is no unguarded overwrite):
+
+- 5 translation workers set only the transformers `env` and don't import `ortEnv`:
+  ```ts
+  if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) { env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl; }
+  ```
+- 5 ASR/WebGPU workers additionally set the raw onnxruntime-web `env` (imported as `ortEnv` from `./_shared/onnxruntime-all`) that their VAD `InferenceSession` uses, and this block runs *before* `initVad`:
+  ```ts
+  if (msg.ortWasmBaseUrl) {
+    if (env.backends?.onnx?.wasm) { env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl; }
+    if (ortEnv?.wasm)            { ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl; }
+  }
+  ```
+
+So the shared helper handles only the transformers `env`; each ASR worker keeps a minimal `if (msg.ortWasmBaseUrl && ortEnv?.wasm) { ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl; }` before its VAD init. The transformers-`env` `wasmPaths` moves into the helper (safe: the transformers pipeline is created after the helper call; `initVad` only uses `ortEnv`). The consolidation is purely behavior-preserving.
+
+**whisper special case:** `whisper-webgpu.worker.ts` has an additional `patchWhisperConfigs` (`:235-274`) that mutates `fileUrls` in place (revoke + recreate `config.json`/`generation_config.json` blobs) *before* the cache is built at `:454`. This is the only place any worker revokes blob URLs. It stays whisper-local; the shared cache helper needs no whisper awareness as long as the patch still runs first.
+
+`_shared/` already exists (`onnxruntime-all.ts`, `transformers-all.ts`) but only for **build-time bundle-chunk dedup** of the multi-MB runtimes — a different concern. Those files are **not modified** by this work (see Architecture).
+
+### Engine side
+
+Verbatim across all 4 engines — the `dispose()` core:
+
+```ts
+if (this.worker) {
+  this.worker.postMessage({ type: 'dispose' });
+  this.worker.terminate();
+  this.worker = null;
+}
+this.isReady = false;
+this.currentModel = null;   // or currentModelId
+```
+
+And the init handshake (`AsrEngine:118-170`, `TranslationEngine:139-193` are structurally identical): on `ready` → set ready + `manager.revokeBlobUrls(fileUrls)` + resolve; on `error` when not ready → `onError?` + revoke + reject; `onerror` → same. Two sub-families diverge: `AsrEngine`/`StreamingAsrEngine` are callback-based (`onResult`/`onPartialResult`/`onStatus`/`onSpeechStart`); `TranslationEngine`/`TtsEngine` are request/response via an id-keyed `pendingRequests` map with reject-all-on-dispose.
+
+**Supertonic constraint** (`TtsEngine.ts:96-99`): supertonic loads its blob URLs in a *single await* so the `Worker` is created within one microtask of `init()`. Any refactor must not insert awaits between `init()` and worker creation on that path.
+
+## Architecture
+
+Two PRs from one coordinated design. The message protocol is the coupling point between the two sides, so it is designed once (and deliberately left unchanged); execution is split for small, revertible reviews.
+
+### PR 1 — worker-side harness (lands first)
+
+Two new pure modules under the existing `src/lib/local-inference/workers/_shared/`:
+
+**`blob-url-cache.ts`** — `export function createBlobUrlCache(fileUrls: Record<string, string>)`. Imports nothing. Returns the `{ match, put }` object; `match` extracts the path after `/resolve/main/`, looks it up, and `fetch`es the blob URL; `put` is a no-op. The 10 copies (including the drifted ancestor and granite's brace variant) converge onto this one.
+
+**`transformers-env.ts`** — `export function initTransformersEnv(env, msg)`. Takes `env` as a **parameter** (the worker keeps importing `env` from `./_shared/transformers-all` and passes it in), so this helper is transformers-agnostic and does not touch the chunk-dedup shim. It absorbs *both* env blocks:
+
+```ts
+export function initTransformersEnv(env, msg: { fileUrls: Record<string,string>; ortWasmBaseUrl?: string }) {
+  if (env.backends?.onnx?.wasm) {
+    env.backends.onnx.wasm.proxy = false;
+    if (msg.ortWasmBaseUrl) env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;  // guarded — matches both families
+  }
+  env.allowRemoteModels = false;
+  env.allowLocalModels = true;
+  env.useBrowserCache = false;
+  env.useCustomCache = true;
+  env.customCache = createBlobUrlCache(msg.fileUrls);
+}
+```
+
+Rewiring: each of the 10 transformers workers deletes its module-top `proxy=false` block and its inline env block, and calls `initTransformersEnv(env, msg)` inside `handleInit` (whisper calls it *after* `patchWhisperConfigs`). Moving `proxy=false` from module-load into the init handler is safe: the worker does nothing between load and the `init` message.
+
+The 5 **translation** workers replace their whole `wasmPaths` + 5-line block with the single call. The 5 **ASR** workers additionally keep a minimal `if (msg.ortWasmBaseUrl && ortEnv?.wasm) { ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl; }` in its original spot (before `initVad`), since the helper only touches the transformers `env`, not `ortEnv`.
+
+**`transformers-all.ts` is not modified.** It solves build-time chunk-dedup (which transformers symbols exist); this work solves source-level dedup (runtime config policy). Keeping them separate preserves the shim's single responsibility. (Caveat: because each worker is its own Rollup build, the ~15-line helpers may be inlined per-worker in the shipped output — fine; the goal here is maintainability, and the bytes are negligible next to the runtime chunks the shims already dedup.)
+
+### PR 2 — engine-side WorkerSession
+
+Two new units under `src/lib/local-inference/engine/`, composed (not inherited) by the engines.
+
+**`WorkerSession.ts`** — lifecycle only, zero domain knowledge:
+
+```ts
+interface WorkerSessionOptions {
+  makeWorker: () => Worker;            // engine chooses URL + {type:'module'} vs classic
+  route: (msg: any) => void;           // every message except the init-handshake ones
+  revokeBlobs: () => void;             // called exactly once, on first settle
+  onFatalError?: (message: string) => void;  // Worker-level onerror after ready
+}
+
+class WorkerSession {
+  constructor(opts: WorkerSessionOptions);  // creates the Worker synchronously, wires onmessage/onerror
+  start(initPayload: object, transfer?: Transferable[]): Promise<any>;  // posts init; resolves on 'ready', rejects on pre-ready 'error'/onerror
+  post(msg: object, transfer?: Transferable[]): void;
+  dispose(): void;                     // postMessage({type:'dispose'}) + terminate() + null
+  get ready(): boolean;
+}
+```
+
+Message handling (preserves current behavior exactly):
+
+- `constructor` calls `makeWorker()` **synchronously** and wires `onmessage`/`onerror`. Creating the worker in the constructor (rather than inside an awaited step) is what honors the supertonic constraint: the engine finishes its blob-loading await, then `new WorkerSession(...)` creates the worker in the same microtask.
+- `start(payload)` stores the handshake resolve/reject, then posts `{type:'init', ...payload}`. Race-free because workers stay silent until they receive `init`.
+- internal `onmessage(msg)`:
+  - `msg.type === 'ready'` and not settled → mark settled, `revokeBlobs()` once, `resolve(msg)`.
+  - `msg.type === 'error'` and not settled → mark settled, `revokeBlobs()` once, `reject(new Error(msg.error))`. (Pre-ready, all errors are fatal-init; id-correlated errors only occur post-ready.)
+  - otherwise → `route(msg)` — this is where `status`/`speech_start`/`partial`/`result`/`disposed` and *post-ready* errors go; the engine decides id-correlation vs fatal.
+- internal `onerror(e)`: `onFatalError?.(message)`; if not settled → `revokeBlobs()` once, reject.
+
+**`RequestRegistry.ts`** — id-keyed correlation for the request/response engines:
+
+```ts
+class RequestRegistry<T> {
+  create(id: string): Promise<T>;     // stores {resolve, reject}
+  resolve(id: string, value: T): void;
+  reject(id: string, error: Error): void;
+  rejectAll(error: Error): void;      // dispose: reject + clear all pending
+}
+```
+
+Per-engine responsibilities after extraction (each keeps its own `workerType` switch, init-payload building, and domain `route`):
+
+| Engine | WorkerSession | RequestRegistry | Extra dispose cleanup wrapping `session.dispose()` |
+|---|---|---|---|
+| `AsrEngine` | ✅ | — (callbacks) | — |
+| `StreamingAsrEngine` | ✅ | — (callbacks) | — |
+| `TranslationEngine` | ✅ | ✅ | `setBingTranslatorDNR(false)` |
+| `TtsEngine` | ✅ (worker paths) | ✅ | `edgeTtsConnection.dispose()` (edge-TTS is a non-worker path it keeps separate) |
+
+The sherpa-onnx classic-ASR path (which fetches `package-metadata.json` to build its init payload) fits: the engine does `new WorkerSession(...)` (worker created), `await fetchMetadata()`, then `session.start(payload)`. The metadata await is *after* worker creation, so no path regresses.
+
+## Testing (characterization-first)
+
+Before touching the engines, pin current observable behavior through each engine's **public API** (mock `ModelManager`, patch `globalThis.Worker` with a `FakeWorker` test double, as the existing supertonic test does). These tests assert behavior, not internals, so they stay green across the extraction — the safety net.
+
+**PR 1 — direct unit tests on the pure helpers:**
+- `createBlobUrlCache`: `match` on an HF `/resolve/main/<file>` URL → `fetch(fileUrls[file])`; missing file → `undefined`; non-HF URL → `undefined`; `undefined` request → `undefined`; `put` is a no-op.
+- `initTransformersEnv`: sets the five `env` flags + `customCache`; sets `proxy=false` and `wasmPaths` only when `backends.onnx.wasm` exists; sets `wasmPaths` only when `msg.ortWasmBaseUrl` is present (the normalized guard); no throw when `backends` is absent.
+
+**PR 2 — characterization (public API) + unit tests on the new units:**
+- Characterization (all 4 engines): `init()` resolves with `loadTimeMs` on `ready` and `revokeBlobUrls` fires exactly once after ready; `init()` rejects on pre-ready `error` and on `onerror`, revoking; `dispose()` posts `{type:'dispose'}` and terminates and resets flags; `AsrEngine` audio/partial/result/status/speech_start callbacks fire; `TranslationEngine`/`TtsEngine` correlate results by id, reject the matching request on an id'd `error`, and reject all pending on dispose; `TtsEngine` supertonic path creates the worker synchronously (no await between `init()` and worker creation); `TranslationEngine` toggles bing DNR.
+- Unit (`WorkerSession`): handshake resolve/reject; revoke-once-on-first-settle; post-ready messages route; `onerror` pre- vs post-settle; `dispose` teardown — all with an injected `FakeWorker` (no `globalThis` patch needed, since `makeWorker` is the seam).
+- Unit (`RequestRegistry`): create/resolve/reject correlation; `rejectAll` on dispose; unknown-id resolve/reject is a no-op.
+
+## Global constraints
+
+- **WASM side only** — no reach into `nativeModelStore` / sidecar (peer-provider rule).
+- **No wire-protocol change** — message shapes and the ASR-vs-translation family drift are preserved.
+- **Supertonic single-await** — worker created synchronously (in `WorkerSession`'s constructor) right after the engine's blob await.
+- **whisper `patchWhisperConfigs`** runs before `initTransformersEnv` builds the cache.
+- **ASR workers keep their `ortEnv.wasm.wasmPaths`** before `initVad` — the helper handles the transformers `env` only. Both worker families already guard `wasmPaths` on `msg.ortWasmBaseUrl`; there is no drift to fix.
+- **`transformers-all.ts` / `onnxruntime-all.ts` unchanged** — build-time chunk-dedup shims are orthogonal to this source-dedup.
+
+## Rollout
+
+1. **PR 1** — `_shared/blob-url-cache.ts` + `_shared/transformers-env.ts` + their unit tests; rewire 10 workers. Fully behavior-preserving. Small, revertible.
+2. **PR 2** — engine characterization tests first (pin behavior), then `WorkerSession` + `RequestRegistry` + their unit tests; rewire the 4 engines to compose them.
+
+Each PR gates on `npm run test` green; PR 2 additionally on manual smoke of a live ASR→translation→TTS session (the tests cannot cover the real Worker/WASM runtime).

--- a/src/lib/local-inference/workers/_shared/blob-url-cache.test.ts
+++ b/src/lib/local-inference/workers/_shared/blob-url-cache.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { createBlobUrlCache } from './blob-url-cache';
+
+describe('createBlobUrlCache', () => {
+  const fileUrls = { 'config.json': 'blob:abc', 'onnx/model.onnx': 'blob:def' };
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => ({ ok: true }) as unknown as Response);
+    vi.stubGlobal('fetch', fetchMock);
+  });
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('resolves an HF /resolve/main/ URL to a fetch of the mapped blob URL', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await cache.match('https://huggingface.co/org/model/resolve/main/config.json');
+    expect(fetchMock).toHaveBeenCalledWith('blob:abc');
+  });
+
+  it('resolves nested paths after /resolve/main/', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await cache.match('https://huggingface.co/org/model/resolve/main/onnx/model.onnx');
+    expect(fetchMock).toHaveBeenCalledWith('blob:def');
+  });
+
+  it('returns undefined for a file not in the map (no fetch)', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    expect(await cache.match('https://huggingface.co/org/model/resolve/main/missing.bin')).toBeUndefined();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined for a non-HF URL (no /resolve/main/)', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    expect(await cache.match('https://example.com/config.json')).toBeUndefined();
+  });
+
+  it('returns undefined for an empty request', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    expect(await cache.match(undefined)).toBeUndefined();
+  });
+
+  it('reads .url from a Request-like object', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await cache.match({ url: 'https://huggingface.co/o/m/resolve/main/config.json' } as unknown as Request);
+    expect(fetchMock).toHaveBeenCalledWith('blob:abc');
+  });
+
+  it('put is a no-op that resolves to undefined', async () => {
+    const cache = createBlobUrlCache(fileUrls);
+    await expect(cache.put('x', {} as Response)).resolves.toBeUndefined();
+  });
+});

--- a/src/lib/local-inference/workers/_shared/blob-url-cache.ts
+++ b/src/lib/local-inference/workers/_shared/blob-url-cache.ts
@@ -1,0 +1,25 @@
+/**
+ * customCache bridge for Transformers.js: resolves the HuggingFace Hub
+ * ".../resolve/main/<path>" URLs it requests to the pre-downloaded IndexedDB
+ * blob URLs passed in `fileUrls`, so no network request leaves the worker.
+ * `put` is a no-op — the files already live in IndexedDB.
+ *
+ * This is the single behavioural definition of the bridge; the 10 transformers.js
+ * workers each used to carry a byte-identical copy.
+ */
+export function createBlobUrlCache(fileUrls: Record<string, string>) {
+  return {
+    async match(request: string | Request | undefined): Promise<Response | undefined> {
+      if (!request) return undefined;
+      const url = typeof request === 'string' ? request : request.url;
+      const marker = '/resolve/main/';
+      const idx = url.indexOf(marker);
+      if (idx === -1) return undefined;
+      const filename = url.slice(idx + marker.length);
+      const blobUrl = fileUrls[filename];
+      if (!blobUrl) return undefined;
+      return fetch(blobUrl);
+    },
+    async put(_request: string | Request, _response: Response): Promise<void> {},
+  };
+}

--- a/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+++ b/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
@@ -35,3 +35,21 @@ describe('worker harness consolidation', () => {
     expect(src, `${name} does not call initTransformersEnv`).toMatch(/initTransformersEnv\(/);
   });
 });
+
+// The shared harness (initTransformersEnv) does not manage ortEnv.wasm.wasmPaths
+// for the VAD InferenceSession — each ASR worker must keep setting it directly.
+// A future edit could drop this silently since the guard above wouldn't catch it.
+const ASR_WORKERS = [
+  'whisper-webgpu.worker.ts',
+  'cohere-transcribe-webgpu.worker.ts',
+  'voxtral-3b-webgpu.worker.ts',
+  'voxtral-webgpu.worker.ts',
+  'granite-speech-webgpu.worker.ts',
+];
+
+describe('ASR worker ortEnv wasmPaths', () => {
+  it.each(ASR_WORKERS)('%s still sets ortEnv.wasm.wasmPaths', (name) => {
+    const src = read(name);
+    expect(src, `${name} no longer assigns ortEnv.wasm.wasmPaths`).toMatch(/ortEnv\.wasm\.wasmPaths\s*=/);
+  });
+});

--- a/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+++ b/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+// Every transformers.js worker must route through the shared harness — no
+// re-inlined createBlobUrlCache, no hand-written env block. Guards against drift.
+const TRANSFORMERS_WORKERS = [
+  'translation.worker.ts',
+  'qwen-translation.worker.ts',
+  'qwen35-translation.worker.ts',
+  'hy-mt-translation.worker.ts',
+  'translategemma-translation.worker.ts',
+  'whisper-webgpu.worker.ts',
+  'cohere-transcribe-webgpu.worker.ts',
+  'voxtral-3b-webgpu.worker.ts',
+  'voxtral-webgpu.worker.ts',
+  'granite-speech-webgpu.worker.ts',
+];
+
+// Capture import.meta.url at module scope: reading it lazily from inside a
+// separately-declared function resolves to a truncated (root-relative) URL
+// under this Vite/Vitest version, so it must be captured here instead.
+const here = import.meta.url;
+
+function read(name: string): string {
+  return readFileSync(fileURLToPath(new URL(`../${name}`, here)), 'utf8');
+}
+
+describe('worker harness consolidation', () => {
+  it.each(TRANSFORMERS_WORKERS)('%s routes through the shared harness', (name) => {
+    const src = read(name);
+    expect(src, `${name} still defines a local createBlobUrlCache`).not.toMatch(/function\s+createBlobUrlCache/);
+    expect(src, `${name} still hand-sets env.customCache`).not.toMatch(/env\.customCache\s*=\s*createBlobUrlCache/);
+    expect(src, `${name} does not import initTransformersEnv`).toContain("from './_shared/transformers-env'");
+    expect(src, `${name} does not call initTransformersEnv`).toMatch(/initTransformersEnv\(/);
+  });
+});

--- a/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+++ b/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
@@ -31,7 +31,7 @@ describe('worker harness consolidation', () => {
     const src = read(name);
     expect(src, `${name} still defines a local createBlobUrlCache`).not.toMatch(/function\s+createBlobUrlCache/);
     expect(src, `${name} still hand-sets env.customCache`).not.toMatch(/env\.customCache\s*=\s*createBlobUrlCache/);
-    expect(src, `${name} does not import initTransformersEnv`).toContain("from './_shared/transformers-env'");
+    expect(src, `${name} does not import initTransformersEnv`).toMatch(/from\s+['"]\.\/_shared\/transformers-env['"]/);
     expect(src, `${name} does not call initTransformersEnv`).toMatch(/initTransformersEnv\(/);
   });
 });
@@ -51,5 +51,19 @@ describe('ASR worker ortEnv wasmPaths', () => {
   it.each(ASR_WORKERS)('%s still sets ortEnv.wasm.wasmPaths', (name) => {
     const src = read(name);
     expect(src, `${name} no longer assigns ortEnv.wasm.wasmPaths`).toMatch(/ortEnv\.wasm\.wasmPaths\s*=/);
+  });
+
+  // The assignment must run BEFORE the VAD InferenceSession is created — that
+  // ordering is the whole reason it's kept out of initTransformersEnv. Presence
+  // alone wouldn't catch a regression that moves it after the initVad() call.
+  // Anchor on the call site (`await initVad(`), not the top-level `async function
+  // initVad(` definition.
+  it.each(ASR_WORKERS)('%s sets ortEnv.wasm.wasmPaths before the initVad() call', (name) => {
+    const src = read(name);
+    const assignIdx = src.search(/ortEnv\.wasm\.wasmPaths\s*=/);
+    const vadCallIdx = src.indexOf('await initVad(');
+    expect(assignIdx, `${name}: ortEnv.wasm.wasmPaths assignment not found`).toBeGreaterThanOrEqual(0);
+    expect(vadCallIdx, `${name}: 'await initVad(' call anchor not found`).toBeGreaterThanOrEqual(0);
+    expect(assignIdx, `${name}: ortEnv.wasm.wasmPaths must be set before the initVad() call`).toBeLessThan(vadCallIdx);
   });
 });

--- a/src/lib/local-inference/workers/_shared/transformers-env.test.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-env.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { initTransformersEnv } from './transformers-env';
+
+function fakeEnv(withWasm = true) {
+  return {
+    backends: withWasm ? { onnx: { wasm: {} as Record<string, unknown> } } : {},
+    allowRemoteModels: undefined as unknown,
+    allowLocalModels: undefined as unknown,
+    useBrowserCache: undefined as unknown,
+    useCustomCache: undefined as unknown,
+    customCache: undefined as unknown,
+  };
+}
+
+describe('initTransformersEnv', () => {
+  beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('sets the four transformers.js flags and a customCache bridge', () => {
+    const env = fakeEnv();
+    initTransformersEnv(env, { fileUrls: { 'config.json': 'blob:x' } });
+    expect(env.allowRemoteModels).toBe(false);
+    expect(env.allowLocalModels).toBe(true);
+    expect(env.useBrowserCache).toBe(false);
+    expect(env.useCustomCache).toBe(true);
+    expect(typeof (env.customCache as { match?: unknown }).match).toBe('function');
+  });
+
+  it('disables the wasm proxy when the backend exists', () => {
+    const env = fakeEnv();
+    initTransformersEnv(env, { fileUrls: {} });
+    expect((env.backends as { onnx: { wasm: { proxy?: boolean } } }).onnx.wasm.proxy).toBe(false);
+  });
+
+  it('sets wasmPaths only when ortWasmBaseUrl is provided', () => {
+    const a = fakeEnv();
+    initTransformersEnv(a, { fileUrls: {}, ortWasmBaseUrl: 'https://host/wasm/ort/' });
+    expect((a.backends as { onnx: { wasm: { wasmPaths?: string } } }).onnx.wasm.wasmPaths).toBe('https://host/wasm/ort/');
+
+    const b = fakeEnv();
+    initTransformersEnv(b, { fileUrls: {} });
+    expect((b.backends as { onnx: { wasm: { wasmPaths?: string } } }).onnx.wasm.wasmPaths).toBeUndefined();
+  });
+
+  it('does not throw when the wasm backend is absent, still sets flags', () => {
+    const env = fakeEnv(false);
+    expect(() => initTransformersEnv(env, { fileUrls: {}, ortWasmBaseUrl: 'x' })).not.toThrow();
+    expect(env.useCustomCache).toBe(true);
+  });
+});

--- a/src/lib/local-inference/workers/_shared/transformers-env.test.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-env.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { initTransformersEnv } from './transformers-env';
 
 function fakeEnv(withWasm = true) {
@@ -13,9 +13,6 @@ function fakeEnv(withWasm = true) {
 }
 
 describe('initTransformersEnv', () => {
-  beforeEach(() => vi.stubGlobal('fetch', vi.fn()));
-  afterEach(() => vi.unstubAllGlobals());
-
   it('sets the four transformers.js flags and a customCache bridge', () => {
     const env = fakeEnv();
     initTransformersEnv(env, { fileUrls: { 'config.json': 'blob:x' } });

--- a/src/lib/local-inference/workers/_shared/transformers-env.test.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-env.test.ts
@@ -4,10 +4,10 @@ import { initTransformersEnv } from './transformers-env';
 function fakeEnv(withWasm = true) {
   return {
     backends: withWasm ? { onnx: { wasm: {} as Record<string, unknown> } } : {},
-    allowRemoteModels: undefined as unknown,
-    allowLocalModels: undefined as unknown,
-    useBrowserCache: undefined as unknown,
-    useCustomCache: undefined as unknown,
+    allowRemoteModels: undefined as boolean | undefined,
+    allowLocalModels: undefined as boolean | undefined,
+    useBrowserCache: undefined as boolean | undefined,
+    useCustomCache: undefined as boolean | undefined,
     customCache: undefined as unknown,
   };
 }

--- a/src/lib/local-inference/workers/_shared/transformers-env.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-env.ts
@@ -19,10 +19,11 @@ export interface TransformersEnvInit {
 
 export interface TransformersEnvLike {
   backends?: { onnx?: { wasm?: { proxy?: boolean; wasmPaths?: string } } };
-  allowRemoteModels?: unknown;
-  allowLocalModels?: unknown;
-  useBrowserCache?: unknown;
-  useCustomCache?: unknown;
+  allowRemoteModels?: boolean;
+  allowLocalModels?: boolean;
+  useBrowserCache?: boolean;
+  useCustomCache?: boolean;
+  // The blob-URL cache object; left untyped to avoid coupling to transformers.js.
   customCache?: unknown;
 }
 

--- a/src/lib/local-inference/workers/_shared/transformers-env.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-env.ts
@@ -1,0 +1,39 @@
+import { createBlobUrlCache } from './blob-url-cache';
+
+/**
+ * Configure the Transformers.js `env` for offline, IndexedDB-backed inference:
+ * disable the WASM proxy and remote/browser caching, point ONNX at the
+ * app-served WASM binaries, and install the blob-URL customCache bridge.
+ *
+ * `env` is passed in (not imported) so this helper stays decoupled from the
+ * `transformers-all` chunk-dedup shim. It configures the transformers `env`
+ * ONLY — ASR workers set their separate onnxruntime-web `ortEnv.wasm.wasmPaths`
+ * themselves, before their VAD InferenceSession is created.
+ *
+ * Folds in the module-top `proxy=false` that every worker also duplicated.
+ */
+export interface TransformersEnvInit {
+  fileUrls: Record<string, string>;
+  ortWasmBaseUrl?: string;
+}
+
+export interface TransformersEnvLike {
+  backends?: { onnx?: { wasm?: { proxy?: boolean; wasmPaths?: string } } };
+  allowRemoteModels?: unknown;
+  allowLocalModels?: unknown;
+  useBrowserCache?: unknown;
+  useCustomCache?: unknown;
+  customCache?: unknown;
+}
+
+export function initTransformersEnv(env: TransformersEnvLike, msg: TransformersEnvInit): void {
+  if (env.backends?.onnx?.wasm) {
+    env.backends.onnx.wasm.proxy = false;
+    if (msg.ortWasmBaseUrl) env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
+  }
+  env.allowRemoteModels = false;
+  env.allowLocalModels = true;
+  env.useBrowserCache = false;
+  env.useCustomCache = true;
+  env.customCache = createBlobUrlCache(msg.fileUrls);
+}

--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -20,6 +20,7 @@ import {
   type ProgressInfo,
 } from './_shared/transformers-all';
 import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
+import { initTransformersEnv } from './_shared/transformers-env';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 
@@ -31,10 +32,6 @@ import type {
 } from '../types';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
-
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // Workaround: HF CDN Range request cache pollution
 const _origFetch = env.fetch;
@@ -150,28 +147,6 @@ let transcriber: AutomaticSpeechRecognitionPipeline | null = null;
 let currentLanguage: string | undefined;
 let processingVad = false;
 let currentTranscriptionPromise: Promise<void> | null = null;
-
-/**
- * Create customCache bridge for IndexedDB blob URLs → Transformers.js.
- * Maps HF Hub resolve URLs to local blob URLs from IndexedDB.
- */
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-      const marker = '/resolve/main/';
-      const idx = url.indexOf(marker);
-      if (idx === -1) return undefined;
-      const filename = url.slice(idx + marker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {
-    },
-  };
-}
 
 // ─── Speech Segment Processing ──────────────────────────────────────────────
 
@@ -304,14 +279,10 @@ async function handleInit(msg: CohereTranscribeAsrInitMessage): Promise<void> {
 
     const startTime = performance.now();
 
-    // Set ORT WASM paths
-    if (msg.ortWasmBaseUrl) {
-      if (env.backends?.onnx?.wasm) {
-        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
-      if (ortEnv?.wasm) {
-        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
+    // ortEnv wasmPaths must be set before initVad's InferenceSession; the
+    // transformers env is configured later via initTransformersEnv.
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
     }
 
     // 1. Init VAD
@@ -319,11 +290,7 @@ async function handleInit(msg: CohereTranscribeAsrInitMessage): Promise<void> {
     await initVad(msg.vadConfig, msg.vadModelUrl);
 
     // 2. Configure Transformers.js for IndexedDB blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     // 3. Load Cohere Transcribe pipeline
     post({ type: 'status', message: 'Loading Cohere Transcribe model (WebGPU)...' });

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -19,6 +19,7 @@ import {
   env,
 } from './_shared/transformers-all';
 import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
+import { initTransformersEnv } from './_shared/transformers-env';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 
@@ -30,10 +31,6 @@ import type {
 } from '../types';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
-
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // HF CDN Range request cache workaround (same as whisper worker)
 const _origFetch = env.fetch;
@@ -176,23 +173,6 @@ let currentTask: 'transcribe' | 'translate' = 'transcribe';
 let currentTargetLanguage: string | undefined;
 let processingVad = false;
 
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-      const marker = '/resolve/main/';
-      const idx = url.indexOf(marker);
-      if (idx === -1) return undefined;
-      const filename = url.slice(idx + marker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {},
-  };
-}
-
 function buildPrompt(): string {
   if (currentTask === 'translate' && currentTargetLanguage) {
     const langName = LANGUAGE_NAMES[currentTargetLanguage] || currentTargetLanguage;
@@ -331,14 +311,10 @@ async function handleInit(msg: GraniteSpeechInitMessage): Promise<void> {
   try {
     const startTime = performance.now();
 
-    // Set ORT WASM paths
-    if (msg.ortWasmBaseUrl) {
-      if (env.backends?.onnx?.wasm) {
-        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
-      if (ortEnv?.wasm) {
-        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
+    // ortEnv wasmPaths must be set before initVad's InferenceSession; the
+    // transformers env is configured later via initTransformersEnv.
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
     }
 
     const webgpuAvailable = await hasWebGPU();
@@ -351,11 +327,7 @@ async function handleInit(msg: GraniteSpeechInitMessage): Promise<void> {
     await initVad(msg.vadConfig, msg.vadModelUrl);
 
     // Configure Transformers.js for IndexedDB blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     // Load processor and model
     post({ type: 'status', message: 'Loading Granite Speech model (WebGPU)...' });

--- a/src/lib/local-inference/workers/hy-mt-translation.worker.ts
+++ b/src/lib/local-inference/workers/hy-mt-translation.worker.ts
@@ -13,12 +13,7 @@
  */
 
 import { pipeline, env } from './_shared/transformers-all';
-
-// Disable WASM proxy (we're already in a worker).
-// wasmPaths is set in the init handler from the main thread's resolved URL.
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
+import { initTransformersEnv } from './_shared/transformers-env';
 
 // ─── BCP-47 → English language names for the prompt template ────────────────
 // Mirrors manifest.languages one-for-one (36 entries).
@@ -65,38 +60,12 @@ type WorkerMessage = InitMessage | TranslateMessage | DisposeMessage;
 
 let generator: any = null;
 
-// ─── Blob URL cache (same pattern as qwen-translation.worker.ts) ───────────
-
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-
-      const resolveMainMarker = '/resolve/main/';
-      const idx = url.indexOf(resolveMainMarker);
-      if (idx === -1) return undefined;
-
-      const filename = url.slice(idx + resolveMainMarker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {},
-  };
-}
-
 // ─── Init handler ──────────────────────────────────────────────────────────
 
 async function handleInit(msg: InitMessage) {
   try {
     const startTime = performance.now();
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId });
-
-    if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {
-      env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-    }
 
     const gpu = (self as any).navigator?.gpu;
     if (!gpu) {
@@ -109,11 +78,7 @@ async function handleInit(msg: InitMessage) {
       return;
     }
 
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 

--- a/src/lib/local-inference/workers/qwen-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen-translation.worker.ts
@@ -7,13 +7,8 @@
  */
 
 import { pipeline, env } from './_shared/transformers-all';
+import { initTransformersEnv } from './_shared/transformers-env';
 import { buildDefaultLocalPrompt } from '../prompts';
-
-// Disable WASM proxy (we're already in a worker).
-// wasmPaths is set in the init handler from the main thread's resolved URL.
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -46,39 +41,12 @@ type WorkerMessage = InitMessage | TranslateMessage | DisposeMessage;
 let generator: any = null;
 let currentModelId: string = '';
 
-// ─── Blob URL cache (same pattern as translation.worker.ts) ────────────────
-
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-
-      const resolveMainMarker = '/resolve/main/';
-      const idx = url.indexOf(resolveMainMarker);
-      if (idx === -1) return undefined;
-
-      const filename = url.slice(idx + resolveMainMarker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {},
-  };
-}
-
 // ─── Init handler ──────────────────────────────────────────────────────────
 
 async function handleInit(msg: InitMessage) {
   try {
     const startTime = performance.now();
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId });
-
-    // Set ORT WASM paths from main thread's resolved URL
-    if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {
-      env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-    }
 
     // WebGPU check
     const gpu = (self as any).navigator?.gpu;
@@ -93,11 +61,7 @@ async function handleInit(msg: InitMessage) {
     }
 
     // Configure Transformers.js to use blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 

--- a/src/lib/local-inference/workers/qwen35-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen35-translation.worker.ts
@@ -12,13 +12,8 @@ import {
   TextStreamer,
   env,
 } from './_shared/transformers-all';
+import { initTransformersEnv } from './_shared/transformers-env';
 import { buildDefaultLocalPrompt } from '../prompts';
-
-// Disable WASM proxy (we're already in a worker).
-// wasmPaths is set in the init handler from the main thread's resolved URL.
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -51,39 +46,12 @@ type WorkerMessage = InitMessage | TranslateMessage | DisposeMessage;
 let model: any = null;
 let processor: any = null;
 
-// ─── Blob URL cache (same pattern as other workers) ──────────────────────
-
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-
-      const resolveMainMarker = '/resolve/main/';
-      const idx = url.indexOf(resolveMainMarker);
-      if (idx === -1) return undefined;
-
-      const filename = url.slice(idx + resolveMainMarker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {},
-  };
-}
-
 // ─── Init handler ──────────────────────────────────────────────────────────
 
 async function handleInit(msg: InitMessage) {
   try {
     const startTime = performance.now();
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId });
-
-    // Set ORT WASM paths from main thread's resolved URL
-    if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {
-      env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-    }
 
     // WebGPU check
     const gpu = (self as any).navigator?.gpu;
@@ -98,11 +66,7 @@ async function handleInit(msg: InitMessage) {
     }
 
     // Configure Transformers.js to use blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 

--- a/src/lib/local-inference/workers/translategemma-translation.worker.ts
+++ b/src/lib/local-inference/workers/translategemma-translation.worker.ts
@@ -11,12 +11,7 @@
  */
 
 import { pipeline, env } from './_shared/transformers-all';
-
-// Disable WASM proxy (we're already in a worker).
-// wasmPaths is set in the init handler from the main thread's resolved URL.
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
+import { initTransformersEnv } from './_shared/transformers-env';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -46,39 +41,12 @@ type WorkerMessage = InitMessage | TranslateMessage | DisposeMessage;
 
 let generator: any = null;
 
-// ─── Blob URL cache (same pattern as qwen-translation.worker.ts) ──────────
-
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-
-      const resolveMainMarker = '/resolve/main/';
-      const idx = url.indexOf(resolveMainMarker);
-      if (idx === -1) return undefined;
-
-      const filename = url.slice(idx + resolveMainMarker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {},
-  };
-}
-
 // ─── Init handler ──────────────────────────────────────────────────────────
 
 async function handleInit(msg: InitMessage) {
   try {
     const startTime = performance.now();
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId });
-
-    // Set ORT WASM paths from main thread's resolved URL
-    if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {
-      env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-    }
 
     // WebGPU check
     const gpu = (self as any).navigator?.gpu;
@@ -93,11 +61,7 @@ async function handleInit(msg: InitMessage) {
     }
 
     // Configure Transformers.js to use blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 

--- a/src/lib/local-inference/workers/translation.worker.ts
+++ b/src/lib/local-inference/workers/translation.worker.ts
@@ -8,12 +8,7 @@
  */
 
 import { pipeline, env, type TranslationPipeline } from './_shared/transformers-all';
-
-// Disable WASM proxy (we're already in a worker).
-// wasmPaths is set in the init handler from the main thread's resolved URL.
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
+import { initTransformersEnv } from './_shared/transformers-env';
 
 /** Detect WebGPU availability in this worker context */
 async function hasWebGPU(): Promise<boolean> {
@@ -54,59 +49,13 @@ let translator: TranslationPipeline | null = null;
 let currentModelId: string | null = null;
 void currentModelId; // Used for tracking, suppress unused warning
 
-/**
- * Create a custom cache object that serves pre-downloaded blob URLs
- * to Transformers.js, avoiding any HuggingFace Hub network requests.
- *
- * Transformers.js requests files via URLs like:
- *   https://huggingface.co/Xenova/opus-mt-ja-en/resolve/main/config.json
- *   https://huggingface.co/Xenova/opus-mt-ja-en/resolve/main/onnx/encoder_model_quantized.onnx
- *
- * We extract the path after /resolve/main/ and look it up in our fileUrls map.
- */
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-
-      const url = typeof request === 'string' ? request : request.url;
-
-      // Extract filename from HuggingFace URL pattern:
-      // https://huggingface.co/{org}/{model}/resolve/main/{path}
-      const resolveMainMarker = '/resolve/main/';
-      const idx = url.indexOf(resolveMainMarker);
-      if (idx === -1) return undefined;
-
-      const filename = url.slice(idx + resolveMainMarker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-
-      // Fetch the blob URL to get a proper Response object
-      const response = await fetch(blobUrl);
-      return response;
-    },
-
-    // No-op: files are already stored in IndexedDB
-    async put(_request: string | Request, _response: Response): Promise<void> {},
-  };
-}
-
 async function handleInit(msg: InitMessage) {
   try {
     const startTime = performance.now();
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId });
 
-    // Set ORT WASM paths from main thread's resolved URL (handles relative base paths)
-    if (msg.ortWasmBaseUrl && env.backends?.onnx?.wasm) {
-      env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-    }
-
     // Configure Transformers.js to use our blob URL cache instead of network
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     // Suppress known "MarianTokenizer is not yet supported by fast tokenizers" warning
     // from @huggingface/transformers — all Opus-MT models trigger this; it's informational only

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -25,6 +25,7 @@ import {
   type ProgressInfo,
 } from './_shared/transformers-all';
 import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
+import { initTransformersEnv } from './_shared/transformers-env';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 
@@ -36,10 +37,6 @@ import type {
 } from '../types';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
-
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // Workaround: HF CDN Range request cache pollution (same as Voxtral 4B / Cohere workers)
 const _origFetch = env.fetch;
@@ -164,29 +161,6 @@ function normalizeToIso639_1(lang: string | undefined): string {
   if (!lang) return '';
   // Strip region suffix: 'en-US' → 'en', 'zh_Hans' → 'zh'
   return lang.trim().toLowerCase().split(/[-_]/)[0];
-}
-
-/**
- * Create customCache bridge for IndexedDB blob URLs → Transformers.js.
- * Maps HF Hub resolve URLs to local blob URLs from IndexedDB.
- * Same pattern as whisper-webgpu, voxtral-webgpu, and cohere-transcribe-webgpu workers.
- */
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-      const marker = '/resolve/main/';
-      const idx = url.indexOf(marker);
-      if (idx === -1) return undefined;
-      const filename = url.slice(idx + marker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {
-    },
-  };
 }
 
 // ─── Batch Speech Segment Processing ────────────────────────────────────────
@@ -357,14 +331,10 @@ async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
   try {
     const startTime = performance.now();
 
-    // Set ORT WASM paths
-    if (msg.ortWasmBaseUrl) {
-      if (env.backends?.onnx?.wasm) {
-        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
-      if (ortEnv?.wasm) {
-        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
+    // ortEnv wasmPaths must be set before initVad's InferenceSession; the
+    // transformers env is configured later via initTransformersEnv.
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
     }
 
     // 1. Init VAD
@@ -372,11 +342,7 @@ async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
     await initVad(msg.vadConfig, msg.vadModelUrl);
 
     // 2. Configure Transformers.js for IndexedDB blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     // 3. Load processor
     post({ type: 'status', message: 'Loading Voxtral 3B processor...' });

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -21,6 +21,7 @@ import {
   type ProgressInfo,
 } from './_shared/transformers-all';
 import { InferenceSession, Tensor, env as ortEnv } from './_shared/onnxruntime-all';
+import { initTransformersEnv } from './_shared/transformers-env';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 
@@ -32,10 +33,6 @@ import type {
 } from '../types';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
-
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // Workaround: HF CDN Range request cache pollution
 const _origFetch = env.fetch;
@@ -405,41 +402,14 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
 
 // ─── Init Handler ───────────────────────────────────────────────────────────
 
-/**
- * Create customCache bridge for IndexedDB blob URLs → Transformers.js.
- * Maps HF Hub resolve URLs to local blob URLs from IndexedDB.
- * Same pattern as whisper-webgpu.worker.ts and translation.worker.ts.
- */
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-      const marker = '/resolve/main/';
-      const idx = url.indexOf(marker);
-      if (idx === -1) return undefined;
-      const filename = url.slice(idx + marker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {
-    },
-  };
-}
-
 async function handleInit(msg: VoxtralAsrInitMessage): Promise<void> {
   try {
     const startTime = performance.now();
 
-    // Set ORT WASM paths
-    if (msg.ortWasmBaseUrl) {
-      if (env.backends?.onnx?.wasm) {
-        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
-      if (ortEnv?.wasm) {
-        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
+    // ortEnv wasmPaths must be set before initVad's InferenceSession; the
+    // transformers env is configured later via initTransformersEnv.
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
     }
 
     // 1. Init VAD
@@ -447,11 +417,7 @@ async function handleInit(msg: VoxtralAsrInitMessage): Promise<void> {
     await initVad(msg.vadConfig, msg.vadModelUrl);
 
     // 2. Configure Transformers.js for IndexedDB blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     // 3. Load Voxtral model
     post({ type: 'status', message: 'Loading Voxtral model (WebGPU)...' });

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -31,9 +31,6 @@ import type {
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
-// Disable WASM proxy (we're already in a worker).
-// wasmPaths is set in the init handler from the main thread's resolved URL.
-
 // Workaround: HF CDN redirects /resolve/main/ → /api/resolve-cache/...
 // Range: bytes=0-0 metadata requests get cached as 206 partial responses,
 // then pollute subsequent full downloads. Fix: no-store for Range requests.

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -18,6 +18,7 @@ import {
   type AutomaticSpeechRecognitionPipeline,
 } from './_shared/transformers-all';
 import {InferenceSession, Tensor, env as ortEnv} from './_shared/onnxruntime-all';
+import {initTransformersEnv} from './_shared/transformers-env';
 import {FrameProcessor, Message} from '@ricky0123/vad-web';
 import type {FrameProcessorEvent} from '@ricky0123/vad-web/dist/frame-processor';
 
@@ -32,9 +33,6 @@ import type {
 
 // Disable WASM proxy (we're already in a worker).
 // wasmPaths is set in the init handler from the main thread's resolved URL.
-if (env.backends?.onnx?.wasm) {
-  env.backends.onnx.wasm.proxy = false;
-}
 
 // Workaround: HF CDN redirects /resolve/main/ → /api/resolve-cache/...
 // Range: bytes=0-0 metadata requests get cached as 206 partial responses,
@@ -202,28 +200,6 @@ function resampleInt16ToFloat32_16k(samples: Int16Array, inputRate: number): Flo
 let transcriber: AutomaticSpeechRecognitionPipeline | null = null;
 let currentLanguage: string | undefined;
 let processingVad = false;
-
-/**
- * Create customCache bridge for IndexedDB blob URLs → Transformers.js.
- * Same pattern as translation.worker.ts.
- */
-function createBlobUrlCache(fileUrls: Record<string, string>) {
-  return {
-    async match(request: string | Request | undefined): Promise<Response | undefined> {
-      if (!request) return undefined;
-      const url = typeof request === 'string' ? request : request.url;
-      const marker = '/resolve/main/';
-      const idx = url.indexOf(marker);
-      if (idx === -1) return undefined;
-      const filename = url.slice(idx + marker.length);
-      const blobUrl = fileUrls[filename];
-      if (!blobUrl) return undefined;
-      return fetch(blobUrl);
-    },
-    async put(_request: string | Request, _response: Response): Promise<void> {
-    },
-  };
-}
 
 /**
  * Patch config.json and generation_config.json blobs for non-standard Whisper
@@ -416,16 +392,10 @@ async function handleInit(msg: WhisperAsrInitMessage): Promise<void> {
   try {
     const startTime = performance.now();
 
-    // Set ORT WASM paths from main thread's resolved URL.
-    // Must set on BOTH env objects: transformers.js env (onnxruntime-web/webgpu)
-    // and plain onnxruntime-web env (used by VAD InferenceSession).
-    if (msg.ortWasmBaseUrl) {
-      if (env.backends?.onnx?.wasm) {
-        env.backends.onnx.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
-      if (ortEnv?.wasm) {
-        ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
-      }
+    // ortEnv wasmPaths must be set before the VAD/whisper InferenceSession; the
+    // transformers env is configured later (after patchWhisperConfigs).
+    if (msg.ortWasmBaseUrl && ortEnv?.wasm) {
+      ortEnv.wasm.wasmPaths = msg.ortWasmBaseUrl;
     }
 
     // 1. Check WebGPU
@@ -447,11 +417,7 @@ async function handleInit(msg: WhisperAsrInitMessage): Promise<void> {
     await patchWhisperConfigs(msg.fileUrls, msg.language);
 
     // 4. Configure Transformers.js for IndexedDB blob URL cache
-    env.allowRemoteModels = false;
-    env.allowLocalModels = true;
-    env.useBrowserCache = false;
-    env.useCustomCache = true;
-    env.customCache = createBlobUrlCache(msg.fileUrls);
+    initTransformersEnv(env, msg);
 
     // 5. Create ASR pipeline
     post({type: 'status', message: `Loading Whisper model on ${device}...`});


### PR DESCRIPTION
## Candidate 6 (worker-side) of the architecture-review series — PR 1 of 2

Extracts the two blocks of transformers.js worker boilerplate that were copy-pasted across the 10 WASM local-inference workers into shared, unit-tested helpers, and rewires every worker through them. **Behavior-preserving; WASM side only** — the Local Native (Python sidecar) provider is a peer and is deliberately untouched.

This is PR 1 of the design in `docs/superpowers/specs/2026-07-13-wasm-worker-session-design.md`. PR 2 (the engine-side `WorkerSession` + `RequestRegistry`) follows separately.

### What changed
- **`_shared/blob-url-cache.ts`** — `createBlobUrlCache(fileUrls)`, the HF-`/resolve/main/` → IndexedDB blob-URL bridge that was byte-identical in all 10 workers.
- **`_shared/transformers-env.ts`** — `initTransformersEnv(env, msg)` folds in the transformers `env` setup each worker duplicated: `proxy=false` (guarded), `wasmPaths` (guarded by `ortWasmBaseUrl`), the four `env` flags, and `env.customCache = createBlobUrlCache(...)`. `env` is passed in (never imported), so the helper stays decoupled from the `transformers-all.ts` chunk-dedup shim.
- **10 workers rewired** to import only `initTransformersEnv` and delete their local copies:
  - 5 translation workers (transformers `env` only).
  - 5 ASR/WebGPU workers keep their separate `ortEnv.wasm.wasmPaths` (the VAD `InferenceSession`'s ORT path) in place **before `initVad`**; whisper keeps `initTransformersEnv` **after `patchWhisperConfigs`**.
- **`harness-consolidation.test.ts`** — a source-scan guard: every transformers worker must route through `initTransformersEnv` (no re-inlined `createBlobUrlCache`), and the 5 ASR workers must retain their `ortEnv.wasm.wasmPaths` assignment.

### Not in scope (deliberately)
- No wire-protocol change — message shapes and the ASR-vs-translation family drift are preserved.
- `transformers-all.ts` / `onnxruntime-all.ts` shims unchanged (build-time chunk dedup, orthogonal concern).
- The 3 non-transformers workers (bing / supertonic / zoom-vad) don't use this harness and are untouched.

### Verification
- Full suite green (1018 tests; +helper unit tests + the guard test).
- `npm run build` passes — all 10 worker chunks bundle.
- Two timing shifts were traced and are inconsequential: `proxy=false` deferral (nothing touches the transformers pipeline before `initTransformersEnv`) and the ASR `wasmPaths` split (`env.backends.onnx.wasm` and `ortEnv` are distinct objects; `initVad` only uses `ortEnv`).

Built task-by-task via subagent-driven development with a per-task spec+quality gate and a final whole-branch review (verdict: ready to merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared offline model-loading and caching support across local inference workers.
  * Improved consistency of WebAssembly environment setup for translation and speech workloads.
* **Bug Fixes**
  * Prevented stale partial downloads during ranged fetches in Whisper.
  * Preserved correct runtime initialization order for speech recognition (including WASM wasm path handling).
* **Tests**
  * Added unit and integration coverage for caching behavior and worker “harness” consolidation safeguards.
* **Documentation**
  * Added design and implementation plan documents for the worker consolidation approach.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->