### PR TITLE
refactor(native): collapse the LOCAL_NATIVE readiness gate into a nativeModelStore facade

### DIFF
--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -473,6 +473,15 @@ export interface NativeReadinessSelection {
   translationVariantByModel: Record<string, string>;
 }
 
+/** Everything readiness reads out of settings, resolved in one go. Handed to the
+ * facade as a thunk rather than a value: a cold sidecar start is slow, and the
+ * user can change the pair / text-only while it runs, so the verdict must be
+ * computed from the selection as of AFTER warmup — not a call-site snapshot. */
+export interface NativeReadinessInput {
+  selection: NativeReadinessSelection;
+  textOnly: boolean;
+}
+
 export interface NativeReadinessResult {
   ready: boolean;
   reason: NativeReadinessReason;

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -449,6 +449,37 @@ export interface NativeSelection {
   ttsModel: string;
 }
 
+/** Why a LOCAL_NATIVE selection is / isn't session-ready. `settingsStore` maps
+ * each reason to a user-facing message; the store never owns i18n strings. */
+export type NativeReadinessReason =
+  | 'ready'
+  | 'not-electron'
+  | 'engine-mismatch'
+  | 'engine-absent'
+  | 'unavailable'
+  | 'starting'
+  | 'asr-incompatible'
+  | 'translation-incompatible'
+  | 'models-missing';
+
+/** The selection fields readiness depends on (a structural subset of
+ * LocalNativeSettings, so the settings slice is assignable to it). */
+export interface NativeReadinessSelection {
+  sourceLanguage: string;
+  targetLanguage: string;
+  asrModel: string;
+  translationModel: string;
+  ttsModel: string;
+  translationVariantByModel: Record<string, string>;
+}
+
+export interface NativeReadinessResult {
+  ready: boolean;
+  reason: NativeReadinessReason;
+  /** Auto-select's changed fields (null = nothing changed); the caller persists them. */
+  corrections: Partial<NativeSelection> | null;
+}
+
 /**
  * Reconcile the native selection for a language pair — the native twin of
  * LOCAL_INFERENCE's `autoSelectModels`. Steps, in order, mirror that logic:

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -39,16 +39,19 @@ class FakeWS {
         return;
       }
       // The sidecar returns ASR, translation, or TTS models depending on `kind` (default asr).
+      // Every real sidecar model row carries `kind` (nativeProtocol.NativeModelInfo requires
+      // it) — the catalog-filtering helpers (nativeAsrCards/nativeTranslationCards/etc.) key
+      // off it, so the fixture rows must too.
       let models;
       if (msg.kind === 'translate') {
-        models = [{ id: 'qwen2.5-0.5b', name: 'Qwen 2.5 0.5B', languages: ['multi'], recommended: true,
+        models = [{ id: 'qwen2.5-0.5b', name: 'Qwen 2.5 0.5B', kind: 'translate', languages: ['multi'], recommended: true,
              tiers: [{ tier: 'gpu-cuda', backend: 'llamacpp_qwen', available: true },
                      { tier: 'cpu', backend: 'llamacpp_qwen', available: true }], sizeBytes: 999604126 }];
       } else if (msg.kind === 'tts') {
-        models = [{ id: 'moss-tts-nano', name: 'MOSS TTS Nano', languages: ['ja', 'zh'], recommended: true,
+        models = [{ id: 'moss-tts-nano', name: 'MOSS TTS Nano', kind: 'tts', languages: ['ja', 'zh'], recommended: true,
              tiers: [{ tier: 'cpu', backend: 'moss_tts', available: true }], sizeBytes: 763206064 }];
       } else {
-        models = [{ id: 'sense-voice', name: 'SenseVoice', languages: ['zh'], recommended: true,
+        models = [{ id: 'sense-voice', name: 'SenseVoice', kind: 'asr', languages: ['zh'], recommended: true,
              tiers: [{ tier: 'cpu', backend: 'sherpa', available: true }], sizeBytes: 944624033 },
            ..._asrExtraModels];
       }
@@ -157,7 +160,7 @@ describe('catalog-derived statusRepos cache (cold-start variant awareness)', () 
   // variant-aware caller happened to run. The catalog feed already carries the
   // full variant ladder, so the store derives the cache when the catalog lands.
   const FUN_ASR = {
-    id: 'fun-asr-mlt-nano', name: 'Fun-ASR MLT Nano', languages: ['multi'], recommended: true,
+    id: 'fun-asr-mlt-nano', name: 'Fun-ASR MLT Nano', kind: 'asr', languages: ['multi'], recommended: true,
     tiers: [{ tier: 'cpu', backend: 'transcribe_cpp', available: true }], sizeBytes: 690744384,
     variantIds: ['q6_k', 'q8_0'],
     variants: [
@@ -335,6 +338,109 @@ describe('nativeModelStore resolved plans retain backend and computeType', () =>
     expect(useNativeModelStore.getState().translationResolved).toMatchObject({ backend: 'ct2_opus_translate', computeType: 'int8' });
     s.setTtsResolved({ model: 'v', device: 'metal', backend: 'mlx_audio_tts', computeType: 'fp32' });
     expect(useNativeModelStore.getState().ttsResolved).toMatchObject({ backend: 'mlx_audio_tts', computeType: 'fp32' });
+  });
+});
+
+describe('ensureSelectionReady (facade)', () => {
+  const SEL = {
+    sourceLanguage: 'zh', targetLanguage: 'en',
+    asrModel: 'sense-voice', translationModel: 'qwen2.5-0.5b', ttsModel: '',
+    translationVariantByModel: {} as Record<string, string>,
+  };
+
+  beforeEach(() => {
+    _shouldReject = false;
+    // The top-level beforeEach resets catalog/statuses/statusRepos but not
+    // modelPreferences — autoSelect's step 1 layers recalled history from a
+    // PRIOR test's rememberModels() for the same `${src}→${tgt}` key on top of
+    // the requested selection, so a leftover here would silently override the
+    // translationModel this block is trying to exercise.
+    useNativeModelStore.setState({ modelPreferences: {} });
+  });
+
+  it('unavailable sidecar → not ready, reason unavailable, no corrections', async () => {
+    useNativeModelStore.setState({ sidecarStatus: 'unavailable' });
+    // ensureCatalog will try to (re)load; make the catalog fetch reject so it stays unavailable.
+    mockModelsCatalogReject();
+    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    expect(r).toEqual({ ready: false, reason: 'unavailable', corrections: null });
+  });
+
+  it('bundle absent → reason engine-absent', async () => {
+    useNativeModelStore.setState({ sidecarStatus: 'unavailable', bundleStatus: 'absent' });
+    // ensureCatalog's refreshBundle() re-queries the IPC bundle status before the
+    // lifecycle check runs; make that call throw (caught, best-effort) so the
+    // seeded bundleStatus survives instead of being overwritten by the default
+    // `{ ok: true }` mock reply (which carries no `state`/`sku`).
+    (globalThis as any).window.electron.invoke = vi.fn().mockRejectedValue(new Error('no ipc'));
+    mockModelsCatalogReject();
+    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    expect(r.reason).toBe('engine-absent');
+  });
+
+  it('bundle mismatch → reason engine-mismatch', async () => {
+    useNativeModelStore.setState({ sidecarStatus: 'unavailable', bundleStatus: 'mismatch' });
+    (globalThis as any).window.electron.invoke = vi.fn().mockRejectedValue(new Error('no ipc'));
+    mockModelsCatalogReject();
+    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    expect(r.reason).toBe('engine-mismatch');
+  });
+
+  it('ready + downloaded compatible pair → ready', async () => {
+    mockModelsCatalogResolve();
+    await useNativeModelStore.getState().ensureCatalog(); // status → ready, catalog seeded
+    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: true });
+    // FakeWS reports every queried model 'ready'; textOnly drops the TTS
+    // requirement so readiness only needs the asr+translation pair.
+    expect(r.ready).toBe(true);
+    expect(r.reason).toBe('ready');
+  });
+
+  it('stale translation for the reversed pair → not ready, reason translation-incompatible', async () => {
+    // FakeWS's default translate card (qwen2.5-0.5b) is `languages: ['multi']`,
+    // which nativeTranslationCards treats as valid for ANY pair — so autoSelect
+    // would always fall back to it and the selection would end up compatible
+    // again. Replace it with a DIRECTIONAL zh→en-only card, and add an 'en'
+    // -capable ASR card (the default sense-voice is zh-only, which would
+    // otherwise fail the ASR check first on this reversed pair and mask the
+    // translation-incompatible reason this test targets).
+    mockModelsCatalogResolve();
+    await useNativeModelStore.getState().ensureCatalog();
+    const { 'qwen2.5-0.5b': _drop, ...catalogWithoutQwen } = useNativeModelStore.getState().catalog;
+    useNativeModelStore.setState({ catalog: {
+      ...catalogWithoutQwen,
+      'whisper-en': { id: 'whisper-en', name: 'Whisper EN', kind: 'asr', languages: ['en'], recommended: false,
+        tiers: [{ tier: 'cpu', backend: 'whisper', available: true }], order: 1, repo: 'whisper-en' },
+      'opus-mt-zh-en': { id: 'opus-mt-zh-en', name: 'Opus MT zh-en', kind: 'translate', languages: ['zh', 'en'],
+        recommended: false, tiers: [{ tier: 'cpu', backend: 'opus', available: true }], order: 1, repo: 'opus-mt-zh-en' },
+    } as any });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(
+      { ...SEL, sourceLanguage: 'en', targetLanguage: 'zh', asrModel: 'whisper-en', translationModel: 'opus-mt-zh-en' },
+      { textOnly: false });
+    // opus-mt-zh-en is a card for zh→en, not the reversed en→zh pair — incompatible
+    // even though its status reports "downloaded".
+    expect(r.ready).toBe(false);
+    expect(r.reason).toBe('translation-incompatible');
+  });
+
+  it('resolves the selected model chosen variant repo on the required-models refresh', async () => {
+    // Seed a multi-variant translate card into the FakeWS catalog for this test,
+    // then assert the LAST model_status carried its recommended repo.
+    // (Mirror the existing multi-variant fixtures at the top of this file.)
+    mockModelsCatalogResolve();
+    await useNativeModelStore.getState().ensureCatalog();
+    const catalog = useNativeModelStore.getState().catalog;
+    useNativeModelStore.setState({ catalog: { ...catalog, 'hy-mt2-1.8b': {
+      id: 'hy-mt2-1.8b', name: 'HY', kind: 'translate', languages: ['multi'], recommended: false,
+      tiers: [], order: 9, repo: '', variantIds: ['q4_k_m', 'q8_0'],
+      variants: [
+        { id: 'fp8', sizeBytes: 8e9, repo: 'tencent/Hy-MT2-1.8B-FP8', supported: true, recommended: true },
+        { id: 'bf16', sizeBytes: 15e9, repo: 'tencent/Hy-MT2-1.8B', supported: true, recommended: false },
+      ],
+    } } as any });
+    await useNativeModelStore.getState().ensureSelectionReady(
+      { ...SEL, translationModel: 'hy-mt2-1.8b' }, { textOnly: false });
+    expect((globalThis as any).__lastStatusRepos).toMatchObject({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
   });
 });
 

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -203,6 +203,12 @@ describe('catalog-derived statusRepos cache (cold-start variant awareness)', () 
     const repos = (globalThis as any).__lastStatusRepos ?? {};
     expect(repos['sense-voice']).toBeUndefined();
   });
+
+  it('deriveVariantRepos skips single-variant cards (via catalog-derived statusRepos)', async () => {
+    await useNativeModelStore.getState().ensureCatalog();
+    // sense-voice (the fixture ASR) has no `variants` → no entry in statusRepos.
+    expect(useNativeModelStore.getState().statusRepos['sense-voice']).toBeUndefined();
+  });
 });
 
 describe('nativeModelStore.deleteModel', () => {

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -17,9 +17,15 @@ vi.mock('../utils/environment', async () => {
 let _shouldReject = false;
 let _asrExtraModels: any[] = [];
 let _catalogCallCount = 0;
+// Models the FakeWS should report as NOT downloaded on a `model_status` query.
+// The FakeWS reports every queried model 'ready' by default (see below); this
+// lets a test force a specific required model to read 'absent' so it can drive
+// ensureSelectionReady to the 'models-missing' reason.
+let _notReadyModels = new Set<string>();
 function mockModelsCatalogResolve() { _shouldReject = false; }
 function mockModelsCatalogReject() { _shouldReject = true; }
 function modelsCatalogCallCount() { return _catalogCallCount; }
+function mockModelNotReady(id: string) { _notReadyModels.add(id); }
 
 class FakeWS {
   static OPEN = 1;
@@ -60,7 +66,8 @@ class FakeWS {
     if (msg.type === 'model_status') {
       (globalThis as any).__lastStatusRepos = msg.repos;
       queueMicrotask(() => this.emit({ type: 'model_status_result', id: msg.id,
-        statuses: Object.fromEntries((msg.models || []).map((m: string) => [m, 'ready'])) }));
+        statuses: Object.fromEntries((msg.models || []).map((m: string) =>
+          [m, _notReadyModels.has(m) ? 'absent' : 'ready'])) }));
     }
     if (msg.type === 'model_delete') queueMicrotask(() =>
       this.emit({ type: 'model_delete_result', id: msg.id, freed: 0 }));
@@ -76,6 +83,7 @@ beforeEach(() => {
   _shouldReject = false;
   _asrExtraModels = [];
   _catalogCallCount = 0;
+  _notReadyModels = new Set();
   useNativeModelStore.setState({ catalog: {}, sidecarStatus: 'idle', sizes: {}, statusRepos: {}, statuses: {} } as any);
 });
 
@@ -350,6 +358,7 @@ describe('ensureSelectionReady (facade)', () => {
 
   beforeEach(() => {
     _shouldReject = false;
+    _notReadyModels = new Set();
     // The top-level beforeEach resets catalog/statuses/statusRepos but not
     // modelPreferences — autoSelect's step 1 layers recalled history from a
     // PRIOR test's rememberModels() for the same `${src}→${tgt}` key on top of
@@ -441,6 +450,51 @@ describe('ensureSelectionReady (facade)', () => {
     await useNativeModelStore.getState().ensureSelectionReady(
       { ...SEL, translationModel: 'hy-mt2-1.8b' }, { textOnly: false });
     expect((globalThis as any).__lastStatusRepos).toMatchObject({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
+  });
+
+  it('sidecar still starting → not ready, reason starting, no corrections', async () => {
+    // ensureCatalog() early-returns when status is already 'starting' (see its
+    // guard: `if (st === 'ready' || st === 'starting') return;`), so the status
+    // never advances past 'starting' and refreshBundle() never runs — pin
+    // bundleStatus to a value outside the mismatch/absent/paused branches (those
+    // take precedence over 'starting' in the reason derivation) so a leftover
+    // bundleStatus from an earlier test in this file can't steal the reason.
+    useNativeModelStore.setState({ sidecarStatus: 'starting', bundleStatus: 'unknown' });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    expect(r).toEqual({ ready: false, reason: 'starting', corrections: null });
+  });
+
+  it('source language with no compatible ASR model → not ready, reason asr-incompatible', async () => {
+    // The fixture catalog's only ASR card (sense-voice) is zh-only. Requesting a
+    // 'en' source leaves nativeAsrCards('en', catalog) empty, so autoSelect's ASR
+    // step (no compatible card, let alone a downloaded one) resets asrModel to ''
+    // — catalog[''] is undefined, so asrCompatible is false regardless of the
+    // translation pairing, and asr precedence (checked first) wins the reason.
+    mockModelsCatalogResolve();
+    await useNativeModelStore.getState().ensureCatalog(); // status → ready, catalog seeded
+    const r = await useNativeModelStore.getState().ensureSelectionReady(
+      { ...SEL, sourceLanguage: 'en', targetLanguage: 'en', asrModel: 'sense-voice' },
+      { textOnly: true });
+    expect(r.ready).toBe(false);
+    expect(r.reason).toBe('asr-incompatible');
+  });
+
+  it('a required TTS model not yet downloaded → not ready, reason models-missing', async () => {
+    // zh source / ja target: sense-voice (asr) and qwen2.5-0.5b (translate, multi)
+    // stay compatible and auto-select keeps them since the FakeWS reports them
+    // 'ready'; ttsModel is '' (Auto), so autoSelect's TTS branch never fires
+    // (it only revalidates an EXPLICIT choice) and leaves it at Auto, which
+    // resolves to moss-tts-nano (the only 'ja'-capable TTS card in the fixture).
+    // Force just that model 'absent' so the asr+translation pair is fully
+    // compatible and downloaded, but the required set as a whole is not —
+    // landing on 'models-missing' rather than 'asr-incompatible'/'translation-incompatible'.
+    mockModelsCatalogResolve();
+    mockModelNotReady('moss-tts-nano');
+    await useNativeModelStore.getState().ensureCatalog();
+    const r = await useNativeModelStore.getState().ensureSelectionReady(
+      { ...SEL, targetLanguage: 'ja' }, { textOnly: false });
+    expect(r.ready).toBe(false);
+    expect(r.reason).toBe('models-missing');
   });
 });
 

--- a/src/stores/nativeModelStore.test.ts
+++ b/src/stores/nativeModelStore.test.ts
@@ -367,11 +367,28 @@ describe('ensureSelectionReady (facade)', () => {
     useNativeModelStore.setState({ modelPreferences: {} });
   });
 
+  it('reads the selection AFTER sidecar warmup, not at call time', async () => {
+    // The facade takes a READ THUNK, not a snapshot, and calls it only once the
+    // sidecar is warm — matching the pre-facade gate, which read get().localNative
+    // after `await ensureCatalog()`. A cold start can take seconds, so a snapshot
+    // taken at the call site would resolve the verdict against a selection the
+    // user has since changed (pair / text-only) mid-warmup.
+    mockModelsCatalogResolve();
+    // beforeEach seeds sidecarStatus 'idle' → ensureCatalog actually runs here.
+    let statusWhenRead: string | undefined;
+    await useNativeModelStore.getState().ensureSelectionReady(() => {
+      statusWhenRead = useNativeModelStore.getState().sidecarStatus;
+      return { selection: SEL, textOnly: true };
+    });
+    // Would be 'idle' if the read were hoisted back above the warmup await.
+    expect(statusWhenRead).toBe('ready');
+  });
+
   it('unavailable sidecar → not ready, reason unavailable, no corrections', async () => {
     useNativeModelStore.setState({ sidecarStatus: 'unavailable' });
     // ensureCatalog will try to (re)load; make the catalog fetch reject so it stays unavailable.
     mockModelsCatalogReject();
-    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({ selection: SEL, textOnly: false }));
     expect(r).toEqual({ ready: false, reason: 'unavailable', corrections: null });
   });
 
@@ -383,7 +400,7 @@ describe('ensureSelectionReady (facade)', () => {
     // `{ ok: true }` mock reply (which carries no `state`/`sku`).
     (globalThis as any).window.electron.invoke = vi.fn().mockRejectedValue(new Error('no ipc'));
     mockModelsCatalogReject();
-    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({ selection: SEL, textOnly: false }));
     expect(r.reason).toBe('engine-absent');
   });
 
@@ -391,14 +408,14 @@ describe('ensureSelectionReady (facade)', () => {
     useNativeModelStore.setState({ sidecarStatus: 'unavailable', bundleStatus: 'mismatch' });
     (globalThis as any).window.electron.invoke = vi.fn().mockRejectedValue(new Error('no ipc'));
     mockModelsCatalogReject();
-    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({ selection: SEL, textOnly: false }));
     expect(r.reason).toBe('engine-mismatch');
   });
 
   it('ready + downloaded compatible pair → ready', async () => {
     mockModelsCatalogResolve();
     await useNativeModelStore.getState().ensureCatalog(); // status → ready, catalog seeded
-    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: true });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({ selection: SEL, textOnly: true }));
     // FakeWS reports every queried model 'ready'; textOnly drops the TTS
     // requirement so readiness only needs the asr+translation pair.
     expect(r.ready).toBe(true);
@@ -423,9 +440,10 @@ describe('ensureSelectionReady (facade)', () => {
       'opus-mt-zh-en': { id: 'opus-mt-zh-en', name: 'Opus MT zh-en', kind: 'translate', languages: ['zh', 'en'],
         recommended: false, tiers: [{ tier: 'cpu', backend: 'opus', available: true }], order: 1, repo: 'opus-mt-zh-en' },
     } as any });
-    const r = await useNativeModelStore.getState().ensureSelectionReady(
-      { ...SEL, sourceLanguage: 'en', targetLanguage: 'zh', asrModel: 'whisper-en', translationModel: 'opus-mt-zh-en' },
-      { textOnly: false });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({
+      selection: { ...SEL, sourceLanguage: 'en', targetLanguage: 'zh', asrModel: 'whisper-en', translationModel: 'opus-mt-zh-en' },
+      textOnly: false,
+    }));
     // opus-mt-zh-en is a card for zh→en, not the reversed en→zh pair — incompatible
     // even though its status reports "downloaded".
     expect(r.ready).toBe(false);
@@ -447,8 +465,9 @@ describe('ensureSelectionReady (facade)', () => {
         { id: 'bf16', sizeBytes: 15e9, repo: 'tencent/Hy-MT2-1.8B', supported: true, recommended: false },
       ],
     } } as any });
-    await useNativeModelStore.getState().ensureSelectionReady(
-      { ...SEL, translationModel: 'hy-mt2-1.8b' }, { textOnly: false });
+    await useNativeModelStore.getState().ensureSelectionReady(() => ({
+      selection: { ...SEL, translationModel: 'hy-mt2-1.8b' }, textOnly: false,
+    }));
     expect((globalThis as any).__lastStatusRepos).toMatchObject({ 'hy-mt2-1.8b': 'tencent/Hy-MT2-1.8B-FP8' });
   });
 
@@ -460,7 +479,7 @@ describe('ensureSelectionReady (facade)', () => {
     // take precedence over 'starting' in the reason derivation) so a leftover
     // bundleStatus from an earlier test in this file can't steal the reason.
     useNativeModelStore.setState({ sidecarStatus: 'starting', bundleStatus: 'unknown' });
-    const r = await useNativeModelStore.getState().ensureSelectionReady(SEL, { textOnly: false });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({ selection: SEL, textOnly: false }));
     expect(r).toEqual({ ready: false, reason: 'starting', corrections: null });
   });
 
@@ -472,9 +491,10 @@ describe('ensureSelectionReady (facade)', () => {
     // translation pairing, and asr precedence (checked first) wins the reason.
     mockModelsCatalogResolve();
     await useNativeModelStore.getState().ensureCatalog(); // status → ready, catalog seeded
-    const r = await useNativeModelStore.getState().ensureSelectionReady(
-      { ...SEL, sourceLanguage: 'en', targetLanguage: 'en', asrModel: 'sense-voice' },
-      { textOnly: true });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({
+      selection: { ...SEL, sourceLanguage: 'en', targetLanguage: 'en', asrModel: 'sense-voice' },
+      textOnly: true,
+    }));
     expect(r.ready).toBe(false);
     expect(r.reason).toBe('asr-incompatible');
   });
@@ -491,8 +511,9 @@ describe('ensureSelectionReady (facade)', () => {
     mockModelsCatalogResolve();
     mockModelNotReady('moss-tts-nano');
     await useNativeModelStore.getState().ensureCatalog();
-    const r = await useNativeModelStore.getState().ensureSelectionReady(
-      { ...SEL, targetLanguage: 'ja' }, { textOnly: false });
+    const r = await useNativeModelStore.getState().ensureSelectionReady(() => ({
+      selection: { ...SEL, targetLanguage: 'ja' }, textOnly: false,
+    }));
     expect(r.ready).toBe(false);
     expect(r.reason).toBe('models-missing');
   });

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -1,7 +1,12 @@
 import { create } from 'zustand';
 import { NativeModelClient } from '../lib/local-inference/native/NativeModelClient';
 import type { NativeModelState, NativeModelInfo, NativeVoiceInfo, VariantInfo, HardwareInfoResultMsg } from '../lib/local-inference/native/nativeProtocol';
-import { autoSelectNative, hardwareGated, statusReposFor, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
+import {
+  autoSelectNative, hardwareGated, statusReposFor,
+  nativeAsrCards, nativeTranslationCards, nativeTtsCards,
+  requiredNativeModels, supportsLanguage,
+  type NativeSelection, type NativeReadinessSelection, type NativeReadinessResult, type NativeReadinessReason,
+} from '../lib/local-inference/native/nativeCatalog';
 import { isElectron } from '../utils/environment';
 
 export type NativeModelStatus = NativeModelState | 'downloading';
@@ -73,6 +78,12 @@ interface NativeModelStore {
   deleteModel: (model: string, repo?: string) => Promise<void>;
   /** True only if every listed model is cached. */
   isReady: (models: string[]) => boolean;
+  /** Full LOCAL_NATIVE session-readiness gate: warm the sidecar, check the
+   *  lifecycle, refresh the pair's statuses (variant-aware), auto-select stale
+   *  choices, and judge compat + downloaded state. Returns ready + a reason and
+   *  the auto-select corrections (the caller persists them). Mirrors the WASM
+   *  useModelStore.ensureSelectionReady in shape (peers, not a shared layer). */
+  ensureSelectionReady: (selection: NativeReadinessSelection, opts: { textOnly: boolean }) => Promise<NativeReadinessResult>;
   /** Persist the chosen models for a language pair/direction. */
   rememberModels: (src: string, tgt: string, sel: NativeSelection) => void;
   /** The remembered selection for a direction (raw; readiness is re-checked by autoSelect). */
@@ -421,6 +432,58 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
   },
 
   isReady: (models) => models.length > 0 && models.every((m) => get().statuses[m] === 'ready'),
