### PR TITLE
feat(sidecar): field-level outbound wire contract at the single send funnel

### DIFF
--- a/sidecar/sokuji_sidecar/server.py
+++ b/sidecar/sokuji_sidecar/server.py
@@ -2,6 +2,8 @@ import json
 import sys
 import websockets
 
+from . import wire
+
 
 class Conn:
     def __init__(self, ws):
@@ -20,9 +22,14 @@ class Conn:
         self._on_close.append(cb)
 
     async def send(self, obj=None, binary=None):
+        """The ONE outbound funnel: every JSON message this process sends —
+        handler replies and engine pushes alike — leaves through here, so the
+        wire contract is enforced in exactly one place (strict in tests,
+        fail-open in production; see wire.py)."""
         if binary is not None:
             await self._ws.send(binary)
         if obj is not None:
+            wire.validate_outbound(obj)
             await self._ws.send(json.dumps(obj))
 
 
@@ -65,10 +72,7 @@ async def _conn(state, ws):
                     _mid = None
                 reply, binary = {"type": "error", "id": _mid, "message": str(e)}, None
             pending_binary = None
-            if binary is not None:
-                await ws.send(binary)
-            if reply is not None:
-                await ws.send(json.dumps(reply))
+            await conn.send(reply, binary)   # same binary-before-json order
     finally:
         # A session connection closing is "stop": free that connection's model from VRAM.
         # Each stage registers its own cleanup at init (conn.on_close), so the server

--- a/sidecar/sokuji_sidecar/server.py
+++ b/sidecar/sokuji_sidecar/server.py
@@ -26,10 +26,13 @@ class Conn:
         handler replies and engine pushes alike — leaves through here, so the
         wire contract is enforced in exactly one place (strict in tests,
         fail-open in production; see wire.py)."""
+        # Validate BEFORE any I/O: a strict-mode violation must leave the
+        # process in a nothing-sent state, not binary-without-its-JSON.
+        if obj is not None:
+            wire.validate_outbound(obj)
         if binary is not None:
             await self._ws.send(binary)
         if obj is not None:
-            wire.validate_outbound(obj)
             await self._ws.send(json.dumps(obj))
 
 

--- a/sidecar/sokuji_sidecar/wire.py
+++ b/sidecar/sokuji_sidecar/wire.py
@@ -40,13 +40,23 @@ class WireContractError(Exception):
 def validate_outbound(obj: dict) -> None:
     """Check one outbound JSON message against the schema. Raises
     WireContractError in strict mode; otherwise reports to stderr and returns
-    (the caller sends the message regardless — fail-open)."""
-    problem = _problem(obj)
-    if problem is None:
-        return
+    (the caller sends the message regardless — fail-open).
+
+    Fail-open covers the validator ITSELF too: in production a crash inside
+    _problem (a handler returning a non-dict, say) is reported and the message
+    passes — the guard must never be more dangerous than what it guards. In
+    strict mode the same crash surfaces raw, pointing at the real bug."""
     if os.environ.get("SOKUJI_WIRE_STRICT") == "1":
-        raise WireContractError(problem)
-    print(f"[wire] contract violation: {problem}", file=sys.stderr, flush=True)
+        problem = _problem(obj)
+        if problem is not None:
+            raise WireContractError(problem)
+        return
+    try:
+        problem = _problem(obj)
+    except Exception as e:
+        problem = f"validator crashed: {e!r}"
+    if problem is not None:
+        print(f"[wire] contract violation: {problem}", file=sys.stderr, flush=True)
 
 
 def _problem(obj: dict) -> str | None:

