### PR TITLE
fix(openai): migrate off deprecated realtime models (API shutoff 2027-01-20)

### DIFF
--- a/src/services/EphemeralTokenService.ts
+++ b/src/services/EphemeralTokenService.ts
@@ -35,7 +35,7 @@ export class EphemeralTokenService {
    * Uses caching to avoid unnecessary API calls
    *
    * @param apiKey - The user's OpenAI API key
-   * @param model - The realtime model to use (e.g., 'gpt-realtime-mini')
+   * @param model - The realtime model to use (e.g., 'gpt-realtime-2.1-mini')
    * @param voice - The voice to use (e.g., 'alloy')
    * @param apiHost - Optional custom API host (for OpenAI Compatible)
    * @returns The ephemeral token string

--- a/src/services/clients/OpenAIClient.ts
+++ b/src/services/clients/OpenAIClient.ts
@@ -172,7 +172,7 @@ export class OpenAIClient implements IClient {
     }
     
     // Fallback to default if no realtime models found
-    return 'gpt-realtime-mini';
+    return 'gpt-realtime-2.1-mini';
   }
 
   /**

--- a/src/services/providers/OpenAIProviderConfig.ts
+++ b/src/services/providers/OpenAIProviderConfig.ts
@@ -33,7 +33,7 @@ export type OpenAISettings = OpenAICompatibleSettingsBase;
 
 export const defaultOpenAICompatibleSettingsBase: OpenAICompatibleSettingsBase = {
   apiKey: '',
-  model: 'gpt-realtime-mini',
+  model: 'gpt-realtime-2.1-mini',
   voice: 'alloy',
   sourceLanguage: 'en',
   targetLanguage: 'zh_CN',
@@ -206,10 +206,13 @@ export class OpenAIProviderConfig extends BaseProviderDescriptor {
     { name: 'Verse', value: 'verse' },
   ];
 
+  // Static fallback shown before an API key is validated; at runtime the real
+  // list comes from /v1/models (validateAndFetchModels). Keep these to current,
+  // non-deprecated realtime models. OpenAI's pre-2.1 realtime/audio families are
+  // shut off 2027-01-20 (see migrateDeprecatedOpenAIModel in settingsStore).
   private static readonly MODELS: ModelOption[] = [
-    { id: 'gpt-realtime-mini', type: 'realtime' },
-    { id: 'gpt-realtime-1.5', type: 'realtime' },
-    { id: 'gpt-realtime-2', type: 'realtime' },
+    { id: 'gpt-realtime-2.1-mini', type: 'realtime' },
+    { id: 'gpt-realtime-2.1', type: 'realtime' },
   ];
 
   // Only models matching this prefix accept the `reasoning.effort` parameter.

--- a/src/stores/openaiModelMigration.test.ts
+++ b/src/stores/openaiModelMigration.test.ts
@@ -17,9 +17,14 @@ describe("deprecated OpenAI realtime model migration", () => {
     expect(migrateDeprecatedOpenAIModel("gpt-realtime-2")).toBe("gpt-realtime-2.1");
   });
 
-  it("leaves current 2.1 models unchanged", () => {
+  it("leaves current and future (>= 2.1) versioned models unchanged", () => {
     expect(migrateDeprecatedOpenAIModel("gpt-realtime-2.1")).toBe("gpt-realtime-2.1");
     expect(migrateDeprecatedOpenAIModel("gpt-realtime-2.1-mini")).toBe("gpt-realtime-2.1-mini");
+    // Forward-compat: newer versions must NOT be downgraded to 2.1.
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-2.2")).toBe("gpt-realtime-2.2");
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-2.2-mini")).toBe("gpt-realtime-2.2-mini");
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-3")).toBe("gpt-realtime-3");
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-10.4")).toBe("gpt-realtime-10.4");
   });
 
   it("leaves non-voice-agent realtime variants (translate/whisper) unchanged", () => {

--- a/src/stores/openaiModelMigration.test.ts
+++ b/src/stores/openaiModelMigration.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { migrateDeprecatedOpenAIModel } from "./settingsStore";
+import { defaultOpenAISettings } from "../services/providers/OpenAIProviderConfig";
+
+describe("deprecated OpenAI realtime model migration", () => {
+  it("maps deprecated mini realtime families to gpt-realtime-2.1-mini", () => {
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-mini")).toBe("gpt-realtime-2.1-mini");
+    expect(migrateDeprecatedOpenAIModel("gpt-4o-mini-realtime")).toBe("gpt-realtime-2.1-mini");
+    expect(migrateDeprecatedOpenAIModel("gpt-4o-mini-realtime-preview-2024-12-17")).toBe("gpt-realtime-2.1-mini");
+  });
+
+  it("maps deprecated full realtime families to gpt-realtime-2.1", () => {
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime")).toBe("gpt-realtime-2.1");
+    expect(migrateDeprecatedOpenAIModel("gpt-4o-realtime-preview")).toBe("gpt-realtime-2.1");
+    // Stale static-list ids that were never confirmed as current OpenAI models.
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-1.5")).toBe("gpt-realtime-2.1");
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-2")).toBe("gpt-realtime-2.1");
+  });
+
+  it("leaves current 2.1 models unchanged", () => {
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-2.1")).toBe("gpt-realtime-2.1");
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-2.1-mini")).toBe("gpt-realtime-2.1-mini");
+  });
+
+  it("leaves non-voice-agent realtime variants (translate/whisper) unchanged", () => {
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-translate")).toBe("gpt-realtime-translate");
+    expect(migrateDeprecatedOpenAIModel("gpt-realtime-whisper")).toBe("gpt-realtime-whisper");
+  });
+
+  it("leaves empty/unknown ids untouched", () => {
+    expect(migrateDeprecatedOpenAIModel("")).toBe("");
+    expect(migrateDeprecatedOpenAIModel("whisper-1")).toBe("whisper-1");
+  });
+
+  it("ships a non-deprecated default model", () => {
+    expect(migrateDeprecatedOpenAIModel(defaultOpenAISettings.model)).toBe(defaultOpenAISettings.model);
+    expect(defaultOpenAISettings.model).toBe("gpt-realtime-2.1-mini");
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -325,11 +325,20 @@ export function migrateLegacyKizunaProvider(p: Provider | string): Provider {
  *  snapshots (e.g. `-preview-2024-12-17`) are also caught. Applied only to the
  *  `openai` slice's `model`, which only ever holds voice-agent realtime ids.
  *  Translate/whisper realtime variants (their own provider slices) and current
- *  2.1 models are left untouched. */
+ *  or future (>= 2.1) versioned models are left untouched. */
 export function migrateDeprecatedOpenAIModel(model: string): string {
   const m = (model ?? '').toLowerCase();
-  // Current models and non-voice-agent realtime families: leave as-is.
-  if (m.startsWith('gpt-realtime-2.1')) return model;
+  // Preserve current AND future versioned voice-agent models: any
+  // gpt-realtime-<major>.<minor> at >= 2.1 is kept as-is (2.1, 2.2, 3, ...), so
+  // a user who later selects a newer 2.x model isn't silently downgraded on the
+  // next settings load. Only the pre-2.1 families below are deprecated.
+  const version = m.match(/^gpt-realtime-(\d+)(?:\.(\d+))?/);
+  if (version) {
+    const major = parseInt(version[1], 10);
+    const minor = parseInt(version[2] ?? '0', 10);
+    if (major > 2 || (major === 2 && minor >= 1)) return model;
+  }
+  // Non-voice-agent realtime families live in their own provider slices.
   if (m.startsWith('gpt-realtime-translate')) return model;
   if (m.startsWith('gpt-realtime-whisper')) return model;
   // Deprecated mini realtime families → gpt-realtime-2.1-mini.

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -318,6 +318,31 @@ export function migrateLegacyKizunaProvider(p: Provider | string): Provider {
   return (p as string) === 'kizunaai' ? Provider.KIZUNA_AI_OPENAI_TRANSLATE : (p as Provider);
 }
 
+/** Migrate a persisted deprecated OpenAI voice-agent realtime model id to its
+ *  current replacement. OpenAI notified (2026-07-20) that the pre-2.1 realtime
+ *  and audio model families/snapshots are removed from the API on 2027-01-20;
+ *  the former default `gpt-realtime-mini` is among them. Prefix-matched so dated
+ *  snapshots (e.g. `-preview-2024-12-17`) are also caught. Applied only to the
+ *  `openai` slice's `model`, which only ever holds voice-agent realtime ids.
+ *  Translate/whisper realtime variants (their own provider slices) and current
+ *  2.1 models are left untouched. */
+export function migrateDeprecatedOpenAIModel(model: string): string {
+  const m = (model ?? '').toLowerCase();
+  // Current models and non-voice-agent realtime families: leave as-is.
+  if (m.startsWith('gpt-realtime-2.1')) return model;
+  if (m.startsWith('gpt-realtime-translate')) return model;
+  if (m.startsWith('gpt-realtime-whisper')) return model;
+  // Deprecated mini realtime families → gpt-realtime-2.1-mini.
+  if (m.startsWith('gpt-realtime-mini') || m.startsWith('gpt-4o-mini-realtime')) {
+    return 'gpt-realtime-2.1-mini';
+  }
+  // Deprecated full realtime families (incl. stale gpt-realtime-1.5 / -2) → 2.1.
+  if (m.startsWith('gpt-realtime') || m.startsWith('gpt-4o-realtime')) {
+    return 'gpt-realtime-2.1';
+  }
+  return model;
+}
+
 /**
  * Resolve the worker type for a specific translation model id.
  * Returns 'opus-mt' when the id is missing or not in the manifest.
@@ -1133,6 +1158,14 @@ const useSettingsStore = create<SettingsStore>()(
             await loadProviderSettings(`settings.${sliceKey}`, PROVIDER_SLICE_REGISTRY[sliceKey].defaults),
           ] as const),
         )) as Partial<SettingsStore>;
+
+        // Migrate a persisted deprecated OpenAI realtime model (pre-2.1 family,
+        // removed from the API 2027-01-20) to its current replacement so
+        // existing users don't reconnect onto a dead model.
+        const openaiSlice = loadedSlices.openai as OpenAISettings | undefined;
+        if (openaiSlice?.model) {
+          openaiSlice.model = migrateDeprecatedOpenAIModel(openaiSlice.model);
+        }
 
         set({
           provider: validProvider,


### PR DESCRIPTION
## Context

OpenAI notified developers on **2026-07-20** that the legacy realtime, audio, and transcription model **families and snapshots** are removed from the API on **2027-01-20** ([OpenAI deprecations](https://developers.openai.com/api/docs/deprecations)). The list includes the model Sokuji shipped as the **default** OpenAI realtime model, `gpt-realtime-mini`.

Official replacements:

| Deprecated | Replacement |
|---|---|
| `gpt-realtime-mini` | `gpt-realtime-2.1-mini` |
| `gpt-realtime` | `gpt-realtime-2.1` |
| `gpt-4o-(mini-)realtime` | `gpt-realtime-2.1(-mini)` |
| `gpt-4o-mini-transcribe-2025-03-20` | `gpt-4o-mini-transcribe-2025-12-15` |

Nothing breaks today (models stay live until 2027-01-20, and the model dropdown is driven by a live `/v1/models` fetch), but any user who never changed the default — including all new users — would hit a dead model after the shutoff. This moves the hardcoded pieces and migrates persisted settings ahead of the deadline.

## Changes

- **Default realtime model** (`OpenAIProviderConfig`): `gpt-realtime-mini` → `gpt-realtime-2.1-mini`.
- **`/v1/models` fetch fallback** (`OpenAIClient.getLatestRealtimeModel`): → `gpt-realtime-2.1-mini`.
- **Static fallback model list**: → `gpt-realtime-2.1-mini`, `gpt-realtime-2.1` (dropped stale `gpt-realtime-1.5` / `gpt-realtime-2`).
- **Persisted-settings migration** (`settingsStore`): new `migrateDeprecatedOpenAIModel()`, applied in `loadSettings` to the `openai` slice's `model`, so existing users' saved deprecated ids are remapped to current ones (prefix-matched to also catch dated snapshots like `-preview-2024-12-17`).
- JSDoc example refreshed in `EphemeralTokenService`.

## Intentionally NOT changed

- **Transcript default `gpt-4o-mini-transcribe`** — only the dated snapshot `-2025-03-20` was deprecated; Sokuji uses the bare alias, which tracks the latest snapshot.
- **OpenAI Translate** (`gpt-realtime-translate` / `gpt-realtime-whisper`) — not on the deprecation list.
- **`reasoningEffort` gate** (`startsWith('gpt-realtime-2')`) — `gpt-realtime-2.1-mini` is itself a reasoning model, so matching it is correct.
- **OpenAI Compatible slice** — custom user-supplied endpoint/model; not remapped.

## Tests

- New `src/stores/openaiModelMigration.test.ts` covering the migration map (mini/full families, dated snapshots, current 2.1 models untouched, translate/whisper untouched, non-deprecated default).
- `src/stores/` + `src/services/` suites green (535 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated default OpenAI realtime model selection and pre-API fallback options to the latest 2.1 model family.
  * Added automatic migration of stored voice-agent realtime model IDs to current 2.1 equivalents.
* **Bug Fixes**
  * Prevented reconnections from using deprecated realtime model identifiers after settings are loaded.
* **Tests**
  * Added automated test coverage for model migration, including deprecated, current, unknown, and non-voice realtime variants.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->