+
+  ensureSelectionReady: async (selection, opts) => {
+    if (!isElectron()) return { ready: false, reason: 'not-electron', corrections: null };
+    await get().ensureCatalog();
+    const status = get().sidecarStatus;
+    if (status !== 'ready') {
+      const bundle = get().bundleStatus;
+      const reason: NativeReadinessReason =
+        bundle === 'mismatch' ? 'engine-mismatch'
+        : (bundle === 'absent' || bundle === 'paused') ? 'engine-absent'
+        : status === 'unavailable' ? 'unavailable'
+        : 'starting';
+      return { ready: false, reason, corrections: null };
+    }
+    const catalog = get().catalog;
+    const pins = selection.translationVariantByModel ?? {};
+    const asCards = (ids: string[]): NativeModelInfo[] =>
+      ids.map((id) => catalog[id]).filter((c): c is NativeModelInfo => !!c);
+    // FIRST refresh: this pair's candidate statuses, variant-aware — so a cold
+    // start doesn't read the default repo and wipe a valid pinned selection.
+    const candidateIds = Array.from(new Set([
+      ...nativeAsrCards(selection.sourceLanguage, catalog),
+      ...nativeTranslationCards(selection.sourceLanguage, selection.targetLanguage, catalog),
+      ...nativeTtsCards(selection.targetLanguage, catalog),
+    ].map((c) => c.downloadId).filter((id): id is string => !!id)));
+    const candidateRepos = deriveVariantRepos(asCards(candidateIds), pins);
+    await get().refresh(candidateIds, Object.keys(candidateRepos).length > 0 ? candidateRepos : undefined);
+    // Reconcile the stale selection against catalog + live statuses. autoSelect
+    // also persists to modelPreferences internally; it RETURNS the changed
+    // settings fields (the caller applies them to settingsStore).
+    const corrections = get().autoSelect(selection.sourceLanguage, selection.targetLanguage, {
+      asrModel: selection.asrModel, translationModel: selection.translationModel, ttsModel: selection.ttsModel,
+    });
+    const effective = corrections ? { ...selection, ...corrections } : selection;
+    const asrOpt = catalog[effective.asrModel];
+    const asrCompatible = !!asrOpt && asrOpt.kind === 'asr' && supportsLanguage(asrOpt, effective.sourceLanguage);
+    const trCompatible = nativeTranslationCards(effective.sourceLanguage, effective.targetLanguage, catalog)
+      .some((c) => c.selectId === effective.translationModel);
+    const models = requiredNativeModels(
+      effective.asrModel, effective.translationModel, effective.ttsModel,
+      effective.sourceLanguage, effective.targetLanguage, catalog, opts.textOnly);
+    // SECOND refresh: the selected models' chosen variant repos (pin ?? recommended).
+    const resolved = deriveVariantRepos(asCards([effective.asrModel, effective.translationModel]), pins);
+    const statusRepos = Object.keys(resolved).length > 0 ? resolved : undefined;
+    await get().refresh(models, statusRepos);
+    const ready = asrCompatible && trCompatible && get().isReady(models);
+    const reason: NativeReadinessReason = ready ? 'ready'
+      : !asrCompatible ? 'asr-incompatible'
+      : !trCompatible ? 'translation-incompatible'
+      : 'models-missing';
+    return { ready, reason, corrections: corrections ?? null };
+  },
 
   rememberModels: (src, tgt, sel) => {
     set((s) => ({ modelPreferences: { ...s.modelPreferences, [`${src}→${tgt}`]: sel } }));

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -114,14 +114,12 @@ const client = new NativeModelClient();
  * Q8_0) read 'absent' from the default-repo check and the ASR chip showed
  * "None" until a variant-aware caller happened to run.
  */