--- a/sidecar/sokuji_sidecar/wire.py
+++ b/sidecar/sokuji_sidecar/wire.py
@@ -1,0 +1,66 @@
+"""Outbound wire contract.
+
+The renderer's ServerMsg union (nativeProtocol.ts) is a hand-written model of
+what this process sends; nothing mechanically connected the two until C4a
+pinned the TYPE NAMES. This module extends that to top-level FIELD names:
+wire_schema.json is the single source of truth, validated here at the one
+outbound funnel (server.Conn.send) and pinned against the TS interfaces by
+nativeProtocol.consistency.test.ts on the renderer side.
+
+Failure stance: strict (raise) when SOKUJI_WIRE_STRICT=1 — the test suite sets
+this, so every message a test pushes through Conn.send is checked for free.
+Otherwise fail-open: print the violation to stderr (NativeHostManager pipes it
+into the Electron log) and let the message through — a contract bug must never
+take down a live session.
+
+Scope: top-level field names + presence only. Values and nested payload shapes
+(NativeModelInfo etc.) are deliberately out of scope — the renderer consumes
+those defensively, and the fatal drift class (type/field renames) lives at the
+top level.
+"""
+import json
+import os
+import sys
+
+with open(os.path.join(os.path.dirname(__file__), "wire_schema.json"),
+          encoding="utf-8") as _f:
+    _raw = json.load(_f)
+_raw.pop("_comment", None)
+SCHEMA: dict[str, dict[str, frozenset]] = {
+    mtype: {"required": frozenset(spec["required"]),
+            "optional": frozenset(spec["optional"])}
+    for mtype, spec in _raw.items()
+}
+
+
+class WireContractError(Exception):
+    pass
+
+
+def validate_outbound(obj: dict) -> None:
+    """Check one outbound JSON message against the schema. Raises
+    WireContractError in strict mode; otherwise reports to stderr and returns
+    (the caller sends the message regardless — fail-open)."""
+    problem = _problem(obj)
+    if problem is None:
+        return
+    if os.environ.get("SOKUJI_WIRE_STRICT") == "1":
+        raise WireContractError(problem)
+    print(f"[wire] contract violation: {problem}", file=sys.stderr, flush=True)
+
+
+def _problem(obj: dict) -> str | None:
+    mtype = obj.get("type")
+    if mtype is None:
+        return f"outbound message has no 'type': {sorted(obj)}"
+    spec = SCHEMA.get(mtype)
+    if spec is None:
+        return f"unknown outbound type: {mtype!r}"
+    keys = set(obj) - {"type"}
+    missing = spec["required"] - keys
+    if missing:
+        return f"{mtype}: missing required field(s) {sorted(missing)}"
+    extra = keys - spec["required"] - spec["optional"]
+    if extra:
+        return f"{mtype}: unexpected field(s) {sorted(extra)}"
+    return None

--- a/sidecar/sokuji_sidecar/wire_schema.json
+++ b/sidecar/sokuji_sidecar/wire_schema.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Outbound wire contract: every JSON message the sidecar sends, top-level field names only (values are not typed here). Single source of truth shared by wire.validate_outbound (runtime, fail-open in prod / strict in tests) and the renderer-side field test in nativeProtocol.consistency.test.ts, which pins this file against the ServerMsg interfaces. 'pong' answers the ping health check and is deliberately absent from ServerMsg (see the type-name net). Keep keys sorted.",
+  "error": {"required": ["message"], "optional": ["id", "model"]},
+  "hardware_info_result": {"required": ["id", "os", "arch", "cpuCores", "gpus", "backendsInstalled", "accelAvailable"], "optional": []},
+  "list_tts_voices_result": {"required": ["id", "voices"], "optional": []},
+  "list_variants_result": {"required": ["id", "variants", "recommended"], "optional": []},
+  "model_delete_result": {"required": ["id", "model", "freed"], "optional": []},
+  "model_download_done": {"required": ["model", "status"], "optional": []},
+  "model_progress": {"required": ["model", "downloaded", "total"], "optional": []},
+  "model_status_result": {"required": ["id", "statuses"], "optional": []},
+  "models_catalog_result": {"required": ["id", "models"], "optional": []},
+  "ok": {"required": ["id"], "optional": []},
+  "partial": {"required": ["text"], "optional": []},
+  "pong": {"required": ["id"], "optional": []},
+  "ready": {"required": ["id", "loadTimeMs"], "optional": ["sampleRate", "backend", "device", "computeType", "rtf", "tokensPerSec", "memoryBytes", "fallbackReason", "streaming", "clones"]},
+  "result": {"required": ["text", "durationMs", "recognitionTimeMs"], "optional": ["startSample"]},
+  "speech_start": {"required": [], "optional": []},
+  "translate_result": {"required": ["id", "sourceText", "translatedText", "inferenceTimeMs"], "optional": []},
+  "tts_chunk": {"required": ["id", "seq"], "optional": []},
+  "tts_done": {"required": ["id", "totalSamples", "generationTimeMs"], "optional": []},
+  "tts_generate_result": {"required": ["id", "sampleRate", "generationTimeMs", "samples"], "optional": []}
+}

