### PR TITLE
feat(providers): gate Local Native sidecar behind VITE_ENABLE_LOCAL_NATIVE

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,6 +70,7 @@ jobs:
           VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
           VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
           VITE_ENABLE_ZOOM_AI: ${{ secrets.VITE_ENABLE_ZOOM_AI }}
+          VITE_ENABLE_LOCAL_NATIVE: ${{ secrets.VITE_ENABLE_LOCAL_NATIVE }}
           # Additional variables only for releases
           VITE_ENABLE_DEBUG: ${{ startsWith(github.ref, 'refs/tags/v') && 'false' || '' }}
           VITE_ENABLE_ANALYTICS: ${{ startsWith(github.ref, 'refs/tags/v') && 'true' || '' }}
@@ -90,6 +91,7 @@ jobs:
           VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
           VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
           VITE_ENABLE_ZOOM_AI: ${{ secrets.VITE_ENABLE_ZOOM_AI }}
+          VITE_ENABLE_LOCAL_NATIVE: ${{ secrets.VITE_ENABLE_LOCAL_NATIVE }}
 
       # electron-builder bundles an x86_64-only `fpm` for building .deb packages.
       # On the arm64 runner, install `fpm` via Ruby gem and tell electron-builder
@@ -126,6 +128,7 @@ jobs:
           VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
           VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
           VITE_ENABLE_ZOOM_AI: ${{ secrets.VITE_ENABLE_ZOOM_AI }}
+          VITE_ENABLE_LOCAL_NATIVE: ${{ secrets.VITE_ENABLE_LOCAL_NATIVE }}
 
       - name: Build macOS PKG (electron-builder)
         if: runner.os == 'macOS'
@@ -147,6 +150,7 @@ jobs:
           VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
           VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
           VITE_ENABLE_ZOOM_AI: ${{ secrets.VITE_ENABLE_ZOOM_AI }}
+          VITE_ENABLE_LOCAL_NATIVE: ${{ secrets.VITE_ENABLE_LOCAL_NATIVE }}
 
       - name: Build Chrome Extension
         if: matrix.os == 'ubuntu-latest' && matrix.arch != 'arm64'
@@ -176,6 +180,7 @@ jobs:
           VITE_ENABLE_VOLCENGINE_AST2: ${{ secrets.VITE_ENABLE_VOLCENGINE_AST2 }}
           VITE_ENABLE_PALABRA_AI: ${{ secrets.VITE_ENABLE_PALABRA_AI }}
           VITE_ENABLE_ZOOM_AI: ${{ secrets.VITE_ENABLE_ZOOM_AI }}
+          VITE_ENABLE_LOCAL_NATIVE: ${{ secrets.VITE_ENABLE_LOCAL_NATIVE }}
 
       # Release-specific steps
       - name: Generate changelog

--- a/src/services/providers/ProviderConfigFactory.ts
+++ b/src/services/providers/ProviderConfigFactory.ts
@@ -13,7 +13,7 @@ import { LocalInferenceProviderConfig } from './LocalInferenceProviderConfig';
 import { LocalNativeProviderConfig } from './LocalNativeProviderConfig';
 import { ZoomAIProviderConfig } from './ZoomAIProviderConfig';
 import { Provider, ProviderType } from '../../types/Provider';