-async function catalogStatusRepos(list: NativeModelInfo[]): Promise<Record<string, string>> {
-  let pins: Record<string, string> = {};
-  try {
-    const { useSettingsStore } = await import('./settingsStore');
-    pins = useSettingsStore.getState().localNative.translationVariantByModel ?? {};
-  } catch { /* settings store unavailable — fall back to recommendations */ }
+/** A card's CHOSEN (pinned ?? recommended) variant repo, for each multi-variant
+ * card in `cards`. Single-variant cards are skipped (their status uses the
+ * default-repo cache). Pure: no store/settings reads — pins are injected. */
+function deriveVariantRepos(cards: NativeModelInfo[], pins: Record<string, string>): Record<string, string> {
   const vd: Record<string, { variants: { id: string; repo: string }[]; recommended: string }> = {};
-  for (const m of list) {
+  for (const m of cards) {
     const vs = m.variants;
     if (!vs || vs.length < 2) continue;
     vd[m.id] = {
@@ -130,6 +128,15 @@ async function catalogStatusRepos(list: NativeModelInfo[]): Promise<Record<strin
     };
   }
   return statusReposFor(Object.keys(vd), vd, pins);
+}
+
+async function catalogStatusRepos(list: NativeModelInfo[]): Promise<Record<string, string>> {
+  let pins: Record<string, string> = {};
+  try {
+    const { useSettingsStore } = await import('./settingsStore');
+    pins = useSettingsStore.getState().localNative.translationVariantByModel ?? {};
+  } catch { /* settings store unavailable — fall back to recommendations */ }
+  return deriveVariantRepos(list, pins);
 }
 
 async function revalidateNativeProvider(): Promise<void> {

--- a/src/stores/nativeModelStore.ts
+++ b/src/stores/nativeModelStore.ts
@@ -5,7 +5,7 @@ import {
   autoSelectNative, hardwareGated, statusReposFor,
   nativeAsrCards, nativeTranslationCards, nativeTtsCards,
   requiredNativeModels, supportsLanguage,
-  type NativeSelection, type NativeReadinessSelection, type NativeReadinessResult, type NativeReadinessReason,
+  type NativeSelection, type NativeReadinessInput, type NativeReadinessResult, type NativeReadinessReason,
 } from '../lib/local-inference/native/nativeCatalog';
 import { isElectron } from '../utils/environment';
 
@@ -82,8 +82,10 @@ interface NativeModelStore {
    *  lifecycle, refresh the pair's statuses (variant-aware), auto-select stale
    *  choices, and judge compat + downloaded state. Returns ready + a reason and
    *  the auto-select corrections (the caller persists them). Mirrors the WASM
-   *  useModelStore.ensureSelectionReady in shape (peers, not a shared layer). */
-  ensureSelectionReady: (selection: NativeReadinessSelection, opts: { textOnly: boolean }) => Promise<NativeReadinessResult>;
+   *  useModelStore.ensureSelectionReady in shape (peers, not a shared layer).
+   *  `read` is a thunk, called only once the sidecar is warm — see
+   *  NativeReadinessInput for why a snapshot would be wrong. */
+  ensureSelectionReady: (read: () => NativeReadinessInput) => Promise<NativeReadinessResult>;
   /** Persist the chosen models for a language pair/direction. */
   rememberModels: (src: string, tgt: string, sel: NativeSelection) => void;
   /** The remembered selection for a direction (raw; readiness is re-checked by autoSelect). */
@@ -433,7 +435,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
 
   isReady: (models) => models.length > 0 && models.every((m) => get().statuses[m] === 'ready'),
 
-  ensureSelectionReady: async (selection, opts) => {
+  ensureSelectionReady: async (read) => {
     if (!isElectron()) return { ready: false, reason: 'not-electron', corrections: null };
     await get().ensureCatalog();
     const status = get().sidecarStatus;
@@ -446,6 +448,10 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
         : 'starting';
       return { ready: false, reason, corrections: null };
     }
+    // Settings are read HERE, not at the call site: the warmup above can take
+    // seconds on a cold start, during which the user may change the pair or
+    // toggle text-only. The pre-facade gate read them at this same point.
+    const { selection, textOnly } = read();
     const catalog = get().catalog;
     const pins = selection.translationVariantByModel ?? {};
     const asCards = (ids: string[]): NativeModelInfo[] =>
@@ -472,7 +478,7 @@ export const useNativeModelStore = create<NativeModelStore>((set, get) => ({
       .some((c) => c.selectId === effective.translationModel);
     const models = requiredNativeModels(
       effective.asrModel, effective.translationModel, effective.ttsModel,
-      effective.sourceLanguage, effective.targetLanguage, catalog, opts.textOnly);
+      effective.sourceLanguage, effective.targetLanguage, catalog, textOnly);
     // SECOND refresh: the selected models' chosen variant repos (pin ?? recommended).
     const resolved = deriveVariantRepos(asCards([effective.asrModel, effective.translationModel]), pins);
     const statusRepos = Object.keys(resolved).length > 0 ? resolved : undefined;

--- a/src/stores/settingsStore.nativeGate.test.ts
+++ b/src/stores/settingsStore.nativeGate.test.ts
@@ -1,7 +1,7 @@
 /**
  * The LOCAL_NATIVE readiness gate (validateApiKey) is a thin wrapper around
- * nativeModelStore's `ensureSelectionReady` facade: it forwards the current
- * localNative selection, applies any corrections the facade returns, and maps
+ * nativeModelStore's `ensureSelectionReady` facade: it hands the facade a thunk
+ * reading the live localNative selection, applies any corrections it returns, and maps
  * the returned reason to a user-facing message via the module-private
  * `msgForNativeReason` helper. All sidecar warmup / lifecycle-gating /
  * auto-select / variant-repo-resolution behavior now lives in and is tested by
@@ -66,6 +66,29 @@ describe('LOCAL_NATIVE gate delegates to ensureSelectionReady', () => {
     expect(r).toEqual({ valid: true, message: '', validating: false });
     expect(useSettingsStore.getState().isApiKeyValid).toBe(true);
     expect(useSettingsStore.getState().availableModels).toEqual([{ id: 'native-asr-translate', type: 'realtime', created: 0 }]);
+  });
+
+  it('hands the facade a live reader, not a pre-warmup snapshot', async () => {
+    // The wrapper's half of the stale-snapshot fix: it passes a thunk, so what
+    // the facade reads reflects the settings at READ time (after it has warmed
+    // the sidecar), not at call time. Simulates a pair/text-only change landing
+    // during a slow cold start.
+    useSettingsStore.setState({
+      localNative: { ...useSettingsStore.getState().localNative, sourceLanguage: 'zh' },
+      textOnly: false,
+    } as any);
+    let seen: any;
+    mockEnsureSelectionReady.mockImplementation(async (read: any) => {
+      useSettingsStore.setState({
+        localNative: { ...useSettingsStore.getState().localNative, sourceLanguage: 'ja' },
+        textOnly: true,
+      } as any);
+      seen = read();
+      return { ready: true, reason: 'ready', corrections: null };
+    });
+    await useSettingsStore.getState().validateApiKey();
+    expect(seen.selection.sourceLanguage).toBe('ja');
+    expect(seen.textOnly).toBe(true);
   });
 
   it('applies corrections to localNative', async () => {

--- a/src/stores/settingsStore.nativeGate.test.ts
+++ b/src/stores/settingsStore.nativeGate.test.ts
@@ -337,3 +337,52 @@ describe('LOCAL_NATIVE gate: sidecar lifecycle gates (Task 10)', () => {
     expect(r.valid).toBe(true);
   });
 });
+
+describe('LOCAL_NATIVE gate: validationMessage is frozen per scenario', () => {
+  it('empty message when ready', async () => {
+    mockIsReady.mockReturnValue(true);
+    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', translationModel: 'qwen2.5-0.5b' });
+    const r = await useSettingsStore.getState().validateApiKey();
+    expect(r.valid).toBe(true);
+    expect(useSettingsStore.getState().validationMessage).toBe('');
+  });
+
+  it('unavailable → retry message', async () => {
+    mockNativeSidecar({ status: 'unavailable' });
+    await useSettingsStore.getState().validateApiKey();
+    expect(useSettingsStore.getState().validationMessage)
+      .toBe('Native engine unavailable — retry in settings');
+  });
+
+  it('starting → starting message', async () => {
+    mockNativeSidecar({ status: 'starting' });
+    await useSettingsStore.getState().validateApiKey();
+    expect(useSettingsStore.getState().validationMessage)
+      .toBe('Starting the local engine…');
+  });
+
+  it('translation incompatible → translation message', async () => {
+    mockIsReady.mockReturnValue(true);
+    setNative({ sourceLanguage: 'en', targetLanguage: 'zh', translationModel: 'opus-mt-zh-en' });
+    await useSettingsStore.getState().validateApiKey();
+    expect(useSettingsStore.getState().validationMessage)
+      .toBe('Select a translation model for this language pair');
+  });
+
+  it('asr incompatible → asr message', async () => {
+    // An ASR model that is not an 'asr'-kind card for the source language.
+    mockIsReady.mockReturnValue(true);
+    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', asrModel: 'no-such-asr', translationModel: 'qwen2.5-0.5b' });
+    await useSettingsStore.getState().validateApiKey();
+    expect(useSettingsStore.getState().validationMessage)
+      .toBe('Select a speech-recognition model for the source language');
+  });
+
+  it('models missing → download message', async () => {
+    mockIsReady.mockReturnValue(false); // compatible selection, but not downloaded
+    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', translationModel: 'qwen2.5-0.5b' });
+    await useSettingsStore.getState().validateApiKey();
+    expect(useSettingsStore.getState().validationMessage)
+      .toBe('Download the native models in settings');
+  });
+});

--- a/src/stores/settingsStore.nativeGate.test.ts
+++ b/src/stores/settingsStore.nativeGate.test.ts
@@ -1,23 +1,15 @@
 /**
- * The LOCAL_NATIVE readiness gate (validateApiKey) must check the CHOSEN quant
- * variant's repo — even on cold start, when the Settings panel (which normally
- * publishes statusRepos) has never mounted this session. The gate therefore
- * resolves the active translation model's variant itself (pin ?? recommended)
- * via listVariants and passes that repo explicitly to refresh.
- *
- * Without this, the gate falls back to the catalog DEFAULT repo (e.g. bf16) and
- * gates Start for a user who only downloaded the recommended/pinned quant.
- *
- * Task 10: the gate also warms the sidecar via ensureCatalog, checks the lifecycle
- * status (starting/unavailable → early return, no selection mutation), and when
- * ready runs global autoSelect to reconcile stale model choices before gating.
+ * The LOCAL_NATIVE readiness gate (validateApiKey) is a thin wrapper around
+ * nativeModelStore's `ensureSelectionReady` facade: it forwards the current
+ * localNative selection, applies any corrections the facade returns, and maps
+ * the returned reason to a user-facing message via the module-private
+ * `msgForNativeReason` helper. All sidecar warmup / lifecycle-gating /
+ * auto-select / variant-repo-resolution behavior now lives in and is tested by
+ * Task 3's facade tests (nativeModelStore.test.ts) — this file only pins the
+ * wrapper contract and the reason→message mapping.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { Provider } from '../types/Provider';
-import type { VariantInfo } from '../lib/local-inference/native/nativeProtocol';
-import type { NativeModelInfo } from '../lib/local-inference/native/nativeProtocol';
-import type { NativeSelection } from '../lib/local-inference/native/nativeCatalog';
-import { nativeTranslationCards } from '../lib/local-inference/native/nativeCatalog';
 
 // ServiceFactory is touched during updateLocalNative/persist — stub it.
 vi.mock('../services/ServiceFactory', () => ({
@@ -35,354 +27,67 @@ vi.mock('../utils/environment', async () => {
   return { ...actual, isElectron: () => true };
 });
 
-// ── mock state (mutable; updated per-test via mockNativeSidecar / beforeEach) ──
-const mockRefresh = vi.fn().mockResolvedValue(undefined);
-const mockIsReady = vi.fn().mockReturnValue(true);
-const mockListVariants = vi.fn();
-const mockEnsureCatalog = vi.fn().mockResolvedValue(undefined);
-const mockAutoSelect = vi.fn().mockReturnValue(null);
-let mockSidecarStatus: 'idle' | 'starting' | 'ready' | 'unavailable' = 'ready';
-let mockCatalog: Record<string, NativeModelInfo> = {};
-
-// Stub the native store + variant lookup the gate dynamically imports.
+// Stub the native store's facade the gate dynamically imports.
+const mockEnsureSelectionReady = vi.fn();
 vi.mock('./nativeModelStore', () => ({
   useNativeModelStore: {
     getState: () => ({
-      refresh: mockRefresh,
-      isReady: mockIsReady,
-      ensureCatalog: mockEnsureCatalog,
-      autoSelect: (...args: unknown[]) => mockAutoSelect(...args),
-      sidecarStatus: mockSidecarStatus,
-      catalog: mockCatalog,
+      ensureSelectionReady: (...a: unknown[]) => mockEnsureSelectionReady(...a),
     }),
   },
-  nativeListVariants: (...a: unknown[]) => mockListVariants(...a),
 }));
 
 const { default: useSettingsStore } = await import('./settingsStore');
 
-const VARIANTS: VariantInfo[] = [
-  { id: 'fp8', computeType: 'fp8', repo: 'tencent/Hy-MT2-7B-FP8', sizeBytes: 8e9, supported: true },
-  { id: 'bfloat16', computeType: 'bfloat16', repo: 'tencent/Hy-MT2-7B', sizeBytes: 15e9, supported: true },
-];
-
-/**
- * Minimal catalog that covers the sense-voice ASR and the two translation
- * models used across the test suite. Both new and existing tests default to
- * this catalog so mock state is consistent.
- */
-const DEFAULT_CATALOG: Record<string, NativeModelInfo> = {
-  'sense-voice': {
-    id: 'sense-voice', name: 'SenseVoice', kind: 'asr',
-    languages: ['multi'], recommended: true, tiers: [], order: 0, repo: '',
-  },
-  'qwen2.5-0.5b': {
-    id: 'qwen2.5-0.5b', name: 'Qwen2.5-0.5B', kind: 'translate',
-    languages: ['multi'], recommended: true, tiers: [], order: 0, repo: '',
-  },
-  'opus-mt-zh-en': {
-    id: 'opus-mt-zh-en', name: 'Opus-MT zh→en', kind: 'translate',
-    languages: ['zh', 'en'], recommended: false, tiers: [], order: 1, repo: '',
-  },
-  // Multi-variant translate cards. The gate must resolve these via variantIds
-  // (data-driven), not a 'hy-mt' prefix check — hy-mt2-7b/hy-mt15-7b cover the
-  // HY-MT family, translategemma-4b proves the check isn't HY-MT-specific.
-  'hy-mt2-7b': {
-    id: 'hy-mt2-7b', name: 'Hunyuan-MT2 7B', kind: 'translate',
-    languages: ['multi'], recommended: false, tiers: [], order: 2, repo: '',
-    variantIds: ['q4_k_m', 'q8_0'],
-    variants: [
-      { id: 'fp8', sizeBytes: 8e9, repo: 'tencent/Hy-MT2-7B-FP8', supported: true, recommended: true },
-      { id: 'bfloat16', sizeBytes: 15e9, repo: 'tencent/Hy-MT2-7B', supported: true, recommended: false },
-    ],
-  },
-  'hy-mt15-7b': {
-    id: 'hy-mt15-7b', name: 'Hunyuan-MT1.5 7B', kind: 'translate',
-    languages: ['multi'], recommended: false, tiers: [], order: 3, repo: '',
-    variantIds: ['q4_k_m', 'q8_0'],
-    variants: [
-      { id: 'fp8', sizeBytes: 8e9, repo: 'tencent/HY-MT1.5-7B-FP8', supported: true, recommended: true },
-      { id: 'bfloat16', sizeBytes: 15e9, repo: 'tencent/HY-MT1.5-7B', supported: true, recommended: false },
-    ],
-  },
-  'translategemma-4b': {
-    id: 'translategemma-4b', name: 'TranslateGemma 4B', kind: 'translate',
-    languages: ['multi'], recommended: false, tiers: [], order: 4, repo: '',
-    variantIds: ['q4_k_m', 'q8_0'],
-    variants: [
-      { id: 'fp8', sizeBytes: 8e9, repo: 'google/translategemma-FP8', supported: true, recommended: true },
-      { id: 'bfloat16', sizeBytes: 15e9, repo: 'google/translategemma', supported: true, recommended: false },
-    ],
-  },
+// The Task-1 frozen per-scenario messages, now keyed by the facade's reason —
+// this table is the wrapper's contract with msgForNativeReason (module-private,
+// so it's exercised indirectly through validateApiKey).
+const REASON_MESSAGE: Record<string, string> = {
+  'ready': '',
+  'not-electron': 'Native sidecar unavailable (desktop app + installed sidecar required)',
+  'engine-mismatch': 'The inference engine needs an update — open provider settings to update it',
+  'engine-absent': 'Download the inference engine in provider settings',
+  'unavailable': 'Native engine unavailable — retry in settings',
+  'starting': 'Starting the local engine…',
+  'asr-incompatible': 'Select a speech-recognition model for the source language',
+  'translation-incompatible': 'Select a translation model for this language pair',
+  'models-missing': 'Download the native models in settings',
 };
 
-/** The catalog used in the Task-10 lifecycle tests. Same shape as DEFAULT_CATALOG. */
-const READY_CATALOG = DEFAULT_CATALOG;
-
-function setNative(over: Record<string, unknown>) {
-  useSettingsStore.setState({
-    provider: Provider.LOCAL_NATIVE,
-    localNative: {
-      ...useSettingsStore.getState().localNative,
-      asrModel: 'sense-voice', sourceLanguage: 'zh', targetLanguage: 'en',
-      translationVariantByModel: {}, ...over,
-    },
-  } as any);
-}
-
-function reposArg(): unknown {
-  // The required-models refresh is the LAST refresh call; the first is the
-  // pre-auto-select candidate-status refresh (also variant-aware since the
-  // cold-start selection-wipe fix — see the dedicated tests below).
-  return mockRefresh.mock.calls.at(-1)?.[1];
-}
-
-/**
- * Configure the mock native store for a given sidecar lifecycle state.
- * When status is 'ready', sets up autoSelect to reconcile the translation
- * model based on the downloaded set (mirrors the real autoSelectNative logic
- * for the translation stage).
- */
-function mockNativeSidecar({ status, catalog = DEFAULT_CATALOG, downloaded = [] }: {
-  status: 'idle' | 'starting' | 'ready' | 'unavailable';
-  catalog?: Record<string, NativeModelInfo>;
-  downloaded?: string[];
-}) {
-  mockSidecarStatus = status;
-  mockCatalog = catalog;
-  const dl = new Set(downloaded);
-  mockAutoSelect.mockImplementation((src: string, tgt: string, current: NativeSelection) => {
-    const trCards = nativeTranslationCards(src, tgt, catalog);
-    const curCard = trCards.find((c) => c.selectId === current.translationModel);
-    if (curCard && dl.has(curCard.downloadId)) return null; // still valid
-    const best = trCards.find((c) => dl.has(c.downloadId));
-    if (!best || best.selectId === current.translationModel) return null;
-    return { translationModel: best.selectId };
-  });
-}
-
-beforeEach(() => {
-  mockRefresh.mockClear();
-  mockIsReady.mockClear();
-  mockListVariants.mockReset();
-  mockListVariants.mockResolvedValue({ variants: VARIANTS, recommended: 'fp8' });
-  mockEnsureCatalog.mockClear();
-  mockAutoSelect.mockReturnValue(null);
-  mockSidecarStatus = 'ready';
-  mockCatalog = DEFAULT_CATALOG;
-});
-
-describe('LOCAL_NATIVE gate is variant-aware on cold start', () => {
-  it('checks the recommended variant repo (not the default) when no pin is set', async () => {
-    setNative({ translationModel: 'hy-mt2-7b' });
-    await useSettingsStore.getState().validateApiKey();
-
-    expect(mockRefresh).toHaveBeenCalled();
-    expect(reposArg()).toEqual({ 'hy-mt2-7b': 'tencent/Hy-MT2-7B-FP8' });
-  });
-
-  it('honors an explicit pin over the recommended variant', async () => {
-    setNative({ translationModel: 'hy-mt2-7b', translationVariantByModel: { 'hy-mt2-7b': 'bfloat16' } });
-    await useSettingsStore.getState().validateApiKey();
-
-    expect(reposArg()).toEqual({ 'hy-mt2-7b': 'tencent/Hy-MT2-7B' });
-  });
-
-  it('also resolves the HY-MT1.5 family (gated by catalog variantIds, not a hy-mt prefix)', async () => {
-    setNative({ translationModel: 'hy-mt15-7b' });
-    await useSettingsStore.getState().validateApiKey();
-
-    // No round-trip: the repo comes straight from the catalog's precomputed
-    // variants (recommended fp8 for HY-MT1.5 in the fixture).
-    expect(mockListVariants).not.toHaveBeenCalled();
-    expect(reposArg()).toEqual({ 'hy-mt15-7b': 'tencent/HY-MT1.5-7B-FP8' });
-  });
-
-  it('resolves a non-HY-MT multi-variant card the same way (the gate is data-driven, not hy-mt-specific)', async () => {
-    setNative({ translationModel: 'translategemma-4b' });
-    await useSettingsStore.getState().validateApiKey();
-
-    expect(mockListVariants).not.toHaveBeenCalled();
-    expect(reposArg()).toEqual({ 'translategemma-4b': 'google/translategemma-FP8' });
-  });
-
-  it('does not fetch variants for a single-variant translation model (repos left to the cache)', async () => {
-    setNative({ translationModel: 'qwen2.5-0.5b' });
-    await useSettingsStore.getState().validateApiKey();
-
-    // qwen2.5-0.5b has no (or a single) catalog variantIds entry, so the variant
-    // block is skipped; the required-models refresh (the last call) gets no
-    // explicit override, so it falls back to the store's statusRepos cache.
-    // (The first refresh is the pre-auto-select candidate-status refresh.)
-    expect(mockListVariants).not.toHaveBeenCalled();
-    expect(mockRefresh).toHaveBeenCalledTimes(2);
-    expect(reposArg()).toBeUndefined();
-  });
-
-  it('resolves variant repos for the PRE-auto-select candidate refresh too (cold-start wipe)', async () => {
-    // Field bug: a multi-variant ASR card (Fun-ASR) whose user-downloaded quant
-    // is the RECOMMENDED one, not the catalog default. On cold start the gate's
-    // first (pre-auto-select) candidate refresh checked the DEFAULT repos, the
-    // statuses came back absent, and auto-select wiped the persisted selection
-    // to '' — the user saw ASR "None" on every app restart and had to reselect.
-    const catalog: Record<string, NativeModelInfo> = {
-      ...DEFAULT_CATALOG,
-      'fun-asr-mlt-nano': {
-        id: 'fun-asr-mlt-nano', name: 'Fun-ASR MLT Nano', kind: 'asr',
-        languages: ['multi'], recommended: true, tiers: [], order: 1, repo: '',
-        variantIds: ['q6_k', 'q4_k_m'],
-        variants: [
-          { id: 'q6_k', sizeBytes: 7e8, repo: 'handy-computer/Fun-ASR-MLT-Nano-2512-gguf/Fun-ASR-MLT-Nano-2512-Q6_K.gguf', supported: true, recommended: false },
-          { id: 'q4_k_m', sizeBytes: 6e8, repo: 'handy-computer/Fun-ASR-MLT-Nano-2512-gguf/Fun-ASR-MLT-Nano-2512-Q4_K_M.gguf', supported: true, recommended: true },
-        ],
-      },
-    };
-    setNative({ asrModel: 'fun-asr-mlt-nano' });
-    mockNativeSidecar({ status: 'ready', catalog, downloaded: ['fun-asr-mlt-nano'] });
-    await useSettingsStore.getState().validateApiKey();
-    const first = mockRefresh.mock.calls[0];
-    expect(first?.[0]).toContain('fun-asr-mlt-nano');
-    expect(first?.[1]).toMatchObject({
-      'fun-asr-mlt-nano': 'handy-computer/Fun-ASR-MLT-Nano-2512-gguf/Fun-ASR-MLT-Nano-2512-Q4_K_M.gguf',
-    });
-  });
-
-  it('the pre-auto-select refresh honors an explicit variant pin', async () => {
-    const catalog: Record<string, NativeModelInfo> = {
-      ...DEFAULT_CATALOG,
-      'fun-asr-mlt-nano': {
-        id: 'fun-asr-mlt-nano', name: 'Fun-ASR MLT Nano', kind: 'asr',
-        languages: ['multi'], recommended: true, tiers: [], order: 1, repo: '',
-        variantIds: ['q6_k', 'q8_0'],
-        variants: [
-          { id: 'q6_k', sizeBytes: 7e8, repo: 'handy-computer/Fun-ASR-MLT-Nano-2512-gguf/Fun-ASR-MLT-Nano-2512-Q6_K.gguf', supported: true, recommended: true },
-          { id: 'q8_0', sizeBytes: 9e8, repo: 'handy-computer/Fun-ASR-MLT-Nano-2512-gguf/Fun-ASR-MLT-Nano-2512-Q8_0.gguf', supported: true, recommended: false },
-        ],
-      },
-    };
-    setNative({ asrModel: 'fun-asr-mlt-nano',
-                translationVariantByModel: { 'fun-asr-mlt-nano': 'q8_0' } });
-    mockNativeSidecar({ status: 'ready', catalog, downloaded: ['fun-asr-mlt-nano'] });
-    await useSettingsStore.getState().validateApiKey();
-    expect(mockRefresh.mock.calls[0]?.[1]).toMatchObject({
-      'fun-asr-mlt-nano': 'handy-computer/Fun-ASR-MLT-Nano-2512-gguf/Fun-ASR-MLT-Nano-2512-Q8_0.gguf',
-    });
-  });
-
-  it('refreshes the pair candidate statuses BEFORE auto-select (so a downloaded model gets picked)', async () => {
-    setNative({ translationModel: 'qwen2.5-0.5b' });
-    mockRefresh.mockClear();
-    mockAutoSelect.mockClear();
-    await useSettingsStore.getState().validateApiKey();
-
-    // The candidate-status refresh must run before auto-select reads statuses,
-    // else auto-select sees an empty status map and can't pick a downloaded model.
-    expect(mockRefresh).toHaveBeenCalled();
-    expect(mockAutoSelect).toHaveBeenCalled();
-    expect(mockRefresh.mock.invocationCallOrder[0])
-      .toBeLessThan(mockAutoSelect.mock.invocationCallOrder[0]);
-    // That first refresh carries the pair's candidate download ids (incl. the ASR card).
-    expect(mockRefresh.mock.calls[0][0]).toContain('sense-voice');
-  });
-});
-
-describe('LOCAL_NATIVE gate rejects a translation model incompatible with the pair', () => {
-  // Repro: zh→en with Opus-MT (zh→en), then reverse to en→zh. The stale
-  // 'opus-mt-zh-en' selection is not a card for en→zh, so the UI shows "None" —
-  // but the model is still downloaded, so isReady() is true. The gate must NOT
-  // report ready, else Start stays enabled with no usable translation model.
-  it('is not ready when the selected translation is stale for the reversed pair (even if downloaded)', async () => {
-    mockIsReady.mockReturnValue(true); // models "downloaded"
-    setNative({ sourceLanguage: 'en', targetLanguage: 'zh', translationModel: 'opus-mt-zh-en' });
-    const r = await useSettingsStore.getState().validateApiKey();
-    expect(r.valid).toBe(false);
-    expect(useSettingsStore.getState().isApiKeyValid).toBe(false);
-  });
-
-  it('stays ready for a direction-correct Opus-MT card (does not over-block)', async () => {
-    mockIsReady.mockReturnValue(true);
-    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', translationModel: 'opus-mt-zh-en' });
-    const r = await useSettingsStore.getState().validateApiKey();
-    expect(r.valid).toBe(true);
-  });
-
-  it('stays ready for a multilingual qwen card on any pair', async () => {
-    mockIsReady.mockReturnValue(true);
-    setNative({ sourceLanguage: 'en', targetLanguage: 'zh', translationModel: 'qwen2.5-0.5b' });
-    const r = await useSettingsStore.getState().validateApiKey();
-    expect(r.valid).toBe(true);
-  });
-});
-
-describe('LOCAL_NATIVE gate: sidecar lifecycle gates (Task 10)', () => {
+describe('LOCAL_NATIVE gate delegates to ensureSelectionReady', () => {
   beforeEach(() => {
     useSettingsStore.setState({ provider: Provider.LOCAL_NATIVE } as any);
+    mockEnsureSelectionReady.mockReset();
   });
 
-  it('reports not-ready and does not mutate selection while sidecar is unavailable', async () => {
-    mockNativeSidecar({ status: 'unavailable' }); // ensureCatalog leaves it unavailable
-    const before = useSettingsStore.getState().localNative.translationModel;
+  it('sets valid + empty message + availableModels when ready', async () => {
+    mockEnsureSelectionReady.mockResolvedValue({ ready: true, reason: 'ready', corrections: null });
     const r = await useSettingsStore.getState().validateApiKey();
-    expect(r.valid).toBe(false);
+    expect(r).toEqual({ valid: true, message: '', validating: false });
+    expect(useSettingsStore.getState().isApiKeyValid).toBe(true);
+    expect(useSettingsStore.getState().availableModels).toEqual([{ id: 'native-asr-translate', type: 'realtime', created: 0 }]);
+  });
+
+  it('applies corrections to localNative', async () => {
+    mockEnsureSelectionReady.mockResolvedValue({ ready: true, reason: 'ready', corrections: { translationModel: 'opus-mt-zh-en' } });
+    await useSettingsStore.getState().validateApiKey();
+    expect(useSettingsStore.getState().localNative.translationModel).toBe('opus-mt-zh-en');
+  });
+
+  it('does not touch localNative when corrections is null', async () => {
+    const before = useSettingsStore.getState().localNative.translationModel;
+    mockEnsureSelectionReady.mockResolvedValue({ ready: false, reason: 'models-missing', corrections: null });
+    await useSettingsStore.getState().validateApiKey();
     expect(useSettingsStore.getState().localNative.translationModel).toBe(before);
   });
 
-  it('runs global auto-select when ready and gates on the reconciled pair', async () => {
-    mockNativeSidecar({ status: 'ready', catalog: READY_CATALOG, downloaded: ['sense-voice', 'qwen2.5-0.5b'] });
-    // stale translation for the new pair → autoSelect reconciles it
-    useSettingsStore.setState((s) => ({ localNative: { ...s.localNative,
-      sourceLanguage: 'en', targetLanguage: 'zh', asrModel: 'sense-voice', translationModel: 'opus-mt-zh-en' } }));
-    const r = await useSettingsStore.getState().validateApiKey();
-    expect(useSettingsStore.getState().localNative.translationModel).not.toBe('opus-mt-zh-en');
-    expect(r.valid).toBe(true);
-  });
-});
-
-describe('LOCAL_NATIVE gate: validationMessage is frozen per scenario', () => {
-  it('empty message when ready', async () => {
-    mockIsReady.mockReturnValue(true);
-    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', translationModel: 'qwen2.5-0.5b' });
-    const r = await useSettingsStore.getState().validateApiKey();
-    expect(r.valid).toBe(true);
-    expect(useSettingsStore.getState().validationMessage).toBe('');
-  });
-
-  it('unavailable → retry message', async () => {
-    mockNativeSidecar({ status: 'unavailable' });
-    await useSettingsStore.getState().validateApiKey();
-    expect(useSettingsStore.getState().validationMessage)
-      .toBe('Native engine unavailable — retry in settings');
-  });
-
-  it('starting → starting message', async () => {
-    mockNativeSidecar({ status: 'starting' });
-    await useSettingsStore.getState().validateApiKey();
-    expect(useSettingsStore.getState().validationMessage)
-      .toBe('Starting the local engine…');
-  });
-
-  it('translation incompatible → translation message', async () => {
-    mockIsReady.mockReturnValue(true);
-    setNative({ sourceLanguage: 'en', targetLanguage: 'zh', translationModel: 'opus-mt-zh-en' });
-    await useSettingsStore.getState().validateApiKey();
-    expect(useSettingsStore.getState().validationMessage)
-      .toBe('Select a translation model for this language pair');
-  });
-
-  it('asr incompatible → asr message', async () => {
-    // An ASR model that is not an 'asr'-kind card for the source language.
-    mockIsReady.mockReturnValue(true);
-    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', asrModel: 'no-such-asr', translationModel: 'qwen2.5-0.5b' });
-    await useSettingsStore.getState().validateApiKey();
-    expect(useSettingsStore.getState().validationMessage)
-      .toBe('Select a speech-recognition model for the source language');
-  });
-
-  it('models missing → download message', async () => {
-    mockIsReady.mockReturnValue(false); // compatible selection, but not downloaded
-    setNative({ sourceLanguage: 'zh', targetLanguage: 'en', translationModel: 'qwen2.5-0.5b' });
-    await useSettingsStore.getState().validateApiKey();
-    expect(useSettingsStore.getState().validationMessage)
-      .toBe('Download the native models in settings');
-  });
+  for (const [reason, expected] of Object.entries(REASON_MESSAGE)) {
+    it(`maps reason "${reason}" to its frozen message`, async () => {
+      mockEnsureSelectionReady.mockResolvedValue({ ready: reason === 'ready', reason, corrections: null });
+      const r = await useSettingsStore.getState().validateApiKey();
+      expect(r.message).toBe(expected);
+      expect(useSettingsStore.getState().validationMessage).toBe(expected);
+      expect(useSettingsStore.getState().isApiKeyValid).toBe(reason === 'ready');
+    });
+  }
 });

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -11,9 +11,8 @@ import {
 } from '../services/interfaces/IClient';
 import { getManifestEntry, getTranslationModel, estimateModelMemoryByDevice } from '../lib/local-inference/modelManifest';
 import { buildDefaultLocalPrompt } from '../lib/local-inference/prompts';
-import { requiredNativeModels, supportsLanguage, statusReposFor, nativeTranslationCards, nativeAsrCards, nativeTtsCards, autoSelectNative, hardwareGated, type NativeSelection } from '../lib/local-inference/native/nativeCatalog';
+import { autoSelectNative, hardwareGated, type NativeSelection, type NativeReadinessReason } from '../lib/local-inference/native/nativeCatalog';
 import { useNativeModelStore } from './nativeModelStore';
-import { isElectron } from '../utils/environment';
 import { useModelStore, type ParticipantModelStatus } from './modelStore';
 import useSessionStore from './sessionStore';
 import { getSubtitleSurface } from '../components/Subtitle/surfaces';
@@ -53,6 +52,22 @@ import {
 } from '../services/providers/LocalNativeProviderConfig';
 import { defaultKizunaOpenaiTranslateSettings } from '../services/providers/KizunaAIOpenAITranslateProviderConfig';
 import { defaultKizunaVolcengineAst2Settings } from '../services/providers/KizunaAIVolcengineAST2ProviderConfig';
+
+/** Map a native readiness reason to its user-facing message. Verbatim port of
+ * the messages the inline LOCAL_NATIVE gate produced. */
+function msgForNativeReason(reason: NativeReadinessReason): string {
+  switch (reason) {
+    case 'ready': return '';
+    case 'not-electron': return 'Native sidecar unavailable (desktop app + installed sidecar required)';
+    case 'engine-mismatch': return i18n.t('settings.localNativeEngineUpdateRequired', 'The inference engine needs an update — open provider settings to update it');
+    case 'engine-absent': return i18n.t('settings.localNativeEngineRequired', 'Download the inference engine in provider settings');
+    case 'unavailable': return i18n.t('settings.localNativeUnavailable', 'Native engine unavailable — retry in settings');
+    case 'starting': return i18n.t('settings.localNativeStarting', 'Starting the local engine…');
+    case 'asr-incompatible': return i18n.t('settings.localNativeAsrIncompatible', 'Select a speech-recognition model for the source language');
+    case 'translation-incompatible': return i18n.t('settings.localNativeTranslationIncompatible', 'Select a translation model for this language pair');
+    case 'models-missing': return i18n.t('settings.localNativeModelsRequired', 'Download the native models in settings');
+  }
+}
 
 export type {
   OpenAISettings, OpenAICompatibleSettings, OpenAICompatibleSettingsBase,
@@ -832,102 +847,17 @@ const useSettingsStore = create<SettingsStore>()(
       const state = get();
       const provider = state.provider;
 
-      // Native (Electron sidecar) inference: no API key. Readiness = the sidecar
-      // catalog is loaded and the reconciled selection passes compat + download
-      // checks. ensureCatalog warms the sidecar; never mutate the selection when
-      // the sidecar is still starting or unavailable.
+      // Native (Electron sidecar) inference: no API key. Readiness is owned by
+      // nativeModelStore's ensureSelectionReady facade (sidecar warmup, lifecycle
+      // gating, auto-select reconciliation, and compat/download checks); this
+      // branch only applies the resulting corrections and maps the reason to a
+      // user-facing message.
       if (provider === Provider.LOCAL_NATIVE) {
         const { useNativeModelStore } = await import('./nativeModelStore');
-        const nstore = useNativeModelStore.getState();
-        if (!isElectron()) {
-          set({ isApiKeyValid: false, availableModels: [], isValidating: false,
-            validationMessage: 'Native sidecar unavailable (desktop app + installed sidecar required)' });
-          return { valid: false, message: 'Native sidecar unavailable (desktop app + installed sidecar required)', validating: false };
-        }
-        // Warm the sidecar + load the full model catalog. Gate on the lifecycle;
-        // never run auto-select on an incomplete/empty catalog.
-        await nstore.ensureCatalog();
-        const status = useNativeModelStore.getState().sidecarStatus;
-        if (status !== 'ready') {
-          // When the ENGINE (bundle) is the reason, say so precisely — the
-          // engine card in provider settings carries the matching CTA (spec S10).
-          const bundle = useNativeModelStore.getState().bundleStatus;
-          const message = bundle === 'mismatch'
-            ? i18n.t('settings.localNativeEngineUpdateRequired',
-                'The inference engine needs an update — open provider settings to update it')
-            : (bundle === 'absent' || bundle === 'paused')
-              ? i18n.t('settings.localNativeEngineRequired',
-                  'Download the inference engine in provider settings')
-              : status === 'unavailable'
-                ? i18n.t('settings.localNativeUnavailable', 'Native engine unavailable — retry in settings')
-                : i18n.t('settings.localNativeStarting', 'Starting the local engine…');
-          set({ isApiKeyValid: false, availableModels: [], validationMessage: message, isValidating: false });
-          return { valid: false, message, validating: false };
-        }
-        const catalog = useNativeModelStore.getState().catalog;
-        const s0 = get().localNative;
-        // Refresh download statuses for THIS pair's candidate models BEFORE
-        // auto-select. Statuses start empty on a cold start, and auto-select reads
-        // them to pick the best *downloaded* model — without this it would see
-        // nothing downloaded and fail to select a model the user already has.
-        const candidateIds = Array.from(new Set([
-          ...nativeAsrCards(s0.sourceLanguage, catalog),
-          ...nativeTranslationCards(s0.sourceLanguage, s0.targetLanguage, catalog),
-          ...nativeTtsCards(s0.targetLanguage, catalog),
-        ].map((c) => c.downloadId).filter((id): id is string => !!id)));
-        // This FIRST refresh must be variant-aware too: on a cold start the
-        // Settings panel (which normally publishes statusRepos) has never
-        // mounted, so checking the catalog DEFAULT repos here marks a card
-        // whose user-downloaded quant is the recommended/pinned one (e.g.
-        // Fun-ASR: default Q6_K, downloaded Q4_K_M) as absent — and the
-        // auto-select below then wipes the persisted selection to '' on
-        // every app restart (the "ASR shows None after reopening" bug).
-        const resolveVariantRepos = (ids: string[]): Record<string, string> => {
-          const vd: Record<string, { variants: { id: string; repo: string }[]; recommended: string }> = {};
-          for (const mid of ids) {
-            const vs = catalog[mid]?.variants;
-            if (!vs || vs.length < 2) continue;
-            vd[mid] = {
-              variants: vs.map((v) => ({ id: v.id, repo: v.repo ?? '' })),
-              recommended: vs.find((v) => v.recommended)?.id ?? vs[0].id,
-            };
-          }
-          return statusReposFor(Object.keys(vd), vd, s0.translationVariantByModel);
-        };
-        const candidateRepos = resolveVariantRepos(candidateIds);
-        await useNativeModelStore.getState().refresh(
-          candidateIds, Object.keys(candidateRepos).length > 0 ? candidateRepos : undefined);
-        // Global auto-select: reconcile the stale selection for this pair against
-        // the catalog + live download statuses, and persist it (fixes both the
-        // Start button and the model-info "None" on a language reversal).
-        const updates = nstore.autoSelect(s0.sourceLanguage, s0.targetLanguage, {
-          asrModel: s0.asrModel, translationModel: s0.translationModel, ttsModel: s0.ttsModel,
-        });
-        if (updates) get().updateLocalNative(updates);
-        const s = get().localNative;
-        const asrOpt = catalog[s.asrModel];
-        const asrCompatible = !!asrOpt && asrOpt.kind === 'asr' && supportsLanguage(asrOpt, s.sourceLanguage);
-        // The selected translation must be a valid card for THIS language pair.
-        const trCompatible = nativeTranslationCards(s.sourceLanguage, s.targetLanguage, catalog)
-          .some((c) => c.selectId === s.translationModel);
-        // Gate on the selected stage models being downloaded into the sidecar cache.
-        // TTS is dropped from the requirement when text-only is on.
-        const models = requiredNativeModels(s.asrModel, s.translationModel, s.ttsModel, s.sourceLanguage, s.targetLanguage, catalog, get().textOnly);
-        // Resolve the selected models' CHOSEN variant repos (pin ?? the
-        // catalog's precomputed recommendation) so the gate checks the right
-        // quant even on cold start — no list_variants round-trip needed: the
-        // models_catalog feed carries the full ladder per card.
-        let statusRepos: Record<string, string> | undefined;
-        const resolved = resolveVariantRepos([s.asrModel, s.translationModel]);
-        // Only override when resolution actually produced a repo; an empty
-        // map ({}) would defeat refresh's `repos ?? cache` fallback.
-        if (Object.keys(resolved).length > 0) statusRepos = resolved;
-        await useNativeModelStore.getState().refresh(models, statusRepos);
-        const ready = asrCompatible && trCompatible && useNativeModelStore.getState().isReady(models);
-        const message = ready ? ''
-          : !asrCompatible ? i18n.t('settings.localNativeAsrIncompatible', 'Select a speech-recognition model for the source language')
-          : !trCompatible ? i18n.t('settings.localNativeTranslationIncompatible', 'Select a translation model for this language pair')
-          : i18n.t('settings.localNativeModelsRequired', 'Download the native models in settings');
+        const { ready, reason, corrections } = await useNativeModelStore.getState()
+          .ensureSelectionReady(get().localNative, { textOnly: get().textOnly });
+        if (corrections) get().updateLocalNative(corrections);
+        const message = msgForNativeReason(reason);
         set({
           isApiKeyValid: ready,
           availableModels: ready ? [{ id: 'native-asr-translate', type: 'realtime' as const, created: 0 }] : [],

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -58,7 +58,7 @@ import { defaultKizunaVolcengineAst2Settings } from '../services/providers/Kizun
 function msgForNativeReason(reason: NativeReadinessReason): string {
   switch (reason) {
     case 'ready': return '';
-    case 'not-electron': return 'Native sidecar unavailable (desktop app + installed sidecar required)';
+    case 'not-electron': return i18n.t('settings.localNativeNotElectron', 'Native sidecar unavailable (desktop app + installed sidecar required)');
     case 'engine-mismatch': return i18n.t('settings.localNativeEngineUpdateRequired', 'The inference engine needs an update — open provider settings to update it');
     case 'engine-absent': return i18n.t('settings.localNativeEngineRequired', 'Download the inference engine in provider settings');
     case 'unavailable': return i18n.t('settings.localNativeUnavailable', 'Native engine unavailable — retry in settings');
@@ -853,9 +853,11 @@ const useSettingsStore = create<SettingsStore>()(
       // branch only applies the resulting corrections and maps the reason to a
       // user-facing message.
       if (provider === Provider.LOCAL_NATIVE) {
-        const { useNativeModelStore } = await import('./nativeModelStore');
+        // Settings go in as a thunk, not a snapshot: the facade warms the sidecar
+        // first (seconds, on a cold start) and reads them only after — so a pair
+        // or text-only change made during warmup is honoured, not resolved stale.
         const { ready, reason, corrections } = await useNativeModelStore.getState()
-          .ensureSelectionReady(get().localNative, { textOnly: get().textOnly });
+          .ensureSelectionReady(() => ({ selection: get().localNative, textOnly: get().textOnly }));
         if (corrections) get().updateLocalNative(corrections);
         const message = msgForNativeReason(reason);
         set({


### PR DESCRIPTION
## What & why

The LOCAL_NATIVE branch of `settingsStore.validateApiKey` had grown to a 98-line
inline readiness gate (warm the sidecar → lifecycle/bundle gate → variant-aware
status refresh → auto-select → compat + downloaded checks → per-reason message),
while the sibling LOCAL_INFERENCE branch right below it delegates to a single
`useModelStore.ensureSelectionReady(...)`. This collapses the native gate into the
same shape: a `nativeModelStore.ensureSelectionReady(selection, { textOnly })`
facade, so the two provider branches read symmetrically.

Behaviour-preserving throughout — no change to what any scenario resolves to.

## Changes

- **New facade** `nativeModelStore.ensureSelectionReady(selection, opts) → { ready, reason, corrections }`
  (`src/stores/nativeModelStore.ts`), a verbatim port of the inline gate. It owns the
  effectful pipeline and returns a `reason` discriminant + the auto-select
  `corrections` for the caller to persist.
- **`settingsStore` shrinks** from 98 lines to ~13: call the facade → apply
  corrections via `updateLocalNative` → map `reason` → i18n via a new private
  `msgForNativeReason` (i18n stays in `settingsStore`, not the store) → set
  validation state. Now structurally parallel to the LOCAL_INFERENCE branch.
- **Dedup**: the variant-repo derivation that was copied in the gate and in the
  store is unified behind one private `deriveVariantRepos(cards, pins)` helper
  (`catalogStatusRepos` and the facade share it). The UI-panel copy is left for a
  later cleanup.
- **Types** `NativeReadinessReason` / `NativeReadinessSelection` / `NativeReadinessResult`
  co-located with `NativeSelection` in `nativeCatalog.ts`.

## Behaviour preservation

- The facade reproduces the gate's call order, both variant-aware refreshes, the
  compat/`isReady` checks, and the reason precedence. The one structural change —
  computing `effective = {...selection, ...corrections}` in memory instead of the
  gate's persist-then-reread — is equivalent for every field consumed after
  auto-select (`autoSelect` only ever changes asr/translation/tts), and the
  deferred `updateLocalNative` is not observable (the sole settings subscriber is
  the extension subtitle surface, inactive for the Electron-only native provider).
- The 9 `reason → message` strings are character-exact ports of the current
  messages (em-dash / ellipsis included); the pre-refactor messages were frozen in
  a characterization test first.
- Peer-provider boundary respected: the native facade mirrors WASM's
  `ensureSelectionReady` in shape only — no shared inference layer between the two
  local providers.

### Review follow-up (post-review, `64322ff2`)

Review found one place the claim above did **not** hold, now fixed:

- **Warmup race.** The first draft snapshotted `localNative` / `textOnly` at the
  call site. The pre-facade gate did *not* — it read them only after
  `await nstore.ensureCatalog()` (`main` settingsStore.ts:868 / :915). Since a
  cold sidecar start takes seconds, a pair or text-only change made during
  warmup was dropped and the verdict resolved against an obsolete selection.
  `ensureSelectionReady` now takes a `() => NativeReadinessInput` **read thunk**
  and calls it once the sidecar is warm — restoring the gate's original timing.
  Two regression tests pin it (store side: reads observe a warm sidecar; wrapper
  side: the gate hands over a live reader), both mutation-verified non-vacuous.
- Residual, accepted: settings are read once, so a change during the two
  `model_status` refreshes is still not picked up — that window is a fast
  round-trip, not a multi-second warmup, and it is the `effective` merge already
  reasoned about above.
- Also applied: `not-electron` wrapped in `i18n.t` for switch uniformity (no
  output change — no `settings.localNative*` key exists in any locale yet, so all
  nine arms resolve to their English fallback); redundant
  `await import('./nativeModelStore')` dropped (statically imported at :15).
- Declined with reasons on the threads: `refresh()`'s silent catch (pre-existing,
  identical in `main`, and a behaviour change to fix — deserves its own PR) and
  making `NativeReadinessResult` a discriminated union (single construction site;
  `corrections` on both arms, so nothing to narrow to).

## Testing

- The gate's internal-call assertions were re-homed to real-store facade tests
  (`nativeModelStore.test.ts`, exercising the actual readiness logic against the
  FakeWS harness, all 9 reasons covered — 3 of them mutation-verified non-vacuous);
  `settingsStore.nativeGate.test.ts` thinned to a wrapper contract (delegation,
  corrections applied/not, and a 9-row `reason → frozen message` table).
- Whole suite: **118 files, 1143 passed, 0 failed, 0 skipped**.
- No changes to the WASM side, the wire protocol, `LocalNativeClient` session
  state, or the model store's IPC/WS lane split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local native inference readiness gating with user-facing status messaging.
  * Automatically selects compatible ASR/translation/TTS models and applies recommended translation variants.
  * Detects missing downloads, incompatible translation direction/model mismatches, and other readiness issues.
  * Applies returned model “corrections” to your saved native settings when applicable.

* **Bug Fixes**
  * Improved handling of translation-direction incompatibility and model availability states.
  * Ensured single-variant models and recommended variant repositories are resolved correctly.

* **Tests**
  * Expanded readiness and catalog/variant resolution coverage for native model selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
