### PR TITLE
fix(subtitle): keep pinned bar above PowerPoint slideshows on Windows

### DIFF
--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -50,6 +50,83 @@ function getLiveWindow() {
   return activeWindow && !activeWindow.isDestroyed() ? activeWindow : null;
 }
 
+// --- Always-on-top enforcement (#326) --------------------------------------
+// On Windows, PowerPoint's slideshow / Presenter View re-asserts its own
+// HWND_TOPMOST z-order whenever window activation changes. A one-shot
+// setAlwaysOnTop() is displaced permanently the moment the pinned bar is
+// merely clicked (activating it deactivates PowerPoint, which re-raises
+// itself above us), and Electron emits no event for "another window went
+// above us". Crucially, the displaced window KEEPS its WS_EX_TOPMOST style —
+// isAlwaysOnTop() still returns true (electron/electron#2097) — so the fix
+// must re-assert UNCONDITIONALLY while pinned:
+//  - a short delayed re-assert on focus/blur — the activation transitions
+//    that make PowerPoint re-raise itself — so recovery is near-immediate;
+//  - a 1s heartbeat as a safety net for re-raises we get no event for
+//    (PowerToys "Always On Top" survives PowerPoint the same way, via
+//    WinEvent-triggered SetWindowPos(HWND_TOPMOST) re-pins).
+// Each re-assert is one setAlwaysOnTop(true, ...) call — never a false→true
+// toggle (drops us out of the topmost band and can knock OTHER topmost
+// windows down, electron#31536) and never moveTop() (its SWP_SHOWWINDOW
+// flag would force-show a hidden window). Windows-only: on macOS the
+// 'floating' NSWindow level is a real window level honored by the WM, and
+// periodic raises would be needless churn.
+const PIN_REASSERT_INTERVAL_MS = 1000;
+const PIN_REASSERT_EVENT_DELAY_MS = 200;
+
+// On Windows, every setAlwaysOnTop with a level in Electron's
+// "behind task bar" set — which includes the 'floating' default — ends with
+// a second SetWindowPos tucking the window just BELOW the taskbar in the
+// topmost band. A PowerPoint slideshow sits ABOVE the taskbar, so a
+// 'floating' pin can never beat it. 'screen-saver' skips that demotion and
+// leaves the bar at the very top of the topmost band. On macOS the level is
+// a real NSWindow level; keep the original 'floating' there.
+function pinLevel() {
+  return process.platform === 'win32' ? 'screen-saver' : 'floating';
+}
+
+let pinHeartbeatTimer = null;
+let pinEventTimer = null;
+
+function reassertOnTop() {
+  const win = getLiveWindow();
+  if (!win) {
+    stopPinEnforcement();
+    return;
+  }
+  // Don't churn the z-order of a window the user can't see; enforcement
+  // resumes on the next tick once the window is visible again.
+  if (!win.isVisible() || win.isMinimized()) return;
+  win.setAlwaysOnTop(true, pinLevel());
+}
+
+function startPinEnforcement() {
+  stopPinEnforcement();
+  if (process.platform !== 'win32') return;
+  pinHeartbeatTimer = setInterval(reassertOnTop, PIN_REASSERT_INTERVAL_MS);
+}
+
+function stopPinEnforcement() {
+  if (pinHeartbeatTimer) {
+    clearInterval(pinHeartbeatTimer);
+    pinHeartbeatTimer = null;
+  }
+  if (pinEventTimer) {
+    clearTimeout(pinEventTimer);
+    pinEventTimer = null;
+  }
+}
+
+// Deferred re-assert after a focus/blur transition: give the other window
+// (PowerPoint) a moment to finish its own re-raise, then top it again.
+function schedulePinReassert() {
+  if (!pinHeartbeatTimer) return; // only while pinned
+  if (pinEventTimer) clearTimeout(pinEventTimer);
+  pinEventTimer = setTimeout(() => {
+    pinEventTimer = null;
+    reassertOnTop();
+  }, PIN_REASSERT_EVENT_DELAY_MS);
+}
+
 ipcMain.handle('subtitle:get-screen-bounds', () => {
   const display = screen.getPrimaryDisplay();
   return display.workArea;
@@ -65,7 +142,12 @@ ipcMain.handle('subtitle:enter', (_event, payload) => {
   normalBoundsSnapshot = win.getBounds();
   beginTransition();
   win.setBounds(clamped);
-  win.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), 'floating');
+  win.setAlwaysOnTop(Boolean(payload?.alwaysOnTop), pinLevel());
+  if (payload?.alwaysOnTop) {
+    startPinEnforcement();
+  } else {
+    stopPinEnforcement();
+  }
   win.setResizable(!payload?.locked);
   if (process.platform === 'darwin') {
     win.setWindowButtonVisibility(false);
@@ -103,6 +185,7 @@ ipcMain.handle('subtitle:exit', (_event, payload) => {
       height: 800,
     });
   }
+  stopPinEnforcement();
   win.setAlwaysOnTop(false);
   win.setResizable(true);
   if (process.platform === 'darwin') {
@@ -115,7 +198,12 @@ ipcMain.handle('subtitle:exit', (_event, payload) => {
 ipcMain.handle('subtitle:set-always-on-top', (_event, flag) => {
   const win = getLiveWindow();
   if (!win) return { ok: false };
-  win.setAlwaysOnTop(Boolean(flag), 'floating');
+  win.setAlwaysOnTop(Boolean(flag), pinLevel());
+  if (flag) {
+    startPinEnforcement();
+  } else {
+    stopPinEnforcement();
+  }
   return { ok: true };
 });
 
@@ -142,9 +230,11 @@ function setupSubtitleHandlers(mainWindow) {
   // to be attached on every createWindow() call.
   activeWindow = mainWindow;
   // Reset snapshot/transition for the fresh window so a stale snapshot
-  // from a previous window can't leak in.
+  // from a previous window can't leak in. A fresh window starts unpinned,
+  // so any enforcement left over from a previous window must stop too.
   normalBoundsSnapshot = null;
   transitionUntil = 0;
+  stopPinEnforcement();
 
   // Debounced bounds-changed broadcaster. Suppressed during transition
   // windows so we don't capture intermediate WM-reported sizes as the
@@ -171,7 +261,12 @@ function setupSubtitleHandlers(mainWindow) {
     mainWindow.webContents.send('subtitle:fullscreen-changed', false);
   mainWindow.on('enter-full-screen', onEnterFullScreen);
   mainWindow.on('leave-full-screen', onLeaveFullScreen);
+  // Activation transitions are the moments PowerPoint re-raises itself
+  // above a pinned bar — respond to them promptly (see enforcement above).
+  mainWindow.on('focus', schedulePinReassert);
+  mainWindow.on('blur', schedulePinReassert);
   mainWindow.on('closed', () => {
+    stopPinEnforcement();
     if (debounceTimer) {
       clearTimeout(debounceTimer);
       debounceTimer = null;

--- a/electron/subtitle-window.js
+++ b/electron/subtitle-window.js
@@ -266,14 +266,17 @@ function setupSubtitleHandlers(mainWindow) {
   mainWindow.on('focus', schedulePinReassert);
   mainWindow.on('blur', schedulePinReassert);
   mainWindow.on('closed', () => {
-    stopPinEnforcement();
     if (debounceTimer) {
       clearTimeout(debounceTimer);
       debounceTimer = null;
     }
     // Drop the reference so handlers know there's no live window until the
-    // next createWindow() rebinds it.
+    // next createWindow() rebinds it. Like the rest of the module-scoped
+    // state, enforcement is only torn down when the closing window is still
+    // the bound one — a stale 'closed' from a window that was already
+    // replaced by a rebind must not stop the new window's enforcement.
     if (activeWindow === mainWindow) {
+      stopPinEnforcement();
       activeWindow = null;
       normalBoundsSnapshot = null;
     }

--- a/electron/subtitle-window.test.js
+++ b/electron/subtitle-window.test.js
@@ -301,6 +301,25 @@ describe('subtitle-window always-on-top enforcement (#326)', () => {
     expect(vi.getTimerCount()).toBe(0);
   });
 
+  it('a stale window closing after a rebind does not stop the new window enforcement', async () => {
+    // createWindow() can run again (macOS dock activate) and rebind the
+    // handlers before the previous window's deferred 'closed' fires. That
+    // stale event must not tear down the timers now serving the new window.
+    const newWin = makeFakeWindow();
+    setupSubtitleHandlers(newWin);
+    await enter({ alwaysOnTop: true }); // pins the new window
+
+    win.destroyed = true;
+    win.emit('closed'); // stale event from the old window
+
+    newWin.setAlwaysOnTop.mockClear();
+    vi.advanceTimersByTime(3000);
+    expect(newWin.setAlwaysOnTop.mock.calls.length).toBe(3);
+
+    newWin.destroyed = true;
+    newWin.emit('closed');
+  });
+
   it('survives the window being destroyed between heartbeats', async () => {
     await enter({ alwaysOnTop: true });
 

--- a/electron/subtitle-window.test.js
+++ b/electron/subtitle-window.test.js
@@ -1,0 +1,327 @@
+// electron/subtitle-window.test.js
+//
+// Main-process tests for the subtitle window IPC handlers, focused on the
+// always-on-top enforcement added for issue #326: on Windows, PowerPoint's
+// slideshow / Presenter View re-asserts its own topmost z-order whenever
+// window activation changes, so a one-shot setAlwaysOnTop() call gets
+// displaced permanently (e.g., as soon as the user merely clicks the pinned
+// subtitle bar). Crucially, the displaced window KEEPS its WS_EX_TOPMOST
+// style — isAlwaysOnTop() still returns true — so the only reliable fix is
+// to unconditionally re-assert the topmost position while pinned.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+// subtitle-window.js is a CommonJS main-process file whose require('electron')
+// is left as a native Node require by vite-node (the real build externalizes
+// 'electron' the same way), so vi.mock('electron') cannot intercept it.
+// Instead, load the module with Node's own require and pre-seed the module
+// cache with a fake 'electron' — production code stays untouched.
+const nodeRequire = createRequire(import.meta.url);
+const electronPath = nodeRequire.resolve('electron');
+const modulePath = nodeRequire.resolve('./subtitle-window.js');
+
+const ipcHandlers = new Map();
+const fakeElectron = {
+  ipcMain: {
+    handle: (channel, fn) => ipcHandlers.set(channel, fn),
+  },
+  screen: {
+    getPrimaryDisplay: () => ({
+      workArea: { x: 0, y: 0, width: 1920, height: 1040 },
+    }),
+  },
+};
+
+function loadSubtitleWindowModule() {
+  nodeRequire.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: fakeElectron,
+  };
+  delete nodeRequire.cache[modulePath]; // fresh module state per test
+  return nodeRequire(modulePath);
+}
+
+function makeFakeWindow() {
+  const listeners = new Map();
+  const win = {
+    destroyed: false,
+    visible: true,
+    minimized: false,
+    setBounds: vi.fn(),
+    getBounds: vi.fn(() => ({ x: 0, y: 0, width: 1200, height: 800 })),
+    setAlwaysOnTop: vi.fn(),
+    moveTop: vi.fn(),
+    setResizable: vi.fn(),
+    setWindowButtonVisibility: vi.fn(),
+    isFullScreen: () => false,
+    setFullScreen: vi.fn(),
+    isVisible: () => win.visible,
+    isMinimized: () => win.minimized,
+    isDestroyed: () => win.destroyed,
+    webContents: { send: vi.fn() },
+    on: (event, fn) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(fn);
+    },
+    emit: (event) => {
+      for (const fn of listeners.get(event) ?? []) fn();
+    },
+  };
+  return win;
+}
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+const setPlatform = (value) =>
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+
+describe('subtitle-window always-on-top enforcement (#326)', () => {
+  let win;
+  let setupSubtitleHandlers;
+
+  const enter = (payload) => ipcHandlers.get('subtitle:enter')({}, payload);
+  const exit = (payload = {}) => ipcHandlers.get('subtitle:exit')({}, payload);
+  const setAot = (flag) => ipcHandlers.get('subtitle:set-always-on-top')({}, flag);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    setPlatform('win32');
+    ipcHandlers.clear();
+    ({ setupSubtitleHandlers } = loadSubtitleWindowModule());
+    win = makeFakeWindow();
+    setupSubtitleHandlers(win);
+  });
+
+  afterEach(() => {
+    // Tear down the window so no enforcement timers leak between tests.
+    win.destroyed = true;
+    win.emit('closed');
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    Object.defineProperty(process, 'platform', originalPlatform);
+    delete nodeRequire.cache[electronPath];
+    delete nodeRequire.cache[modulePath];
+  });
+
+  it('pins with the screen-saver level on Windows so the bar is not re-inserted below the taskbar', async () => {
+    // Electron's 'floating' level (the macOS default here) makes every
+    // setAlwaysOnTop call on Windows end with a second SetWindowPos that
+    // tucks the window just below Shell_TrayWnd — below a PowerPoint
+    // slideshow, which sits above the taskbar in the topmost band.
+    await enter({ alwaysOnTop: true });
+    expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+  });
+
+  it('keeps the floating level on macOS', async () => {
+    setPlatform('darwin');
+    await enter({ alwaysOnTop: true });
+    expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'floating');
+  });
+
+  it('periodically re-asserts topmost while pinned in subtitle mode', async () => {
+    await enter({ alwaysOnTop: true });
+    win.setAlwaysOnTop.mockClear();
+
+    vi.advanceTimersByTime(3000);
+
+    // The re-assert must be unconditional: when PowerPoint stacks itself
+    // above us the WS_EX_TOPMOST style is intact (isAlwaysOnTop() === true),
+    // so any "already on top" guard would skip exactly the case that matters.
+    // Exactly one call per 1s tick — a duplicate (stacked) interval would
+    // produce more.
+    expect(win.setAlwaysOnTop.mock.calls).toEqual([
+      [true, 'screen-saver'],
+      [true, 'screen-saver'],
+      [true, 'screen-saver'],
+    ]);
+    // Never a false→true toggle: setAlwaysOnTop(false) drops the bar out of
+    // the topmost band each tick and can knock OTHER topmost windows down
+    // (electron/electron#31536). The toEqual above pins this (no [false]
+    // call), as does the focus/blur assertion below.
+    // moveTop() must NOT be used either: its SWP_SHOWWINDOW flag force-shows
+    // a hidden window, and HWND_TOP escalates the z-order arms race.
+    expect(win.moveTop).not.toHaveBeenCalled();
+  });
+
+  it('does not enforce when subtitle mode is entered without alwaysOnTop', async () => {
+    await enter({ alwaysOnTop: false });
+    win.setAlwaysOnTop.mockClear();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('stops enforcement on subtitle:exit', async () => {
+    await enter({ alwaysOnTop: true });
+    await exit();
+    win.setAlwaysOnTop.mockClear();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('stops enforcement when the pin is toggled off, restarts when toggled on', async () => {
+    await enter({ alwaysOnTop: true });
+
+    await setAot(false);
+    win.setAlwaysOnTop.mockClear();
+    vi.advanceTimersByTime(5000);
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+
+    await setAot(true);
+    win.setAlwaysOnTop.mockClear();
+    vi.advanceTimersByTime(3000);
+    expect(win.setAlwaysOnTop.mock.calls.length).toBe(3);
+  });
+
+  it('re-asserts promptly after the window is clicked (focus), without waiting for the heartbeat', async () => {
+    // Clicking the pinned bar activates it; PowerPoint reacts to losing
+    // activation by re-raising the slideshow above us a few ms later. A
+    // short delayed re-assert must win that race well before the 1s
+    // heartbeat.
+    await enter({ alwaysOnTop: true });
+    win.setAlwaysOnTop.mockClear();
+
+    win.emit('focus');
+    vi.advanceTimersByTime(500);
+
+    expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+    // Single-call re-assert only — never a false→true toggle.
+    expect(win.setAlwaysOnTop.mock.calls.every(([flag]) => flag === true)).toBe(true);
+  });
+
+  it('re-asserts promptly after the window loses focus (blur)', async () => {
+    await enter({ alwaysOnTop: true });
+    win.setAlwaysOnTop.mockClear();
+
+    win.emit('blur');
+    vi.advanceTimersByTime(500);
+
+    expect(win.setAlwaysOnTop).toHaveBeenCalledWith(true, 'screen-saver');
+    expect(win.setAlwaysOnTop.mock.calls.every(([flag]) => flag === true)).toBe(true);
+  });
+
+  it('cancels a pending focus/blur re-assert when the pin is turned off', async () => {
+    // Click the bar (schedules the 200ms re-assert), then unpin before it
+    // fires: the stale timer must not re-pin an unpinned window.
+    await enter({ alwaysOnTop: true });
+    win.emit('focus');
+
+    await setAot(false);
+    win.setAlwaysOnTop.mockClear();
+    vi.advanceTimersByTime(500);
+
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('cancels a pending focus/blur re-assert on subtitle:exit', async () => {
+    await enter({ alwaysOnTop: true });
+    win.emit('focus');
+
+    await exit();
+    win.setAlwaysOnTop.mockClear();
+    vi.advanceTimersByTime(500);
+
+    // A stale re-assert here would silently re-pin the restored main window
+    // at screen-saver level — stuck above every other app.
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('does not stack heartbeats when subtitle:enter runs again without an exit', async () => {
+    await enter({ alwaysOnTop: true });
+    await enter({ alwaysOnTop: true });
+    win.setAlwaysOnTop.mockClear();
+
+    vi.advanceTimersByTime(3000);
+    expect(win.setAlwaysOnTop.mock.calls.length).toBe(3);
+
+    // And a single toggle-off silences everything — an orphaned duplicate
+    // interval would keep firing.
+    await setAot(false);
+    win.setAlwaysOnTop.mockClear();
+    vi.advanceTimersByTime(5000);
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('stops enforcement when re-entering subtitle mode with the pin off', async () => {
+    await enter({ alwaysOnTop: true });
+    await enter({ alwaysOnTop: false });
+    win.setAlwaysOnTop.mockClear();
+
+    vi.advanceTimersByTime(5000);
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('focus/blur do not re-assert when not pinned', async () => {
+    await enter({ alwaysOnTop: false });
+    win.setAlwaysOnTop.mockClear();
+
+    win.emit('focus');
+    win.emit('blur');
+    vi.advanceTimersByTime(500);
+
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('skips re-asserting while the window is hidden or minimized', async () => {
+    // main.js exposes a minimize control for the frameless window; z-order
+    // churn on an invisible window is pointless and (with SWP_SHOWWINDOW
+    // style calls) risks forcing it back on screen.
+    await enter({ alwaysOnTop: true });
+    win.setAlwaysOnTop.mockClear();
+
+    win.minimized = true;
+    vi.advanceTimersByTime(3000);
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+
+    win.minimized = false;
+    win.visible = false;
+    vi.advanceTimersByTime(3000);
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+
+    // Enforcement resumes (not stopped) once the window is visible again.
+    win.visible = true;
+    vi.advanceTimersByTime(3000);
+    expect(win.setAlwaysOnTop.mock.calls.length).toBe(3);
+  });
+
+  it('stops enforcement and clears all timers when the window is closed', async () => {
+    await enter({ alwaysOnTop: true });
+
+    win.destroyed = true;
+    win.emit('closed');
+    win.setAlwaysOnTop.mockClear();
+
+    vi.advanceTimersByTime(5000);
+
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('survives the window being destroyed between heartbeats', async () => {
+    await enter({ alwaysOnTop: true });
+
+    win.destroyed = true; // destroyed without 'closed' having fired yet
+    win.setAlwaysOnTop.mockClear();
+
+    expect(() => vi.advanceTimersByTime(3000)).not.toThrow();
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+
+  it('does not run the enforcement heartbeat on non-Windows platforms', async () => {
+    setPlatform('darwin');
+    await enter({ alwaysOnTop: true });
+    win.setAlwaysOnTop.mockClear();
+
+    win.emit('focus');
+    win.emit('blur');
+    vi.advanceTimersByTime(5000);
+
+    // macOS 'floating' level already keeps the window above fullscreen
+    // presentations; keep the original one-shot behavior there.
+    expect(win.setAlwaysOnTop).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Closes #326

## Problem

With the subtitle bar pinned (Always on Top), a PowerPoint slideshow / Presenter View on Windows permanently covers it as soon as the bar is merely clicked — including clicks on the drag region or resize edges without any actual drag. PowerToys' Always-on-Top recovers in the same scenario; Sokuji never did.

## Root cause (two layers, verified against Electron/Chromium source)

1. **The `'floating'` level loses to PowerPoint by construction.** On Windows, Electron follows every `setAlwaysOnTop(true, 'floating')` with a second `SetWindowPos` that tucks the window just **below the taskbar** (`MoveBehindTaskBarIfNeeded`, level set `{floating, torn-off-menu, modal-panel, main-menu, status}`). A PowerPoint slideshow sits **above** the taskbar in the topmost band, so a `'floating'` pin can never end up above it.
2. **No recovery after displacement.** Clicking the pinned bar activates it; PowerPoint reacts to losing activation by re-raising its slideshow window. The displaced bar **keeps** `WS_EX_TOPMOST` — `isAlwaysOnTop()` still returns `true` (electron/electron#2097) — so nothing short of an *unconditional* re-assert can restore it, and the app only ever pinned once.

## Fix (Windows-only; macOS/Linux behavior unchanged)

- Pin with the `'screen-saver'` level, which skips the behind-taskbar demotion and leaves the bar at the top of the topmost band. Bar bounds remain clamped to the work area, so it does not actually occlude the taskbar.
- While pinned, re-assert the topmost position:
  - a 200 ms-delayed re-assert on `focus`/`blur` — the activation transitions that make PowerPoint re-raise itself — so recovery is near-immediate;
  - a 1 s heartbeat as a safety net (equivalent to PowerToys' WinEvent-triggered `SetWindowPos(HWND_TOPMOST)` re-pins).
- Each re-assert is a **single** `setAlwaysOnTop(true, …)` call: never a `false→true` toggle (drops the bar out of the topmost band each tick and can knock *other* topmost windows down — electron/electron#31536), never `moveTop()` (its `SWP_SHOWWINDOW` flag would force-show a hidden window). Re-asserts are skipped while the window is hidden or minimized, and repeated `true` re-asserts emit no `always-on-top-changed` events (the event only fires when the boolean state flips).
- Enforcement starts/stops with `subtitle:enter`/`subtitle:exit`/pin toggle/window close, and a pending event re-assert is cancelled on unpin so it can never re-pin the restored main window.

## Testing

- 17 new main-process tests (`electron/subtitle-window.test.js`, same `createRequire` pattern as the existing `native-host-manager`/`sidecar-bundle` tests) covering the enforcement lifecycle (enter/exit/toggle/re-enter/double-enter/close/destroyed), prompt focus/blur recovery, timer cancellation on unpin, hidden/minimized skip, and platform gating (heartbeat is win32-only; macOS keeps the original one-shot `'floating'` behavior).
- Key invariants were **mutation-tested**: the `false→true` toggle variant, a missing event-timer cleanup, and stacked heartbeats each fail the suite.
- Full suite: 123 files / 1279 tests pass.
- Manually verified on Windows against a PowerPoint slideshow: clicking the bar, clicking the drag region, and clicking resize edges no longer lose the bar; it recovers within ~200 ms.

Note: the May design spec (`docs/superpowers/specs/2026-05-10-subtitle-mode-design.md`) documents the original `'floating'` level; left as-is since specs are dated historical records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “always on top” subtitle window pinning on Windows so it stays above PowerPoint slides.
  * Added automatic re-assertion after focus/blur and activation transitions, with behavior tailored per platform.
  * Fixed enforcement lifecycle so it starts/stops correctly when pinning is toggled, subtitle mode is exited, or the window is closed/replaced—without stacking duplicate timers.

* **Tests**
  * Added main-process tests covering Windows/macOS pinning behavior, heartbeat re-assertion, focus/blur handling, visibility/minimize rules, and timer cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->