--- a/sidecar/tests/conftest.py
+++ b/sidecar/tests/conftest.py
@@ -1,0 +1,7 @@
+import os
+
+# Strict wire contract for the whole suite: any outbound message flowing
+# through server.Conn.send with a type/field the schema doesn't declare raises
+# instead of being quietly sent — every conn-path test doubles as a contract
+# checkpoint. Production (no env var) fails open: stderr warning, message sent.
+os.environ.setdefault("SOKUJI_WIRE_STRICT", "1")

--- a/sidecar/tests/conftest.py
+++ b/sidecar/tests/conftest.py
@@ -4,4 +4,7 @@ import os
 # through server.Conn.send with a type/field the schema doesn't declare raises
 # instead of being quietly sent — every conn-path test doubles as a contract
 # checkpoint. Production (no env var) fails open: stderr warning, message sent.
-os.environ.setdefault("SOKUJI_WIRE_STRICT", "1")
+# Unconditional (not setdefault): an ambient SOKUJI_WIRE_STRICT=0 in the shell
+# must not silently defeat suite-wide strictness — that would be a false green.
+# The one test that legitimately needs non-strict opts out via monkeypatch.delenv.
+os.environ["SOKUJI_WIRE_STRICT"] = "1"

--- a/sidecar/tests/test_server_conn.py
+++ b/sidecar/tests/test_server_conn.py
@@ -53,6 +53,11 @@ def test_conn_send_enforces_the_wire_contract():
     with pytest.raises(wire.WireContractError):
         asyncio.run(conn.send({"type": "ok"}))   # missing required id
     assert ws.sent == []
+    # Validation runs BEFORE any I/O: with a paired binary frame, a violating
+    # JSON must not leave an orphan binary already on the wire.
+    with pytest.raises(wire.WireContractError):
+        asyncio.run(conn.send({"type": "ok"}, binary=b"\x00\x01"))
+    assert ws.sent == []
 
 
 def test_handle_message_passes_conn_to_handler():

--- a/sidecar/tests/test_server_conn.py
+++ b/sidecar/tests/test_server_conn.py
@@ -1,5 +1,8 @@
-import asyncio, json
+import asyncio
+
+import pytest, json
 from sokuji_sidecar import server
+from sokuji_sidecar import wire
 from sokuji_sidecar.server import handle_message, Conn, _conn
 
 
@@ -34,9 +37,22 @@ class _IterWS:
 def test_conn_send_json_and_binary():
     ws = FakeWS()
     conn = Conn(ws)
-    asyncio.run(conn.send({"a": 1}))
+    # Conn.send is the wire-contract funnel, so even transport tests speak a
+    # real message shape.
+    asyncio.run(conn.send({"type": "ok", "id": 1}))
     asyncio.run(conn.send(binary=b"\x00\x01"))
-    assert ws.sent == [json.dumps({"a": 1}), b"\x00\x01"]
+    assert ws.sent == [json.dumps({"type": "ok", "id": 1}), b"\x00\x01"]
+
+
+def test_conn_send_enforces_the_wire_contract():
+    # The funnel is the enforcement point: a message violating wire_schema.json
+    # must raise (strict mode, set suite-wide in conftest) BEFORE anything
+    # leaves the process.
+    ws = FakeWS()
+    conn = Conn(ws)
+    with pytest.raises(wire.WireContractError):
+        asyncio.run(conn.send({"type": "ok"}))   # missing required id
+    assert ws.sent == []
 
 
 def test_handle_message_passes_conn_to_handler():
@@ -243,7 +259,7 @@ def test_conn_close_runs_registered_cleanups_in_order():
     async def _stage_init(state, msg, _b, conn=None):
         conn.on_close(lambda: calls.append("first"))
         conn.on_close(lambda: calls.append("second"))
-        return {"type": "ready", "id": msg.get("id")}, None
+        return {"type": "ready", "id": msg.get("id"), "loadTimeMs": 0}, None
 
     state = {"handlers": {"stage_init": _stage_init}}
     asyncio.run(_conn(state, _IterWS([json.dumps({"type": "stage_init", "id": 1})])))
