### PR TITLE
chore(sidecar): bump transcribe-cpp 0.1.1 → 0.1.3

### DIFF
--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -28,7 +28,7 @@ nltk==3.10.0
 # (kanji homograph readings); quality follow-up tracked in issue #322.
 pyopenjtalk-plus==0.4.1.post8
 # ASR runtime (ggml family; CPU+Vulkan wheels on linux/win, Metal on macOS)
-transcribe-cpp==0.1.1
+transcribe-cpp==0.1.3
 # macOS MLX TTS lane (spec D5): Apple-Silicon-only mlx-audio wheel. The
 # environment marker keeps it out of the Linux/Windows venvs (mlx_tts.py
 # lazy-imports mlx_audio, so those platforms stay importable). Metal-only.


### PR DESCRIPTION
## What

Bump the sidecar ASR runtime `transcribe-cpp` from `0.1.1` → `0.1.3` (latest on PyPI). This is the single live pin in `sidecar/requirements.txt`; `transcribe-cpp-native` is a transitive dep and upgrades to `0.1.3.*` automatically.

## Why it's safe

Upstream `v0.1.1..v0.1.3` is **GPU backend-selection + platform-build fixes only** — no new model families, no new capabilities, no API changes:

- `better auto gpu selection` (discrete GPUs probed before integrated)
- `gate auto backend off Metal GPUs without simdgroup matmul` (older-Mac safety fallback)
- `help windows vulkan build easier`

The Python binding (`__init__.py`) diff is **byte-identical apart from the version string** plus one doc-comment clarification on `gpu_device=0`. Our `accel.py` passes `backend=` explicitly and probes via `transcribe_cpp.backends()` — both unchanged. `0.1.3` native wheels cover every platform we ship (macOS arm64/x86_64, Linux aarch64/x86_64, Windows amd64).

## Verification (GB10, aarch64 + Vulkan)

- `pip install transcribe-cpp==0.1.3` → native bumped to `0.1.3`, `backends()` → `['Vulkan0', 'CPU']`
- **139 sidecar ASR unit tests pass** (`test_transcribe_backend.py` + `test_accel.py` + `test_asr_engine.py`)
- **Real end-to-end smoke passes**: loaded cached `SenseVoiceSmall-Q8_0`, transcribed `en.wav`, assertion green (`SOKUJI_RUN_TRANSCRIBE_CPP=1`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the speech recognition runtime to a newer release for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->