### PR TITLE
refactor(local-inference): engine-side WorkerSession + RequestRegistry (candidate 5, PR 2)

### DIFF
--- a/docs/superpowers/plans/2026-07-13-wasm-worker-session-pr2.md
+++ b/docs/superpowers/plans/2026-07-13-wasm-worker-session-pr2.md
@@ -1,0 +1,1202 @@
+# WASM Engine WorkerSession (PR 2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the Worker lifecycle copied verbatim across the 4 WASM local-inference engines into a composed `WorkerSession`, and the id-keyed request correlation into a `RequestRegistry`, so all 4 engines share one tested seam instead of four hand-rolled copies — behavior-preserving, guarded by characterization tests written first.
+
+**Architecture:** Two new units under `src/lib/local-inference/engine/`: `WorkerSession` (lifecycle only — synchronous worker creation, init handshake, revoke-blobs-once-on-first-settle, `onerror`, `dispose` core, `post`) and `RequestRegistry<T>` (id→{resolve,reject} map + reject-all). Each engine *composes* them (no inheritance), keeping its own `workerType` switch, init-payload building, and domain message routing. `TranslationEngine` uses `RequestRegistry`; `TtsEngine` keeps its bespoke single-slot pending + edge-TTS. Every engine is put under characterization tests (public-API, `MockWorker`-injected) that pass on the current code, then stay green across the extraction.
+
+**Tech Stack:** TypeScript, Vitest (jsdom), Web Workers, `ModelManager` (blob-URL provider).
+
+## Global Constraints
+
+- **WASM side only.** Touch only `src/lib/local-inference/engine/*` and its tests. Do NOT touch `nativeModelStore`, the Python sidecar, the workers, or `_shared/`.
+- **Behavior-preserving.** Public-API behavior of every engine (`init`/`feedAudio`/`flush`/`translate`/`generate`/`generateStream`/`dispose` + callbacks/promises) is unchanged. The characterization tests are the contract.
+- **No wire-protocol change.** Message shapes posted to / received from workers are unchanged. `WorkerSession` posts the init message verbatim and forwards non-handshake messages untouched.
+- **Supertonic single-await.** `TtsEngine` must still create the `Worker` within one microtask of finishing its blob-load await. `WorkerSession` creates the worker **synchronously in its constructor**, so the engine does `await <blobs>` then `new WorkerSession(...)` with no await between.
+- **`StreamingAsrEngine` reorder is allowed & must be documented.** It currently creates the worker *before* loading blobs; it is reordered to load-blobs-first (like the other 3) so it can construct `WorkerSession` synchronously. Safe: the worker is idle until `init`.
+- **Revoke-once semantics.** Blob URLs are revoked exactly once, on the first settle (`ready`, or a pre-ready `error`/`onerror`). Post-ready errors do not re-revoke. `WorkerSession` centralizes this via a `revokeBlobs` thunk the engine supplies (edge-TTS supplies a no-op — nothing to revoke).
+- English-only comments. Conventional commits. Commit after every task.
+- Tests must pass on the **current** engine code first (characterization), then again after the refactor. Run the focused engine test during iteration; run `npm run test -- --run` before each commit.
+
+The 4 engines and their shape:
+
+| Engine | Request model | Blob-load order | Extra dispose cleanup |
+|---|---|---|---|
+| `AsrEngine` | callbacks | blobs before worker | — |
+| `StreamingAsrEngine` | callbacks | worker before blobs (→ reorder) | — |
+| `TranslationEngine` | id-keyed `Map` → `RequestRegistry` | blobs before worker | `setBingTranslatorDNR(false)` |
+| `TtsEngine` | single-slot `pendingGenerate`/`pendingStream` + edge-TTS | blobs before worker | `edgeTtsConnection.dispose()` |
+
+---
+
+### Task 1: `RequestRegistry<T>` + unit tests
+
+**Files:**
+- Create: `src/lib/local-inference/engine/RequestRegistry.ts`
+- Test: `src/lib/local-inference/engine/RequestRegistry.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `class RequestRegistry<T> { create(id: string): Promise<T>; resolve(id: string, value: T): void; reject(id: string, error: Error): void; rejectAll(error: Error): void; readonly size: number }`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/local-inference/engine/RequestRegistry.test.ts`:
+
+```ts
+import { describe, it, expect } from 'vitest';
+import { RequestRegistry } from './RequestRegistry';
+
+describe('RequestRegistry', () => {
+  it('resolves the pending promise for a matching id', async () => {
+    const r = new RequestRegistry<string>();
+    const p = r.create('a');
+    r.resolve('a', 'done');
+    await expect(p).resolves.toBe('done');
+    expect(r.size).toBe(0); // settled entries are removed
+  });
+
+  it('rejects the pending promise for a matching id', async () => {
+    const r = new RequestRegistry<string>();
+    const p = r.create('a');
+    r.reject('a', new Error('boom'));
+    await expect(p).rejects.toThrow('boom');
+    expect(r.size).toBe(0);
+  });
+
+  it('resolve/reject for an unknown id is a no-op', () => {
+    const r = new RequestRegistry<string>();
+    expect(() => r.resolve('missing', 'x')).not.toThrow();
+    expect(() => r.reject('missing', new Error('x'))).not.toThrow();
+    expect(r.size).toBe(0);
+  });
+
+  it('tracks multiple concurrent pending requests independently', async () => {
+    const r = new RequestRegistry<number>();
+    const a = r.create('a');
+    const b = r.create('b');
+    expect(r.size).toBe(2);
+    r.resolve('b', 2);
+    r.resolve('a', 1);
+    await expect(a).resolves.toBe(1);
+    await expect(b).resolves.toBe(2);
+    expect(r.size).toBe(0);
+  });
+
+  it('rejectAll rejects every pending request and clears the map', async () => {
+    const r = new RequestRegistry<number>();
+    const a = r.create('a');
+    const b = r.create('b');
+    r.rejectAll(new Error('disposed'));
+    await expect(a).rejects.toThrow('disposed');
+    await expect(b).rejects.toThrow('disposed');
+    expect(r.size).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/RequestRegistry.test.ts`
+Expected: FAIL — `Failed to resolve import "./RequestRegistry"`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `src/lib/local-inference/engine/RequestRegistry.ts`:
+
+```ts
+/**
+ * Correlates worker responses to their awaiting callers by request id.
+ * Extracted from TranslationEngine's hand-rolled `pendingRequests` map so the
+ * id→{resolve,reject} bookkeeping (and reject-all-on-dispose) lives in one
+ * tested place. Settled entries are removed so `size` reflects only in-flight
+ * requests.
+ */
+export class RequestRegistry<T> {
+  private readonly pending = new Map<string, { resolve: (v: T) => void; reject: (e: Error) => void }>();
+
+  /** Register a request id and return a promise settled by resolve()/reject(). */
+  create(id: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+  }
+
+  resolve(id: string, value: T): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    entry.resolve(value);
+  }
+
+  reject(id: string, error: Error): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    entry.reject(error);
+  }
+
+  /** Reject every in-flight request (used on dispose) and clear the map. */
+  rejectAll(error: Error): void {
+    for (const [, entry] of this.pending) entry.reject(error);
+    this.pending.clear();
+  }
+
+  get size(): number {
+    return this.pending.size;
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/RequestRegistry.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/local-inference/engine/RequestRegistry.ts src/lib/local-inference/engine/RequestRegistry.test.ts
+git commit -m "feat(local-inference): RequestRegistry for engine request/response correlation"
+```
+
+---
+
+### Task 2: `WorkerSession` + shared `MockWorker` test helper + unit tests
+
+**Files:**
+- Create: `src/lib/local-inference/engine/WorkerSession.ts`
+- Create: `src/lib/local-inference/engine/testing/mockWorker.ts` (test-only helper, imported by this and later tasks)
+- Test: `src/lib/local-inference/engine/WorkerSession.test.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `interface WorkerSessionOptions { makeWorker: () => Worker; onMessage: (msg: any) => void; revokeBlobs?: () => void; onFatalError?: (message: string) => void }`
+  - `class WorkerSession { constructor(opts: WorkerSessionOptions); start(initMessage: object, transfer?: Transferable[]): Promise<any>; post(msg: object, transfer?: Transferable[]): void; dispose(): void; get ready(): boolean }`
+  - `class MockWorker` with `static instances`, `static last()`, `static reset()`, `emit(data)`, `emitError(message)`, spied `postMessage`/`terminate`; and `installMockWorker(): () => void` that swaps `globalThis.Worker` and returns a restore fn.
+
+- [ ] **Step 1: Write the shared MockWorker helper**
+
+Create `src/lib/local-inference/engine/testing/mockWorker.ts`:
+
+```ts
+import { vi } from 'vitest';
+
+/** A drop-in stand-in for the DOM Worker, capturing postMessage and letting
+ *  tests drive onmessage/onerror. Used by WorkerSession unit tests (via
+ *  `makeWorker: () => new MockWorker(...)`) and by engine characterization
+ *  tests (via `installMockWorker()`, which patches globalThis.Worker). */
+export class MockWorker {
+  static instances: MockWorker[] = [];
+  postMessage = vi.fn();
+  terminate = vi.fn();
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+
+  constructor(public url: string | URL, public opts?: WorkerOptions) {
+    MockWorker.instances.push(this);
+  }
+
+  /** Simulate a message from the worker to the main thread. */
+  emit(data: unknown): void {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+
+  /** Simulate a worker-level error event. */
+  emitError(message: string): void {
+    this.onerror?.({ message } as ErrorEvent);
+  }
+
+  static last(): MockWorker {
+    return MockWorker.instances[MockWorker.instances.length - 1];
+  }
+
+  static reset(): void {
+    MockWorker.instances = [];
+  }
+}
+
+/** Patch globalThis.Worker with MockWorker. Returns a restore function. */
+export function installMockWorker(): () => void {
+  const original = (globalThis as any).Worker;
+  MockWorker.reset();
+  (globalThis as any).Worker = MockWorker;
+  return () => { (globalThis as any).Worker = original; };
+}
+```
+
+- [ ] **Step 2: Write the failing WorkerSession test**
+
+Create `src/lib/local-inference/engine/WorkerSession.test.ts`:
+
+```ts
+import { describe, it, expect, vi } from 'vitest';
+import { WorkerSession } from './WorkerSession';
+import { MockWorker } from './testing/mockWorker';
+
+function makeSession(over: Partial<{
+  onMessage: (m: any) => void; revokeBlobs: () => void; onFatalError: (m: string) => void;
+}> = {}) {
+  const worker = new MockWorker('x');
+  const session = new WorkerSession({
+    makeWorker: () => worker as unknown as Worker,
+    onMessage: over.onMessage ?? vi.fn(),
+    revokeBlobs: over.revokeBlobs,
+    onFatalError: over.onFatalError,
+  });
+  return { worker, session };
+}
+
+describe('WorkerSession', () => {
+  it('creates the worker synchronously in the constructor', () => {
+    const worker = new MockWorker('x');
+    const makeWorker = vi.fn(() => worker as unknown as Worker);
+    new WorkerSession({ makeWorker, onMessage: vi.fn() });
+    expect(makeWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it('start() posts the init message and resolves on ready, revoking once', async () => {
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs });
+    const p = session.start({ type: 'init', fileUrls: {} });
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'init', fileUrls: {} });
+    expect(session.ready).toBe(false);
+    worker.emit({ type: 'ready', loadTimeMs: 42 });
+    await expect(p).resolves.toEqual({ type: 'ready', loadTimeMs: 42 });
+    expect(session.ready).toBe(true);
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects and revokes once on a pre-ready error message (and fires onFatalError)', async () => {
+    const revokeBlobs = vi.fn();
+    const onFatalError = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs, onFatalError });
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'error', error: 'load failed' });
+    await expect(p).rejects.toThrow('load failed');
+    expect(onFatalError).toHaveBeenCalledWith('load failed');
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+    expect(session.ready).toBe(false);
+  });
+
+  it('rejects and revokes once on a pre-ready worker onerror', async () => {
+    const revokeBlobs = vi.fn();
+    const onFatalError = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs, onFatalError });
+    const p = session.start({ type: 'init' });
+    worker.emitError('worker crashed');
+    await expect(p).rejects.toThrow('worker crashed');
+    expect(onFatalError).toHaveBeenCalledWith('worker crashed');
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes non-handshake messages to onMessage (including post-ready errors), no re-revoke', async () => {
+    const onMessage = vi.fn();
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ onMessage, revokeBlobs });
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'status', message: 'loading' });   // pre-ready status → routed
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await p;
+    worker.emit({ type: 'result', text: 'hi' });           // post-ready → routed
+    worker.emit({ type: 'error', id: 'r1', error: 'req failed' }); // post-ready error → routed
+    expect(onMessage).toHaveBeenCalledWith({ type: 'status', message: 'loading' });
+    expect(onMessage).toHaveBeenCalledWith({ type: 'result', text: 'hi' });
+    expect(onMessage).toHaveBeenCalledWith({ type: 'error', id: 'r1', error: 'req failed' });
+    expect(revokeBlobs).toHaveBeenCalledTimes(1); // only the ready settle revoked
+  });
+
+  it('post-ready onerror fires onFatalError but does not reject/re-revoke', async () => {
+    const onFatalError = vi.fn();
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ onFatalError, revokeBlobs });
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await p;
+    worker.emitError('late error');
+    expect(onFatalError).toHaveBeenCalledWith('late error');
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('post() forwards a message, with transfer list when provided', () => {
+    const { worker, session } = makeSession();
+    const buf = new ArrayBuffer(8);
+    session.post({ type: 'audio', samples: 1 }, [buf]);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'audio', samples: 1 }, [buf]);
+    session.post({ type: 'flush' });
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'flush' });
+  });
+
+  it('dispose() posts dispose, terminates, and clears ready', async () => {
+    const { worker, session } = makeSession();
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await p;
+    session.dispose();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(session.ready).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/WorkerSession.test.ts`
+Expected: FAIL — `Failed to resolve import "./WorkerSession"`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `src/lib/local-inference/engine/WorkerSession.ts`:
+
+```ts
+/**
+ * WorkerSession — the Worker lifecycle shared by all WASM local-inference
+ * engines, extracted from four verbatim copies. It owns ONLY lifecycle:
+ * synchronous worker creation, the init handshake (post init → await 'ready' /
+ * reject on pre-ready 'error'/onerror), revoke-blobs-once-on-first-settle, the
+ * onerror path, dispose, and post(). It has zero domain knowledge — the engine
+ * supplies `onMessage` for its domain messages and `revokeBlobs`/`onFatalError`.
+ *
+ * Creating the worker in the constructor (not inside an awaited step) is what
+ * honors TtsEngine's supertonic constraint: the engine awaits its blobs, then
+ * `new WorkerSession(...)` creates the worker in the same microtask.
+ */
+export interface WorkerSessionOptions {
+  /** Create the Worker. Called synchronously in the constructor. */
+  makeWorker: () => Worker;
+  /** Every message except the init-handshake 'ready'/'error' (status, partial,
+   *  result, audio-chunk, disposed, and POST-ready errors). */
+  onMessage: (msg: any) => void;
+  /** Called exactly once, on the first settle. Omit when there is nothing to
+   *  revoke (e.g. edge-TTS). */
+  revokeBlobs?: () => void;
+  /** Worker-level failure: the pre-ready 'error' message, and any onerror
+   *  event (pre- or post-ready). Mirrors each engine's `onError` callback. */
+  onFatalError?: (message: string) => void;
+}
+
+export class WorkerSession {
+  private readonly worker: Worker;
+  private settled = false;
+  private revoked = false;
+  private _ready = false;
+  private resolveReady: ((msg: any) => void) | null = null;
+  private rejectReady: ((err: Error) => void) | null = null;
+
+  constructor(private readonly opts: WorkerSessionOptions) {
+    this.worker = opts.makeWorker();
+    this.worker.onmessage = (e: MessageEvent) => this.handleMessage(e.data);
+    this.worker.onerror = (e: ErrorEvent) => this.handleError(e.message || 'Worker error');
+  }
+
+  /** Post the init message and resolve when the worker reports 'ready'
+   *  (reject on a pre-ready 'error' message or onerror). */
+  start(initMessage: object, transfer?: Transferable[]): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+      this.post(initMessage, transfer);
+    });
+  }
+
+  post(msg: object, transfer?: Transferable[]): void {
+    if (transfer && transfer.length) this.worker.postMessage(msg, transfer);
+    else this.worker.postMessage(msg);
+  }
+
+  get ready(): boolean {
+    return this._ready;
+  }
+
+  dispose(): void {
+    this.worker.postMessage({ type: 'dispose' });
+    this.worker.terminate();
+    this._ready = false;
+  }
+
+  private handleMessage(msg: any): void {
+    if (!this.settled && msg?.type === 'ready') {
+      this.settled = true;
+      this._ready = true;
+      this.revokeOnce();
+      this.resolveReady?.(msg);
+      return;
+    }
+    if (!this.settled && msg?.type === 'error') {
+      this.settled = true;
+      this.revokeOnce();
+      this.opts.onFatalError?.(msg.error);
+      this.rejectReady?.(new Error(msg.error));
+      return;
+    }
+    this.opts.onMessage(msg);
+  }
+
+  private handleError(message: string): void {
+    this.opts.onFatalError?.(message);
+    if (!this.settled) {
+      this.settled = true;
+      this.revokeOnce();
+      this.rejectReady?.(new Error(message));
+    }
+  }
+
+  private revokeOnce(): void {
+    if (this.revoked) return;
+    this.revoked = true;
+    this.opts.revokeBlobs?.();
+  }
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/WorkerSession.test.ts`
+Expected: PASS (8 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/local-inference/engine/WorkerSession.ts src/lib/local-inference/engine/testing/mockWorker.ts src/lib/local-inference/engine/WorkerSession.test.ts
+git commit -m "feat(local-inference): WorkerSession lifecycle seam + MockWorker test helper"
+```
+
+---
+
+### Task 3: `AsrEngine` characterization tests
+
+**Files:**
+- Test: `src/lib/local-inference/engine/AsrEngine.test.ts`
+
+**Interfaces:**
+- Consumes: `MockWorker`, `installMockWorker` from Task 2.
+- Produces: nothing (tests only). These pin `AsrEngine`'s public behavior and MUST pass on the current (pre-refactor) code.
+
+Context for the implementer: `AsrEngine.init(modelId)` loads blob URLs via `ModelManager` (mock it), creates a `Worker`, wires `onmessage`/`onerror`, posts an init message, and resolves `{loadTimeMs}` on the worker's `ready`. On `ready` it also calls `ModelManager.revokeBlobUrls(fileUrls)`. `feedAudio`/`flush` post messages only when ready. `dispose` posts `{type:'dispose'}` and terminates. Use a non-webgpu model id so the worker is the module `whisper-webgpu` path OR the default sherpa path — pick `sensevoice-int8` (default sherpa path) to avoid the metadata-fetch branch, OR mock `fetch` for the metadata. This test uses the **sherpa default path**, which requires a `package-metadata.json` blob; mock `fetch` to return `{}`.
+
+- [ ] **Step 1: Write the characterization tests**
+
+Create `src/lib/local-inference/engine/AsrEngine.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AsrEngine } from './AsrEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+
+describe('AsrEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    // sensevoice-int8 → default sherpa path, which fetches package-metadata.json
+    vi.spyOn(ModelManager.prototype, 'isModelReady').mockResolvedValue(true);
+    vi.spyOn(ModelManager.prototype, 'getModelVariantInfo').mockResolvedValue({ dtype: 'int8' } as any);
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({
+      'package-metadata.json': 'blob:meta',
+      'sense.onnx': 'blob:model',
+    });
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => ({ json: async () => ({}) }) as any));
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('resolves init with loadTimeMs on ready and revokes blob URLs once', async () => {
+    const engine = new AsrEngine();
+    const initP = engine.init('sensevoice-int8');
+    // Let the pre-worker awaits (isModelReady, getModelBlobUrls, metadata fetch) settle.
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled()); // init posted
+    worker.emit({ type: 'ready', loadTimeMs: 7 });
+    await expect(initP).resolves.toEqual({ loadTimeMs: 7 });
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers status/speech_start/partial/result via callbacks after ready', async () => {
+    const engine = new AsrEngine();
+    const onStatus = vi.fn(); const onSpeechStart = vi.fn();
+    const onPartial = vi.fn(); const onResult = vi.fn();
+    engine.onStatus = onStatus; engine.onSpeechStart = onSpeechStart;
+    engine.onPartialResult = onPartial; engine.onResult = onResult;
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.emit({ type: 'status', message: 'loading' });
+    worker.emit({ type: 'speech_start' });
+    worker.emit({ type: 'partial', text: 'he' });
+    worker.emit({ type: 'result', text: 'hello', durationMs: 10, recognitionTimeMs: 5 });
+    expect(onStatus).toHaveBeenCalledWith('loading');
+    expect(onSpeechStart).toHaveBeenCalledTimes(1);
+    expect(onPartial).toHaveBeenCalledWith('he');
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ text: 'hello', durationMs: 10, recognitionTimeMs: 5 }));
+  });
+
+  it('rejects init and revokes on a pre-ready error, firing onError', async () => {
+    const engine = new AsrEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'bad model' });
+    await expect(initP).rejects.toThrow('bad model');
+    expect(onError).toHaveBeenCalledWith('bad model');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('feedAudio posts an audio message (transferring the buffer) only when ready', async () => {
+    const engine = new AsrEngine();
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    const before = new Int16Array([1, 2, 3]);
+    engine.feedAudio(before, 24000);            // not ready yet → ignored
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.postMessage.mockClear();
+    const samples = new Int16Array([4, 5, 6]);
+    engine.feedAudio(samples, 24000);
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      { type: 'audio', samples, sampleRate: 24000 },
+      [samples.buffer],
+    );
+  });
+
+  it('dispose posts dispose, terminates, and resets ready', async () => {
+    const engine = new AsrEngine();
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    engine.dispose();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(engine.ready).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run against the CURRENT AsrEngine (must pass — this is characterization)**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/AsrEngine.test.ts`
+Expected: PASS (5 tests). If a test fails, the assertion doesn't match current behavior — fix the test to reflect what the code actually does (do NOT change `AsrEngine.ts` in this task). If the sherpa metadata path makes an assertion flaky, adjust the `fetch`/`getModelBlobUrls` mocks — the goal is to pin real current behavior.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/local-inference/engine/AsrEngine.test.ts
+git commit -m "test(local-inference): characterization tests for AsrEngine (pre-refactor)"
+```
+
+---
+
+### Task 4: Refactor `AsrEngine` to compose `WorkerSession`
+
+**Files:**
+- Modify: `src/lib/local-inference/engine/AsrEngine.ts`
+
+**Interfaces:**
+- Consumes: `WorkerSession` (Task 2).
+- Produces: nothing new (behavior-preserving; the Task 3 tests are the contract).
+
+Recipe (read `AsrEngine.ts` first; keep every public member and all callbacks):
+
+1. Add `import { WorkerSession } from './WorkerSession';`.
+2. Replace the private field `private worker: Worker | null = null;` with `private session: WorkerSession | null = null;`. Keep `isReady`? Remove it — derive readiness from the session. Replace `this.isReady` reads with `this.session?.ready ?? false`, and the `get ready()` getter returns `this.session?.ready ?? false`. Keep `private currentModel`.
+3. In `init`, keep the pre-Promise blob loading exactly as-is (`isModelReady`, `getModelVariantInfo`, `getModelBlobUrls`, the `workerType` decision, the Cohere language guard). Replace the `return new Promise((resolve, reject) => { ... })` body:
+   - Build a `makeWorker` thunk from the existing `switch (workerType)` (each `case` returns the corresponding `new Worker(...)` instead of assigning `this.worker`). Example shape:
+     ```ts
+     const makeWorker = (): Worker => {
+       switch (workerType) {
+         case 'whisper-webgpu':
+           return new Worker(new URL('../workers/whisper-webgpu.worker.ts', import.meta.url), { type: 'module' });
+         case 'cohere-transcribe-webgpu':
+           return new Worker(new URL('../workers/cohere-transcribe-webgpu.worker.ts', import.meta.url), { type: 'module' });
+         case 'voxtral-3b-webgpu':
+           return new Worker(new URL('../workers/voxtral-3b-webgpu.worker.ts', import.meta.url), { type: 'module' });
+         case 'granite-speech-webgpu':
+           return new Worker(new URL('../workers/granite-speech-webgpu.worker.ts', import.meta.url), { type: 'module' });
+         default:
+           return new Worker('./workers/sherpa-onnx-asr.worker.js');
+       }
+     };
+     ```
+   - Create the session with a `route` that is the current `onmessage` switch MINUS the `ready`/`error` cases (those move to WorkerSession), MINUS `disposed` (no-op):
+     ```ts
+     const session = new WorkerSession({
+       makeWorker,
+       revokeBlobs: () => manager.revokeBlobUrls(fileUrls),
+       onFatalError: (message) => this.onError?.(message),
+       onMessage: (msg) => {
+         switch (msg.type) {
+           case 'status': this.onStatus?.(msg.message); break;
+           case 'speech_start': this.onSpeechStart?.(); break;
+           case 'partial': this.onPartialResult?.(msg.text); break;
+           case 'result':
+             this.onResult?.({
+               text: msg.text,
+               startSample: 'startSample' in msg ? msg.startSample : undefined,
+               durationMs: msg.durationMs,
+               recognitionTimeMs: msg.recognitionTimeMs,
+             });
+             break;
+           case 'error': this.onError?.(msg.error); break;   // post-ready only (pre-ready handled by WorkerSession)
+         }
+       },
+     });
+     this.session = session;
+     ```
+   - Build the init message exactly as the current code posts it (the two webgpu shapes, the granite shape, and the sherpa metadata-fetch shape), then `const ready = await session.start(<initMessage>);` and set `this.currentModel = model;` — but note the sherpa path's metadata fetch is `await`ed *after* `new WorkerSession(...)` (worker already created), then `start(initMessage)`. For the webgpu paths, `start` is called immediately.
+   - Replace `resolve({ loadTimeMs: msg.loadTimeMs })` with `return { loadTimeMs: ready.loadTimeMs };` (the method already returns a Promise since it becomes `async` around the session; or keep the `new Promise` wrapper and resolve). **Simplest: make the whole post-blob section `await session.start(...)` and `return { loadTimeMs: ready.loadTimeMs }`** — `init` is already `async`.
+   - On init failure, `session.start` rejects (WorkerSession revokes + fires onFatalError). Wrap the sherpa metadata-fetch failure so it still revokes: if `fetch`/metadata throws before `start`, call `manager.revokeBlobUrls(fileUrls)` and rethrow (preserve current behavior at `AsrEngine.ts` where the metadata catch revokes + rejects).
+4. `feedAudio`: `if (!this.session?.ready) return; this.session.post({ type: 'audio', samples, sampleRate }, [samples.buffer]);`
+5. `flush`: `if (!this.session?.ready) return; this.session.post({ type: 'flush' });`
+6. `dispose`: `this.session?.dispose(); this.session = null; this.currentModel = null;`
+
+- [ ] **Step 1: Apply the recipe to `AsrEngine.ts`.**
+
+- [ ] **Step 2: Run the characterization tests (must stay green)**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/AsrEngine.test.ts`
+Expected: PASS (all 5 from Task 3, unchanged).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm run test -- --run`
+Expected: PASS, no regressions.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/local-inference/engine/AsrEngine.ts
+git commit -m "refactor(local-inference): AsrEngine composes WorkerSession"
+```
+
+---
+
+### Task 5: `StreamingAsrEngine` characterization tests
+
+**Files:**
+- Test: `src/lib/local-inference/engine/StreamingAsrEngine.test.ts`
+
+**Interfaces:**
+- Consumes: `MockWorker`, `installMockWorker` from Task 2.
+
+Context: `StreamingAsrEngine` is callback-based like `AsrEngine` but currently creates the worker *before* loading blobs. Its `ready` (`voxtral-webgpu`) does NOT revoke inside init's inline handler — it wraps `onmessage` to revoke on ready/error. Use a streaming model id: `stream-en-kroko` uses the default sherpa streaming path (metadata fetch); `voxtral-mini-4b-webgpu` uses the module path. This test uses the **voxtral-webgpu path** (no metadata fetch, cleaner). Note the current voxtral path revokes via the onmessage wrapper on ready/error.
+
+- [ ] **Step 1: Write the characterization tests**
+
+Create `src/lib/local-inference/engine/StreamingAsrEngine.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamingAsrEngine } from './StreamingAsrEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+
+describe('StreamingAsrEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    vi.spyOn(ModelManager.prototype, 'isModelReady').mockResolvedValue(true);
+    vi.spyOn(ModelManager.prototype, 'getModelVariantInfo').mockResolvedValue({ dtype: 'q4' } as any);
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({ 'model.onnx': 'blob:m' });
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); });
+
+  it('resolves init on ready and revokes blob URLs once', async () => {
+    const engine = new StreamingAsrEngine();
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+    worker.emit({ type: 'ready', loadTimeMs: 9 });
+    await expect(initP).resolves.toEqual({ loadTimeMs: 9 });
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers partial and final results via callbacks', async () => {
+    const engine = new StreamingAsrEngine();
+    const onPartial = vi.fn(); const onResult = vi.fn();
+    engine.onPartialResult = onPartial; engine.onResult = onResult;
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.emit({ type: 'partial', text: 'wor' });
+    worker.emit({ type: 'result', text: 'world', durationMs: 8, recognitionTimeMs: 4 });
+    expect(onPartial).toHaveBeenCalledWith('wor');
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ text: 'world', durationMs: 8, recognitionTimeMs: 4 }));
+  });
+
+  it('rejects init and revokes on a pre-ready error', async () => {
+    const engine = new StreamingAsrEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'stream fail' });
+    await expect(initP).rejects.toThrow('stream fail');
+    expect(onError).toHaveBeenCalledWith('stream fail');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('feedAudio and flush post only when ready', async () => {
+    const engine = new StreamingAsrEngine();
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.postMessage.mockClear();
+    const samples = new Int16Array([1, 2]);
+    engine.feedAudio(samples, 24000);
+    engine.flush();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'audio', samples, sampleRate: 24000 }, [samples.buffer]);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'flush' });
+  });
+
+  it('dispose posts dispose, terminates, resets ready', async () => {
+    const engine = new StreamingAsrEngine();
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    engine.dispose();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(engine.ready).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run against current code (must pass)**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/StreamingAsrEngine.test.ts`
+Expected: PASS (5 tests). Adjust mocks/assertions to match real current behavior if needed; do NOT change `StreamingAsrEngine.ts` here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/local-inference/engine/StreamingAsrEngine.test.ts
+git commit -m "test(local-inference): characterization tests for StreamingAsrEngine (pre-refactor)"
+```
+
+---
+
+### Task 6: Refactor `StreamingAsrEngine` to compose `WorkerSession` (with reorder)
+
+**Files:**
+- Modify: `src/lib/local-inference/engine/StreamingAsrEngine.ts`
+
+**Interfaces:**
+- Consumes: `WorkerSession`.
+
+Recipe (read the file first). This engine currently creates the worker inside `new Promise(async ...)` *before* loading blobs, and wraps `onmessage` to revoke. The refactor **reorders to load-blobs-first** so the session is constructed synchronously (Global Constraint: documented, safe).
+
+1. Add `import { WorkerSession } from './WorkerSession';`. Replace `private worker` with `private session: WorkerSession | null = null;`. Replace `isReady` reads with `this.session?.ready`; `get ready()` returns `this.session?.ready ?? false`.
+2. Rewrite `init` to be `async` without the `new Promise(async ...)` wrapper:
+   - Compute `workerType`. **Load blobs first** (move the per-branch `isModelReady`/`getModelBlobUrls`/`getModelVariantInfo`/metadata-fetch work to before worker creation), matching each branch:
+     - `voxtral-webgpu`: `if (!await manager.isModelReady(modelId)) throw ...; const fileUrls = await manager.getModelBlobUrls(modelId); const { dtype } = await manager.getModelVariantInfo(modelId);`
+     - default sherpa: `if (!await manager.isModelReady(modelId)) throw ...; const fileUrls = await manager.getModelBlobUrls(modelId); const metadataBlobUrl = fileUrls['package-metadata.json']; if (!metadataBlobUrl) throw ...; const dataPackageMetadata = await (await fetch(metadataBlobUrl)).json(); const dataFileUrls = <copy without package-metadata.json>;`
+   - Build `makeWorker` from the `switch` (return the `new Worker(...)` for each case).
+   - `const session = new WorkerSession({ makeWorker, revokeBlobs: () => manager.revokeBlobUrls(fileUrls), onFatalError: (m) => this.onError?.(m), onMessage: (msg) => { switch (msg.type) { case 'status': this.onStatus?.(msg.message); break; case 'speech_start': this.onSpeechStart?.(); break; case 'partial': this.onPartialResult?.(msg.text); break; case 'result': this.onResult?.({ text: msg.text, durationMs: msg.durationMs, recognitionTimeMs: msg.recognitionTimeMs }); break; case 'error': this.onError?.(msg.error); break; } } }); this.session = session;`
+   - Build the init message per branch (voxtral shape vs sherpa shape, exactly as currently posted) and `const ready = await session.start(<initMessage>); this.currentModel = model; return { loadTimeMs: ready.loadTimeMs };`
+   - Delete the two `onmessage`-wrapper cleanup blocks (revocation now flows through `WorkerSession`'s `revokeBlobs` on first settle — same net behavior).
+3. `feedAudio`/`flush`/`dispose`: same shape as Task 4 (`this.session?.ready` guards; `this.session.post(...)`; `dispose` → `this.session?.dispose(); this.session = null; this.currentModel = null;`).
+
+- [ ] **Step 1: Apply the recipe.**
+
+- [ ] **Step 2: Characterization tests stay green**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/StreamingAsrEngine.test.ts`
+Expected: PASS (all 5).
+
+- [ ] **Step 3: Full suite**
+
+Run: `npm run test -- --run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/local-inference/engine/StreamingAsrEngine.ts
+git commit -m "refactor(local-inference): StreamingAsrEngine composes WorkerSession (load blobs before worker)"
+```
+
+---
+
+### Task 7: `TranslationEngine` characterization tests
+
+**Files:**
+- Test: `src/lib/local-inference/engine/TranslationEngine.test.ts`
+
+Context: `TranslationEngine` is request/response — `translate(text, systemPrompt, wrapTranscript)` returns a Promise correlated by an id (`tr_N`). Results arrive as `{type:'result', id, ...}`; id'd errors reject that request; dispose rejects all pending. It also toggles Bing DNR for the `bing` worker (skip that path — use the default `opus-mt` path). Use a translation model that resolves to `opus-mt` (e.g. `opus-mt-ja-en`). Its init loads blobs before the worker.
+
+- [ ] **Step 1: Write the characterization tests**
+
+Create `src/lib/local-inference/engine/TranslationEngine.test.ts`:
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TranslationEngine } from './TranslationEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+
+async function initReady(engine: TranslationEngine, model = 'opus-mt-ja-en') {
+  const initP = engine.init('ja', 'en', model);
+  await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+  const worker = MockWorker.last();
+  await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+  worker.emit({ type: 'ready', loadTimeMs: 3, device: 'wasm' });
+  await initP;
+  return worker;
+}
+
+describe('TranslationEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    vi.spyOn(ModelManager.prototype, 'isModelReady').mockResolvedValue(true);
+    vi.spyOn(ModelManager.prototype, 'getModelVariantInfo').mockResolvedValue({ dtype: 'default' } as any);
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({ 'config.json': 'blob:c' });
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); });
+
+  it('resolves init on ready and revokes blob URLs once', async () => {
+    const engine = new TranslationEngine();
+    await initReady(engine);
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('translate() correlates the result by id', async () => {
+    const engine = new TranslationEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+    const p = engine.translate('こんにちは', 'sys', true);
+    // capture the id the engine assigned
+    const sent = worker.postMessage.mock.calls[0][0] as any;
+    expect(sent.type).toBe('translate');
+    worker.emit({ type: 'result', id: sent.id, sourceText: 'こんにちは', translatedText: 'hello', inferenceTimeMs: 12 });
+    await expect(p).resolves.toEqual(expect.objectContaining({ translatedText: 'hello', inferenceTimeMs: 12 }));
+  });
+
+  it('an id-scoped error rejects only that request', async () => {
+    const engine = new TranslationEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+    const p = engine.translate('x', 'sys', false);
+    const sent = worker.postMessage.mock.calls[0][0] as any;
+    worker.emit({ type: 'error', id: sent.id, error: 'translate failed' });
+    await expect(p).rejects.toThrow('translate failed');
+  });
+
+  it('dispose rejects all pending translate() promises and posts dispose', async () => {
+    const engine = new TranslationEngine();
+    const worker = await initReady(engine);
+    const p1 = engine.translate('a', 's', false);
+    const p2 = engine.translate('b', 's', false);
+    engine.dispose();
+    await expect(p1).rejects.toThrow(/disposed/i);
+    await expect(p2).rejects.toThrow(/disposed/i);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects init and revokes on a pre-ready error', async () => {
+    const engine = new TranslationEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('ja', 'en', 'opus-mt-ja-en');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'model load failed' });
+    await expect(initP).rejects.toThrow('model load failed');
+    expect(onError).toHaveBeenCalledWith('model load failed');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run against current code (must pass)**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/TranslationEngine.test.ts`
+Expected: PASS (5). Adjust to match real current behavior if a message field differs; do NOT change `TranslationEngine.ts` here.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/local-inference/engine/TranslationEngine.test.ts
+git commit -m "test(local-inference): characterization tests for TranslationEngine (pre-refactor)"
+```
+
+---
+
+### Task 8: Refactor `TranslationEngine` to compose `WorkerSession` + `RequestRegistry`
+
+**Files:**
+- Modify: `src/lib/local-inference/engine/TranslationEngine.ts`
+
+**Interfaces:**
+- Consumes: `WorkerSession` (Task 2), `RequestRegistry` (Task 1).
+
+Recipe (read the file first):
+
+1. Add `import { WorkerSession } from './WorkerSession';` and `import { RequestRegistry } from './RequestRegistry';`.
+2. Replace `private worker` with `private session: WorkerSession | null = null;`. Replace `private pendingRequests = new Map<...>()` with `private readonly reqs = new RequestRegistry<TranslationResult>();`. Keep `requestCounter`, `sourceLang`, `targetLang`, `currentModelId`, `bingDnrActive`. Replace `isReady` reads with `this.session?.ready`.
+3. Keep the pre-Promise blob loading + the Bing DNR pre-step exactly as-is. In the `new Promise` body:
+   - `makeWorker` from the `switch (workerType)` (each case returns its `new Worker(...)`).
+   - `const session = new WorkerSession({ makeWorker, revokeBlobs: () => manager.revokeBlobUrls(fileUrls), onFatalError: (m) => this.onError?.(m), onMessage: (msg) => this.route(msg) }); this.session = session;`
+   - `const ready = await session.start({ type: 'init', hfModelId: entry.hfModelId, fileUrls, sourceLang, targetLang, dtype, ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href }); this.currentModelId = modelCacheKey; return { loadTimeMs: ready.loadTimeMs, device: ready.device || 'wasm' };`
+4. Add a private `route(msg)` method carrying the current onmessage's non-handshake cases:
+   ```ts
+   private route(msg: any): void {
+     switch (msg.type) {
+       case 'result':
+         this.reqs.resolve(msg.id, {
+           sourceText: msg.sourceText, translatedText: msg.translatedText,
+           inferenceTimeMs: msg.inferenceTimeMs, systemPrompt: msg.systemPrompt,
+         });
+         break;
+       case 'error':
+         if (msg.id) this.reqs.reject(msg.id, new Error(msg.error));
+         else this.onError?.(msg.error);   // post-ready fatal (pre-ready handled by WorkerSession)
+         break;
+     }
+   }
+   ```
+5. `translate`: keep the id assignment; replace the pending-map set + postMessage with the registry + session:
+   ```ts
+   const id = `tr_${++this.requestCounter}`;
+   const p = this.reqs.create(id);
+   this.session!.post({ type: 'translate', id, text, sourceLang: this.sourceLang, targetLang: this.targetLang, systemPrompt, wrapTranscript });
+   return p;
+   ```
+   (keep the `if (!this.session?.ready) throw ...` guard at the top.)
+6. `dispose`: `this.session?.dispose(); this.session = null;` + keep the Bing DNR teardown; replace the pending-reject loop with `this.reqs.rejectAll(new Error('TranslationEngine disposed'));`; reset `currentModelId`/`sourceLang`/`targetLang`.
+
+- [ ] **Step 1: Apply the recipe.**
+
+- [ ] **Step 2: Characterization tests stay green**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/TranslationEngine.test.ts`
+Expected: PASS (all 5).
+
+- [ ] **Step 3: Full suite**
+
+Run: `npm run test -- --run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/local-inference/engine/TranslationEngine.ts
+git commit -m "refactor(local-inference): TranslationEngine composes WorkerSession + RequestRegistry"
+```
+
+---
+
+### Task 9: `TtsEngine` characterization tests
+
+**Files:**
+- Test: `src/lib/local-inference/engine/TtsEngine.test.ts`
+
+Context: `TtsEngine` is single-slot request/response — `generate(text,sid,speed)` resolves on `{type:'result'}`; `generateStream(...)` streams `audio-chunk` via an `onChunk` and resolves on `audio-done`; only one in flight at a time (guards throw if already pending). It also has an edge-TTS non-worker path (skip it). Use the **supertonic** model (`supertonic-3`) — the existing `TtsEngine.supertonic.test.ts` shows the exact `ModelManager`/`voiceStorage` mocks needed. This new test focuses on the generic lifecycle + generate + stream + dispose behaviors (the supertonic test already covers the single-await construction ordering — do not duplicate it).
+
+- [ ] **Step 1: Write the characterization tests**
+
+Create `src/lib/local-inference/engine/TtsEngine.test.ts` (reuse the mock setup shape from `TtsEngine.supertonic.test.ts` for `ModelManager` + `voiceStorage`, but drive via `MockWorker` from the shared helper):
+
+```ts
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TtsEngine } from './TtsEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+import * as voiceStorage from '../voiceStorage';
+
+const SUPERTONIC_BLOBS = {
+  'onnx/duration_predictor.onnx': 'blob:dp', 'onnx/text_encoder.onnx': 'blob:te',
+  'onnx/vector_estimator.onnx': 'blob:ve', 'onnx/vocoder.onnx': 'blob:vc',
+  'onnx/tts.json': 'blob:tts', 'onnx/unicode_indexer.json': 'blob:idx',
+  'voice_styles/F1.json': 'blob:f1',
+};
+
+async function initReady(engine: TtsEngine) {
+  const initP = engine.init('supertonic-3');
+  await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+  const worker = MockWorker.last();
+  await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+  worker.emit({ type: 'ready', numSpeakers: 1, sampleRate: 24000, loadTimeMs: 5 });
+  await initP;
+  return worker;
+}
+
+describe('TtsEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    URL.createObjectURL = vi.fn(() => `blob:${Math.random()}`);
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue(SUPERTONIC_BLOBS as any);
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+    vi.spyOn(voiceStorage, 'listVoices').mockResolvedValue([]);
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); });
+
+  it('resolves init on ready and revokes blob URLs once', async () => {
+    const engine = new TtsEngine();
+    await initReady(engine);
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('generate() resolves on the result message', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+    const samples = new Float32Array([0.1, 0.2]);
+    const p = engine.generate('hi', 0, 1.0);
+    expect(worker.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'generate' }));
+    worker.emit({ type: 'result', samples, sampleRate: 24000, generationTimeMs: 20 });
+    await expect(p).resolves.toEqual(expect.objectContaining({ sampleRate: 24000 }));
+  });
+
+  it('generateStream() forwards audio-chunk to onChunk and resolves on audio-done', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    const chunks: Float32Array[] = [];
+    const p = engine.generateStream('hi', (s) => chunks.push(s), 0, 1.0);
+    worker.emit({ type: 'audio-chunk', samples: new Float32Array([1]), sampleRate: 24000 });
+    worker.emit({ type: 'audio-done', generationTimeMs: 30 });
+    await expect(p).resolves.toEqual(expect.objectContaining({ generationTimeMs: 30 }));
+    expect(chunks.length).toBe(1);
+  });
+
+  it('dispose rejects a pending generate and posts dispose', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    const p = engine.generate('hi', 0, 1.0);
+    engine.dispose();
+    await expect(p).rejects.toThrow(/disposed/i);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(engine.ready).toBe(false);
+  });
+
+  it('a pre-ready error rejects init and revokes', async () => {
+    const engine = new TtsEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('supertonic-3');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'tts load failed' });
+    await expect(initP).rejects.toThrow('tts load failed');
+    expect(onError).toHaveBeenCalledWith('tts load failed');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run against current code (must pass)**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/TtsEngine.test.ts`
+Expected: PASS (5). The `generate`/`stream` message field names and the `ready` payload (`numSpeakers`/`sampleRate`) must match what `TtsEngine.ts` actually reads — adjust the emitted messages to the real shapes (consult `TtsEngine.ts`'s onmessage) if an assertion fails. Do NOT change `TtsEngine.ts` here. Also confirm `TtsEngine.supertonic.test.ts` still passes unchanged.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/local-inference/engine/TtsEngine.test.ts
+git commit -m "test(local-inference): characterization tests for TtsEngine (pre-refactor)"
+```
+
+---
+
+### Task 10: Refactor `TtsEngine` to compose `WorkerSession` (keep bespoke pending + edge-TTS)
+
+**Files:**
+- Modify: `src/lib/local-inference/engine/TtsEngine.ts`
+
+**Interfaces:**
+- Consumes: `WorkerSession`. Does NOT use `RequestRegistry` (single-slot pending).
+
+Recipe (read the file first — this is the most involved engine):
+
+1. Add `import { WorkerSession } from './WorkerSession';`. Replace `private worker` with `private session: WorkerSession | null = null;`. Keep `pendingGenerate`, `pendingStream`, `edgeTtsConnection`, `_numSpeakers`, `_sampleRate`, `currentModel`. Replace `isReady` reads with `this.session?.ready`; `get ready()` → `this.session?.ready ?? false`.
+2. In `init`, keep the pre-Promise blob loading exactly as-is (this preserves the supertonic single-await ordering — Global Constraint). In the `new Promise` body:
+   - `makeWorker` from the current `switch` that picks the worker URL (edge-tts / piper-plus / supertonic / default). Each case returns `new Worker(...)`.
+   - `revokeBlobs`: `isEdgeTts ? undefined : () => ModelManager.getInstance().revokeBlobUrls(fileUrls)` — edge-TTS has nothing to revoke (matches the current `if (!isEdgeTts) revoke` guards).
+   - `onFatalError`: `(message) => { this.onError?.(message); this.pendingGenerate?.reject(new Error(message)); this.pendingGenerate = null; this.pendingStream?.reject(new Error(message)); this.pendingStream = null; }` — mirrors the current `onerror` handler's pending rejection. (Note: use explicit `if (this.pendingGenerate) {...}` blocks to null after reject, matching current code.)
+   - `onMessage: (msg) => this.route(msg)` where `route` carries the current onmessage non-handshake cases: `status` (→ onStatus / whatever it currently does), `result` (→ `pendingGenerate`), `audio-chunk` (→ `pendingStream.onChunk`), `audio-done` (→ `pendingStream`), `error` (post-ready: `onError?` + reject `pendingGenerate`/`pendingStream`), `disposed` (no-op). Copy the exact bodies from the current onmessage `case`s (lines for `result`/`audio-chunk`/`audio-done`/`error`).
+   - Set `this._numSpeakers`/`this._sampleRate` from the `ready` message in the `.then()` of start (the current `ready` case reads these): `const ready = await session.start(<the engine-specific init message, exactly as currently posted>); this.currentModel = model; this._numSpeakers = ready.numSpeakers ?? 0; this._sampleRate = ready.sampleRate ?? 0; return { ... };` — match the current `ready` case's field reads and the `init` return shape.
+   - `this.session = session;` immediately after construction.
+3. `generate` / `generateStream`: keep the "already pending" guards and the single-slot assignment; replace `this.worker.postMessage(...)` / `this.worker!.postMessage(...)` with `this.session!.post(...)`. Keep the `const worker = this.worker;` capture pattern by capturing `const session = this.session;` instead, and post via `session.post(...)`. The edge-TTS branch of `generateStream` still uses `this.edgeTtsConnection` and posts `decode-start`/`decode-end`/audio-in to the worker via `this.session.post(...)`.
+4. `dispose`: keep edge-TTS + pending rejection; replace the worker block with `this.session?.dispose(); this.session = null;`. Keep resetting `_numSpeakers`/`_sampleRate`/`currentModel`.
+5. `reloadVoices` calls `this.dispose()` then `this.init(...)` — unchanged.
+
+- [ ] **Step 1: Apply the recipe.**
+
+- [ ] **Step 2: Both TtsEngine test files stay green**
+
+Run: `npm run test -- --run src/lib/local-inference/engine/TtsEngine.test.ts src/lib/local-inference/engine/TtsEngine.supertonic.test.ts`
+Expected: PASS (both files). The supertonic test's construction-ordering assertions must still hold (worker created synchronously after the blob await).
+
+- [ ] **Step 3: Full suite**
+
+Run: `npm run test -- --run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/local-inference/engine/TtsEngine.ts
+git commit -m "refactor(local-inference): TtsEngine composes WorkerSession (keeps single-slot pending + edge-TTS)"
+```
+
+---
+
+### Task 11: Final verification — dedup check, full suite, build
+
+**Files:** none (verification only).
+
+- [ ] **Step 1: Confirm the lifecycle dedup landed**
+
+Run:
+```bash
+cd src/lib/local-inference/engine
+grep -c "this.worker" AsrEngine.ts StreamingAsrEngine.ts TranslationEngine.ts TtsEngine.ts
+grep -c "new WorkerSession" AsrEngine.ts StreamingAsrEngine.ts TranslationEngine.ts TtsEngine.ts
+```
+Expected: the `this.worker` count is `0` for all four (the field is gone), and `new WorkerSession` is `1` for each. If any `this.worker` remains, that engine wasn't fully migrated.
+
+- [ ] **Step 2: Full test suite**
+
+Run: `npm run test -- --run`
+Expected: PASS — includes RequestRegistry, WorkerSession, and the 4 engine characterization suites, plus the pre-existing supertonic test.
+
+- [ ] **Step 3: Integration build**
+
+Run: `npm run build`
+Expected: build succeeds (the engines still compile and the workers bundle).
+
+> **Coverage note:** the engines have no live-Worker runtime test; the characterization tests pin observable behavior against a `MockWorker`, and the build proves compilation. A manual smoke of one local-inference ASR→translation→TTS session before merge is the behavioral backstop (recommended, not required for task completion).
+
+- [ ] **Step 4: Commit (if any verification touched files)**
+
+No file changes expected in this task. If the greps revealed a missed migration, fix that engine (re-run its characterization suite) and commit under the relevant engine's message.