-import { isKizunaAIEnabled, isPalabraAIEnabled, isElectron, isExtension } from '../../utils/environment';
+import { isKizunaAIEnabled, isPalabraAIEnabled, isLocalNativeEnabled, isElectron, isExtension } from '../../utils/environment';
 
 export class ProviderConfigFactory {
   private static configs: Map<ProviderType, ProviderDescriptor> = new Map();
@@ -41,8 +41,10 @@ export class ProviderConfigFactory {
     // Only register OpenAI Compatible provider in Electron environment
     if (isElectron()) {
       ProviderConfigFactory.configs.set(Provider.OPENAI_COMPATIBLE, new OpenAICompatibleProviderConfig());
-      // Native (Electron sidecar) local inference — Electron only
-      ProviderConfigFactory.configs.set(Provider.LOCAL_NATIVE, new LocalNativeProviderConfig());
+      // Native (Electron sidecar) local inference — Electron only, behind feature flag
+      if (isLocalNativeEnabled()) {
+        ProviderConfigFactory.configs.set(Provider.LOCAL_NATIVE, new LocalNativeProviderConfig());
+      }
     }
 
     // Volcengine Speech Translate — always available (stable)

--- a/src/services/providers/descriptorRegistry.test.ts
+++ b/src/services/providers/descriptorRegistry.test.ts
@@ -1,11 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
-// Force the remaining provider gates on — Kizuna/Palabra feature flags plus
-// Electron/Extension platform detection — so ALL descriptors register regardless
-// of build env. (Volcengine ST/AST2 and Zoom AI are now always-on, no flag.)
+// Force the remaining provider gates on — Kizuna/Palabra/Local-Native feature
+// flags plus Electron/Extension platform detection — so ALL descriptors register
+// regardless of build env. (Volcengine ST/AST2 and Zoom AI are now always-on, no flag.)
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
   isPalabraAIEnabled: () => true,
+  isLocalNativeEnabled: () => true,
   isElectron: () => true,
   isExtension: () => false,
   getRelayWsUrl: () => 'wss://r.example/v1',

--- a/src/services/providers/localNativeGating.test.ts
+++ b/src/services/providers/localNativeGating.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi } from 'vitest';
+// Disabled-path coverage for the VITE_ENABLE_LOCAL_NATIVE gate: force every other
+// flag on but isLocalNativeEnabled() off, so the registry is built exactly as a
+// production build (flag unset) would build it. Lives in its own file because each
+// test file gets an isolated module registry — the factory's static block runs once
+// under this mock, whereas descriptorRegistry.test.ts pins the enabled path.
+vi.mock('../../utils/environment', async (orig) => ({
+  ...(await orig<any>()),
+  isKizunaAIEnabled: () => true,
+  isPalabraAIEnabled: () => true,
+  isVolcengineSTEnabled: () => true,
+  isVolcengineAST2Enabled: () => true,
+  isZoomAIEnabled: () => true,
+  isLocalNativeEnabled: () => false,
+  isElectron: () => true,
+  isExtension: () => false,
+  getRelayWsUrl: () => 'wss://r.example/v1',
+}));
+import { ProviderConfigFactory } from './ProviderConfigFactory';
+import { Provider } from '../../types/Provider';
+
+describe('LOCAL_NATIVE feature-flag gating (disabled path)', () => {
+  it('omits LOCAL_NATIVE when the flag is off but keeps the other Electron providers', () => {
+    const ids = ProviderConfigFactory.getAvailableProviders();
+    expect(ids).not.toContain(Provider.LOCAL_NATIVE);
+    // OPENAI_COMPATIBLE and VOLCENGINE_AST2 are Electron-gated but not behind the
+    // Local Native flag, so they must remain registered.
+    expect(ids).toContain(Provider.OPENAI_COMPATIBLE);
+    expect(ids).toContain(Provider.VOLCENGINE_AST2);
+    // One fewer than the 12 in descriptorRegistry.test.ts (which forces the flag on).
+    expect(ids.length).toBe(11);
+  });
+});

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -207,6 +207,17 @@ export function isPalabraAIEnabled(): boolean {
   return import.meta.env.VITE_ENABLE_PALABRA_AI === 'true';
 }
 
+/**
+ * Check if Local Native (Electron sidecar) provider should be enabled.
+ * Development: always true. Production: requires VITE_ENABLE_LOCAL_NATIVE === 'true'.
+ */
+export function isLocalNativeEnabled(): boolean {
+  if (isDevelopmentMode()) {
+    return true;
+  }
+  return import.meta.env.VITE_ENABLE_LOCAL_NATIVE === 'true';
+}
+
 // ============================================================================
 // Operating System Detection
 // ============================================================================

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_POSTHOG_KEY?: string;
   readonly VITE_POSTHOG_HOST?: string;
   readonly VITE_ENABLE_KIZUNA_AI?: string;
+  readonly VITE_ENABLE_LOCAL_NATIVE?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary

The Local Native (Electron sidecar) provider was registered under `isElectron()` with no feature flag, so it shipped **visible in every Electron production build**. This adds a compile-time Vite flag to temporarily hide it in production while keeping it visible during development.

## Changes

- **`src/utils/environment.ts`** — new `isLocalNativeEnabled()` helper, mirroring the existing `VITE_ENABLE_*` convention (dev short-circuits to `true`; production requires `VITE_ENABLE_LOCAL_NATIVE === 'true'`).
- **`src/services/providers/ProviderConfigFactory.ts`** — gate the `LOCAL_NATIVE` registration on the new helper (`OPENAI_COMPATIBLE` stays unconditional-on-Electron).
- **`src/services/providers/descriptorRegistry.test.ts`** — force the flag on in the mock so the registry `count === 12` assertion and per-provider loops stay valid.
- **`src/vite-env.d.ts`** — declare `VITE_ENABLE_LOCAL_NATIVE` for consistency with `VITE_ENABLE_KIZUNA_AI`.

## Behavior

| Context | Result |
|---|---|
| `npm run dev` (development) | **shown** (dev short-circuit) |
| `npm run build` (production, flag unset) | **hidden** |
| `VITE_ENABLE_LOCAL_NATIVE=true npm run build` | **shown** |

No `.env` file is modified: the base `.env` is loaded by production builds, so writing `=true` there would leak into production and defeat the change. Absence of the var = hidden in production.

The provider dropdown derives from the factory registry, so no UI changes are needed. The default provider is already `OPENAI`, and a stale `LOCAL_NATIVE` selection falls back to OpenAI via existing guards in `settingsStore`.

## Verification

- `descriptorRegistry.test.ts` — 25 tests pass, `count === 12` intact.
- Helper gating verified for prod-hidden / prod-flag-on / dev-shown paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configuration flag to control availability of the local-native provider (enabled by default in development; configurable in other environments).

* **Bug Fixes**
  * Provider registration for local-native is now properly gated based on the new setting (including in Electron runtimes).

* **Tests**
  * Added coverage to verify local-native is omitted when the flag is disabled while other providers remain available.

* **Chores**
  * Updated build/CI steps to pass the new configuration value during tagged release builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->