@@ -261,17 +277,20 @@ def test_conn_close_isolates_a_raising_cleanup():
 
         conn.on_close(_boom)
         conn.on_close(lambda: calls.append("after"))
-        return {"type": "ready", "id": msg.get("id")}, None
+        return {"type": "ready", "id": msg.get("id"), "loadTimeMs": 0}, None
 
     state = {"handlers": {"stage_init": _stage_init}}
     asyncio.run(_conn(state, _IterWS([json.dumps({"type": "stage_init", "id": 1})])))
     assert calls == ["boom", "after"]
 
 
-def test_server_accepts_large_binary_frame():
+def test_server_accepts_large_binary_frame(monkeypatch):
     """A reference-voice clip (set_voice) arrives as one large binary frame; it can
     exceed the websockets 1 MiB default max_size. The server must accept it rather
     than closing the connection with 1009 (message too big)."""
+    # Pure transport test with a deliberately synthetic protocol (probe/probe_result);
+    # opt out of the strict wire contract rather than teach the schema fake types.
+    monkeypatch.delenv("SOKUJI_WIRE_STRICT", raising=False)
     import websockets
 
     async def run():

--- a/sidecar/tests/test_wire.py
+++ b/sidecar/tests/test_wire.py
@@ -66,3 +66,18 @@ def test_schema_json_is_the_loaded_source():
         raw = json.load(f)
     raw.pop("_comment", None)
     assert set(raw) == set(wire.SCHEMA)
+
+
+def test_validator_crash_fails_open_outside_strict_mode(monkeypatch, capsys):
+    # The guard must never be more dangerous than what it guards: a validator
+    # crash (here: a non-dict "message") is reported and swallowed in prod.
+    monkeypatch.delenv("SOKUJI_WIRE_STRICT", raising=False)
+    wire.validate_outbound(["not", "a", "dict"])  # type: ignore[arg-type]
+    err = capsys.readouterr().err
+    assert "[wire]" in err and "validator crashed" in err
+
+
+def test_validator_crash_is_loud_in_strict_mode(monkeypatch):
+    monkeypatch.setenv("SOKUJI_WIRE_STRICT", "1")
+    with pytest.raises(AttributeError):        # the RAW bug, not a wrapped one
+        wire.validate_outbound(["not", "a", "dict"])  # type: ignore[arg-type]

--- a/sidecar/tests/test_wire.py
+++ b/sidecar/tests/test_wire.py
@@ -1,0 +1,68 @@
+"""The outbound wire contract: schema shape + validate_outbound behavior.
+
+Strictness contract: SOKUJI_WIRE_STRICT=1 (set for the whole suite in conftest)
+makes a violation raise, so every message that flows through Conn.send in any
+test is checked for free. Without the flag (production) a violation is printed
+to stderr and the message is still sent — a contract bug must never take down
+a live session (same fail-open stance as _conn's never-drop-the-connection).
+"""
+import json
+import os
+
+import pytest
+
+from sokuji_sidecar import wire
+
+
+def test_schema_covers_every_type_and_shapes_are_sane():
+    # 18 ServerMsg members + pong. The renderer-side field test pins the schema
+    # against nativeProtocol.ts; this end just guards the file's basic shape.
+    assert len(wire.SCHEMA) == 19
+    assert "pong" in wire.SCHEMA
+    for mtype, spec in wire.SCHEMA.items():
+        assert set(spec) == {"required", "optional"}, mtype
+        assert "type" not in spec["required"] and "type" not in spec["optional"], mtype
+        assert not (set(spec["required"]) & set(spec["optional"])), mtype
+
+
+def test_valid_messages_pass_in_strict_mode(monkeypatch):
+    monkeypatch.setenv("SOKUJI_WIRE_STRICT", "1")
+    wire.validate_outbound({"type": "ok", "id": 3})
+    wire.validate_outbound({"type": "ready", "id": 1, "loadTimeMs": 5,
+                            "backend": "moss_onnx", "rtf": 0.2})
+    wire.validate_outbound({"type": "error", "message": "boom"})          # id optional
+    wire.validate_outbound({"type": "speech_start"})                       # no fields
+    wire.validate_outbound({"type": "result", "text": "hi",
+                            "durationMs": 10, "recognitionTimeMs": 2})
+
+
+@pytest.mark.parametrize("bad, match", [
+    ({"type": "no_such_message", "id": 1}, "unknown outbound type"),
+    ({"type": "ok"}, "missing required"),                                  # no id
+    ({"type": "ok", "id": 1, "extra": True}, "unexpected field"),
+    ({"id": 1}, "has no 'type'"),
+])
+def test_violations_raise_in_strict_mode(monkeypatch, bad, match):
+    monkeypatch.setenv("SOKUJI_WIRE_STRICT", "1")
+    with pytest.raises(wire.WireContractError, match=match):
+        wire.validate_outbound(bad)
+
+
+def test_violations_fail_open_outside_strict_mode(monkeypatch, capsys):
+    monkeypatch.delenv("SOKUJI_WIRE_STRICT", raising=False)
+    wire.validate_outbound({"type": "ok"})            # would raise in strict
+    err = capsys.readouterr().err
+    assert "[wire]" in err and "missing required" in err
+
+
+def test_conftest_turns_strict_on_for_the_suite():
+    # The whole point: every Conn.send in every other test is a checkpoint.
+    assert os.environ.get("SOKUJI_WIRE_STRICT") == "1"
+
+
+def test_schema_json_is_the_loaded_source():
+    p = os.path.join(os.path.dirname(wire.__file__), "wire_schema.json")
+    with open(p, encoding="utf-8") as f:
+        raw = json.load(f)
+    raw.pop("_comment", None)
+    assert set(raw) == set(wire.SCHEMA)