--- a/docs/superpowers/specs/2026-07-13-wasm-worker-session-design.md
+++ b/docs/superpowers/specs/2026-07-13-wasm-worker-session-design.md
@@ -160,7 +160,7 @@ Message handling (preserves current behavior exactly):
   - otherwise → `route(msg)` — this is where `status`/`speech_start`/`partial`/`result`/`disposed` and *post-ready* errors go; the engine decides id-correlation vs fatal.
 - internal `onerror(e)`: `onFatalError?.(message)`; if not settled → `revokeBlobs()` once, reject.
 
-**`RequestRegistry.ts`** — id-keyed correlation for the request/response engines:
+**`RequestRegistry.ts`** — id-keyed correlation, used **only by `TranslationEngine`** (the one engine with a `Map<id, {resolve,reject}>` + `tr_N` counter + reject-all-on-dispose):
 
 ```ts
 class RequestRegistry<T> {
@@ -171,16 +171,18 @@ class RequestRegistry<T> {
 }
 ```
 
+`TtsEngine` is deliberately NOT on `RequestRegistry`: its request model is **single-slot** (`pendingGenerate` + a `pendingStream` that carries an `onChunk`), not id-keyed — plus a non-worker edge-TTS side path. It composes `WorkerSession` for lifecycle only and keeps its bespoke pending fields as-is.
+
 Per-engine responsibilities after extraction (each keeps its own `workerType` switch, init-payload building, and domain `route`):
 
