### PR TITLE
fix: show the per-item detected language on conversation bubbles (#340)

### DIFF
--- a/src/components/MainPanel/ConversationRow.test.tsx
+++ b/src/components/MainPanel/ConversationRow.test.tsx
@@ -58,6 +58,29 @@ describe('ConversationRow — expanded (default) mode', () => {
     expect(container.querySelector('.lang-badge')).not.toBeNull();
   });
 
+  it('badge prefers the item\'s detectedLanguage over the configured mapping', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker', role: 'user', detectedLanguage: 'de' })}
+        prevItem={null}
+      />,
+    );
+    expect(container.querySelector('.lang-badge')?.textContent).toBe('DE');
+  });
+
+  it('badge falls back to the configured mapping when detectedLanguage is absent', () => {
+    const { container } = render(
+      <ConversationRow
+        {...baseProps}
+        item={makeItem({ source: 'speaker', role: 'user' })}
+        prevItem={null}
+      />,
+    );
+    // speaker/user → sourceLanguage ('zh')
+    expect(container.querySelector('.lang-badge')?.textContent).toBe('ZH');
+  });
+
   it('renders the row play button on assistant rows when canPlay is true', () => {
     const { container } = render(
       <ConversationRow

--- a/src/components/MainPanel/ConversationRow.tsx
+++ b/src/components/MainPanel/ConversationRow.tsx
@@ -6,13 +6,13 @@ import './ConversationRow.scss';
 import '../../styles/karaoke.scss';
 
 interface ConversationRowProps {
+  // sourceLanguage/targetLanguage are display-only fields attached by MainPanel's
+  // tag(); source and detectedLanguage already live on ConversationItem.
   item: ConversationItem & {
-    source?: 'speaker' | 'participant';
     sourceLanguage?: string;
     targetLanguage?: string;
-    detectedLanguage?: string;
   };
-  prevItem?: (ConversationItem & { source?: 'speaker' | 'participant' }) | null;
+  prevItem?: ConversationItem | null;
   sourceLanguage: string;
   targetLanguage: string;
   isPlaying: boolean;
@@ -77,9 +77,12 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
   // other providers with per-item language identification supply it) over the
   // configured source/target pair — the configured pair is wrong for two-way
   // translation and auto-detect. Falls back to the configured mapping.
+  // `||` (not `??`): an empty-string detectedLanguage from a future provider
+  // must fall back to the configured mapping rather than render a blank badge —
+  // a language code is never legitimately falsy.
   const detectedLanguage = item.detectedLanguage;
   const lang = useMemo(
-    () => detectedLanguage ?? languageForItem(source, role, itemSourceLanguage, itemTargetLanguage),
+    () => detectedLanguage || languageForItem(source, role, itemSourceLanguage, itemTargetLanguage),
     [detectedLanguage, source, role, itemSourceLanguage, itemTargetLanguage],
   );
 

--- a/src/components/MainPanel/ConversationRow.tsx
+++ b/src/components/MainPanel/ConversationRow.tsx
@@ -10,6 +10,7 @@ interface ConversationRowProps {
     source?: 'speaker' | 'participant';
     sourceLanguage?: string;
     targetLanguage?: string;
+    detectedLanguage?: string;
   };
   prevItem?: (ConversationItem & { source?: 'speaker' | 'participant' }) | null;
   sourceLanguage: string;
@@ -72,9 +73,14 @@ const ConversationRow: React.FC<ConversationRowProps> = ({
   // or for transient cases where the snapshot hasn't been attached yet.
   const itemSourceLanguage = item.sourceLanguage ?? sourceLanguage;
   const itemTargetLanguage = item.targetLanguage ?? targetLanguage;
+  // Prefer the language actually detected for this item's text (Soniox and
+  // other providers with per-item language identification supply it) over the
+  // configured source/target pair — the configured pair is wrong for two-way
+  // translation and auto-detect. Falls back to the configured mapping.
+  const detectedLanguage = item.detectedLanguage;
   const lang = useMemo(
-    () => languageForItem(source, role, itemSourceLanguage, itemTargetLanguage),
-    [source, role, itemSourceLanguage, itemTargetLanguage],
+    () => detectedLanguage ?? languageForItem(source, role, itemSourceLanguage, itemTargetLanguage),
+    [detectedLanguage, source, role, itemSourceLanguage, itemTargetLanguage],
   );
 
   const scopeName = t(

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -356,6 +356,40 @@ describe('SonioxClient keepReplayAudio (per-item audio accumulation for the inli
   });
 });
 
+describe('SonioxClient detectedLanguage (bubble badge shows the actual per-item language, not the configured pair)', () => {
+  const user = (c: SonioxClient) => c.getConversationItems().find((i) => i.role === 'user');
+  const asst = (c: SonioxClient) => c.getConversationItems().find((i) => i.role === 'assistant');
+
+  it('tags each item with the token language — even when it contradicts the configured pair (backwards two-way case)', async () => {
+    // Configured zh→en, but the person actually spoke English.
+    const { client, stt } = await connectedClient({ sourceLanguage: 'zh', targetLanguage: 'en' });
+    stt.emit({ tokens: [
+      tok('Hello', { is_final: true, translation_status: 'original', language: 'en' }),     // spoken English
+      tok('你好', { is_final: true, translation_status: 'translation', language: 'zh' }),    // translated to Chinese
+    ] });
+    expect(user(client)!.detectedLanguage).toBe('en');   // NOT the configured 'zh'
+    expect(asst(client)!.detectedLanguage).toBe('zh');    // NOT the configured 'en'
+  });
+
+  it('carries detectedLanguage through <end> completion', async () => {
+    const { client, stt } = await connectedClient();
+    stt.emit({ tokens: [
+      tok('Hi', { is_final: true, translation_status: 'original', language: 'de' }),
+      tok('Hallo', { is_final: true, translation_status: 'translation', language: 'fr' }),
+      tok('<end>'),
+    ] });
+    expect(user(client)!.status).toBe('completed');
+    expect(user(client)!.detectedLanguage).toBe('de');
+    expect(asst(client)!.detectedLanguage).toBe('fr');
+  });
+
+  it('leaves detectedLanguage undefined when the tokens carry no language (badge falls back to configured)', async () => {
+    const { client, stt } = await connectedClient();
+    stt.emit({ tokens: [tok('x', { is_final: true, translation_status: 'original' })] });
+    expect(user(client)!.detectedLanguage).toBeUndefined();
+  });
+});
+
 describe('SonioxClient disconnect race (a socket that connects after Stop must be discarded)', () => {
   const tick = () => new Promise((r) => setTimeout(r, 0));
 

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -60,6 +60,14 @@ export class SonioxClient implements IClient {
   private currentAssistantItemId: string | null = null;
   private userFinal = '';
   private assistantFinal = '';
+  // Detected language of the in-flight utterance's text, per side, from the
+  // tokens themselves: the transcript (original) token's `language` is the
+  // spoken language; the translation token's `language` is the language it was
+  // translated into. Surfaced as ConversationItem.detectedLanguage so the
+  // bubble badge shows what was actually spoken/produced, not the configured
+  // pair (which is wrong for two_way and auto-detect). Reset per utterance.
+  private userLanguage: string | null = null;
+  private assistantLanguage: string | null = null;
   // TTS language for the in-flight utterance (two_way: from the first final
   // translation token; one_way: always the target language)
   private utteranceTtsLanguage: string | null = null;
@@ -256,6 +264,7 @@ export class SonioxClient implements IClient {
         }
       }
       if (isTranslation) {
+        if (token.language) this.assistantLanguage = token.language; // translated-into language
         if (token.is_final) {
           this.assistantFinal += text;
           this.feedTts(text, token);
@@ -263,6 +272,7 @@ export class SonioxClient implements IClient {
           assistantPartial += text;
         }
       } else {
+        if (token.language) this.userLanguage = token.language; // spoken language
         if (token.is_final) {
           this.userFinal += text;
         } else {
@@ -404,7 +414,7 @@ export class SonioxClient implements IClient {
   private upsertItem(
     role: 'user' | 'assistant',
     currentId: string | null,
-    patch: Pick<ConversationItem, 'status' | 'formatted' | 'content'>
+    patch: Pick<ConversationItem, 'status' | 'formatted' | 'content' | 'detectedLanguage'>
   ): ConversationItem {
     const idx = currentId ? this.conversationItems.findIndex((i) => i.id === currentId) : -1;
     const previous = idx !== -1 ? this.conversationItems[idx] : undefined;
@@ -424,10 +434,12 @@ export class SonioxClient implements IClient {
     const text = finalText + partialText;
     if (!text) return;
     const currentId = role === 'user' ? this.currentUserItemId : this.currentAssistantItemId;
+    const detected = role === 'user' ? this.userLanguage : this.assistantLanguage;
     const item = this.upsertItem(role, currentId, {
       status: 'in_progress',
       formatted: { text, transcript: text },
       content: [{ type: 'text', text }],
+      ...(detected ? { detectedLanguage: detected } : {}),
     });
     if (this.bidirectional && this.utteranceSide) item.source = this.utteranceSide;
     if (role === 'user') this.currentUserItemId = item.id; else this.currentAssistantItemId = item.id;
@@ -448,10 +460,12 @@ export class SonioxClient implements IClient {
       // (keepReplayAudio only — undefined otherwise, a no-op).
       const prev = existingId ? this.conversationItems.find((i) => i.id === existingId) : undefined;
       const audio = prev?.formatted?.audio as Int16Array | undefined;
+      const detected = role === 'user' ? this.userLanguage : this.assistantLanguage;
       const item = this.upsertItem(role, existingId, {
         status: 'completed',
         formatted: audio ? { text, transcript: text, audio } : { text, transcript: text },
         content: [{ type: 'text', text }],
+        ...(detected ? { detectedLanguage: detected } : {}),
       });
       if (this.bidirectional && this.utteranceSide) item.source = this.utteranceSide;
       this.eventHandlers.onConversationUpdated?.({ item, delta: {} });
@@ -465,6 +479,8 @@ export class SonioxClient implements IClient {
     // still attach to it (MainPanel's audio-delta path ignores item status).
     this.userFinal = '';
     this.assistantFinal = '';
+    this.userLanguage = null;
+    this.assistantLanguage = null;
     this.utteranceTtsLanguage = null;
     this.utteranceSide = null;
     // Debug-timeline milestone: the text this utterance sent to TTS to be
@@ -642,6 +658,8 @@ export class SonioxClient implements IClient {
     this.audioItemSide = null;
     this.userFinal = '';
     this.assistantFinal = '';
+    this.userLanguage = null;
+    this.assistantLanguage = null;
     this.utteranceTtsLanguage = null;
     this.utteranceSide = null;
     this.ttsSpokenText = '';

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -13,6 +13,16 @@ export interface ConversationItem {
   status: 'in_progress' | 'completed' | 'incomplete' | 'cancelled';
   source?: 'speaker' | 'participant'; // Source of the conversation item (speaker's mic or participant's system audio)
   createdAt?: number; // Timestamp for accurate sorting
+  /**
+   * The language actually detected for THIS item's text (e.g. Soniox reports
+   * a per-token `language`), as an ISO code. When present, the conversation
+   * bubble's language badge shows this instead of the configured
+   * source/target — correct for two-way translation and auto-detect, where the
+   * configured pair doesn't match what was spoken. Clients that don't receive
+   * per-item language leave it undefined and the badge falls back to the
+   * configured value.
+   */
+  detectedLanguage?: string;
   formatted?: {
     text?: string;
     transcript?: string;


### PR DESCRIPTION
Closes #340.

## Problem

The language badge on each conversation bubble (`ZH` / `EN`) came from the **configured** source/target languages, not the language actually detected for that item. This is wrong whenever the configured pair doesn't match what was spoken:

- **Two-way translation** (Soniox `two_way`, Doubao/Volcengine AST 2.0 `zhen`): with `zh ↔ en` configured, speaking **English** produced a transcript bubble labeled `ZH` and a translation bubble labeled `EN` — both backwards for that utterance.
- **Auto-detect source**: with source = Auto, every transcript bubble showed `AUTO` regardless of what was spoken.

## Fix

Generic pipeline (all providers), Soniox populated first:

- `ConversationItem` gains an optional `detectedLanguage` (ISO code — the language of *that item's* text).
- The bubble badge prefers `item.detectedLanguage` over the configured mapping, falling back when it's absent — so providers that don't supply per-item language are unchanged.
- `SonioxClient` populates it from the tokens it already receives: the transcript (`original`) token's `language` is the spoken language; the `translation` token's `language` is the language it was translated into. Captured per side, carried through `<end>` completion, reset per utterance.

Other providers with per-item language identification (Gemini, Doubao/Volcengine AST 2.0, …) can populate `detectedLanguage` later; until then they fall back to the configured mapping exactly as before.

## Verification

- Unit tests: `SonioxClient` (backwards two-way case, carry-through `<end>`, no-language fallback) and `ConversationRow` (prefers `detectedLanguage`, falls back otherwise). Full suite 132 files / 1380 tests green.
- Live: `source = Auto` with Chinese speech now shows a `ZH` transcript badge (was `AUTO`) and an `EN` translation badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hvwf1iGKeCaMxB9UFMgHHS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conversation items now carry per-utterance language detection and surface it in the UI.
  * Language badges prefer the item’s detected language when available, falling back to the configured source/target languages when not.
* **Bug Fixes**
  * Improved language labeling behavior for cases where detected language conflicts with the expected direction, and when STT frames omit language data.
* **Tests**
  * Added unit tests covering detected-language selection, preservation through completion, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->