--- a/src/lib/local-inference/native/nativeProtocol.consistency.test.ts
+++ b/src/lib/local-inference/native/nativeProtocol.consistency.test.ts
@@ -126,6 +126,12 @@ function loadWireSchema(): Map<string, { required: Set<string>; optional: Set<st
   delete raw._comment;
   const out = new Map<string, { required: Set<string>; optional: Set<string> }>();
   for (const [mtype, spec] of Object.entries<any>(raw)) {
+    // new Set(undefined) is silently empty — a malformed entry must throw,
+    // not masquerade as field drift.
+    if (!Array.isArray(spec?.required) || !Array.isArray(spec?.optional)) {
+      throw new Error(`wire_schema.json entry '${mtype}' is malformed: ` +
+        `required/optional must both be arrays`);
+    }
     out.set(mtype, { required: new Set(spec.required), optional: new Set(spec.optional) });
   }
   if (out.size < MIN_SERVER_MSG_MEMBERS) {
@@ -138,7 +144,12 @@ function loadWireSchema(): Map<string, { required: Set<string>; optional: Set<st
  *  interface bodies. Throws on anything it cannot parse rather than returning a
  *  partial set. */
 function extractServerMsgFields(): Map<string, { required: Set<string>; optional: Set<string> }> {
-  const source = readFileSync(PROTOCOL_FILE, 'utf-8');
+  // Comments are stripped before brace counting: a brace inside a comment must
+  // not corrupt body extraction. Any stripping mistake here fails LOUD — the
+  // extracted sets are diffed bidirectionally against the schema.
+  const source = readFileSync(PROTOCOL_FILE, 'utf-8')
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/\/\/[^\n]*/g, '');
   const out = new Map<string, { required: Set<string>; optional: Set<string> }>();
   for (const [name, discriminant] of extractServerMsgDiscriminants()) {
     const start = source.indexOf(`export interface ${name} {`);
@@ -150,7 +161,7 @@ function extractServerMsgFields(): Map<string, { required: Set<string>; optional
       else if (source[i] === '}' && --depth === 0) { end = i; break; }
     }
     if (depth !== 0) throw new Error(`unbalanced braces in interface ${name}`);
-    const body = source.slice(open + 1, end).replace(/\/\/[^\n]*/g, '');
+    const body = source.slice(open + 1, end);
     const required = new Set<string>(); const optional = new Set<string>();
     let level = 0; let field = '';
     const commit = (chunk: string) => {

--- a/src/lib/local-inference/native/nativeProtocol.consistency.test.ts
+++ b/src/lib/local-inference/native/nativeProtocol.consistency.test.ts
@@ -111,3 +111,88 @@ describe('nativeProtocol ServerMsg stays consistent with the sidecar wire', () =
     expect(unmodelled).toEqual([]);
   });
 });
+
+
+// ── Field-level contract ──────────────────────────────────────────────────────
+// C4a pinned the TYPE NAMES across the boundary; wire_schema.json (loaded by the
+// sidecar's wire.validate_outbound at its single outbound funnel) extends the
+// contract to top-level FIELD names. These tests pin that schema against the
+// ServerMsg interfaces, so a field added/renamed on one side goes red here.
+
+const WIRE_SCHEMA_FILE = join(SIDECAR_DIR, 'wire_schema.json');
+
+function loadWireSchema(): Map<string, { required: Set<string>; optional: Set<string> }> {
+  const raw = JSON.parse(readFileSync(WIRE_SCHEMA_FILE, 'utf-8'));
+  delete raw._comment;
+  const out = new Map<string, { required: Set<string>; optional: Set<string> }>();
+  for (const [mtype, spec] of Object.entries<any>(raw)) {
+    out.set(mtype, { required: new Set(spec.required), optional: new Set(spec.optional) });
+  }
+  if (out.size < MIN_SERVER_MSG_MEMBERS) {
+    throw new Error(`wire schema parsed to only ${out.size} messages — broken load`);
+  }
+  return out;
+}
+
+/** Top-level field names (+ optionality) per ServerMsg member, parsed from the
+ *  interface bodies. Throws on anything it cannot parse rather than returning a
+ *  partial set. */
+function extractServerMsgFields(): Map<string, { required: Set<string>; optional: Set<string> }> {
+  const source = readFileSync(PROTOCOL_FILE, 'utf-8');
+  const out = new Map<string, { required: Set<string>; optional: Set<string> }>();
+  for (const [name, discriminant] of extractServerMsgDiscriminants()) {
+    const start = source.indexOf(`export interface ${name} {`);
+    const open = source.indexOf('{', start);
+    // Brace-counted body: HardwareInfoResultMsg nests an inline object type.
+    let depth = 0; let end = open;
+    for (let i = open; i < source.length; i++) {
+      if (source[i] === '{') depth++;
+      else if (source[i] === '}' && --depth === 0) { end = i; break; }
+    }
+    if (depth !== 0) throw new Error(`unbalanced braces in interface ${name}`);
+    const body = source.slice(open + 1, end).replace(/\/\/[^\n]*/g, '');
+    const required = new Set<string>(); const optional = new Set<string>();
+    let level = 0; let field = '';
+    const commit = (chunk: string) => {
+      const m = chunk.match(/^\s*(\w+)(\?)?\s*:/);
+      if (!m) return;
+      if (m[1] === 'type') return;
+      (m[2] ? optional : required).add(m[1]);
+    };
+    for (const ch of body) {
+      if (ch === '{') level++;
+      else if (ch === '}') level--;
+      if (ch === ';' && level === 0) { commit(field); field = ''; } else field += ch;
+    }
+    commit(field);
+    out.set(discriminant, { required, optional });
+  }
+  return out;
+}
+
+describe('nativeProtocol ServerMsg fields stay consistent with the wire schema', () => {
+  it('every ServerMsg member matches the schema field-for-field', () => {
+    const schema = loadWireSchema();
+    const mismatches: string[] = [];
+    for (const [mtype, ts] of extractServerMsgFields()) {
+      const spec = schema.get(mtype);
+      if (!spec) { mismatches.push(`${mtype}: absent from wire_schema.json`); continue; }
+      const diff = (label: string, a: Set<string>, b: Set<string>) => {
+        for (const f of a) if (!b.has(f)) mismatches.push(`${mtype}.${f}: ${label}`);
+      };
+      diff('required in TS, not in schema', ts.required, spec.required);
+      diff('required in schema, not in TS', spec.required, ts.required);
+      diff('optional in TS, not in schema', ts.optional, spec.optional);
+      diff('optional in schema, not in TS', spec.optional, ts.optional);
+    }
+    expect(mismatches).toEqual([]);
+  });
+
+  it('the schema covers exactly ServerMsg plus the ping health-check', () => {
+    const modelled = new Set(extractServerMsgDiscriminants().map(([, t]) => t));
+    const schemaKeys = new Set(loadWireSchema().keys());
+    const missing = [...modelled].filter(t => !schemaKeys.has(t)).sort();
+    const extra = [...schemaKeys].filter(t => !modelled.has(t) && !SIDECAR_ONLY.has(t)).sort();
+    expect({ missing, extra }).toEqual({ missing: [], extra: [] });
+  });
+});


### PR DESCRIPTION
## What & why

PR #320 pinned the **type names** crossing the renderer↔sidecar boundary. This extends the
contract to **top-level field names** — the remaining silent-drift class: rename
`generationTimeMs` on one side and both codebases keep compiling, both suites stay green,
and the UI just quietly shows nothing.

The obvious design (rewrite all 41 handwritten reply dicts into typed constructors) would
be a wide, conflict-prone sweep with little enforcement to show for it — the sidecar has no
mypy, so Python-side types are documentation. This takes the cheap road instead: the
process has (after a two-line unification) exactly **one outbound funnel**, so the contract
is enforced at the boundary and **zero emit sites change**.

## Changes

- **`wire_schema.json`** — 19 outbound messages (the 18 `ServerMsg` members + `pong`),
  each with `required`/`optional` top-level field sets. Single source of truth, read by
  both sides.
- **`wire.py` + `Conn.send`** — `_conn`'s reply path now goes through `Conn.send` (same
  binary-before-json order), making it the one door every outbound JSON message leaves
  through; `wire.validate_outbound` checks each message there. Unknown type, missing
  required field, or unexpected field is a violation.
- **Failure stance** — `SOKUJI_WIRE_STRICT=1` (set suite-wide in the new
  `tests/conftest.py`) makes a violation **raise**, so every conn-path test in the suite
  doubles as a contract checkpoint. Production (no env var) **fails open**: the violation
  goes to stderr (NativeHostManager pipes it into the Electron log) and the message is
  still sent — a contract bug must never take down a live session, the same stance as
  `_conn`'s never-drop-the-connection.
- **Renderer-side field net** — `nativeProtocol.consistency.test.ts` gains two assertions
  pinning the schema field-for-field against the `ServerMsg` interfaces, both directions
  (required↔non-optional, optional↔optional), with `pong` allowlisted as before. The
  extractor brace-counts interface bodies (one member nests an inline object type) and
  strips line comments.

Deliberate scope limits: **top-level field names and presence only** — values are not
typed, and nested payload shapes (`NativeModelInfo` etc.) are not validated; the renderer
consumes those defensively and the fatal drift class lives at the top level. Adding a wire
field now costs three edits (emit site + schema + TS interface) — and forgetting any one
of them turns a specific test red, which is the point.

## What the strict sweep found

Running the full suite with enforcement on: **zero violations across all 41 production
emit sites** — the hand-written wire and the hand-written model already agree. The four
adjustments are test fixtures that spoke a fake wire: two stage fakes returning `ready`
without `loadTimeMs`, one `Conn.send` transport test now speaking a real message, and the
large-binary transport test explicitly opting out (it uses a deliberately synthetic
protocol to test framing, not the contract).

## Testing

- Sidecar: **840 passed, 20 skipped, 0 failed** (base 830; +9 wire tests +1 funnel pin).
- TypeScript: **1248 passed, 0 failed** (base 1246; +2 field-net assertions).
- Mutation-verified against the committed baseline, all three directions: removing a field
  from the schema → renderer net red; adding a bogus optional to a TS interface → renderer
  net red; removing the funnel's validate call → the funnel pin test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability Improvements**
  * Enforced a schema-based outbound JSON wire contract for sidecar messages.
  * Routed all JSON sending through the same validation path while preserving binary-before-JSON ordering.
  * In strict mode, invalid payloads now raise explicit contract errors; otherwise, validation fails open with diagnostics.

* **New Features**
  * Added an explicit wire schema definition covering supported message types and required/optional fields.

* **Testing**
  * Strengthened wire and connection tests for contract enforcement, fail-open logging, and schema parity with the renderer protocol.
  * Updated scenarios for large binary frames to account for strict validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->