-| Engine | WorkerSession | RequestRegistry | Extra dispose cleanup wrapping `session.dispose()` |
-|---|---|---|---|
-| `AsrEngine` | ✅ | — (callbacks) | — |
-| `StreamingAsrEngine` | ✅ | — (callbacks) | — |
-| `TranslationEngine` | ✅ | ✅ | `setBingTranslatorDNR(false)` |
-| `TtsEngine` | ✅ (worker paths) | ✅ | `edgeTtsConnection.dispose()` (edge-TTS is a non-worker path it keeps separate) |
+| Engine | WorkerSession | RequestRegistry | Domain state kept in the engine | Extra dispose cleanup wrapping `session.dispose()` |
+|---|---|---|---|---|
+| `AsrEngine` | ✅ | — | callbacks (onResult/onPartialResult/…) | — |
+| `StreamingAsrEngine` | ✅ | — | callbacks | — |
+| `TranslationEngine` | ✅ | ✅ | — (registry holds pending) | `setBingTranslatorDNR(false)` + `reqs.rejectAll(...)` |
+| `TtsEngine` | ✅ (worker paths) | — | single-slot `pendingGenerate`/`pendingStream` + `edgeTtsConnection` | reject both pending + `edgeTtsConnection.dispose()` |
 
-The sherpa-onnx classic-ASR path (which fetches `package-metadata.json` to build its init payload) fits: the engine does `new WorkerSession(...)` (worker created), `await fetchMetadata()`, then `session.start(payload)`. The metadata await is *after* worker creation, so no path regresses.
+**Init-ordering heterogeneity.** 3 of 4 engines load blobs (`await getModelBlobUrls`) *before* creating the worker, then create it and post init. `StreamingAsrEngine` is the outlier: it creates the worker *first*, then loads blobs *inside* an `async` Promise executor, wrapping `onmessage` to revoke on ready/error. To fit `WorkerSession`'s synchronous-constructor model, `StreamingAsrEngine` is reordered to load-blobs-first (like the others), then `new WorkerSession(...)`. This is a minor, must-document timing change (the worker is created slightly later, after the blob await), safe because the worker stays idle until `init`. The sherpa-onnx classic path (fetch `package-metadata.json` to build the payload) does its metadata `await` *after* `new WorkerSession(...)`, so no path regresses there.
 
 ## Testing (characterization-first)
 

