### PR TITLE
fix(dev): stop vite watching venv/worktree dirs to avoid ENOSPC

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -190,6 +190,21 @@ export default defineConfig(({ command, mode }) => {
     server: {
       port: 5173,
       host: true,
+      watch: {
+        // Vite recursively watches the whole project tree. Python virtualenvs
+        // living under git worktrees (.claude/worktrees/**/.spike/venv — with
+        // site-packages holding 100k+ files like onnx/torch) blow past the
+        // inotify max_user_watches limit and crash the dev server with ENOSPC.
+        // None of these dirs feed the build, so exclude them from the watcher.
+        // Merged with Vite's defaults (node_modules, .git already ignored).
+        ignored: [
+          '**/.claude/worktrees/**',
+          '**/.spike/**',
+          '**/venv/**',
+          '**/.venv/**',
+          '**/__pycache__/**',
+        ],
+      },
       // Cross-origin isolation for the dev server (electron:dev / web dev only).
       // Electron 40's Chromium requires COEP for ES module workers even when SAB
       // comes from --enable-features=SharedArrayBuffer, so without these the


### PR DESCRIPTION
## Problem

Running `npm run electron:dev` crashed the Vite dev server with:

```
Error: ENOSPC: System limit for number of file watchers reached, watch
'.../.claude/worktrees/feat+cosyvoice3-tts/.spike/venv/lib/python3.12/site-packages/onnx/reference/ops/__pycache__/op_gru.cpython-312.pyc'
```

Vite's dev server recursively watches the whole project tree. Python virtualenvs living under git worktrees (`.claude/worktrees/**/.spike/venv`) have `site-packages` (onnx, torch, …) holding 100k+ files, which exhausts the inotify `max_user_watches` limit and takes the dev server down. This happens even when the dev server is launched from the main checkout, because worktrees sit under the watched tree.

## Fix

Add `server.watch.ignored` for the worktree / venv / `__pycache__` dirs. None of them feed the renderer build.

Vite 7.3.3 **merges** `server.watch.ignored` with its built-in defaults (`**/.git/**`, `**/node_modules/**`, `**/test-results/**`, cacheDir) — the user array is appended, not overriding — so existing exclusions are preserved (verified against `node_modules/vite/dist/node/chunks/config.js:16710`).

## Verification

Loaded the config through Vite's own `loadConfigFromFile({ command: 'serve', mode: 'development' })` and asserted `server.watch.ignored` resolves to exactly the five added patterns. Config transpiles and all plugins import cleanly.

Note: this is the dev-server watcher fix. Raising the OS limit (`fs.inotify.max_user_watches`) is a complementary, machine-level mitigation and is not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)