### PR TITLE
docs(readme): add Soniox and Zoom AI to the provider lists (en/ja/zh)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 Built by [Kizuna AI Lab](https://github.com/kizuna-ai-lab) — we use AI to break language and accessibility barriers, creating genuine human connections. "Kizuna" (絆) means "bond" in Japanese, and Sokuji (即時) is our flagship tool to make real-time communication possible across any language.
 
-Sokuji is a cross-platform live speech translation app for desktop and browser. It supports **Local Inference** — on-device ASR, translation, and TTS powered by WASM and WebGPU, with no API key required, no expensive GPU needed, fully offline, and completely private. It also integrates with cloud providers including OpenAI, Google Gemini, Palabra.ai, Kizuna AI, Doubao AST 2.0, and OpenAI-compatible APIs.
+Sokuji is a cross-platform live speech translation app for desktop and browser. It supports **Local Inference** — on-device ASR, translation, and TTS powered by WASM and WebGPU, with no API key required, no expensive GPU needed, fully offline, and completely private. It also integrates with cloud providers including OpenAI, Google Gemini, Palabra.ai, Kizuna AI, Doubao AST 2.0, Soniox, Zoom AI, and OpenAI-compatible APIs.
 
 ---
 
@@ -57,7 +57,7 @@ graph LR
 
 | | |
 |---|---|
-| **Providers** | 7 — OpenAI, Gemini, Palabra.ai, Kizuna AI, Doubao AST 2.0, OpenAI Compatible, Local Inference |
+| **Providers** | 9 — OpenAI, Gemini, Palabra.ai, Kizuna AI, Doubao AST 2.0, Soniox, Zoom AI, OpenAI Compatible, Local Inference |
 | **Local Models** | 48 ASR models, 55+ translation pairs, 136 TTS voices |
 | **Languages** | 99+ (speech recognition) · 55+ (translation) · 53 (text-to-speech) |
 | **Platforms** | Linux · Windows · macOS · Chrome · Edge |
@@ -146,6 +146,8 @@ Run everything on your device — no API keys, no internet, no expensive GPU, co
 | **Palabra.ai** | WebRTC low-latency · voice cloning · auto sentence segmentation · partial transcription translation · 60+ source / 40+ target languages |
 | **Kizuna AI** | Sign in and go — API key managed by backend · same OpenAI models with optimized defaults |
 | **Doubao AST 2.0** | Speech-to-speech with speaker voice cloning · bidirectional Chinese↔English · Ogg Opus audio output |
+| **Soniox** | Real-time speech-to-speech · one-way & two-way translation · 60+ languages / 3,600+ pairs · auto language detection · 12 voices · bring-your-own-key |
+| **Zoom AI Services** | Text-only live captions · bring your own Zoom Build Platform key · works on any site, not just Zoom · Zoom's native language pairs |
 | **OpenAI Compatible** | Bring your own endpoint — any OpenAI Realtime API-compatible service (Electron only) |
 | **Local Inference** | Fully offline · ASR → Translation → TTS on-device · no API key · no GPU required |
 

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -30,7 +30,7 @@
 
 [Kizuna AI Lab](https://github.com/kizuna-ai-lab) が開発 — AIを活用して言語とアクセシビリティの壁を打ち破り、人と人との真のつながりを創造します。「絆」は日本語で「bond」、即時（Sokuji）はリアルタイムコミュニケーションを可能にするフラッグシップツールです。
 
-Sokujiは、デスクトップとブラウザに対応したクロスプラットフォームのリアルタイム音声翻訳アプリです。**ローカル推論**をサポート — WASMとWebGPUによるオンデバイスASR・翻訳・TTSで、APIキー不要、高価なGPU不要、完全オフライン、プライバシー完全保護。OpenAI、Google Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、OpenAI互換APIなどのクラウドプロバイダーにも対応。
+Sokujiは、デスクトップとブラウザに対応したクロスプラットフォームのリアルタイム音声翻訳アプリです。**ローカル推論**をサポート — WASMとWebGPUによるオンデバイスASR・翻訳・TTSで、APIキー不要、高価なGPU不要、完全オフライン、プライバシー完全保護。OpenAI、Google Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、Soniox、Zoom AI、OpenAI互換APIなどのクラウドプロバイダーにも対応。
 
 ---
 
@@ -57,7 +57,7 @@ graph LR
 
 | | |
 |---|---|
-| **プロバイダー** | 7 — OpenAI、Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、OpenAI互換、ローカル推論 |
+| **プロバイダー** | 9 — OpenAI、Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、Soniox、Zoom AI、OpenAI互換、ローカル推論 |
 | **ローカルモデル** | ASR 50モデル、翻訳 55以上の言語ペア、TTS 136ボイス |
 | **言語** | 99以上（音声認識）· 55以上（翻訳）· 53（音声合成） |
 | **プラットフォーム** | Linux · Windows · macOS · Chrome · Edge |
@@ -146,6 +146,8 @@ npm run electron:build      # 本番ビルド
 | **Palabra.ai** | WebRTC低遅延 · ボイスクローニング · 自動文分割 · 部分転写翻訳 · 60以上のソース / 40以上のターゲット言語 |
 | **Kizuna AI** | サインインするだけ — APIキーはバックエンド管理 · OpenAIモデルを最適化されたデフォルトで |
 | **豆包 AST 2.0** | 話者ボイスクローニング付き音声翻訳 · 中国語↔英語双方向 · Ogg Opus音声出力 |
+| **Soniox** | リアルタイム音声間翻訳 · 一方向＆双方向翻訳 · 60以上の言語 / 3,600以上のペア · 自動言語識別 · 12ボイス · APIキー持ち込み |
+| **Zoom AI Services** | テキストのみのライブ字幕 · Zoom Build Platform キーを持ち込み · Zoom以外のあらゆるサイトで動作 · Zoomのネイティブ言語ペア |
 | **OpenAI互換** | 独自エンドポイント対応 — OpenAI Realtime API互換サービス（Electronのみ） |
 | **ローカル推論** | 完全オフライン · ASR → 翻訳 → TTSをオンデバイスで · APIキー不要 · GPU不要 |
 

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -30,7 +30,7 @@
 
 由 [Kizuna AI Lab](https://github.com/kizuna-ai-lab) 开发 — 我们利用 AI 打破语言和无障碍壁垒，创造真正的人与人之间的连接。"絆"（Kizuna）在日语中意为"羁绊"，即時（Sokuji）是我们让跨语言实时沟通成为可能的旗舰工具。
 
-Sokuji 是一款跨平台实时语音翻译应用，同时支持桌面端和浏览器端。支持**本地推理** — 通过 WASM 和 WebGPU 在设备上运行 ASR、翻译和 TTS，无需 API 密钥，无需昂贵的 GPU，完全离线，隐私完全保护。同时集成 OpenAI、Google Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0 和 OpenAI 兼容 API 等云端服务商。
+Sokuji 是一款跨平台实时语音翻译应用，同时支持桌面端和浏览器端。支持**本地推理** — 通过 WASM 和 WebGPU 在设备上运行 ASR、翻译和 TTS，无需 API 密钥，无需昂贵的 GPU，完全离线，隐私完全保护。同时集成 OpenAI、Google Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、Soniox、Zoom AI 和 OpenAI 兼容 API 等云端服务商。
 
 ---
 
@@ -57,7 +57,7 @@ graph LR
 
 | | |
 |---|---|
-| **服务商** | 7 — OpenAI、Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、OpenAI 兼容、本地推理 |
+| **服务商** | 9 — OpenAI、Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、Soniox、Zoom AI、OpenAI 兼容、本地推理 |
 | **本地模型** | 50 个 ASR 模型、55+ 翻译语言对、136 个 TTS 语音 |
 | **语言** | 99+（语音识别）· 55+（翻译）· 53（语音合成） |
 | **平台** | Linux · Windows · macOS · Chrome · Edge |
@@ -146,6 +146,8 @@ npm run electron:build      # 生产构建
 | **Palabra.ai** | WebRTC 低延迟 · 语音克隆 · 自动句子分割 · 部分转录翻译 · 60+ 源语言 / 40+ 目标语言 |
 | **Kizuna AI** | 登录即用 — API 密钥由后端管理 · 使用优化默认设置的 OpenAI 模型 |
 | **豆包 AST 2.0** | 带说话人语音克隆的语音翻译 · 中英双向翻译 · Ogg Opus 音频输出 |
+| **Soniox** | 实时语音到语音互译 · 单向和双向翻译 · 60+ 语言 / 3,600+ 语言对 · 自动语言识别 · 12 种语音 · 自带 API 密钥 |
+| **Zoom AI Services** | 纯文本实时字幕 · 自带 Zoom Build Platform 密钥 · 不限于 Zoom，任意网站可用 · Zoom 原生语言对 |
 | **OpenAI 兼容** | 自带端点 — 任何兼容 OpenAI Realtime API 的服务（仅限 Electron） |
 | **本地推理** | 完全离线 · ASR → 翻译 → TTS 设备端运行 · 无需 API 密钥 · 无需 GPU |
 


### PR DESCRIPTION
Now that Soniox ships in v0.33.0, bring the provider lists in the READMEs up to date. Soniox (v0.33.0) and Zoom AI Services (v0.31.1) were both missing from the curated provider list.

Adds **Soniox** and **Zoom AI Services** to all three READMEs (`README.md`, `docs/README.ja.md`, `docs/README.zh.md`) in three places each:

- the intro paragraph
- the stats row (`Providers | 7 → 9`)
- the **Cloud Providers** table

Docs-only; no code changes.

(Volcengine ST is intentionally not added separately — Doubao AST 2.0 already represents the Volcengine entry.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Soniox and Zoom AI Services to the listed cloud integrations.
  * Updated provider counts across the English, Japanese, and Chinese documentation.
  * Documented capabilities and key requirements for both newly supported services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->