--- a/src/lib/local-inference/engine/AsrEngine.test.ts
+++ b/src/lib/local-inference/engine/AsrEngine.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AsrEngine } from './AsrEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+
+describe('AsrEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    // sensevoice-int8 → default sherpa path, which fetches package-metadata.json
+    vi.spyOn(ModelManager.prototype, 'isModelReady').mockResolvedValue(true);
+    vi.spyOn(ModelManager.prototype, 'getModelVariantInfo').mockResolvedValue({ dtype: 'int8' } as any);
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({
+      'package-metadata.json': 'blob:meta',
+      'sense.onnx': 'blob:model',
+    });
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+    vi.stubGlobal('fetch', vi.fn(async () => ({ json: async () => ({}) }) as any));
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); vi.unstubAllGlobals(); });
+
+  it('resolves init with loadTimeMs on ready and revokes blob URLs once', async () => {
+    const engine = new AsrEngine();
+    const initP = engine.init('sensevoice-int8');
+    // Let the pre-worker awaits (isModelReady, getModelBlobUrls, metadata fetch) settle.
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled()); // init posted
+    worker.emit({ type: 'ready', loadTimeMs: 7 });
+    await expect(initP).resolves.toEqual({ loadTimeMs: 7 });
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers status/speech_start/partial/result via callbacks after ready', async () => {
+    const engine = new AsrEngine();
+    const onStatus = vi.fn(); const onSpeechStart = vi.fn();
+    const onPartial = vi.fn(); const onResult = vi.fn();
+    engine.onStatus = onStatus; engine.onSpeechStart = onSpeechStart;
+    engine.onPartialResult = onPartial; engine.onResult = onResult;
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.emit({ type: 'status', message: 'loading' });
+    worker.emit({ type: 'speech_start' });
+    worker.emit({ type: 'partial', text: 'he' });
+    worker.emit({ type: 'result', text: 'hello', durationMs: 10, recognitionTimeMs: 5 });
+    expect(onStatus).toHaveBeenCalledWith('loading');
+    expect(onSpeechStart).toHaveBeenCalledTimes(1);
+    expect(onPartial).toHaveBeenCalledWith('he');
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ text: 'hello', durationMs: 10, recognitionTimeMs: 5 }));
+  });
+
+  it('rejects init and revokes on a pre-ready error, firing onError', async () => {
+    const engine = new AsrEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'bad model' });
+    await expect(initP).rejects.toThrow('bad model');
+    expect(onError).toHaveBeenCalledWith('bad model');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('feedAudio posts an audio message (transferring the buffer) only when ready', async () => {
+    const engine = new AsrEngine();
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    const before = new Int16Array([1, 2, 3]);
+    engine.feedAudio(before, 24000);            // not ready yet → ignored
+    const audioCallsBeforeReady = worker.postMessage.mock.calls.filter(
+      ([msg]: [{ type: string }]) => msg?.type === 'audio',
+    ).length;
+    expect(audioCallsBeforeReady).toBe(0);
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.postMessage.mockClear();
+    const samples = new Int16Array([4, 5, 6]);
+    engine.feedAudio(samples, 24000);
+    expect(worker.postMessage).toHaveBeenCalledWith(
+      { type: 'audio', samples, sampleRate: 24000 },
+      [samples.buffer],
+    );
+  });
+
+  it('dispose posts dispose, terminates, and resets ready', async () => {
+    const engine = new AsrEngine();
+    const initP = engine.init('sensevoice-int8');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    engine.dispose();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(engine.ready).toBe(false);
+  });
+});

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -81,6 +81,39 @@ export class AsrEngine {
       throw new Error('Cohere Transcribe requires a source language');
     }
 
+    // sherpa-onnx: extract metadata and pass .data blob URL. This runs BEFORE
+    // `new WorkerSession(...)` (below) so the metadata fetch — which can fail
+    // or overlap with a worker error — completes before the session's
+    // resolve/reject handlers exist; those are only bound inside
+    // `session.start()`. If the worker were constructed first and this fetch
+    // awaited afterward, a worker onerror/pre-ready 'error' firing during the
+    // fetch would settle the session with no reject handler attached yet,
+    // and the eventual `session.start(...)` call would hang forever.
+    let dataFileUrls: Record<string, string> | undefined;
+    let dataPackageMetadata: Record<string, unknown> | undefined;
+    if (workerType === 'sherpa-onnx') {
+      const metadataBlobUrl = fileUrls['package-metadata.json'];
+      if (!metadataBlobUrl) {
+        manager.revokeBlobUrls(fileUrls);
+        throw new Error(`Missing package-metadata.json for ASR model "${modelId}"`);
+      }
+
+      try {
+        const response = await fetch(metadataBlobUrl);
+        dataPackageMetadata = await response.json();
+      } catch (err: any) {
+        manager.revokeBlobUrls(fileUrls);
+        throw new Error(`Failed to read package metadata: ${err.message}`);
+      }
+
+      dataFileUrls = {};
+      for (const [name, url] of Object.entries(fileUrls)) {
+        if (name !== 'package-metadata.json') {
+          dataFileUrls[name] = url;
+        }
+      }
+    }
+
     // Create worker based on type
     const makeWorker = (): Worker => {
       switch (workerType) {
@@ -147,7 +180,9 @@ export class AsrEngine {
     });
     this.session = session;
 
-    // Send init message — format depends on worker type
+    // Send init message — format depends on worker type. No `await` sits
+    // between `new WorkerSession(...)` above and any `session.start(...)`
+    // call below, on any path.
     let ready: { loadTimeMs: number };
     if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu' || workerType === 'voxtral-3b-webgpu') {
       ready = await session.start({
@@ -174,29 +209,8 @@ export class AsrEngine {
         vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
       });
     } else {
-      // sherpa-onnx: extract metadata and pass .data blob URL
-      const metadataBlobUrl = fileUrls['package-metadata.json'];
-      if (!metadataBlobUrl) {
-        manager.revokeBlobUrls(fileUrls);
-        throw new Error(`Missing package-metadata.json for ASR model "${modelId}"`);
-      }
-
-      let dataPackageMetadata: Record<string, unknown>;
-      try {
-        const response = await fetch(metadataBlobUrl);
-        dataPackageMetadata = await response.json();
-      } catch (err: any) {
-        manager.revokeBlobUrls(fileUrls);
-        throw new Error(`Failed to read package metadata: ${err.message}`);
-      }
-
-      const dataFileUrls: Record<string, string> = {};
-      for (const [name, url] of Object.entries(fileUrls)) {
-        if (name !== 'package-metadata.json') {
-          dataFileUrls[name] = url;
-        }
-      }
-
+      // sherpa-onnx: dataFileUrls/dataPackageMetadata were loaded above,
+      // before the WorkerSession was constructed.
       ready = await session.start({
         type: 'init',
         fileUrls: dataFileUrls,

--- a/src/lib/local-inference/engine/AsrEngine.ts
+++ b/src/lib/local-inference/engine/AsrEngine.ts
@@ -18,6 +18,7 @@ import {
   type ModelManifestEntry,
 } from '../modelManifest';
 import { ModelManager } from '../ModelManager';
+import { WorkerSession } from './WorkerSession';
 
 export interface AsrResult {
   text: string;
@@ -32,8 +33,7 @@ type StatusCallback = (message: string) => void;
 type ErrorCallback = (error: string) => void;
 
 export class AsrEngine {
-  private worker: Worker | null = null;
-  private isReady = false;
+  private session: WorkerSession | null = null;
   private currentModel: ModelManifestEntry | null = null;
 
   onResult: ResultCallback | null = null;
@@ -57,12 +57,12 @@ export class AsrEngine {
     }
 
     // If already loaded with same model, skip
-    if (this.isReady && this.currentModel?.id === modelId) {
+    if (this.session?.ready && this.currentModel?.id === modelId) {
       return { loadTimeMs: 0 };
     }
 
     // Dispose previous worker if switching models
-    if (this.worker) {
+    if (this.session) {
       this.dispose();
     }
 
@@ -81,51 +81,42 @@ export class AsrEngine {
       throw new Error('Cohere Transcribe requires a source language');
     }
 
-    return new Promise((resolve, reject) => {
-      // Create worker based on type
+    // Create worker based on type
+    const makeWorker = (): Worker => {
       switch (workerType) {
         case 'whisper-webgpu':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/whisper-webgpu.worker.ts', import.meta.url),
             { type: 'module' },
           );
-          break;
         case 'cohere-transcribe-webgpu':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/cohere-transcribe-webgpu.worker.ts', import.meta.url),
             { type: 'module' },
           );
-          break;
         case 'voxtral-3b-webgpu':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/voxtral-3b-webgpu.worker.ts', import.meta.url),
             { type: 'module' },
           );
-          break;
         case 'granite-speech-webgpu':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/granite-speech-webgpu.worker.ts', import.meta.url),
             { type: 'module' },
           );
-          break;
         default: // sherpa-onnx
-          this.worker = new Worker('./workers/sherpa-onnx-asr.worker.js');
-          break;
+          return new Worker('./workers/sherpa-onnx-asr.worker.js');
       }
+    };
 
-      // Cohere and Voxtral 3B workers emit StreamingAsrWorkerOutMessage
-      // (includes 'partial'); other workers emit AsrWorkerOutMessage. Handle the union.
-      this.worker.onmessage = (event: MessageEvent<AsrWorkerOutMessage | StreamingAsrWorkerOutMessage>) => {
-        const msg = event.data;
+    // Cohere and Voxtral 3B workers emit StreamingAsrWorkerOutMessage
+    // (includes 'partial'); other workers emit AsrWorkerOutMessage. Handle the union.
+    const session = new WorkerSession({
+      makeWorker,
+      revokeBlobs: () => manager.revokeBlobUrls(fileUrls),
+      onFatalError: (message) => this.onError?.(message),
+      onMessage: (msg: AsrWorkerOutMessage | StreamingAsrWorkerOutMessage) => {
         switch (msg.type) {
-          case 'ready':
-            this.isReady = true;
-            this.currentModel = model;
-            // Revoke blob URLs after worker has loaded (frees memory, worker has its own copies)
-            manager.revokeBlobUrls(fileUrls);
-            resolve({ loadTimeMs: msg.loadTimeMs });
-            break;
-
           case 'status':
             this.onStatus?.(msg.message);
             break;
@@ -148,85 +139,76 @@ export class AsrEngine {
             break;
 
           case 'error':
+            // Post-ready error; pre-ready 'error' is handled by WorkerSession.
             this.onError?.(msg.error);
-            if (!this.isReady) {
-              manager.revokeBlobUrls(fileUrls);
-              reject(new Error(msg.error));
-            }
-            break;
-
-          case 'disposed':
             break;
         }
-      };
-
-      this.worker.onerror = (error) => {
-        const message = error.message || 'ASR Worker error';
-        this.onError?.(message);
-        if (!this.isReady) {
-          manager.revokeBlobUrls(fileUrls);
-          reject(new Error(message));
-        }
-      };
-
-      // Send init message — format depends on worker type
-      if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu' || workerType === 'voxtral-3b-webgpu') {
-        this.worker.postMessage({
-          type: 'init',
-          fileUrls,
-          hfModelId: model.hfModelId,
-          language,
-          vadConfig,
-          dtype,
-          ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
-          vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
-        });
-      } else if (workerType === 'granite-speech-webgpu') {
-        this.worker.postMessage({
-          type: 'init',
-          fileUrls,
-          hfModelId: model.hfModelId,
-          language,
-          vadConfig,
-          task: taskConfig?.task ?? 'transcribe',
-          targetLanguage: taskConfig?.targetLanguage,
-          dtype,
-          ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
-          vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
-        });
-      } else {
-        // sherpa-onnx: extract metadata and pass .data blob URL
-        const metadataBlobUrl = fileUrls['package-metadata.json'];
-        if (!metadataBlobUrl) {
-          manager.revokeBlobUrls(fileUrls);
-          reject(new Error(`Missing package-metadata.json for ASR model "${modelId}"`));
-          return;
-        }
-
-        fetch(metadataBlobUrl)
-          .then(r => r.json())
-          .then(dataPackageMetadata => {
-            const dataFileUrls: Record<string, string> = {};
-            for (const [name, url] of Object.entries(fileUrls)) {
-              if (name !== 'package-metadata.json') {
-                dataFileUrls[name] = url;
-              }
-            }
-            this.worker!.postMessage({
-              type: 'init',
-              fileUrls: dataFileUrls,
-              asrEngine: model.asrEngine,
-              vadConfig,
-              runtimeBaseUrl: new URL(ASR_BUNDLED_RUNTIME_PATH, window.location.href).href,
-              dataPackageMetadata,
-            });
-          })
-          .catch(err => {
-            manager.revokeBlobUrls(fileUrls);
-            reject(new Error(`Failed to read package metadata: ${err.message}`));
-          });
-      }
+      },
     });
+    this.session = session;
+
+    // Send init message — format depends on worker type
+    let ready: { loadTimeMs: number };
+    if (workerType === 'whisper-webgpu' || workerType === 'cohere-transcribe-webgpu' || workerType === 'voxtral-3b-webgpu') {
+      ready = await session.start({
+        type: 'init',
+        fileUrls,
+        hfModelId: model.hfModelId,
+        language,
+        vadConfig,
+        dtype,
+        ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
+        vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
+      });
+    } else if (workerType === 'granite-speech-webgpu') {
+      ready = await session.start({
+        type: 'init',
+        fileUrls,
+        hfModelId: model.hfModelId,
+        language,
+        vadConfig,
+        task: taskConfig?.task ?? 'transcribe',
+        targetLanguage: taskConfig?.targetLanguage,
+        dtype,
+        ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
+        vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
+      });
+    } else {
+      // sherpa-onnx: extract metadata and pass .data blob URL
+      const metadataBlobUrl = fileUrls['package-metadata.json'];
+      if (!metadataBlobUrl) {
+        manager.revokeBlobUrls(fileUrls);
+        throw new Error(`Missing package-metadata.json for ASR model "${modelId}"`);
+      }
+
+      let dataPackageMetadata: Record<string, unknown>;
+      try {
+        const response = await fetch(metadataBlobUrl);
+        dataPackageMetadata = await response.json();
+      } catch (err: any) {
+        manager.revokeBlobUrls(fileUrls);
+        throw new Error(`Failed to read package metadata: ${err.message}`);
+      }
+
+      const dataFileUrls: Record<string, string> = {};
+      for (const [name, url] of Object.entries(fileUrls)) {
+        if (name !== 'package-metadata.json') {
+          dataFileUrls[name] = url;
+        }
+      }
+
+      ready = await session.start({
+        type: 'init',
+        fileUrls: dataFileUrls,
+        asrEngine: model.asrEngine,
+        vadConfig,
+        runtimeBaseUrl: new URL(ASR_BUNDLED_RUNTIME_PATH, window.location.href).href,
+        dataPackageMetadata,
+      });
+    }
+
+    this.currentModel = model;
+    return { loadTimeMs: ready.loadTimeMs };
   }
 
   /**
@@ -238,10 +220,10 @@ export class AsrEngine {
    * @param sampleRate - Sample rate of the input audio (e.g. 24000)
    */
   feedAudio(samples: Int16Array, sampleRate: number): void {
-    if (!this.worker || !this.isReady) return;
+    if (!this.session?.ready) return;
 
     // Transfer the buffer for zero-copy performance
-    this.worker.postMessage(
+    this.session.post(
       { type: 'audio', samples, sampleRate },
       [samples.buffer]
     );
@@ -252,8 +234,8 @@ export class AsrEngine {
    * Used on PTT release to force recognition without waiting for silence detection.
    */
   flush(): void {
-    if (!this.worker || !this.isReady) return;
-    this.worker.postMessage({ type: 'flush' });
+    if (!this.session?.ready) return;
+    this.session.post({ type: 'flush' });
   }
 
   /**
@@ -264,7 +246,7 @@ export class AsrEngine {
   }
 
   get ready(): boolean {
-    return this.isReady;
+    return this.session?.ready ?? false;
   }
 
   get model(): ModelManifestEntry | null {
@@ -272,12 +254,8 @@ export class AsrEngine {
   }
 
   dispose(): void {
-    if (this.worker) {
-      this.worker.postMessage({ type: 'dispose' });
-      this.worker.terminate();
-      this.worker = null;
-    }
-    this.isReady = false;
+    this.session?.dispose();
+    this.session = null;
     this.currentModel = null;
   }
 }

--- a/src/lib/local-inference/engine/RequestRegistry.test.ts
+++ b/src/lib/local-inference/engine/RequestRegistry.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { RequestRegistry } from './RequestRegistry';
+
+describe('RequestRegistry', () => {
+  it('resolves the pending promise for a matching id', async () => {
+    const r = new RequestRegistry<string>();
+    const p = r.create('a');
+    r.resolve('a', 'done');
+    await expect(p).resolves.toBe('done');
+    expect(r.size).toBe(0); // settled entries are removed
+  });
+
+  it('rejects the pending promise for a matching id', async () => {
+    const r = new RequestRegistry<string>();
+    const p = r.create('a');
+    r.reject('a', new Error('boom'));
+    await expect(p).rejects.toThrow('boom');
+    expect(r.size).toBe(0);
+  });
+
+  it('resolve/reject for an unknown id is a no-op', () => {
+    const r = new RequestRegistry<string>();
+    expect(() => r.resolve('missing', 'x')).not.toThrow();
+    expect(() => r.reject('missing', new Error('x'))).not.toThrow();
+    expect(r.size).toBe(0);
+  });
+
+  it('tracks multiple concurrent pending requests independently', async () => {
+    const r = new RequestRegistry<number>();
+    const a = r.create('a');
+    const b = r.create('b');
+    expect(r.size).toBe(2);
+    r.resolve('b', 2);
+    r.resolve('a', 1);
+    await expect(a).resolves.toBe(1);
+    await expect(b).resolves.toBe(2);
+    expect(r.size).toBe(0);
+  });
+
+  it('rejectAll rejects every pending request and clears the map', async () => {
+    const r = new RequestRegistry<number>();
+    const a = r.create('a');
+    const b = r.create('b');
+    r.rejectAll(new Error('disposed'));
+    await expect(a).rejects.toThrow('disposed');
+    await expect(b).rejects.toThrow('disposed');
+    expect(r.size).toBe(0);
+  });
+});

--- a/src/lib/local-inference/engine/RequestRegistry.ts
+++ b/src/lib/local-inference/engine/RequestRegistry.ts
@@ -1,0 +1,41 @@
+/**
+ * Correlates worker responses to their awaiting callers by request id.
+ * Extracted from TranslationEngine's hand-rolled `pendingRequests` map so the
+ * id→{resolve,reject} bookkeeping (and reject-all-on-dispose) lives in one
+ * tested place. Settled entries are removed so `size` reflects only in-flight
+ * requests.
+ */
+export class RequestRegistry<T> {
+  private readonly pending = new Map<string, { resolve: (v: T) => void; reject: (e: Error) => void }>();
+
+  /** Register a request id and return a promise settled by resolve()/reject(). */
+  create(id: string): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+    });
+  }
+
+  resolve(id: string, value: T): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    entry.resolve(value);
+  }
+
+  reject(id: string, error: Error): void {
+    const entry = this.pending.get(id);
+    if (!entry) return;
+    this.pending.delete(id);
+    entry.reject(error);
+  }
+
+  /** Reject every in-flight request (used on dispose) and clear the map. */
+  rejectAll(error: Error): void {
+    for (const [, entry] of this.pending) entry.reject(error);
+    this.pending.clear();
+  }
+
+  get size(): number {
+    return this.pending.size;
+  }
+}

--- a/src/lib/local-inference/engine/StreamingAsrEngine.test.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.test.ts
@@ -135,5 +135,21 @@ describe('StreamingAsrEngine (characterization)', () => {
         expect.objectContaining({ 'package-metadata.json': 'blob:meta', 'model.onnx': 'blob:m' }),
       );
     });
+
+    it('revokes the raw blob map when the metadata fetch fails (no leak on init failure)', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('network down')));
+      const engine = new StreamingAsrEngine();
+      await expect(engine.init('stream-en-kroko')).rejects.toThrow(/package metadata/i);
+      expect(revokeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ 'package-metadata.json': 'blob:meta', 'model.onnx': 'blob:m' }),
+      );
+    });
+
+    it('revokes the raw blob map when package-metadata.json is missing', async () => {
+      vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({ 'model.onnx': 'blob:m' });
+      const engine = new StreamingAsrEngine();
+      await expect(engine.init('stream-en-kroko')).rejects.toThrow(/Missing package-metadata/i);
+      expect(revokeSpy).toHaveBeenCalledWith(expect.objectContaining({ 'model.onnx': 'blob:m' }));
+    });
   });
 });

--- a/src/lib/local-inference/engine/StreamingAsrEngine.test.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StreamingAsrEngine } from './StreamingAsrEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+
+describe('StreamingAsrEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    // voxtral-mini-4b-webgpu → voxtral-webgpu module worker path, no metadata fetch.
+    vi.spyOn(ModelManager.prototype, 'isModelReady').mockResolvedValue(true);
+    vi.spyOn(ModelManager.prototype, 'getModelVariantInfo').mockResolvedValue({ dtype: 'q4' } as any);
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({ 'model.onnx': 'blob:m' });
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); });
+
+  it('resolves init on ready and revokes blob URLs once', async () => {
+    const engine = new StreamingAsrEngine();
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+    worker.emit({ type: 'ready', loadTimeMs: 9 });
+    await expect(initP).resolves.toEqual({ loadTimeMs: 9 });
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('delivers partial and final results via callbacks', async () => {
+    const engine = new StreamingAsrEngine();
+    const onPartial = vi.fn(); const onResult = vi.fn();
+    engine.onPartialResult = onPartial; engine.onResult = onResult;
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.emit({ type: 'partial', text: 'wor' });
+    worker.emit({ type: 'result', text: 'world', durationMs: 8, recognitionTimeMs: 4 });
+    expect(onPartial).toHaveBeenCalledWith('wor');
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ text: 'world', durationMs: 8, recognitionTimeMs: 4 }));
+  });
+
+  it('rejects init and revokes on a pre-ready error', async () => {
+    const engine = new StreamingAsrEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    // Wait for postMessage: the cleanup-revoking onmessage wrapper is only
+    // installed after the isModelReady/getModelBlobUrls/getModelVariantInfo
+    // awaits resolve, right before postMessage is sent. An error emitted
+    // before that point hits the original (unwrapped) handler and still
+    // rejects + fires onError, but does NOT revoke — so we wait here to
+    // characterize the (wrapped) revoke-on-error path.
+    await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+    worker.emit({ type: 'error', error: 'stream fail' });
+    await expect(initP).rejects.toThrow('stream fail');
+    expect(onError).toHaveBeenCalledWith('stream fail');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('feedAudio and flush post only when ready', async () => {
+    const engine = new StreamingAsrEngine();
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+
+    // Not ready yet — feedAudio/flush must be silently ignored.
+    engine.feedAudio(new Int16Array([9]), 24000);
+    engine.flush();
+    const preReadyCalls = worker.postMessage.mock.calls.filter(
+      ([msg]: [{ type: string }]) => msg?.type === 'audio' || msg?.type === 'flush',
+    );
+    expect(preReadyCalls).toHaveLength(0);
+
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    worker.postMessage.mockClear();
+    const samples = new Int16Array([1, 2]);
+    engine.feedAudio(samples, 24000);
+    engine.flush();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'audio', samples, sampleRate: 24000 }, [samples.buffer]);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'flush' });
+  });
+
+  it('dispose posts dispose, terminates, resets ready', async () => {
+    const engine = new StreamingAsrEngine();
+    const initP = engine.init('voxtral-mini-4b-webgpu');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    const worker = MockWorker.last();
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await initP;
+    engine.dispose();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(engine.ready).toBe(false);
+  });
+});

--- a/src/lib/local-inference/engine/StreamingAsrEngine.test.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.test.ts
@@ -99,4 +99,41 @@ describe('StreamingAsrEngine (characterization)', () => {
     expect(worker.terminate).toHaveBeenCalledTimes(1);
     expect(engine.ready).toBe(false);
   });
+
+  describe('sherpa-onnx streaming path (stream-en-kroko)', () => {
+    // Regression guard: the sherpa worker payload must be filtered (no
+    // package-metadata.json), but revokeBlobUrls must be called with the RAW
+    // map so package-metadata.json's object URL is not leaked. This is
+    // distinct from the voxtral-webgpu suite above, where raw == payload and
+    // this filtering distinction can't be observed.
+    beforeEach(() => {
+      vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({
+        'package-metadata.json': 'blob:meta',
+        'model.onnx': 'blob:m',
+      });
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ json: async () => ({}) }));
+    });
+    afterEach(() => { vi.unstubAllGlobals(); });
+
+    it('revokes the raw blob map, including package-metadata.json, on ready', async () => {
+      const engine = new StreamingAsrEngine();
+      const initP = engine.init('stream-en-kroko');
+      await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+      const worker = MockWorker.last();
+      await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+
+      // The worker payload must be filtered: no package-metadata.json.
+      const [initMessage] = worker.postMessage.mock.calls[0];
+      expect(initMessage.fileUrls).toEqual({ 'model.onnx': 'blob:m' });
+
+      worker.emit({ type: 'ready', loadTimeMs: 5 });
+      await expect(initP).resolves.toEqual({ loadTimeMs: 5 });
+
+      // revokeBlobUrls must receive the RAW map (package-metadata.json included).
+      expect(revokeSpy).toHaveBeenCalledTimes(1);
+      expect(revokeSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ 'package-metadata.json': 'blob:meta', 'model.onnx': 'blob:m' }),
+      );
+    });
+  });
 });

--- a/src/lib/local-inference/engine/StreamingAsrEngine.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.ts
@@ -66,7 +66,14 @@ export class StreamingAsrEngine {
     // Load model file blob URLs (and any worker-specific metadata) before
     // creating the worker, so the WorkerSession can be constructed
     // synchronously once everything it needs is in hand.
+    // `fileUrls` always holds the RAW/unfiltered blob-URL map for the model —
+    // it's what `revokeBlobs` below revokes, so every object URL we created
+    // must stay reachable through it (including package-metadata.json on the
+    // sherpa path, which is filtered OUT of the worker payload but must still
+    // be revoked). `dataFileUrls` (sherpa-only) holds the filtered payload
+    // actually sent to the worker.
     let fileUrls: Record<string, string>;
+    let dataFileUrls: Record<string, string> | undefined;
     let dtype: string | Record<string, string> | undefined;
     let dataPackageMetadata: Record<string, unknown> | undefined;
 
@@ -81,22 +88,21 @@ export class StreamingAsrEngine {
       if (!await manager.isModelReady(modelId)) {
         throw new Error(`Streaming ASR model "${modelId}" is not downloaded.`);
       }
-      const rawFileUrls = await manager.getModelBlobUrls(modelId);
+      fileUrls = await manager.getModelBlobUrls(modelId);
 
-      const metadataBlobUrl = rawFileUrls['package-metadata.json'];
+      const metadataBlobUrl = fileUrls['package-metadata.json'];
       if (!metadataBlobUrl) {
         throw new Error(`Missing package-metadata.json for streaming ASR model "${modelId}"`);
       }
       const metadataResponse = await fetch(metadataBlobUrl);
       dataPackageMetadata = await metadataResponse.json();
 
-      const dataFileUrls: Record<string, string> = {};
-      for (const [name, url] of Object.entries(rawFileUrls)) {
+      dataFileUrls = {};
+      for (const [name, url] of Object.entries(fileUrls)) {
         if (name !== 'package-metadata.json') {
           dataFileUrls[name] = url;
         }
       }
-      fileUrls = dataFileUrls;
     }
 
     // Create worker based on type
@@ -161,7 +167,7 @@ export class StreamingAsrEngine {
         })
       : await session.start({
           type: 'init',
-          fileUrls,
+          fileUrls: dataFileUrls,
           asrEngine: model.asrEngine,
           runtimeBaseUrl: new URL(ASR_STREAM_BUNDLED_RUNTIME_PATH, window.location.href).href,
           dataPackageMetadata,

--- a/src/lib/local-inference/engine/StreamingAsrEngine.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.ts
@@ -81,21 +81,32 @@ export class StreamingAsrEngine {
       if (!await manager.isModelReady(modelId)) {
         throw new Error(`Model "${modelId}" is not downloaded.`);
       }
-      fileUrls = await manager.getModelBlobUrls(modelId);
+      // Variant info before blob URLs: if it throws, no object URLs exist yet
+      // to leak (matches AsrEngine's ordering).
       ({ dtype } = await manager.getModelVariantInfo(modelId));
+      fileUrls = await manager.getModelBlobUrls(modelId);
     } else {
-      // sherpa-onnx streaming path (unchanged logic)
+      // sherpa-onnx streaming path
       if (!await manager.isModelReady(modelId)) {
         throw new Error(`Streaming ASR model "${modelId}" is not downloaded.`);
       }
       fileUrls = await manager.getModelBlobUrls(modelId);
 
+      // `revokeBlobs` isn't wired up until the WorkerSession is constructed
+      // below, so any throw here must revoke the raw map itself, or the model's
+      // object URLs leak on init failure (matches AsrEngine's sherpa path).
       const metadataBlobUrl = fileUrls['package-metadata.json'];
       if (!metadataBlobUrl) {
+        manager.revokeBlobUrls(fileUrls);
         throw new Error(`Missing package-metadata.json for streaming ASR model "${modelId}"`);
       }
-      const metadataResponse = await fetch(metadataBlobUrl);
-      dataPackageMetadata = await metadataResponse.json();
+      try {
+        const metadataResponse = await fetch(metadataBlobUrl);
+        dataPackageMetadata = await metadataResponse.json();
+      } catch (err: any) {
+        manager.revokeBlobUrls(fileUrls);
+        throw new Error(`Failed to read package metadata: ${err.message}`);
+      }
 
       dataFileUrls = {};
       for (const [name, url] of Object.entries(fileUrls)) {

--- a/src/lib/local-inference/engine/StreamingAsrEngine.ts
+++ b/src/lib/local-inference/engine/StreamingAsrEngine.ts
@@ -19,6 +19,7 @@ import {
   type ModelManifestEntry,
 } from '../modelManifest';
 import { ModelManager } from '../ModelManager';
+import { WorkerSession } from './WorkerSession';
 
 
 export interface StreamingAsrResult {
@@ -33,8 +34,7 @@ type StatusCallback = (message: string) => void;
 type ErrorCallback = (error: string) => void;
 
 export class StreamingAsrEngine {
-  private worker: Worker | null = null;
-  private isReady = false;
+  private session: WorkerSession | null = null;
   private currentModel: ModelManifestEntry | null = null;
 
   onResult: ResultCallback | null = null;
@@ -51,155 +51,124 @@ export class StreamingAsrEngine {
     }
 
     // If already loaded with same model, skip
-    if (this.isReady && this.currentModel?.id === modelId) {
+    if (this.session?.ready && this.currentModel?.id === modelId) {
       return { loadTimeMs: 0 };
     }
 
     // Dispose previous worker if switching models
-    if (this.worker) {
+    if (this.session) {
       this.dispose();
     }
 
     const manager = ModelManager.getInstance();
     const workerType = model.asrWorkerType || 'sherpa-onnx';
 
-    return new Promise(async (resolve, reject) => {
-      try {
-        // Create worker based on type
-        switch (workerType) {
-          case 'voxtral-webgpu':
-            this.worker = new Worker(
-              new URL('../workers/voxtral-webgpu.worker.ts', import.meta.url),
-              { type: 'module' },
-            );
-            break;
-          default: // sherpa-onnx streaming
-            this.worker = new Worker('./workers/sherpa-onnx-streaming-asr.worker.js');
-            break;
-        }
+    // Load model file blob URLs (and any worker-specific metadata) before
+    // creating the worker, so the WorkerSession can be constructed
+    // synchronously once everything it needs is in hand.
+    let fileUrls: Record<string, string>;
+    let dtype: string | Record<string, string> | undefined;
+    let dataPackageMetadata: Record<string, unknown> | undefined;
 
-        this.worker.onmessage = (event: MessageEvent<StreamingAsrWorkerOutMessage>) => {
-          const msg = event.data;
-          switch (msg.type) {
-            case 'ready':
-              this.isReady = true;
-              this.currentModel = model;
-              resolve({ loadTimeMs: msg.loadTimeMs });
-              break;
-
-            case 'status':
-              this.onStatus?.(msg.message);
-              break;
-
-            case 'speech_start':
-              this.onSpeechStart?.();
-              break;
-
-            case 'partial':
-              this.onPartialResult?.(msg.text);
-              break;
-
-            case 'result':
-              this.onResult?.({
-                text: msg.text,
-                durationMs: msg.durationMs,
-                recognitionTimeMs: msg.recognitionTimeMs,
-              });
-              break;
-
-            case 'error':
-              this.onError?.(msg.error);
-              if (!this.isReady) {
-                reject(new Error(msg.error));
-              }
-              break;
-
-            case 'disposed':
-              break;
-          }
-        };
-
-        this.worker.onerror = (error) => {
-          const message = error.message || 'Streaming ASR Worker error';
-          this.onError?.(message);
-          if (!this.isReady) {
-            reject(new Error(message));
-          }
-        };
-
-        // Send init message based on worker type
-        if (workerType === 'voxtral-webgpu') {
-          if (!await manager.isModelReady(modelId)) {
-            throw new Error(`Model "${modelId}" is not downloaded.`);
-          }
-          const fileUrls = await manager.getModelBlobUrls(modelId);
-          const { dtype } = await manager.getModelVariantInfo(modelId);
-
-          // Cleanup blob URLs on ready or init error
-          const cleanup = () => manager.revokeBlobUrls(fileUrls);
-          const origOnMessage = this.worker.onmessage;
-          this.worker.onmessage = (event: MessageEvent<StreamingAsrWorkerOutMessage>) => {
-            const msg = event.data;
-            if (msg.type === 'ready' || (msg.type === 'error' && !this.isReady)) {
-              cleanup();
-            }
-            origOnMessage?.call(this.worker, event);
-          };
-
-          this.worker.postMessage({
-            type: 'init',
-            fileUrls,
-            hfModelId: model.hfModelId,
-            language: options?.language,
-            vadConfig: options?.vadConfig,
-            dtype,
-            vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
-            ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
-          });
-        } else {
-          // sherpa-onnx streaming path (unchanged logic)
-          if (!await manager.isModelReady(modelId)) {
-            throw new Error(`Streaming ASR model "${modelId}" is not downloaded.`);
-          }
-          const fileUrls = await manager.getModelBlobUrls(modelId);
-
-          const metadataBlobUrl = fileUrls['package-metadata.json'];
-          if (!metadataBlobUrl) {
-            throw new Error(`Missing package-metadata.json for streaming ASR model "${modelId}"`);
-          }
-          const metadataResponse = await fetch(metadataBlobUrl);
-          const dataPackageMetadata = await metadataResponse.json();
-
-          const dataFileUrls: Record<string, string> = {};
-          for (const [name, url] of Object.entries(fileUrls)) {
-            if (name !== 'package-metadata.json') {
-              dataFileUrls[name] = url;
-            }
-          }
-
-          // Store fileUrls reference for cleanup on ready/error
-          const cleanup = () => manager.revokeBlobUrls(fileUrls);
-          const origOnMessage = this.worker.onmessage;
-          this.worker.onmessage = (event: MessageEvent<StreamingAsrWorkerOutMessage>) => {
-            const msg = event.data;
-            if (msg.type === 'ready' || (msg.type === 'error' && !this.isReady)) {
-              cleanup();
-            }
-            origOnMessage?.call(this.worker, event);
-          };
-
-          this.worker.postMessage({
-            type: 'init',
-            fileUrls: dataFileUrls,
-            asrEngine: model.asrEngine,
-            runtimeBaseUrl: new URL(ASR_STREAM_BUNDLED_RUNTIME_PATH, window.location.href).href,
-            dataPackageMetadata,
-          });
-        }
-      } catch (err) {
-        reject(err);
+    if (workerType === 'voxtral-webgpu') {
+      if (!await manager.isModelReady(modelId)) {
+        throw new Error(`Model "${modelId}" is not downloaded.`);
       }
+      fileUrls = await manager.getModelBlobUrls(modelId);
+      ({ dtype } = await manager.getModelVariantInfo(modelId));
+    } else {
+      // sherpa-onnx streaming path (unchanged logic)
+      if (!await manager.isModelReady(modelId)) {
+        throw new Error(`Streaming ASR model "${modelId}" is not downloaded.`);
+      }
+      const rawFileUrls = await manager.getModelBlobUrls(modelId);
+
+      const metadataBlobUrl = rawFileUrls['package-metadata.json'];
+      if (!metadataBlobUrl) {
+        throw new Error(`Missing package-metadata.json for streaming ASR model "${modelId}"`);
+      }
+      const metadataResponse = await fetch(metadataBlobUrl);
+      dataPackageMetadata = await metadataResponse.json();
+
+      const dataFileUrls: Record<string, string> = {};
+      for (const [name, url] of Object.entries(rawFileUrls)) {
+        if (name !== 'package-metadata.json') {
+          dataFileUrls[name] = url;
+        }
+      }
+      fileUrls = dataFileUrls;
+    }
+
+    // Create worker based on type
+    const makeWorker = (): Worker => {
+      switch (workerType) {
+        case 'voxtral-webgpu':
+          return new Worker(
+            new URL('../workers/voxtral-webgpu.worker.ts', import.meta.url),
+            { type: 'module' },
+          );
+        default: // sherpa-onnx streaming
+          return new Worker('./workers/sherpa-onnx-streaming-asr.worker.js');
+      }
+    };
+
+    const session = new WorkerSession({
+      makeWorker,
+      revokeBlobs: () => manager.revokeBlobUrls(fileUrls),
+      onFatalError: (message) => this.onError?.(message),
+      onMessage: (msg: StreamingAsrWorkerOutMessage) => {
+        switch (msg.type) {
+          case 'status':
+            this.onStatus?.(msg.message);
+            break;
+
+          case 'speech_start':
+            this.onSpeechStart?.();
+            break;
+
+          case 'partial':
+            this.onPartialResult?.(msg.text);
+            break;
+
+          case 'result':
+            this.onResult?.({
+              text: msg.text,
+              durationMs: msg.durationMs,
+              recognitionTimeMs: msg.recognitionTimeMs,
+            });
+            break;
+
+          case 'error':
+            // Post-ready error; pre-ready 'error' is handled by WorkerSession.
+            this.onError?.(msg.error);
+            break;
+        }
+      },
     });
+    this.session = session;
+
+    // Send init message based on worker type
+    const ready = workerType === 'voxtral-webgpu'
+      ? await session.start({
+          type: 'init',
+          fileUrls,
+          hfModelId: model.hfModelId,
+          language: options?.language,
+          vadConfig: options?.vadConfig,
+          dtype,
+          vadModelUrl: new URL('./wasm/vad/silero_vad_v5.onnx', window.location.href).href,
+          ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
+        })
+      : await session.start({
+          type: 'init',
+          fileUrls,
+          asrEngine: model.asrEngine,
+          runtimeBaseUrl: new URL(ASR_STREAM_BUNDLED_RUNTIME_PATH, window.location.href).href,
+          dataPackageMetadata,
+        });
+
+    this.currentModel = model;
+    return { loadTimeMs: ready.loadTimeMs };
   }
 
   /**
@@ -212,10 +181,10 @@ export class StreamingAsrEngine {
    * @param sampleRate - Sample rate of the input audio (e.g. 24000)
    */
   feedAudio(samples: Int16Array, sampleRate: number): void {
-    if (!this.worker || !this.isReady) return;
+    if (!this.session?.ready) return;
 
     // Transfer the buffer for zero-copy performance
-    this.worker.postMessage(
+    this.session.post(
       { type: 'audio', samples, sampleRate },
       [samples.buffer]
     );
@@ -227,8 +196,8 @@ export class StreamingAsrEngine {
    * as a final result when the user releases the PTT key.
    */
   flush(): void {
-    if (!this.worker || !this.isReady) return;
-    this.worker.postMessage({ type: 'flush' });
+    if (!this.session?.ready) return;
+    this.session.post({ type: 'flush' });
   }
 
   /**
@@ -239,7 +208,7 @@ export class StreamingAsrEngine {
   }
 
   get ready(): boolean {
-    return this.isReady;
+    return this.session?.ready ?? false;
   }
 
   get model(): ModelManifestEntry | null {
@@ -247,12 +216,8 @@ export class StreamingAsrEngine {
   }
 
   dispose(): void {
-    if (this.worker) {
-      this.worker.postMessage({ type: 'dispose' });
-      this.worker.terminate();
-      this.worker = null;
-    }
-    this.isReady = false;
+    this.session?.dispose();
+    this.session = null;
     this.currentModel = null;
   }
 }

--- a/src/lib/local-inference/engine/TranslationEngine.test.ts
+++ b/src/lib/local-inference/engine/TranslationEngine.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TranslationEngine } from './TranslationEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+
+async function initReady(engine: TranslationEngine, model = 'opus-mt-ja-en') {
+  const initP = engine.init('ja', 'en', model);
+  await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+  const worker = MockWorker.last();
+  await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+  worker.emit({ type: 'ready', loadTimeMs: 3, device: 'wasm' });
+  await initP;
+  return worker;
+}
+
+describe('TranslationEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    vi.spyOn(ModelManager.prototype, 'isModelReady').mockResolvedValue(true);
+    vi.spyOn(ModelManager.prototype, 'getModelVariantInfo').mockResolvedValue({ dtype: 'default' } as any);
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue({ 'config.json': 'blob:c' });
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); });
+
+  it('resolves init on ready and revokes blob URLs once', async () => {
+    const engine = new TranslationEngine();
+    await initReady(engine);
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('translate() correlates the result by id', async () => {
+    const engine = new TranslationEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+    const p = engine.translate('こんにちは', 'sys', true);
+    // capture the id the engine assigned
+    const sent = worker.postMessage.mock.calls[0][0] as any;
+    expect(sent.type).toBe('translate');
+    worker.emit({ type: 'result', id: sent.id, sourceText: 'こんにちは', translatedText: 'hello', inferenceTimeMs: 12 });
+    await expect(p).resolves.toEqual(expect.objectContaining({ translatedText: 'hello', inferenceTimeMs: 12 }));
+  });
+
+  it('an id-scoped error rejects only that request', async () => {
+    const engine = new TranslationEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+    const p = engine.translate('x', 'sys', false);
+    const sent = worker.postMessage.mock.calls[0][0] as any;
+    worker.emit({ type: 'error', id: sent.id, error: 'translate failed' });
+    await expect(p).rejects.toThrow('translate failed');
+  });
+
+  it('dispose rejects all pending translate() promises and posts dispose', async () => {
+    const engine = new TranslationEngine();
+    const worker = await initReady(engine);
+    const p1 = engine.translate('a', 's', false);
+    const p2 = engine.translate('b', 's', false);
+    engine.dispose();
+    await expect(p1).rejects.toThrow(/disposed/i);
+    await expect(p2).rejects.toThrow(/disposed/i);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects init and revokes on a pre-ready error', async () => {
+    const engine = new TranslationEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('ja', 'en', 'opus-mt-ja-en');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'model load failed' });
+    await expect(initP).rejects.toThrow('model load failed');
+    expect(onError).toHaveBeenCalledWith('model load failed');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/local-inference/engine/TranslationEngine.ts
+++ b/src/lib/local-inference/engine/TranslationEngine.ts
@@ -8,6 +8,8 @@
 import { getTranslationModel, getManifestEntry, getManifestByType } from '../modelManifest';
 import { ModelManager } from '../ModelManager';
 import { isExtension } from '../../../utils/environment';
+import { WorkerSession } from './WorkerSession';
+import { RequestRegistry } from './RequestRegistry';
 
 export interface TranslationResult {
   sourceText: string;
@@ -19,15 +21,11 @@ export interface TranslationResult {
 type ErrorCallback = (error: string) => void;
 
 export class TranslationEngine {
-  private worker: Worker | null = null;
-  private isReady = false;
+  private session: WorkerSession | null = null;
   private currentModelId: string | null = null;
   private sourceLang = '';
   private targetLang = '';
-  private pendingRequests = new Map<string, {
-    resolve: (result: TranslationResult) => void;
-    reject: (error: Error) => void;
-  }>();
+  private readonly reqs = new RequestRegistry<TranslationResult>();
   private requestCounter = 0;
   private bingDnrActive = false;
 
@@ -57,13 +55,13 @@ export class TranslationEngine {
     const modelCacheKey = entry.hfModelId ?? entry.id;
 
     // If already loaded with same model and same language pair, skip
-    if (this.isReady && this.currentModelId === modelCacheKey
+    if (this.session?.ready && this.currentModelId === modelCacheKey
       && this.sourceLang === sourceLang && this.targetLang === targetLang) {
       return { loadTimeMs: 0, device: entry.isCloudModel ? 'cloud' : (entry.requiredDevice || 'wasm') };
     }
 
     // Dispose previous worker if switching models
-    if (this.worker) {
+    if (this.session) {
       this.dispose();
     }
 
@@ -96,106 +94,91 @@ export class TranslationEngine {
       this.bingDnrActive = true;
     }
 
-    return new Promise((resolve, reject) => {
+    const makeWorker = (): Worker => {
       switch (workerType) {
         case 'bing':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/bing-translation.worker.ts', import.meta.url),
             { type: 'module' }
           );
-          break;
         case 'qwen35':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/qwen35-translation.worker.ts', import.meta.url),
             { type: 'module' }
           );
-          break;
         case 'qwen':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/qwen-translation.worker.ts', import.meta.url),
             { type: 'module' }
           );
-          break;
         case 'translategemma':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/translategemma-translation.worker.ts', import.meta.url),
             { type: 'module' }
           );
-          break;
         case 'hy-mt':
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/hy-mt-translation.worker.ts', import.meta.url),
             { type: 'module' }
           );
-          break;
         default: // opus-mt
-          this.worker = new Worker(
+          return new Worker(
             new URL('../workers/translation.worker.ts', import.meta.url),
             { type: 'module' }
           );
-          break;
       }
+    };
 
-      this.worker.onmessage = (event) => {
-        const msg = event.data;
-        switch (msg.type) {
-          case 'ready':
-            this.isReady = true;
-            this.currentModelId = modelCacheKey;
-            // Revoke blob URLs after worker has loaded (frees memory; no-op for cloud models)
-            manager.revokeBlobUrls(fileUrls);
-            resolve({ loadTimeMs: msg.loadTimeMs, device: msg.device || 'wasm' });
-            break;
-
-          case 'result': {
-            const pending = this.pendingRequests.get(msg.id);
-            if (pending) {
-              this.pendingRequests.delete(msg.id);
-              pending.resolve({
-                sourceText: msg.sourceText,
-                translatedText: msg.translatedText,
-                inferenceTimeMs: msg.inferenceTimeMs,
-                systemPrompt: msg.systemPrompt,
-              });
-            }
-            break;
-          }
-
-          case 'error': {
-            if (msg.id) {
-              const pending = this.pendingRequests.get(msg.id);
-              if (pending) {
-                this.pendingRequests.delete(msg.id);
-                pending.reject(new Error(msg.error));
-              }
-            } else {
-              this.onError?.(msg.error);
-              if (!this.isReady) {
-                manager.revokeBlobUrls(fileUrls);
-                reject(new Error(msg.error));
-              }
-            }
-            break;
-          }
-
-          case 'disposed':
-            break;
-        }
-      };
-
-      this.worker.onerror = (error) => {
-        const message = error.message || 'Worker error';
-        this.onError?.(message);
-        if (!this.isReady) {
-          manager.revokeBlobUrls(fileUrls);
-          reject(new Error(message));
-        }
-      };
-
-      // Send init message with blob URLs + language info + dtype from variant.
-      // hfModelId / fileUrls / dtype are empty/undefined for cloud models (e.g. bing); those workers only read sourceLang/targetLang.
-      this.worker.postMessage({ type: 'init', hfModelId: entry.hfModelId, fileUrls, sourceLang, targetLang, dtype, ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href });
+    const session = new WorkerSession({
+      makeWorker,
+      revokeBlobs: () => manager.revokeBlobUrls(fileUrls),
+      onFatalError: (message) => this.onError?.(message),
+      onMessage: (msg) => this.route(msg),
     });
+    this.session = session;
+
+    // Send init message with blob URLs + language info + dtype from variant.
+    // hfModelId / fileUrls / dtype are empty/undefined for cloud models (e.g. bing); those workers only read sourceLang/targetLang.
+    const ready = await session.start({
+      type: 'init',
+      hfModelId: entry.hfModelId,
+      fileUrls,
+      sourceLang,
+      targetLang,
+      dtype,
+      ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
+    });
+    this.currentModelId = modelCacheKey;
+    return { loadTimeMs: ready.loadTimeMs, device: ready.device || 'wasm' };
+  }
+
+  /**
+   * Route non-handshake worker messages to the appropriate handler.
+   * The init handshake ('ready' / pre-ready 'error') is handled by WorkerSession.
+   */
+  private route(msg: any): void {
+    switch (msg.type) {
+      case 'result':
+        this.reqs.resolve(msg.id, {
+          sourceText: msg.sourceText,
+          translatedText: msg.translatedText,
+          inferenceTimeMs: msg.inferenceTimeMs,
+          systemPrompt: msg.systemPrompt,
+        });
+        break;
+
+      case 'error':
+        if (msg.id) {
+          this.reqs.reject(msg.id, new Error(msg.error));
+        } else {
+          // Post-ready fatal error; pre-ready fatal error is handled by WorkerSession.
+          this.onError?.(msg.error);
+        }
+        break;
+
+      case 'disposed':
+        break;
+    }
   }
 
   /**
@@ -206,24 +189,22 @@ export class TranslationEngine {
    * @param wrapTranscript    If true, wrap user message in <transcript> tags. Ignored by non-LLM workers.
    */
   async translate(text: string, systemPrompt: string, wrapTranscript: boolean): Promise<TranslationResult> {
-    if (!this.worker || !this.isReady) {
+    if (!this.session?.ready) {
       throw new Error('TranslationEngine not initialized. Call init() first.');
     }
 
     const id = `tr_${++this.requestCounter}`;
-
-    return new Promise((resolve, reject) => {
-      this.pendingRequests.set(id, { resolve, reject });
-      this.worker!.postMessage({
-        type: 'translate',
-        id,
-        text,
-        sourceLang: this.sourceLang,
-        targetLang: this.targetLang,
-        systemPrompt,
-        wrapTranscript,
-      });
+    const p = this.reqs.create(id);
+    this.session!.post({
+      type: 'translate',
+      id,
+      text,
+      sourceLang: this.sourceLang,
+      targetLang: this.targetLang,
+      systemPrompt,
+      wrapTranscript,
     });
+    return p;
   }
 
   /**
@@ -249,7 +230,7 @@ export class TranslationEngine {
   }
 
   get ready(): boolean {
-    return this.isReady;
+    return this.session?.ready ?? false;
   }
 
   get modelId(): string | null {
@@ -257,25 +238,18 @@ export class TranslationEngine {
   }
 
   dispose(): void {
-    if (this.worker) {
-      this.worker.postMessage({ type: 'dispose' });
-      this.worker.terminate();
-      this.worker = null;
-    }
+    this.session?.dispose();
+    this.session = null;
     if (this.bingDnrActive) {
       setBingTranslatorDNR(false);
       this.bingDnrActive = false;
     }
-    this.isReady = false;
     this.currentModelId = null;
     this.sourceLang = '';
     this.targetLang = '';
 
     // Reject all pending requests
-    for (const [, pending] of this.pendingRequests) {
-      pending.reject(new Error('TranslationEngine disposed'));
-    }
-    this.pendingRequests.clear();
+    this.reqs.rejectAll(new Error('TranslationEngine disposed'));
   }
 }
 

--- a/src/lib/local-inference/engine/TtsEngine.test.ts
+++ b/src/lib/local-inference/engine/TtsEngine.test.ts
@@ -112,4 +112,46 @@ describe('TtsEngine (characterization)', () => {
     expect(onError).toHaveBeenCalledWith('tts load failed');
     expect(revokeSpy).toHaveBeenCalledTimes(1);
   });
+
+  // TtsEngine holds only one in-flight slot: `pendingGenerate`/`pendingStream`
+  // are single-entry fields, not queues. `generate()` and `generateStream()`
+  // both guard on them at the very top of the (async) method body — before
+  // any `await` — with `throw new Error('A generation request is already in
+  // progress')`. Because the method is `async`, that synchronous throw is
+  // wrapped into a rejected Promise rather than thrown to the caller
+  // directly, so callers observe it as a rejection. This is exactly the
+  // single-slot behavior the Task 10 refactor must preserve.
+  it('generate() rejects a second concurrent call while one is already pending', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+
+    const firstP = engine.generate('first', 0, 1.0); // left unsettled on purpose
+    await expect(engine.generate('second', 0, 1.0))
+      .rejects.toThrow('A generation request is already in progress');
+
+    // Only the first call reached the worker — the second was rejected
+    // before ever posting a message.
+    expect(worker.postMessage).toHaveBeenCalledTimes(1);
+
+    // Settle the still-pending first request so it doesn't leak into other tests.
+    worker.emit({ type: 'result', samples: new Float32Array(), sampleRate: 24000, generationTimeMs: 1 });
+    await expect(firstP).resolves.toEqual(expect.objectContaining({ sampleRate: 24000 }));
+  });
+
+  it('generateStream() rejects while a generate() call is already pending', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+
+    const pendingGenerateP = engine.generate('hi', 0, 1.0); // left unsettled on purpose
+    await expect(engine.generateStream('hi', 0, 1.0))
+      .rejects.toThrow('A generation request is already in progress');
+
+    // The guard fires before the decode-start handshake, so generateStream()
+    // never touches the worker or EdgeTtsConnection.
+    expect(worker.postMessage).not.toHaveBeenCalledWith({ type: 'decode-start' });
+
+    worker.emit({ type: 'result', samples: new Float32Array(), sampleRate: 24000, generationTimeMs: 1 });
+    await pendingGenerateP;
+  });
 });

--- a/src/lib/local-inference/engine/TtsEngine.test.ts
+++ b/src/lib/local-inference/engine/TtsEngine.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { TtsEngine } from './TtsEngine';
+import { MockWorker, installMockWorker } from './testing/mockWorker';
+import { ModelManager } from '../ModelManager';
+import * as voiceStorage from '../voiceStorage';
+import { EdgeTtsConnection } from '../../edge-tts/EdgeTtsConnection';
+
+const SUPERTONIC_BLOBS = {
+  'onnx/duration_predictor.onnx': 'blob:dp', 'onnx/text_encoder.onnx': 'blob:te',
+  'onnx/vector_estimator.onnx': 'blob:ve', 'onnx/vocoder.onnx': 'blob:vc',
+  'onnx/tts.json': 'blob:tts', 'onnx/unicode_indexer.json': 'blob:idx',
+  'voice_styles/F1.json': 'blob:f1',
+};
+
+async function initReady(engine: TtsEngine) {
+  const initP = engine.init('supertonic-3');
+  await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+  const worker = MockWorker.last();
+  await vi.waitFor(() => expect(worker.postMessage).toHaveBeenCalled());
+  worker.emit({ type: 'ready', numSpeakers: 1, sampleRate: 24000, loadTimeMs: 5 });
+  await initP;
+  return worker;
+}
+
+describe('TtsEngine (characterization)', () => {
+  let restore: () => void;
+  let revokeSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    restore = installMockWorker();
+    URL.createObjectURL = vi.fn(() => `blob:${Math.random()}`);
+    URL.revokeObjectURL = vi.fn();
+    vi.spyOn(ModelManager.prototype, 'getModelBlobUrls').mockResolvedValue(SUPERTONIC_BLOBS as any);
+    revokeSpy = vi.spyOn(ModelManager.prototype, 'revokeBlobUrls').mockImplementation(() => {});
+    vi.spyOn(voiceStorage, 'listVoices').mockResolvedValue([]);
+  });
+  afterEach(() => { restore(); vi.restoreAllMocks(); });
+
+  it('resolves init on ready and revokes blob URLs once', async () => {
+    const engine = new TtsEngine();
+    await initReady(engine);
+    expect(engine.ready).toBe(true);
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('generate() resolves on the result message', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    worker.postMessage.mockClear();
+    const samples = new Float32Array([0.1, 0.2]);
+    const p = engine.generate('hi', 0, 1.0);
+    expect(worker.postMessage).toHaveBeenCalledWith(expect.objectContaining({ type: 'generate' }));
+    worker.emit({ type: 'result', samples, sampleRate: 24000, generationTimeMs: 20 });
+    await expect(p).resolves.toEqual(expect.objectContaining({ sampleRate: 24000 }));
+  });
+
+  // generateStream() is TtsEngine's *only* streaming path today, and it is
+  // unconditionally backed by EdgeTtsConnection (a real WebSocket client) —
+  // it does not branch on the currently loaded model's engine. It first
+  // round-trips a 'decode-ready' handshake through `worker.addEventListener`
+  // (not `worker.onmessage`, so `MockWorker#emit` can't drive it directly),
+  // then hands the actual synthesis off to EdgeTtsConnection. To pin the
+  // observable audio-chunk/audio-done routing without opening a real socket,
+  // we invoke the captured 'message' listener manually for the handshake and
+  // stub out EdgeTtsConnection so `generate()` resolves without networking.
+  it('generateStream() forwards audio-chunk to onChunk and resolves on audio-done', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    const edgeGenerateSpy = vi.spyOn(EdgeTtsConnection.prototype, 'generate').mockResolvedValue(undefined);
+
+    const chunks: Float32Array[] = [];
+    const p = engine.generateStream('hi', 0, 1.0, undefined, (s) => chunks.push(s));
+
+    // The decode-ready handshake is posted and awaited synchronously before
+    // the first `await` inside generateStream(), so it's already recorded.
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'decode-start' });
+    const messageListenerCall = worker.addEventListener.mock.calls.find(
+      (call: unknown[]) => call[0] === 'message',
+    );
+    expect(messageListenerCall).toBeDefined();
+    const handler = messageListenerCall![1] as (e: MessageEvent) => void;
+    handler({ data: { type: 'decode-ready' } } as MessageEvent);
+
+    // Let the post-handshake continuation run (sets pendingStream, calls
+    // EdgeTtsConnection.generate — mocked, so it settles without a socket).
+    await vi.waitFor(() => expect(edgeGenerateSpy).toHaveBeenCalledTimes(1));
+
+    worker.emit({ type: 'audio-chunk', samples: new Float32Array([1]), sampleRate: 24000 });
+    worker.emit({ type: 'audio-done', generationTimeMs: 30 });
+    await expect(p).resolves.toEqual(expect.objectContaining({ generationTimeMs: 30 }));
+    expect(chunks.length).toBe(1);
+  });
+
+  it('dispose rejects a pending generate and posts dispose', async () => {
+    const engine = new TtsEngine();
+    const worker = await initReady(engine);
+    const p = engine.generate('hi', 0, 1.0);
+    engine.dispose();
+    await expect(p).rejects.toThrow(/disposed/i);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(engine.ready).toBe(false);
+  });
+
+  it('a pre-ready error rejects init and revokes', async () => {
+    const engine = new TtsEngine();
+    const onError = vi.fn(); engine.onError = onError;
+    const initP = engine.init('supertonic-3');
+    await vi.waitFor(() => expect(MockWorker.instances.length).toBe(1));
+    MockWorker.last().emit({ type: 'error', error: 'tts load failed' });
+    await expect(initP).rejects.toThrow('tts load failed');
+    expect(onError).toHaveBeenCalledWith('tts load failed');
+    expect(revokeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/local-inference/engine/TtsEngine.ts
+++ b/src/lib/local-inference/engine/TtsEngine.ts
@@ -18,6 +18,7 @@ import { ModelManager } from '../ModelManager';
 import { EdgeTtsConnection } from '../../edge-tts/EdgeTtsConnection';
 import { listVoices } from '../voiceStorage';
 import { importedSidFromDbKey } from '../sidMapping';
+import { WorkerSession } from './WorkerSession';
 
 export interface TtsResult {
   samples: Float32Array;
@@ -31,8 +32,7 @@ type StatusCallback = (message: string) => void;
 type ErrorCallback = (error: string) => void;
 
 export class TtsEngine {
-  private worker: Worker | null = null;
-  private isReady = false;
+  private session: WorkerSession | null = null;
   private currentModel: ModelManifestEntry | null = null;
   private _numSpeakers = 0;
   private _sampleRate = 0;
@@ -72,12 +72,12 @@ export class TtsEngine {
     }
 
     // If already loaded with same model, skip
-    if (this.isReady && this.currentModel?.id === modelId) {
+    if (this.session?.ready && this.currentModel?.id === modelId) {
       return { loadTimeMs: 0, numSpeakers: this._numSpeakers, sampleRate: this._sampleRate };
     }
 
     // Dispose previous worker if switching models
-    if (this.worker) {
+    if (this.session) {
       this.dispose();
     }
 
@@ -146,107 +146,31 @@ export class TtsEngine {
       }
     }
 
-    return new Promise((resolve, reject) => {
-      // Select worker based on engine type. Supertonic uses Vite's bundled
-      // module-worker pattern (TypeScript source, ORT compiled into bundle).
-      // The other workers are hand-written JS served from public/.
+    // Select worker based on engine type. Supertonic uses Vite's bundled
+    // module-worker pattern (TypeScript source, ORT compiled into bundle).
+    // The other workers are hand-written JS served from public/.
+    const makeWorker = (): Worker => {
       if (isSupertonic) {
-        this.worker = new Worker(
+        return new Worker(
           new URL('../workers/supertonic-tts.worker.ts', import.meta.url),
           { type: 'module' },
         );
-      } else {
-        const workerUrl = isEdgeTts
-          ? './workers/edge-tts.worker.js'
-          : isPiperPlus
-            ? './workers/piper-plus-tts.worker.js'
-            : './workers/sherpa-onnx-tts.worker.js';
-        this.worker = new Worker(workerUrl);
       }
+      const workerUrl = isEdgeTts
+        ? './workers/edge-tts.worker.js'
+        : isPiperPlus
+          ? './workers/piper-plus-tts.worker.js'
+          : './workers/sherpa-onnx-tts.worker.js';
+      return new Worker(workerUrl);
+    };
 
-      this.worker.onmessage = (event: MessageEvent<TtsWorkerOutMessage>) => {
-        const msg = event.data;
-        switch (msg.type) {
-          case 'ready':
-            this.isReady = true;
-            this.currentModel = model;
-            this._numSpeakers = msg.numSpeakers;
-            this._sampleRate = msg.sampleRate;
-            if (!isEdgeTts) {
-              const manager = ModelManager.getInstance();
-              manager.revokeBlobUrls(fileUrls);
-            }
-            resolve({
-              loadTimeMs: msg.loadTimeMs,
-              numSpeakers: msg.numSpeakers,
-              sampleRate: msg.sampleRate,
-              voices: msg.voices,
-              backend: msg.backend,
-            });
-            break;
-
-          case 'status':
-            this.onStatus?.(msg.message);
-            break;
-
-          case 'result':
-            if (this.pendingGenerate) {
-              this.pendingGenerate.resolve({
-                samples: msg.samples,
-                sampleRate: msg.sampleRate,
-                generationTimeMs: msg.generationTimeMs,
-              });
-              this.pendingGenerate = null;
-            }
-            break;
-
-          case 'audio-chunk':
-            if (this.pendingStream) {
-              this.pendingStream.onChunk(msg.samples, msg.sampleRate);
-            }
-            break;
-
-          case 'audio-done':
-            if (this.pendingStream) {
-              this.pendingStream.resolve({ generationTimeMs: msg.generationTimeMs });
-              this.pendingStream = null;
-            }
-            break;
-
-          case 'error':
-            this.onError?.(msg.error);
-            if (!this.isReady) {
-              if (!isEdgeTts) {
-                const manager = ModelManager.getInstance();
-                manager.revokeBlobUrls(fileUrls);
-              }
-              reject(new Error(msg.error));
-            }
-            if (this.pendingGenerate) {
-              this.pendingGenerate.reject(new Error(msg.error));
-              this.pendingGenerate = null;
-            }
-            if (this.pendingStream) {
-              this.pendingStream.reject(new Error(msg.error));
-              this.pendingStream = null;
-            }
-            break;
-
-          case 'disposed':
-            break;
-        }
-      };
-
-      this.worker.onerror = (error) => {
-        const message = error.message || 'TTS Worker error';
+    const session = new WorkerSession({
+      makeWorker,
+      onMessage: (msg: TtsWorkerOutMessage) => this.route(msg),
+      // Edge TTS has nothing to revoke — it uses the network directly, not IndexedDB blobs.
+      revokeBlobs: isEdgeTts ? undefined : () => ModelManager.getInstance().revokeBlobUrls(fileUrls),
+      onFatalError: (message) => {
         this.onError?.(message);
-        if (!this.isReady) {
-          if (!isEdgeTts) {
-            const manager = ModelManager.getInstance();
-            manager.revokeBlobUrls(fileUrls);
-          }
-          reject(new Error(message));
-        }
         if (this.pendingGenerate) {
           this.pendingGenerate.reject(new Error(message));
           this.pendingGenerate = null;
@@ -255,54 +179,124 @@ export class TtsEngine {
           this.pendingStream.reject(new Error(message));
           this.pendingStream = null;
         }
-      };
-
-      // Send engine-specific init message
-      if (isEdgeTts) {
-        this.worker.postMessage({ type: 'init' });
-      } else if (isPiperPlus) {
-        this.worker.postMessage({
-          type: 'init',
-          fileUrls,
-          runtimeBaseUrl: new URL(PIPER_PLUS_BUNDLED_RUNTIME_PATH, window.location.href).href,
-          ortBaseUrl: new URL(ORT_BUNDLED_PATH, window.location.href).href,
-          engine: 'piper-plus',
-          ttsConfig: model.ttsConfig || {},
-        });
-      } else if (isSupertonic) {
-        const presets = model.ttsConfig?.presetVoices ?? [];
-        const presetEntries = presets.map(p => ({
-          sid: p.sid,
-          name: p.name,
-          source: 'preset' as const,
-          gender: p.gender,
-          blobUrl: fileUrls[p.file],
-        })).filter(v => v.blobUrl);
-
-        // Merge preset + imported voices (imported loaded before Promise, sid = dbKey + 10)
-        const voiceList = [...presetEntries, ...supertonicImportedEntries];
-
-        this.worker.postMessage({
-          type: 'init',
-          fileUrls: dataFileUrls,
-          voiceList,
-          // Trailing slash matches whisper-webgpu / voxtral-webgpu workers;
-          // ORT uses this as `ort.env.wasm.wasmPaths` to find jsep wasm files.
-          ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
-          ttsConfig: model.ttsConfig || {},
-        });
-      } else {
-        this.worker.postMessage({
-          type: 'init',
-          modelFile: model.modelFile || '',
-          engine: model.engine || '',
-          ttsConfig: model.ttsConfig || {},
-          runtimeBaseUrl: new URL(TTS_BUNDLED_RUNTIME_PATH, window.location.href).href,
-          dataPackageMetadata,
-          fileUrls: dataFileUrls,
-        });
-      }
+      },
     });
+    this.session = session;
+
+    // Build the engine-specific init message
+    let initMessage: Record<string, unknown>;
+    if (isEdgeTts) {
+      initMessage = { type: 'init' };
+    } else if (isPiperPlus) {
+      initMessage = {
+        type: 'init',
+        fileUrls,
+        runtimeBaseUrl: new URL(PIPER_PLUS_BUNDLED_RUNTIME_PATH, window.location.href).href,
+        ortBaseUrl: new URL(ORT_BUNDLED_PATH, window.location.href).href,
+        engine: 'piper-plus',
+        ttsConfig: model.ttsConfig || {},
+      };
+    } else if (isSupertonic) {
+      const presets = model.ttsConfig?.presetVoices ?? [];
+      const presetEntries = presets.map(p => ({
+        sid: p.sid,
+        name: p.name,
+        source: 'preset' as const,
+        gender: p.gender,
+        blobUrl: fileUrls[p.file],
+      })).filter(v => v.blobUrl);
+
+      // Merge preset + imported voices (imported loaded before the worker was created, sid = dbKey + 10)
+      const voiceList = [...presetEntries, ...supertonicImportedEntries];
+
+      initMessage = {
+        type: 'init',
+        fileUrls: dataFileUrls,
+        voiceList,
+        // Trailing slash matches whisper-webgpu / voxtral-webgpu workers;
+        // ORT uses this as `ort.env.wasm.wasmPaths` to find jsep wasm files.
+        ortWasmBaseUrl: new URL('./wasm/ort/', window.location.href).href,
+        ttsConfig: model.ttsConfig || {},
+      };
+    } else {
+      initMessage = {
+        type: 'init',
+        modelFile: model.modelFile || '',
+        engine: model.engine || '',
+        ttsConfig: model.ttsConfig || {},
+        runtimeBaseUrl: new URL(TTS_BUNDLED_RUNTIME_PATH, window.location.href).href,
+        dataPackageMetadata,
+        fileUrls: dataFileUrls,
+      };
+    }
+
+    const ready = await session.start(initMessage);
+    this.currentModel = model;
+    this._numSpeakers = ready.numSpeakers ?? 0;
+    this._sampleRate = ready.sampleRate ?? 0;
+    return {
+      loadTimeMs: ready.loadTimeMs,
+      numSpeakers: ready.numSpeakers,
+      sampleRate: ready.sampleRate,
+      voices: ready.voices,
+      backend: ready.backend,
+    };
+  }
+
+  /**
+   * Route non-handshake worker messages to the appropriate handler.
+   * The init handshake ('ready' / pre-ready 'error') is handled by WorkerSession.
+   * 'decode-ready' is consumed by the ad-hoc listener registered in
+   * generateStream() via WorkerSession#addMessageListener, not here.
+   */
+  private route(msg: TtsWorkerOutMessage): void {
+    switch (msg.type) {
+      case 'status':
+        this.onStatus?.(msg.message);
+        break;
+
+      case 'result':
+        if (this.pendingGenerate) {
+          this.pendingGenerate.resolve({
+            samples: msg.samples,
+            sampleRate: msg.sampleRate,
+            generationTimeMs: msg.generationTimeMs,
+          });
+          this.pendingGenerate = null;
+        }
+        break;
+
+      case 'audio-chunk':
+        if (this.pendingStream) {
+          this.pendingStream.onChunk(msg.samples, msg.sampleRate);
+        }
+        break;
+
+      case 'audio-done':
+        if (this.pendingStream) {
+          this.pendingStream.resolve({ generationTimeMs: msg.generationTimeMs });
+          this.pendingStream = null;
+        }
+        break;
+
+      case 'error':
+        // Post-ready error; pre-ready 'error' is handled by WorkerSession (onFatalError).
+        this.onError?.(msg.error);
+        if (this.pendingGenerate) {
+          this.pendingGenerate.reject(new Error(msg.error));
+          this.pendingGenerate = null;
+        }
+        if (this.pendingStream) {
+          this.pendingStream.reject(new Error(msg.error));
+          this.pendingStream = null;
+        }
+        break;
+
+      case 'disposed':
+      case 'ready':
+      case 'decode-ready':
+        break;
+    }
   }
 
   /**
@@ -315,7 +309,7 @@ export class TtsEngine {
    * @param lang - Language code for multilingual models (e.g. 'ja', 'en')
    */
   async generate(text: string, sid = 0, speed = 1.0, lang?: string): Promise<TtsResult> {
-    if (!this.worker || !this.isReady) {
+    if (!this.session?.ready) {
       throw new Error('TTS engine not initialized');
     }
 
@@ -341,7 +335,7 @@ export class TtsEngine {
 
     return new Promise((resolve, reject) => {
       this.pendingGenerate = { resolve, reject };
-      this.worker!.postMessage({ type: 'generate', text: sanitizedText, sid, speed, lang });
+      this.session!.post({ type: 'generate', text: sanitizedText, sid, speed, lang });
     });
   }
 
@@ -359,7 +353,7 @@ export class TtsEngine {
     onChunk?: AudioChunkCallback,
     voice?: string,
   ): Promise<{ generationTimeMs: number }> {
-    if (!this.worker || !this.isReady) {
+    if (!this.session?.ready) {
       throw new Error('TTS engine not initialized');
     }
     if (this.pendingGenerate || this.pendingStream) {
@@ -376,20 +370,20 @@ export class TtsEngine {
     // Wait for worker decoder to be ready (reset is async).
     // The handler rejects on 'error' to avoid hanging the pipeline if reset fails,
     // and is always removed once it settles.
-    const worker = this.worker;
+    const session = this.session;
     await new Promise<void>((resolve, reject) => {
       const handler = (event: MessageEvent<TtsWorkerOutMessage>) => {
         const data = event.data;
         if (data.type === 'decode-ready') {
-          worker.removeEventListener('message', handler);
+          remove();
           resolve();
         } else if (data.type === 'error') {
-          worker.removeEventListener('message', handler);
+          remove();
           reject(new Error(data.error));
         }
       };
-      worker.addEventListener('message', handler);
-      worker.postMessage({ type: 'decode-start' });
+      const remove = session.addMessageListener(handler);
+      session.post({ type: 'decode-start' });
     });
 
     // Set up worker to receive decoded PCM chunks
@@ -416,11 +410,11 @@ export class TtsEngine {
         // Guard against this by copying to a tight buffer whenever the sizes
         // disagree.
         (mp3Data: Uint8Array) => {
-          if (!this.worker) return;
+          if (!this.session) return;
           const tight = (mp3Data.byteOffset === 0 && mp3Data.byteLength === mp3Data.buffer.byteLength)
             ? mp3Data
             : new Uint8Array(mp3Data); // copies only mp3Data's bytes into a new exact-sized buffer
-          this.worker.postMessage(
+          this.session.post(
             { type: 'decode-chunk', mp3Data: tight.buffer },
             [tight.buffer],
           );
@@ -428,8 +422,8 @@ export class TtsEngine {
         // onDone — tell worker decoding is complete
         () => {
           const generationTimeMs = Math.round(performance.now() - startTime);
-          if (this.worker) {
-            this.worker.postMessage({ type: 'decode-end', generationTimeMs });
+          if (this.session) {
+            this.session.post({ type: 'decode-end', generationTimeMs });
           }
         },
         // onError
@@ -457,7 +451,7 @@ export class TtsEngine {
   }
 
   get ready(): boolean {
-    return this.isReady;
+    return this.session?.ready ?? false;
   }
 
   get model(): ModelManifestEntry | null {
@@ -514,12 +508,8 @@ export class TtsEngine {
       this.pendingGenerate.reject(new Error('TTS engine disposed'));
       this.pendingGenerate = null;
     }
-    if (this.worker) {
-      this.worker.postMessage({ type: 'dispose' });
-      this.worker.terminate();
-      this.worker = null;
-    }
-    this.isReady = false;
+    this.session?.dispose();
+    this.session = null;
     this.currentModel = null;
     this._numSpeakers = 0;
     this._sampleRate = 0;

--- a/src/lib/local-inference/engine/WorkerSession.test.ts
+++ b/src/lib/local-inference/engine/WorkerSession.test.ts
@@ -117,4 +117,39 @@ describe('WorkerSession', () => {
     expect(worker.terminate).toHaveBeenCalledTimes(1);
     expect(session.ready).toBe(false);
   });
+
+  it('dispose() during a pending start() rejects init() instead of hanging', async () => {
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs });
+    const p = session.start({ type: 'init' }); // never emit 'ready'
+    session.dispose();
+    await expect(p).rejects.toThrow(/disposed/i);
+    expect(revokeBlobs).toHaveBeenCalledTimes(1); // clean up the aborted load
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('terminates the worker when the init handshake fails (pre-ready error)', async () => {
+    const { worker, session } = makeSession();
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'error', error: 'load failed' });
+    await expect(p).rejects.toThrow('load failed');
+    expect(worker.terminate).toHaveBeenCalledTimes(1); // dead worker freed, not left dangling
+  });
+
+  it('terminates the worker when a pre-ready onerror fails the handshake', async () => {
+    const { worker, session } = makeSession();
+    const p = session.start({ type: 'init' });
+    worker.emitError('worker crashed');
+    await expect(p).rejects.toThrow('worker crashed');
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not double-terminate when dispose() follows a failed handshake', async () => {
+    const { worker, session } = makeSession();
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'error', error: 'load failed' });
+    await expect(p).rejects.toThrow('load failed');
+    session.dispose(); // torn already → no-op
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/lib/local-inference/engine/WorkerSession.test.ts
+++ b/src/lib/local-inference/engine/WorkerSession.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { WorkerSession } from './WorkerSession';
+import { MockWorker } from './testing/mockWorker';
+
+function makeSession(over: Partial<{
+  onMessage: (m: any) => void; revokeBlobs: () => void; onFatalError: (m: string) => void;
+}> = {}) {
+  const worker = new MockWorker('x');
+  const session = new WorkerSession({
+    makeWorker: () => worker as unknown as Worker,
+    onMessage: over.onMessage ?? vi.fn(),
+    revokeBlobs: over.revokeBlobs,
+    onFatalError: over.onFatalError,
+  });
+  return { worker, session };
+}
+
+describe('WorkerSession', () => {
+  it('creates the worker synchronously in the constructor', () => {
+    const worker = new MockWorker('x');
+    const makeWorker = vi.fn(() => worker as unknown as Worker);
+    new WorkerSession({ makeWorker, onMessage: vi.fn() });
+    expect(makeWorker).toHaveBeenCalledTimes(1);
+  });
+
+  it('start() posts the init message and resolves on ready, revoking once', async () => {
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs });
+    const p = session.start({ type: 'init', fileUrls: {} });
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'init', fileUrls: {} });
+    expect(session.ready).toBe(false);
+    worker.emit({ type: 'ready', loadTimeMs: 42 });
+    await expect(p).resolves.toEqual({ type: 'ready', loadTimeMs: 42 });
+    expect(session.ready).toBe(true);
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects and revokes once on a pre-ready error message (and fires onFatalError)', async () => {
+    const revokeBlobs = vi.fn();
+    const onFatalError = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs, onFatalError });
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'error', error: 'load failed' });
+    await expect(p).rejects.toThrow('load failed');
+    expect(onFatalError).toHaveBeenCalledWith('load failed');
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+    expect(session.ready).toBe(false);
+  });
+
+  it('rejects and revokes once on a pre-ready worker onerror', async () => {
+    const revokeBlobs = vi.fn();
+    const onFatalError = vi.fn();
+    const { worker, session } = makeSession({ revokeBlobs, onFatalError });
+    const p = session.start({ type: 'init' });
+    worker.emitError('worker crashed');
+    await expect(p).rejects.toThrow('worker crashed');
+    expect(onFatalError).toHaveBeenCalledWith('worker crashed');
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('routes non-handshake messages to onMessage (including post-ready errors), no re-revoke', async () => {
+    const onMessage = vi.fn();
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ onMessage, revokeBlobs });
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'status', message: 'loading' });   // pre-ready status → routed
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await p;
+    worker.emit({ type: 'result', text: 'hi' });           // post-ready → routed
+    worker.emit({ type: 'error', id: 'r1', error: 'req failed' }); // post-ready error → routed
+    expect(onMessage).toHaveBeenCalledWith({ type: 'status', message: 'loading' });
+    expect(onMessage).toHaveBeenCalledWith({ type: 'result', text: 'hi' });
+    expect(onMessage).toHaveBeenCalledWith({ type: 'error', id: 'r1', error: 'req failed' });
+    expect(revokeBlobs).toHaveBeenCalledTimes(1); // only the ready settle revoked
+  });
+
+  it('post-ready onerror fires onFatalError but does not reject/re-revoke', async () => {
+    const onFatalError = vi.fn();
+    const revokeBlobs = vi.fn();
+    const { worker, session } = makeSession({ onFatalError, revokeBlobs });
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await p;
+    worker.emitError('late error');
+    expect(onFatalError).toHaveBeenCalledWith('late error');
+    expect(revokeBlobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('post() forwards a message, with transfer list when provided', () => {
+    const { worker, session } = makeSession();
+    const buf = new ArrayBuffer(8);
+    session.post({ type: 'audio', samples: 1 }, [buf]);
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'audio', samples: 1 }, [buf]);
+    session.post({ type: 'flush' });
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'flush' });
+  });
+
+  it('dispose() posts dispose, terminates, and clears ready', async () => {
+    const { worker, session } = makeSession();
+    const p = session.start({ type: 'init' });
+    worker.emit({ type: 'ready', loadTimeMs: 1 });
+    await p;
+    session.dispose();
+    expect(worker.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+    expect(worker.terminate).toHaveBeenCalledTimes(1);
+    expect(session.ready).toBe(false);
+  });
+});

--- a/src/lib/local-inference/engine/WorkerSession.test.ts
+++ b/src/lib/local-inference/engine/WorkerSession.test.ts
@@ -95,6 +95,16 @@ describe('WorkerSession', () => {
     expect(worker.postMessage).toHaveBeenCalledWith({ type: 'flush' });
   });
 
+  it('addMessageListener() registers a raw message listener and returns a remover', () => {
+    const { worker, session } = makeSession();
+    const handler = vi.fn();
+    const remove = session.addMessageListener(handler);
+    expect(worker.addEventListener).toHaveBeenCalledWith('message', handler);
+    expect(worker.removeEventListener).not.toHaveBeenCalled();
+    remove();
+    expect(worker.removeEventListener).toHaveBeenCalledWith('message', handler);
+  });
+
   it('dispose() posts dispose, terminates, and clears ready', async () => {
     const { worker, session } = makeSession();
     const p = session.start({ type: 'init' });

--- a/src/lib/local-inference/engine/WorkerSession.test.ts
+++ b/src/lib/local-inference/engine/WorkerSession.test.ts
@@ -61,7 +61,8 @@ describe('WorkerSession', () => {
   it('routes non-handshake messages to onMessage (including post-ready errors), no re-revoke', async () => {
     const onMessage = vi.fn();
     const revokeBlobs = vi.fn();
-    const { worker, session } = makeSession({ onMessage, revokeBlobs });
+    const onFatalError = vi.fn();
+    const { worker, session } = makeSession({ onMessage, revokeBlobs, onFatalError });
     const p = session.start({ type: 'init' });
     worker.emit({ type: 'status', message: 'loading' });   // pre-ready status → routed
     worker.emit({ type: 'ready', loadTimeMs: 1 });
@@ -72,6 +73,7 @@ describe('WorkerSession', () => {
     expect(onMessage).toHaveBeenCalledWith({ type: 'result', text: 'hi' });
     expect(onMessage).toHaveBeenCalledWith({ type: 'error', id: 'r1', error: 'req failed' });
     expect(revokeBlobs).toHaveBeenCalledTimes(1); // only the ready settle revoked
+    expect(onFatalError).not.toHaveBeenCalled(); // post-ready 'error' messages route to onMessage, not onFatalError
   });
 
   it('post-ready onerror fires onFatalError but does not reject/re-revoke', async () => {

--- a/src/lib/local-inference/engine/WorkerSession.ts
+++ b/src/lib/local-inference/engine/WorkerSession.ts
@@ -1,0 +1,98 @@
+/**
+ * WorkerSession — the Worker lifecycle shared by all WASM local-inference
+ * engines, extracted from four verbatim copies. It owns ONLY lifecycle:
+ * synchronous worker creation, the init handshake (post init → await 'ready' /
+ * reject on pre-ready 'error'/onerror), revoke-blobs-once-on-first-settle, the
+ * onerror path, dispose, and post(). It has zero domain knowledge — the engine
+ * supplies `onMessage` for its domain messages and `revokeBlobs`/`onFatalError`.
+ *
+ * Creating the worker in the constructor (not inside an awaited step) is what
+ * honors TtsEngine's supertonic constraint: the engine awaits its blobs, then
+ * `new WorkerSession(...)` creates the worker in the same microtask.
+ */
+export interface WorkerSessionOptions {
+  /** Create the Worker. Called synchronously in the constructor. */
+  makeWorker: () => Worker;
+  /** Every message except the init-handshake 'ready'/'error' (status, partial,
+   *  result, audio-chunk, disposed, and POST-ready errors). */
+  onMessage: (msg: any) => void;
+  /** Called exactly once, on the first settle. Omit when there is nothing to
+   *  revoke (e.g. edge-TTS). */
+  revokeBlobs?: () => void;
+  /** Worker-level failure: the pre-ready 'error' message, and any onerror
+   *  event (pre- or post-ready). Mirrors each engine's `onError` callback. */
+  onFatalError?: (message: string) => void;
+}
+
+export class WorkerSession {
+  private readonly worker: Worker;
+  private settled = false;
+  private revoked = false;
+  private _ready = false;
+  private resolveReady: ((msg: any) => void) | null = null;
+  private rejectReady: ((err: Error) => void) | null = null;
+
+  constructor(private readonly opts: WorkerSessionOptions) {
+    this.worker = opts.makeWorker();
+    this.worker.onmessage = (e: MessageEvent) => this.handleMessage(e.data);
+    this.worker.onerror = (e: ErrorEvent) => this.handleError(e.message || 'Worker error');
+  }
+
+  /** Post the init message and resolve when the worker reports 'ready'
+   *  (reject on a pre-ready 'error' message or onerror). */
+  start(initMessage: object, transfer?: Transferable[]): Promise<any> {
+    return new Promise((resolve, reject) => {
+      this.resolveReady = resolve;
+      this.rejectReady = reject;
+      this.post(initMessage, transfer);
+    });
+  }
+
+  post(msg: object, transfer?: Transferable[]): void {
+    if (transfer && transfer.length) this.worker.postMessage(msg, transfer);
+    else this.worker.postMessage(msg);
+  }
+
+  get ready(): boolean {
+    return this._ready;
+  }
+
+  dispose(): void {
+    this.worker.postMessage({ type: 'dispose' });
+    this.worker.terminate();
+    this._ready = false;
+  }
+
+  private handleMessage(msg: any): void {
+    if (!this.settled && msg?.type === 'ready') {
+      this.settled = true;
+      this._ready = true;
+      this.revokeOnce();
+      this.resolveReady?.(msg);
+      return;
+    }
+    if (!this.settled && msg?.type === 'error') {
+      this.settled = true;
+      this.revokeOnce();
+      this.opts.onFatalError?.(msg.error);
+      this.rejectReady?.(new Error(msg.error));
+      return;
+    }
+    this.opts.onMessage(msg);
+  }
+
+  private handleError(message: string): void {
+    this.opts.onFatalError?.(message);
+    if (!this.settled) {
+      this.settled = true;
+      this.revokeOnce();
+      this.rejectReady?.(new Error(message));
+    }
+  }
+
+  private revokeOnce(): void {
+    if (this.revoked) return;
+    this.revoked = true;
+    this.opts.revokeBlobs?.();
+  }
+}

--- a/src/lib/local-inference/engine/WorkerSession.ts
+++ b/src/lib/local-inference/engine/WorkerSession.ts
@@ -28,6 +28,7 @@ export class WorkerSession {
   private readonly worker: Worker;
   private settled = false;
   private revoked = false;
+  private torn = false;
   private _ready = false;
   private resolveReady: ((msg: any) => void) | null = null;
   private rejectReady: ((err: Error) => void) | null = null;
@@ -65,6 +66,16 @@ export class WorkerSession {
   }
 
   dispose(): void {
+    if (this.torn) return;
+    // Disposed mid-handshake (e.g. a model switch aborts a still-loading init):
+    // settle the pending start() so init() rejects instead of hanging forever —
+    // terminating a Worker does not guarantee an onerror event.
+    if (!this.settled) {
+      this.settled = true;
+      this.revokeOnce();
+      this.rejectReady?.(new Error('WorkerSession disposed'));
+    }
+    this.torn = true;
     this.worker.postMessage({ type: 'dispose' });
     this.worker.terminate();
     this._ready = false;
@@ -83,6 +94,7 @@ export class WorkerSession {
       this.revokeOnce();
       this.opts.onFatalError?.(msg.error);
       this.rejectReady?.(new Error(msg.error));
+      this.tearDownDeadWorker();
       return;
     }
     this.opts.onMessage(msg);
@@ -94,7 +106,18 @@ export class WorkerSession {
       this.settled = true;
       this.revokeOnce();
       this.rejectReady?.(new Error(message));
+      this.tearDownDeadWorker();
     }
+  }
+
+  /** The init handshake failed — the worker will never become ready, so
+   *  terminate it now rather than leaving it (and its thread) dangling until
+   *  the engine's next init()/dispose(). Idempotent with dispose() via `torn`. */
+  private tearDownDeadWorker(): void {
+    if (this.torn) return;
+    this.torn = true;
+    this.worker.terminate();
+    this._ready = false;
   }
 
   private revokeOnce(): void {

--- a/src/lib/local-inference/engine/WorkerSession.ts
+++ b/src/lib/local-inference/engine/WorkerSession.ts
@@ -53,6 +53,13 @@ export class WorkerSession {
     else this.worker.postMessage(msg);
   }
 
+  /** Register a raw 'message' listener on the worker (for per-request sub-protocols
+   *  like TTS decode-ready). Returns a remover. The handler receives the raw MessageEvent. */
+  addMessageListener(handler: (e: MessageEvent) => void): () => void {
+    this.worker.addEventListener('message', handler);
+    return () => this.worker.removeEventListener('message', handler);
+  }
+
   get ready(): boolean {
     return this._ready;
   }

--- a/src/lib/local-inference/engine/testing/mockWorker.ts
+++ b/src/lib/local-inference/engine/testing/mockWorker.ts
@@ -1,0 +1,45 @@
+import { vi } from 'vitest';
+
+/** A drop-in stand-in for the DOM Worker, capturing postMessage and letting
+ *  tests drive onmessage/onerror. Used by WorkerSession unit tests (via
+ *  `makeWorker: () => new MockWorker(...)`) and by engine characterization
+ *  tests (via `installMockWorker()`, which patches globalThis.Worker). */
+export class MockWorker {
+  static instances: MockWorker[] = [];
+  postMessage = vi.fn();
+  terminate = vi.fn();
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onerror: ((e: ErrorEvent) => void) | null = null;
+  addEventListener = vi.fn();
+  removeEventListener = vi.fn();
+
+  constructor(public url: string | URL, public opts?: WorkerOptions) {
+    MockWorker.instances.push(this);
+  }
+
+  /** Simulate a message from the worker to the main thread. */
+  emit(data: unknown): void {
+    this.onmessage?.({ data } as MessageEvent);
+  }
+
+  /** Simulate a worker-level error event. */
+  emitError(message: string): void {
+    this.onerror?.({ message } as ErrorEvent);
+  }
+
+  static last(): MockWorker {
+    return MockWorker.instances[MockWorker.instances.length - 1];
+  }
+
+  static reset(): void {
+    MockWorker.instances = [];
+  }
+}
+
+/** Patch globalThis.Worker with MockWorker. Returns a restore function. */
+export function installMockWorker(): () => void {
+  const original = (globalThis as any).Worker;
+  MockWorker.reset();
+  (globalThis as any).Worker = MockWorker;
+  return () => { (globalThis as any).Worker = original; };
+}


### PR DESCRIPTION
## Candidate 5 (engine-side) of the architecture-review series — PR 2 of 2

Extracts the Worker lifecycle that was copy-pasted across the 4 WASM local-inference engines into a composed `WorkerSession`, and the id-keyed request correlation into a `RequestRegistry`, then rewires all 4 engines to compose them. **Behavior-preserving; WASM engine side only** — the Local Native (Python sidecar) provider is a peer and is untouched.

Completes the two-PR design in `docs/superpowers/specs/2026-07-13-wasm-worker-session-design.md` (PR 1 = the worker-side harness, #305, already merged).

### What changed
- **`WorkerSession.ts`** — the lifecycle seam (zero domain knowledge): synchronous worker creation, the init handshake (post init → resolve on `ready` / reject on pre-ready `error`/`onerror`), **revoke-blobs-exactly-once on first settle**, the `onerror` path, `dispose`, `post`, and an `addMessageListener` for TtsEngine's edge-TTS `decode-ready` sub-protocol. Each engine supplies `makeWorker` / `route` (`onMessage`) / `revokeBlobs` / `onFatalError`.
- **`RequestRegistry<T>.ts`** — id→{resolve,reject} map + `rejectAll`, used by `TranslationEngine` (its `tr_N` correlation). `TtsEngine` keeps its own single-slot `pendingGenerate`/`pendingStream` + edge-TTS (not id-keyed) and composes `WorkerSession` for lifecycle only.
- **4 engines rewired** to compose the seam — `this.worker`/`isReady` fields removed (readiness now derives from `session.ready`):
  - `AsrEngine`, `StreamingAsrEngine` (callback-based)
  - `TranslationEngine` (WorkerSession + RequestRegistry)
  - `TtsEngine` (WorkerSession + bespoke single-slot pending + edge-TTS)
  - `StreamingAsrEngine` was reordered to load blobs *before* creating the worker (was the lone create-worker-then-load-blobs engine), so it fits WorkerSession's synchronous constructor.
- **A shared `testing/mockWorker.ts` helper** + **characterization test suites for all 4 engines** (public-API, `MockWorker`-injected).

### How it was built
Task-by-task via characterization-first subagent-driven development: each engine got a characterization suite pinning its *current* behavior **before** the refactor, and the refactor had to keep it green. That net caught two real defects mid-flight — a `StreamingAsrEngine` sherpa `package-metadata.json` blob-URL leak (filtered vs raw revoke map), and a missing single-slot-guard test — plus a final-review `AsrEngine` init-hang window (worker failure during the sherpa metadata fetch, before `start()` bound its reject) that was closed by loading metadata before constructing the session.

### Verification
- Full suite green (1064 tests; RequestRegistry, WorkerSession, and 4 engine characterization suites, plus the pre-existing supertonic test).
- `npm run build` passes — renderer + all worker chunks + electron bundle.
- Dedup confirmed: `this.worker` = 0 and `new WorkerSession` = 1 in every engine.
- No live-Worker runtime test exists, so a manual local-inference ASR→translation→TTS smoke before merge is the recommended behavioral backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of local inference engine initialization and disposal.
  * Made worker failure and fatal-error handling more consistent, including rejecting pending translation requests during cleanup.
  * Improved cleanup of temporary resources on both success and error paths, helping prevent stale/in-flight work after failures.
  * Preserved existing audio transcription, streaming, translation, and speech generation behavior.

* **Tests**
  * Added characterization tests covering initialization handshakes, streaming/audio gating, error paths, request correlation, and disposal for local inference engines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->