### PR TITLE
feat(win): sandbox crash self-healing (detect → repair → no-sandbox fallback) — #352

### DIFF
--- a/docs/superpowers/plans/2026-07-24-win-sandbox-recovery.md
+++ b/docs/superpowers/plans/2026-07-24-win-sandbox-recovery.md
@@ -94,5 +94,11 @@ Constants: `CRASH_MARKER = 'sandbox-crash-marker.json'`, `FALLBACK_MARKER = 'no-
 
 ### Task 6: Windows E2E (isolated dir), then PR
 
-- [ ] `npm run package`, copy output to `C:\SokujiSandboxTest\`, inject orphan ACE on that dir only, verify crash→relaunch→confirmed dialog→repair→clean sandbox launch; then unconfirmed, no-sandbox fallback, version regression. Clean up.
+- [x] Real-icacls parser validation: injected explicit orphan ACE on `C:\SokujiSandboxTest`, parser correctly flagged it explicit; subdir showed inherited `(I)` and was correctly NOT flagged.
+- [x] Real-icacls repair validation: `repairDirectory` ran real `icacls /remove *<SID>`; parent AND subdir rescanned clean (inheritance self-heals).
+- [x] Packaged app baseline: launches and stays alive with the feature wired, no crash marker, no regression to normal startup.
+- [x] Packaged-app E2E caught a real bug: `require('./sandbox-recovery')` failed with "Cannot find module" because the file wasn't a registered vite electron entry. Fixed in vite.config.ts; repackaged and re-verified.
+- [x] Confirmed recovery dialog RENDERS in the real packaged app: planted a crash marker + injected ACE, launched; read via UI Automation → title "Sokuji — Sandbox Startup Problem", correct body, "Affected locations: C:\SokujiSandboxTest" (real icacls scan found the orphan on the exe dir), issue URL, and the three buttons [Repair permissions (recommended)] [Continue without sandbox] [Quit]. No transparent main window created (recovery ran before createWindow).
+- [~] Runtime GPU crash NOT reproduced on this machine (Win11 26200): injecting the orphan ACE did not deny the sandbox token here (3 child processes spawned fine), so the live passive-detection→relaunch chain could not be exercised end-to-end. Bug is environment-specific (reporter confirmed on their machine). Trigger constants come from the reporter's symbolicated data.
+- [~] Driving the modal dialog's button click via synthetic input (UIA InvokePattern / LegacyIAccessible / keyboard / mouse) did not register in this session (non-interactive input limitation; no backup log was written, confirming the click never reached the handler — not a code fault). The button→performRepair wiring is covered by unit tests; performRepair delegates to repairDirectory, which WAS validated against real icacls (ACE removed, inheritance self-heals).
 - [ ] Push branch, open PR referencing #352 + upstream electron#51761.

--- a/docs/superpowers/plans/2026-07-24-win-sandbox-recovery.md
+++ b/docs/superpowers/plans/2026-07-24-win-sandbox-recovery.md
@@ -1,0 +1,98 @@
+# Windows Sandbox Crash Self-Healing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Detect Chromium sandbox startup crashes on Windows caused by orphaned AppContainer SID ACEs, guide the user through a permission repair, and provide a `--no-sandbox` fallback — all user-confirmed, all Windows-gated. (issue #352)
+
+**Architecture:** A single self-contained module `electron/sandbox-recovery.js` holds all logic (pure parsers + state-machine deciders + dependency-injected side-effect helpers + electron orchestration). `electron/main.js` gets exactly three wiring points. Everything is gated on `process.platform === 'win32'`; other platforms are untouched.
+
+**Tech Stack:** Node CommonJS (electron main), `child_process.execFileSync('icacls', ...)`, vitest for tests.
+
+## Global Constraints
+
+- Windows-only: every exported orchestration function early-returns on non-win32; no behavior change elsewhere.
+- No silent mutation: every ACL write and every sandbox downgrade happens only after a user clicks a dialog button.
+- Confirmation requires the ACL scan, not just the crash signature. Never offer Repair when the scan is clean.
+- Orphan SID regex: `/S-1-15-2(?:-\d+){6,}/` — excludes legit `S-1-15-2-1` / `S-1-15-2-2`. Match SIDs only, never localized account names.
+- Never use `icacls /reset` or `icacls /save`. Repair is precise `/remove "*<SID>"` only, with a text backup log first.
+- icacls output decoded as `latin1` (byte-safe) and processed line-by-line; only ASCII SID + flag tokens are extracted.
+- Dialog copy is English (matches `vb-cable-installer.js` precedent). Do not wire renderer i18n into main.
+- Correctness gate is vitest, NOT tsc (repo has ~113 pre-existing tsc errors). Do not break the existing 1380+ tests.
+- English-only comments/docs; conventional commits.
+
+## File Structure
+
+- **Create** `electron/sandbox-recovery.js` — all logic.
+- **Create** `electron/sandbox-recovery.test.js` — vitest unit tests (runs on Linux + Windows; no real icacls, deps injected).
+- **Create** `electron/__fixtures__/icacls-*.txt` — real-shaped icacls output fixtures (or inline fixtures in the test).
+- **Modify** `electron/main.js` — three wiring points only.
+
+## Module API (`electron/sandbox-recovery.js`)
+
+Pure (no electron, no I/O):
+- `parseIcaclsAces(text) -> Array<{sid, inherited}>`
+- `findExplicitOrphanSids(text) -> string[]` (unique, non-inherited orphan SIDs)
+- `isGpuSandboxCrash(details) -> boolean` (type GPU + reason crashed|abnormal-exit + exitCode -2147483645|2147483651)
+- `evaluateCrashRelaunch(existingMarker, now, appVersion, opts?) -> {marker, shouldRelaunch}` (1h window, max 2 auto-relaunch)
+- `evaluateNoSandbox(marker, currentVersion) -> {noSandbox, clearMarker}`
+- `buildBackupLog(scanResults, isoStamp) -> string`
+
+Dependency-injected side effects (deps = {fs, execFileSync, now, env, log}):
+- `scanDirectory(dir, deps) -> {dir, sids, rawOutput, error}`
+- `repairDirectory(dir, sids, deps) -> {dir, removed, errors}`
+- `getScanDirectories(app, env) -> string[]`
+- `readJsonFile(fs, path)`, marker read/write/delete helpers
+
+Electron orchestration (app/dialog passed in; win32-gated):
+- `applyNoSandboxFlag(app, options?) -> boolean` — wiring #1 (top of main.js)
+- `registerCrashDetection(app, options?)` — wiring #3 (top of main.js)
+- `handleRecoveryMode(app, dialog, options?) -> boolean` (proceedToCreateWindow) — wiring #2 (whenReady, before createWindow)
+
+Constants: `CRASH_MARKER = 'sandbox-crash-marker.json'`, `FALLBACK_MARKER = 'no-sandbox-fallback.json'`, `ISSUE_URL`.
+
+---
+
+### Task 1: icacls parser + orphan detection (pure)
+
+- [ ] Write failing tests for `parseIcaclsAces` / `findExplicitOrphanSids` using fixtures: clean dir, inherited `(I)` orphan, explicit orphan, legit named `S-1-15-2-1`/`S-1-15-2-2` raw SID lines, non-English locale account name with explicit orphan SID.
+- [ ] Run → fail (not defined).
+- [ ] Implement parser (line split, orphan SID regex, trailing-flags extraction, `(I)` exact-group inheritance check).
+- [ ] Run → pass.
+- [ ] Commit.
+
+### Task 2: crash signature + state machines (pure)
+
+- [ ] Write failing tests for `isGpuSandboxCrash` (signed/unsigned exit codes, wrong type/reason rejected), `evaluateCrashRelaunch` (window filtering, 2-relaunch cap, null marker), `evaluateNoSandbox` (no marker / same version / changed version).
+- [ ] Run → fail.
+- [ ] Implement the three deciders.
+- [ ] Run → pass.
+- [ ] Commit.
+
+### Task 3: scan/repair/backup with injected deps
+
+- [ ] Write failing tests: `scanDirectory` parses mocked execFileSync output + handles thrown error; `repairDirectory` builds `['<dir>','/remove','*<sid>']` args and records errors; `buildBackupLog` includes dirs, SIDs, raw output, issue URL.
+- [ ] Run → fail.
+- [ ] Implement.
+- [ ] Run → pass.
+- [ ] Commit.
+
+### Task 4: orchestration (applyNoSandboxFlag / registerCrashDetection / handleRecoveryMode) with mock app+dialog
+
+- [ ] Write failing tests: non-win32 no-op; applyNoSandboxFlag appends switch on same-version marker, clears on changed; registerCrashDetection writes marker + relaunch on first GPU crash, no relaunch past cap; handleRecoveryMode returns true when no marker, confirmed path (repair success → relaunch, repair fail → fallback dialog), unconfirmed path offers no repair, continue-no-sandbox writes fallback marker.
+- [ ] Run → fail.
+- [ ] Implement orchestration + dialog helpers (`showMessageBoxSync`, `noLink:true`).
+- [ ] Run → pass.
+- [ ] Commit.
+
+### Task 5: main.js wiring (3 points)
+
+- [ ] Add `const sandboxRecovery = process.platform === 'win32' ? require('./sandbox-recovery') : null;` near top requires.
+- [ ] After appendSwitch block (line ~84): `applyNoSandboxFlag(app)` + `registerCrashDetection(app)`.
+- [ ] whenReady top: `if (sandboxRecovery && !sandboxRecovery.handleRecoveryMode(app, dialog)) return;`
+- [ ] Run full vitest suite → green.
+- [ ] Commit.
+
+### Task 6: Windows E2E (isolated dir), then PR
+
+- [ ] `npm run package`, copy output to `C:\SokujiSandboxTest\`, inject orphan ACE on that dir only, verify crash→relaunch→confirmed dialog→repair→clean sandbox launch; then unconfirmed, no-sandbox fallback, version regression. Clean up.
+- [ ] Push branch, open PR referencing #352 + upstream electron#51761.

--- a/electron/main.js
+++ b/electron/main.js
@@ -88,9 +88,13 @@ app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 // ready, and register the passive GPU-crash detector. Recovery mode itself runs
 // in whenReady (below), before the transparent main window is created.
 const sandboxRecovery = process.platform === 'win32' ? require('./sandbox-recovery') : null;
+// sandbox-recovery relaunches via app.exit(), which skips before-quit/will-quit,
+// so it must run the sidecar teardown itself or the native sidecar orphans and
+// keeps its Windows file locks. (removeVirtualAudioDevices is a Linux-only no-op.)
+const sandboxRecoveryOptions = { deps: { beforeExit: () => { try { nativeHost.stop(); } catch (_) {} } } };
 if (sandboxRecovery) {
-  sandboxRecovery.applyNoSandboxFlag(app);
-  sandboxRecovery.registerCrashDetection(app);
+  sandboxRecovery.applyNoSandboxFlag(app, sandboxRecoveryOptions);
+  sandboxRecovery.registerCrashDetection(app, sandboxRecoveryOptions);
 }
 
 // Keep a global reference of the window object to prevent garbage collection
@@ -395,7 +399,7 @@ app.whenReady().then(async () => {
   // Windows sandbox recovery (issue #352): if a prior run left a crash marker,
   // scan ACLs and show the native recovery dialog BEFORE creating the (transparent)
   // main window. May relaunch or exit; if so, do not proceed to createWindow().
-  if (sandboxRecovery && !sandboxRecovery.handleRecoveryMode(app, dialog)) {
+  if (sandboxRecovery && !sandboxRecovery.handleRecoveryMode(app, dialog, sandboxRecoveryOptions)) {
     return;
   }
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -83,6 +83,16 @@ app.commandLine.appendSwitch('disable-renderer-backgrounding');
 app.commandLine.appendSwitch('disable-background-timer-throttling');
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows');
 
+// Windows sandbox crash self-healing (issue #352). On win32 only: apply the
+// persistent --no-sandbox fallback (if a prior recovery set it) BEFORE app is
+// ready, and register the passive GPU-crash detector. Recovery mode itself runs
+// in whenReady (below), before the transparent main window is created.
+const sandboxRecovery = process.platform === 'win32' ? require('./sandbox-recovery') : null;
+if (sandboxRecovery) {
+  sandboxRecovery.applyNoSandboxFlag(app);
+  sandboxRecovery.registerCrashDetection(app);
+}
+
 // Keep a global reference of the window object to prevent garbage collection
 let mainWindow;
 
@@ -382,6 +392,13 @@ function createWindow() {
 
 // Create window when Electron is ready
 app.whenReady().then(async () => {
+  // Windows sandbox recovery (issue #352): if a prior run left a crash marker,
+  // scan ACLs and show the native recovery dialog BEFORE creating the (transparent)
+  // main window. May relaunch or exit; if so, do not proceed to createWindow().
+  if (sandboxRecovery && !sandboxRecovery.handleRecoveryMode(app, dialog)) {
+    return;
+  }
+
   const isDev = import.meta.env.MODE === 'development' || !app.isPackaged;
 
   // Initialize Better Auth adapter

--- a/electron/sandbox-recovery.js
+++ b/electron/sandbox-recovery.js
@@ -215,10 +215,299 @@ function buildBackupLog(scanResults, isoStamp) {
   return log;
 }
 
+// ---------------------------------------------------------------------------
+// Orchestration (electron `app`/`dialog` passed in; all win32-gated).
+// State markers live in userData (%APPDATA%\sokuji, the Roaming tree), which is
+// unaffected by the corrupted Local-tree DACL.
+// ---------------------------------------------------------------------------
+
+const path = require('path');
+
+const CRASH_MARKER = 'sandbox-crash-marker.json';
+const FALLBACK_MARKER = 'no-sandbox-fallback.json';
+
+/** Real dependencies, overridable in tests via options.deps. */
+function defaultDeps() {
+  return {
+    platform: process.platform,
+    fs: require('fs'),
+    execFileSync: require('child_process').execFileSync,
+    now: () => Date.now(),
+    env: process.env,
+    log: (...a) => console.log('[Sokuji] [SandboxRecovery]', ...a),
+  };
+}
+
+function mergeDeps(deps) {
+  return { ...defaultDeps(), ...(deps || {}) };
+}
+
+function readJsonFile(fs, filePath) {
+  try {
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function safeUnlink(fs, filePath) {
+  try {
+    fs.unlinkSync(filePath);
+  } catch {
+    /* already gone */
+  }
+}
+
+/**
+ * Directories whose DACL can carry the inherited orphan ACE: the install dir,
+ * %LOCALAPPDATA% and %USERPROFILE%. Deduped; missing env vars skipped.
+ * @param {{getPath: Function}} app
+ * @param {Record<string,string>} env
+ * @returns {string[]}
+ */
+function getScanDirectories(app, env) {
+  const dirs = [];
+  try {
+    dirs.push(path.dirname(app.getPath('exe')));
+  } catch {
+    /* ignore */
+  }
+  if (env.LOCALAPPDATA) dirs.push(env.LOCALAPPDATA);
+  if (env.USERPROFILE) dirs.push(env.USERPROFILE);
+  return [...new Set(dirs)];
+}
+
+/**
+ * Wiring point #1 — at the very top of main.js, before app is ready.
+ * Reads the persistent no-sandbox fallback marker and, if it applies to the
+ * current version, appends the --no-sandbox switch. A version change clears the
+ * marker so the sandbox is retried (the ACL may have been fixed meanwhile).
+ * @returns {boolean} whether --no-sandbox was applied.
+ */
+function applyNoSandboxFlag(app, options = {}) {
+  const deps = mergeDeps(options.deps);
+  if (deps.platform !== 'win32') return false;
+  const userData = options.userDataDir || app.getPath('userData');
+  const filePath = path.join(userData, FALLBACK_MARKER);
+  const marker = readJsonFile(deps.fs, filePath);
+  const { noSandbox, clearMarker } = evaluateNoSandbox(marker, app.getVersion());
+  if (clearMarker) {
+    safeUnlink(deps.fs, filePath);
+    deps.log('fallback marker version changed; cleared, retrying with sandbox');
+  }
+  if (noSandbox) {
+    app.commandLine.appendSwitch('no-sandbox');
+    deps.log('applying --no-sandbox from persistent fallback marker');
+  }
+  return noSandbox;
+}
+
+/**
+ * Wiring point #3 — register the passive GPU-crash detector. On a matching
+ * crash it synchronously writes the crash marker (so recovery survives even if
+ * Chromium's FATAL kills us first) and relaunches into recovery mode, up to the
+ * hourly auto-relaunch cap.
+ */
+function registerCrashDetection(app, options = {}) {
+  const deps = mergeDeps(options.deps);
+  if (deps.platform !== 'win32') return;
+  const userData = options.userDataDir || app.getPath('userData');
+  const crashPath = path.join(userData, CRASH_MARKER);
+
+  app.on('child-process-gone', (event, details) => {
+    if (!isGpuSandboxCrash(details)) return;
+    deps.log('GPU sandbox crash detected:', JSON.stringify(details));
+    const existing = readJsonFile(deps.fs, crashPath);
+    const { marker, shouldRelaunch } = evaluateCrashRelaunch(
+      existing,
+      deps.now(),
+      app.getVersion()
+    );
+    try {
+      deps.fs.writeFileSync(crashPath, JSON.stringify(marker));
+    } catch (e) {
+      deps.log('failed to write crash marker:', e && e.message);
+    }
+    if (shouldRelaunch) {
+      deps.log('relaunching into recovery mode');
+      app.relaunch();
+      app.exit(0);
+    } else {
+      deps.log('auto-relaunch cap reached; marker left for next manual launch');
+    }
+  });
+}
+
+function stampFromNow(now) {
+  // ISO-8601 with filename-safe separators, e.g. 2026-07-24T04-00-00-000Z.
+  return new Date(now).toISOString().replace(/[:.]/g, '-');
+}
+
+/**
+ * Back up, then remove the explicit orphan ACEs, then re-scan to verify.
+ * @returns {{success: boolean, remaining: object[], backupPath: string}}
+ */
+function performRepair(confirmed, userData, deps) {
+  const backupPath = path.join(userData, `sandbox-recovery-backup-${stampFromNow(deps.now())}.log`);
+  try {
+    deps.fs.writeFileSync(backupPath, buildBackupLog(confirmed, stampFromNow(deps.now())));
+    deps.log('wrote ACL backup to', backupPath);
+  } catch (e) {
+    deps.log('failed to write backup log:', e && e.message);
+  }
+
+  let hadErrors = false;
+  for (const r of confirmed) {
+    const result = repairDirectory(r.dir, r.sids, deps);
+    if (result.errors.length > 0) {
+      hadErrors = true;
+      deps.log('icacls /remove errors at', r.dir, JSON.stringify(result.errors));
+    }
+  }
+
+  const rescan = confirmed.map((r) => scanDirectory(r.dir, deps));
+  const remaining = rescan.filter((r) => r.sids.length > 0 || r.error);
+  return { success: remaining.length === 0 && !hadErrors, remaining, backupPath };
+}
+
+function writeFallbackAndRelaunch(app, deps, userData, crashPath) {
+  const fallbackPath = path.join(userData, FALLBACK_MARKER);
+  try {
+    deps.fs.writeFileSync(fallbackPath, JSON.stringify({ appVersion: app.getVersion() }));
+    deps.log('wrote no-sandbox fallback marker for', app.getVersion());
+  } catch (e) {
+    deps.log('failed to write fallback marker:', e && e.message);
+  }
+  safeUnlink(deps.fs, crashPath);
+  app.relaunch();
+  app.exit(0);
+}
+
+function quit(app, deps, crashPath) {
+  safeUnlink(deps.fs, crashPath);
+  app.exit(0);
+}
+
+function showConfirmedDialog(dialog, confirmed) {
+  const dirs = confirmed.map((r) => r.dir).join('\n');
+  return dialog.showMessageBoxSync({
+    type: 'warning',
+    title: 'Sokuji — Sandbox Startup Problem',
+    message:
+      "Another program corrupted Windows permissions, preventing Sokuji's security sandbox from starting.",
+    detail:
+      'This is a known problem caused by leftover sandbox permissions from tools such as ' +
+      'OpenAI Codex CLI or Google Antigravity. Sokuji can repair it without administrator ' +
+      'rights — only the orphaned permission entries are removed; nothing else is touched.\n\n' +
+      `Affected locations:\n${dirs}\n\n` +
+      `More details: ${ISSUE_URL}`,
+    buttons: ['Repair permissions (recommended)', 'Continue without sandbox', 'Quit'],
+    defaultId: 0,
+    cancelId: 2,
+    noLink: true,
+  });
+}
+
+function showUnconfirmedDialog(dialog) {
+  return dialog.showMessageBoxSync({
+    type: 'warning',
+    title: 'Sokuji — Sandbox Startup Problem',
+    message: "Sokuji's security sandbox process repeatedly failed to start.",
+    detail:
+      'The cause could not be confirmed automatically. It is often corrupted Windows ' +
+      'permissions or antivirus injection. You can continue with the sandbox disabled ' +
+      '(reduced isolation) or quit and investigate.\n\n' +
+      `More details: ${ISSUE_URL}`,
+    buttons: ['Continue without sandbox', 'Quit'],
+    defaultId: 0,
+    cancelId: 1,
+    noLink: true,
+  });
+}
+
+function showRepairFailedDialog(dialog, repairResult) {
+  const remaining = repairResult.remaining.map((r) => r.dir).join('\n');
+  return dialog.showMessageBoxSync({
+    type: 'error',
+    title: 'Sokuji — Repair Incomplete',
+    message: 'The permission repair did not fully succeed.',
+    detail:
+      'Some orphaned entries could not be removed (they may require different ownership).\n' +
+      (remaining ? `Still affected:\n${remaining}\n\n` : '\n') +
+      `A backup of the original permissions was saved to:\n${repairResult.backupPath}\n\n` +
+      `More details: ${ISSUE_URL}`,
+    buttons: ['Continue without sandbox', 'Quit'],
+    defaultId: 0,
+    cancelId: 1,
+    noLink: true,
+  });
+}
+
+/**
+ * Wiring point #2 — run inside whenReady BEFORE createWindow. The main window is
+ * transparent, so a dead renderer shows as an empty pane; the dialog must be
+ * shown from the (unsandboxed) browser process before any window exists.
+ *
+ * @returns {boolean} true => proceed to createWindow; false => we have already
+ *   relaunched or exited and the caller must NOT create a window.
+ */
+function handleRecoveryMode(app, dialog, options = {}) {
+  const deps = mergeDeps(options.deps);
+  if (deps.platform !== 'win32') return true;
+  const userData = options.userDataDir || app.getPath('userData');
+  const crashPath = path.join(userData, CRASH_MARKER);
+
+  const crashMarker = readJsonFile(deps.fs, crashPath);
+  if (!crashMarker) return true; // normal startup
+
+  deps.log('crash marker present; entering recovery mode');
+  const scanResults = getScanDirectories(app, deps.env).map((d) => scanDirectory(d, deps));
+  const confirmed = scanResults.filter((r) => r.sids.length > 0);
+
+  if (confirmed.length > 0) {
+    const choice = showConfirmedDialog(dialog, confirmed);
+    if (choice === 0) {
+      const repairResult = performRepair(confirmed, userData, deps);
+      if (repairResult.success) {
+        deps.log('repair verified clean; relaunching with sandbox');
+        safeUnlink(deps.fs, crashPath);
+        app.relaunch();
+        app.exit(0);
+        return false;
+      }
+      const followUp = showRepairFailedDialog(dialog, repairResult);
+      if (followUp === 0) {
+        writeFallbackAndRelaunch(app, deps, userData, crashPath);
+      } else {
+        quit(app, deps, crashPath);
+      }
+      return false;
+    }
+    if (choice === 1) {
+      writeFallbackAndRelaunch(app, deps, userData, crashPath);
+    } else {
+      quit(app, deps, crashPath);
+    }
+    return false;
+  }
+
+  // Unconfirmed: crash signature fired but the ACL scan is clean. Never offer
+  // to modify ACLs without a confirmed diagnosis.
+  const choice = showUnconfirmedDialog(dialog);
+  if (choice === 0) {
+    writeFallbackAndRelaunch(app, deps, userData, crashPath);
+  } else {
+    quit(app, deps, crashPath);
+  }
+  return false;
+}
+
 module.exports = {
   ORPHAN_SID_RE,
   ISSUE_URL,
   UPSTREAM_URL,
+  CRASH_MARKER,
+  FALLBACK_MARKER,
   parseIcaclsAces,
   findExplicitOrphanSids,
   isGpuSandboxCrash,
@@ -227,4 +516,8 @@ module.exports = {
   scanDirectory,
   repairDirectory,
   buildBackupLog,
+  getScanDirectories,
+  applyNoSandboxFlag,
+  registerCrashDetection,
+  handleRecoveryMode,
 };

--- a/electron/sandbox-recovery.js
+++ b/electron/sandbox-recovery.js
@@ -144,11 +144,87 @@ function evaluateNoSandbox(marker, currentVersion) {
   return { noSandbox: false, clearMarker: true };
 }
 
+const ISSUE_URL = 'https://github.com/kizuna-ai-lab/sokuji/issues/352';
+const UPSTREAM_URL = 'https://github.com/electron/electron/issues/51761';
+
+/**
+ * Run `icacls <dir>` and return the explicit orphan SIDs it defines.
+ * icacls output is decoded as latin1 (byte-preserving) so an OEM code page and
+ * localized account names never break the ASCII SID/flag extraction.
+ *
+ * @param {string} dir
+ * @param {{execFileSync: Function}} deps
+ * @returns {{dir: string, sids: string[], rawOutput: string, error: string|null}}
+ */
+function scanDirectory(dir, deps) {
+  try {
+    const out = deps.execFileSync('icacls', [dir], { windowsHide: true });
+    const text = Buffer.isBuffer(out) ? out.toString('latin1') : String(out);
+    return { dir, sids: findExplicitOrphanSids(text), rawOutput: text, error: null };
+  } catch (err) {
+    return { dir, sids: [], rawOutput: '', error: (err && err.message) || String(err) };
+  }
+}
+
+/**
+ * Remove each given orphan SID's explicit ACE from a directory via
+ * `icacls <dir> /remove "*<SID>"`. The "*" prefix selects by raw SID; plain
+ * /remove strips both grant and deny ACEs. Never uses /reset. Continues past a
+ * failed SID and records it.
+ *
+ * @param {string} dir
+ * @param {string[]} sids
+ * @param {{execFileSync: Function}} deps
+ * @returns {{dir: string, removed: string[], errors: Array<{sid: string, error: string}>}}
+ */
+function repairDirectory(dir, sids, deps) {
+  const removed = [];
+  const errors = [];
+  for (const sid of sids) {
+    try {
+      deps.execFileSync('icacls', [dir, '/remove', `*${sid}`], { windowsHide: true });
+      removed.push(sid);
+    } catch (err) {
+      errors.push({ sid, error: (err && err.message) || String(err) });
+    }
+  }
+  return { dir, removed, errors };
+}
+
+/**
+ * Build the human-readable text backup written before any ACL change, so a
+ * removed ACE can be restored by hand with `icacls /grant` if ever needed.
+ *
+ * @param {Array<{dir: string, sids: string[], rawOutput: string}>} scanResults
+ * @param {string} isoStamp
+ * @returns {string}
+ */
+function buildBackupLog(scanResults, isoStamp) {
+  let log = `Sokuji sandbox recovery backup — ${isoStamp}\n`;
+  log += `Issue:    ${ISSUE_URL}\n`;
+  log += `Upstream: ${UPSTREAM_URL}\n`;
+  log += `\nThe explicit orphan AppContainer ACEs listed below were removed with\n`;
+  log += `"icacls <dir> /remove *<SID>". To restore one manually, grant it back\n`;
+  log += `with "icacls <dir> /grant *<SID>:(<perm>)".\n\n`;
+  for (const r of scanResults) {
+    log += `=== Directory: ${r.dir} ===\n`;
+    log += `Removed explicit orphan SIDs:\n`;
+    for (const sid of r.sids) log += `  - ${sid}\n`;
+    log += `\nFull icacls output before removal:\n${r.rawOutput}\n\n`;
+  }
+  return log;
+}
+
 module.exports = {
   ORPHAN_SID_RE,
+  ISSUE_URL,
+  UPSTREAM_URL,
   parseIcaclsAces,
   findExplicitOrphanSids,
   isGpuSandboxCrash,
   evaluateCrashRelaunch,
   evaluateNoSandbox,
+  scanDirectory,
+  repairDirectory,
+  buildBackupLog,
 };

--- a/electron/sandbox-recovery.js
+++ b/electron/sandbox-recovery.js
@@ -1,0 +1,82 @@
+/**
+ * Windows sandbox crash self-healing (issue #352).
+ *
+ * On some Windows machines, other software (e.g. OpenAI Codex CLI's elevated
+ * sandbox, Google Antigravity's Gemini sandbox, or MSIX installers that leave
+ * ACEs behind on uninstall) writes an orphaned AppContainer SID ACE onto
+ * %LOCALAPPDATA% or %USERPROFILE%. That ACE is inherited by Sokuji's install
+ * and data directories. Chromium's sandboxed child processes (GPU, renderer)
+ * launch under a restricted token that the corrupted DACL then locks out of
+ * the install directory, so the child dies at CHECK(InitializeICU()) while
+ * memory-mapping icudtl.dat. After three GPU crashes Chromium fatally kills the
+ * whole app, which the user sees as a silent startup crash.
+ *
+ * The orphan ACE can be removed without administrator rights (the user owns
+ * their own profile directories, which implies WRITE_DAC). Removing just the
+ * explicit orphan ACE heals the whole inheritance chain.
+ *
+ * Everything here is gated on win32 at the call sites in main.js. This module
+ * intentionally does NOT require('electron') at load time so it stays unit
+ * testable under plain Node/vitest; electron `app`/`dialog` are passed in.
+ *
+ * Upstream: https://github.com/electron/electron/issues/51761
+ * Issue:    https://github.com/kizuna-ai-lab/sokuji/issues/352
+ */
+
+// Orphan AppContainer package SID: "S-1-15-2" followed by 6+ sub-authority
+// groups. This deliberately excludes the legit well-known capability SIDs
+// S-1-15-2-1 (ALL APPLICATION PACKAGES) and S-1-15-2-2 (ALL RESTRICTED
+// APPLICATION PACKAGES), which have only a single sub-authority.
+const ORPHAN_SID_RE = /S-1-15-2(?:-\d+){6,}/;
+
+/**
+ * Parse one directory's `icacls <dir>` output into orphan-SID ACE records.
+ *
+ * Processes line by line and extracts only ASCII SID + flag tokens, so the OEM
+ * code page and any localized account names in the surrounding text are
+ * irrelevant. An ACE is treated as inherited only when its trailing flag list
+ * contains the standalone "(I)" group (distinct from "(OI)", "(CI)", "(IO)").
+ *
+ * @param {string} text - icacls output (already decoded to a JS string).
+ * @returns {Array<{sid: string, inherited: boolean}>} one entry per line that
+ *   carries an orphan AppContainer SID.
+ */
+function parseIcaclsAces(text) {
+  const results = [];
+  for (const line of String(text).split(/\r?\n/)) {
+    const sidMatch = line.match(ORPHAN_SID_RE);
+    if (!sidMatch) continue;
+
+    // Grab the trailing run of consecutive "(...)" flag groups. The account
+    // name may itself contain "(S-1-15-2-...)", but that is separated from the
+    // flags by the ":" delimiter, so the trailing run never includes it.
+    const flagsMatch = line.match(/((?:\([^)]*\))+)\s*$/);
+    const flags = flagsMatch ? flagsMatch[1] : '';
+    const groups = (flags.match(/\(([^)]*)\)/g) || []).map((g) => g.slice(1, -1));
+    const inherited = groups.includes('I');
+
+    results.push({ sid: sidMatch[0], inherited });
+  }
+  return results;
+}
+
+/**
+ * Unique list of EXPLICIT (non-inherited) orphan SIDs defined at a directory.
+ * These are the only ACEs the repair step ever removes.
+ *
+ * @param {string} text - icacls output.
+ * @returns {string[]}
+ */
+function findExplicitOrphanSids(text) {
+  const seen = new Set();
+  for (const ace of parseIcaclsAces(text)) {
+    if (!ace.inherited) seen.add(ace.sid);
+  }
+  return [...seen];
+}
+
+module.exports = {
+  ORPHAN_SID_RE,
+  parseIcaclsAces,
+  findExplicitOrphanSids,
+};

--- a/electron/sandbox-recovery.js
+++ b/electron/sandbox-recovery.js
@@ -75,8 +75,80 @@ function findExplicitOrphanSids(text) {
   return [...seen];
 }
 
+// STATUS_BREAKPOINT (0x80000003) is how a Chromium child process exits when a
+// startup CHECK fails — including CHECK(InitializeICU()), the first file op the
+// restricted-token child performs. Electron surfaces it as a signed int32
+// (-2147483645); some builds/paths report it unsigned (2147483651). This is a
+// generic "child died at a startup CHECK" signature, NOT proof of the ACL bug,
+// so it only triggers a diagnostic ACL scan — never a blind repair.
+const STATUS_BREAKPOINT_SIGNED = -2147483645;
+const STATUS_BREAKPOINT_UNSIGNED = 2147483651;
+
+/**
+ * Whether a `child-process-gone` event looks like the sandbox startup crash.
+ * @param {{type?: string, reason?: string, exitCode?: number} | null} details
+ * @returns {boolean}
+ */
+function isGpuSandboxCrash(details) {
+  if (!details || details.type !== 'GPU') return false;
+  if (details.reason !== 'crashed' && details.reason !== 'abnormal-exit') return false;
+  return (
+    details.exitCode === STATUS_BREAKPOINT_SIGNED ||
+    details.exitCode === STATUS_BREAKPOINT_UNSIGNED
+  );
+}
+
+const CRASH_WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const MAX_AUTO_RELAUNCH = 2;
+
+/**
+ * Decide whether to auto-relaunch after a sandbox crash, and produce the next
+ * crash-marker contents. Caps automatic relaunches to avoid a crash loop; once
+ * the cap is hit the crash is still recorded so the next manual launch enters
+ * recovery mode.
+ *
+ * @param {{timestamps?: number[]} | null} existingMarker
+ * @param {number} now - current epoch ms.
+ * @param {string} appVersion
+ * @param {{windowMs?: number, maxAutoRelaunch?: number}} [opts]
+ * @returns {{marker: {timestamps: number[], appVersion: string}, shouldRelaunch: boolean}}
+ */
+function evaluateCrashRelaunch(existingMarker, now, appVersion, opts = {}) {
+  const windowMs = opts.windowMs ?? CRASH_WINDOW_MS;
+  const maxAutoRelaunch = opts.maxAutoRelaunch ?? MAX_AUTO_RELAUNCH;
+  const priorRaw = Array.isArray(existingMarker && existingMarker.timestamps)
+    ? existingMarker.timestamps
+    : [];
+  const prior = priorRaw.filter((t) => typeof t === 'number' && now - t < windowMs);
+  const marker = { timestamps: [...prior, now], appVersion };
+  const shouldRelaunch = prior.length < maxAutoRelaunch;
+  return { marker, shouldRelaunch };
+}
+
+/**
+ * Decide how to treat the persistent no-sandbox fallback marker at startup.
+ * Same version => keep running without the sandbox. Different version =>
+ * discard the marker and try the sandbox again (the ACL may have been fixed).
+ *
+ * @param {{appVersion?: string} | null} marker
+ * @param {string} currentVersion
+ * @returns {{noSandbox: boolean, clearMarker: boolean}}
+ */
+function evaluateNoSandbox(marker, currentVersion) {
+  if (!marker || typeof marker.appVersion !== 'string') {
+    return { noSandbox: false, clearMarker: false };
+  }
+  if (marker.appVersion === currentVersion) {
+    return { noSandbox: true, clearMarker: false };
+  }
+  return { noSandbox: false, clearMarker: true };
+}
+
 module.exports = {
   ORPHAN_SID_RE,
   parseIcaclsAces,
   findExplicitOrphanSids,
+  isGpuSandboxCrash,
+  evaluateCrashRelaunch,
+  evaluateNoSandbox,
 };

--- a/electron/sandbox-recovery.js
+++ b/electron/sandbox-recovery.js
@@ -235,6 +235,11 @@ function defaultDeps() {
     now: () => Date.now(),
     env: process.env,
     log: (...a) => console.log('[Sokuji] [SandboxRecovery]', ...a),
+    // Runs before every app.exit()/relaunch this module triggers. app.exit()
+    // skips before-quit/will-quit, so main.js's cleanupAndExit (which stops the
+    // native sidecar and releases its Windows file locks) would otherwise never
+    // run, orphaning the sidecar process. main.js injects the real teardown.
+    beforeExit: () => {},
   };
 }
 
@@ -330,6 +335,7 @@ function registerCrashDetection(app, options = {}) {
     }
     if (shouldRelaunch) {
       deps.log('relaunching into recovery mode');
+      deps.beforeExit();
       app.relaunch();
       app.exit(0);
     } else {
@@ -349,8 +355,10 @@ function stampFromNow(now) {
  */
 function performRepair(confirmed, userData, deps) {
   const backupPath = path.join(userData, `sandbox-recovery-backup-${stampFromNow(deps.now())}.log`);
+  let backupWritten = false;
   try {
     deps.fs.writeFileSync(backupPath, buildBackupLog(confirmed, stampFromNow(deps.now())));
+    backupWritten = true;
     deps.log('wrote ACL backup to', backupPath);
   } catch (e) {
     deps.log('failed to write backup log:', e && e.message);
@@ -367,7 +375,7 @@ function performRepair(confirmed, userData, deps) {
 
   const rescan = confirmed.map((r) => scanDirectory(r.dir, deps));
   const remaining = rescan.filter((r) => r.sids.length > 0 || r.error);
-  return { success: remaining.length === 0 && !hadErrors, remaining, backupPath };
+  return { success: remaining.length === 0 && !hadErrors, remaining, backupPath, backupWritten };
 }
 
 function writeFallbackAndRelaunch(app, deps, userData, crashPath) {
@@ -379,12 +387,14 @@ function writeFallbackAndRelaunch(app, deps, userData, crashPath) {
     deps.log('failed to write fallback marker:', e && e.message);
   }
   safeUnlink(deps.fs, crashPath);
+  deps.beforeExit();
   app.relaunch();
   app.exit(0);
 }
 
 function quit(app, deps, crashPath) {
   safeUnlink(deps.fs, crashPath);
+  deps.beforeExit();
   app.exit(0);
 }
 
@@ -427,6 +437,9 @@ function showUnconfirmedDialog(dialog) {
 
 function showRepairFailedDialog(dialog, repairResult) {
   const remaining = repairResult.remaining.map((r) => r.dir).join('\n');
+  const backupLine = repairResult.backupWritten
+    ? `A backup of the original permissions was saved to:\n${repairResult.backupPath}\n\n`
+    : '';
   return dialog.showMessageBoxSync({
     type: 'error',
     title: 'Sokuji — Repair Incomplete',
@@ -434,7 +447,7 @@ function showRepairFailedDialog(dialog, repairResult) {
     detail:
       'Some orphaned entries could not be removed (they may require different ownership).\n' +
       (remaining ? `Still affected:\n${remaining}\n\n` : '\n') +
-      `A backup of the original permissions was saved to:\n${repairResult.backupPath}\n\n` +
+      backupLine +
       `More details: ${ISSUE_URL}`,
     buttons: ['Continue without sandbox', 'Quit'],
     defaultId: 0,
@@ -471,6 +484,7 @@ function handleRecoveryMode(app, dialog, options = {}) {
       if (repairResult.success) {
         deps.log('repair verified clean; relaunching with sandbox');
         safeUnlink(deps.fs, crashPath);
+        deps.beforeExit();
         app.relaunch();
         app.exit(0);
         return false;

--- a/electron/sandbox-recovery.test.js
+++ b/electron/sandbox-recovery.test.js
@@ -8,6 +8,12 @@ import {
   scanDirectory,
   repairDirectory,
   buildBackupLog,
+  getScanDirectories,
+  applyNoSandboxFlag,
+  registerCrashDetection,
+  handleRecoveryMode,
+  CRASH_MARKER,
+  FALLBACK_MARKER,
 } from './sandbox-recovery.js';
 
 // A realistic orphan AppContainer package SID: "S-1-15-2" followed by 7
@@ -307,5 +313,307 @@ describe('buildBackupLog', () => {
     expect(log).toContain(ORPHAN_A);
     expect(log).toContain('issues/352');
     expect(log).toContain(EXPLICIT_ORPHAN);
+  });
+});
+
+// ---- Orchestration test helpers (mock electron app/dialog + injected deps) --
+
+const CONFIRMED_DIR = 'C:/Install';
+
+function makeApp(over = {}) {
+  const handlers = {};
+  return {
+    _handlers: handlers,
+    getVersion: () => over.version || '0.34.1',
+    getPath: (k) =>
+      k === 'exe'
+        ? over.exe || 'C:/Install/sokuji.exe'
+        : k === 'userData'
+          ? over.userData || 'C:/UD'
+          : '',
+    commandLine: { appendSwitch: vi.fn() },
+    on: vi.fn((evt, cb) => {
+      handlers[evt] = cb;
+    }),
+    relaunch: vi.fn(),
+    exit: vi.fn(),
+  };
+}
+
+function makeDeps(over = {}) {
+  return {
+    platform: 'win32',
+    fs: over.fs || {
+      readFileSync: vi.fn(() => {
+        throw new Error('ENOENT');
+      }),
+      writeFileSync: vi.fn(),
+      unlinkSync: vi.fn(),
+    },
+    execFileSync: over.execFileSync || vi.fn(),
+    now: over.now || (() => 0),
+    env: over.env || { LOCALAPPDATA: 'C:/Users/j/AppData/Local', USERPROFILE: 'C:/Users/j' },
+    log: () => {},
+  };
+}
+
+describe('getScanDirectories', () => {
+  it('returns the exe dir, LOCALAPPDATA and USERPROFILE, deduped', () => {
+    const app = makeApp();
+    const dirs = getScanDirectories(app, {
+      LOCALAPPDATA: 'C:/Users/j/AppData/Local',
+      USERPROFILE: 'C:/Users/j',
+    });
+    expect(dirs).toEqual(['C:/Install', 'C:/Users/j/AppData/Local', 'C:/Users/j']);
+  });
+
+  it('skips missing env vars and dedupes overlaps', () => {
+    const app = makeApp({ exe: 'C:/Users/j/sokuji.exe' });
+    const dirs = getScanDirectories(app, { USERPROFILE: 'C:/Users/j' });
+    expect(dirs).toEqual(['C:/Users/j']);
+  });
+});
+
+describe('applyNoSandboxFlag', () => {
+  it('is a no-op on non-win32', () => {
+    const app = makeApp();
+    const deps = makeDeps();
+    deps.platform = 'linux';
+    expect(applyNoSandboxFlag(app, { deps, userDataDir: 'C:/UD' })).toBe(false);
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalled();
+  });
+
+  it('appends --no-sandbox when the marker version matches', () => {
+    const app = makeApp();
+    const deps = makeDeps({
+      fs: {
+        readFileSync: vi.fn(() => JSON.stringify({ appVersion: '0.34.1' })),
+        writeFileSync: vi.fn(),
+        unlinkSync: vi.fn(),
+      },
+    });
+    expect(applyNoSandboxFlag(app, { deps, userDataDir: 'C:/UD' })).toBe(true);
+    expect(app.commandLine.appendSwitch).toHaveBeenCalledWith('no-sandbox');
+    expect(deps.fs.unlinkSync).not.toHaveBeenCalled();
+  });
+
+  it('clears a stale marker and keeps the sandbox when the version changed', () => {
+    const app = makeApp({ version: '0.34.1' });
+    const deps = makeDeps({
+      fs: {
+        readFileSync: vi.fn(() => JSON.stringify({ appVersion: '0.34.0' })),
+        writeFileSync: vi.fn(),
+        unlinkSync: vi.fn(),
+      },
+    });
+    expect(applyNoSandboxFlag(app, { deps, userDataDir: 'C:/UD' })).toBe(false);
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalled();
+    expect(deps.fs.unlinkSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when there is no marker', () => {
+    const app = makeApp();
+    const deps = makeDeps();
+    expect(applyNoSandboxFlag(app, { deps, userDataDir: 'C:/UD' })).toBe(false);
+    expect(app.commandLine.appendSwitch).not.toHaveBeenCalled();
+    expect(deps.fs.unlinkSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('registerCrashDetection', () => {
+  const gpuCrash = { type: 'GPU', reason: 'crashed', exitCode: -2147483645 };
+
+  it('does not register the listener on non-win32', () => {
+    const app = makeApp();
+    const deps = makeDeps();
+    deps.platform = 'darwin';
+    registerCrashDetection(app, { deps, userDataDir: 'C:/UD' });
+    expect(app.on).not.toHaveBeenCalled();
+  });
+
+  it('writes a crash marker and relaunches on the first GPU sandbox crash', () => {
+    const app = makeApp();
+    const deps = makeDeps();
+    registerCrashDetection(app, { deps, userDataDir: 'C:/UD' });
+    expect(app.on).toHaveBeenCalledWith('child-process-gone', expect.any(Function));
+    app._handlers['child-process-gone']({}, gpuCrash);
+    expect(deps.fs.writeFileSync).toHaveBeenCalledTimes(1);
+    const json = deps.fs.writeFileSync.mock.calls[0][1];
+    expect(JSON.parse(json).timestamps).toHaveLength(1);
+    expect(app.relaunch).toHaveBeenCalled();
+    expect(app.exit).toHaveBeenCalledWith(0);
+  });
+
+  it('ignores unrelated child-process-gone events', () => {
+    const app = makeApp();
+    const deps = makeDeps();
+    registerCrashDetection(app, { deps, userDataDir: 'C:/UD' });
+    app._handlers['child-process-gone'](
+      {},
+      { type: 'Utility', reason: 'crashed', exitCode: -2147483645 }
+    );
+    expect(deps.fs.writeFileSync).not.toHaveBeenCalled();
+    expect(app.relaunch).not.toHaveBeenCalled();
+  });
+
+  it('records the crash but does NOT relaunch once the hourly cap is hit', () => {
+    const app = makeApp();
+    const deps = makeDeps({
+      now: () => 1_000_000,
+      fs: {
+        readFileSync: vi.fn(() =>
+          JSON.stringify({ timestamps: [999_000, 999_500], appVersion: '0.34.1' })
+        ),
+        writeFileSync: vi.fn(),
+        unlinkSync: vi.fn(),
+      },
+    });
+    registerCrashDetection(app, { deps, userDataDir: 'C:/UD' });
+    app._handlers['child-process-gone']({}, gpuCrash);
+    expect(deps.fs.writeFileSync).toHaveBeenCalledTimes(1);
+    expect(app.relaunch).not.toHaveBeenCalled();
+    expect(app.exit).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleRecoveryMode', () => {
+  function crashMarkerFs(over = {}) {
+    return {
+      readFileSync: vi.fn(() => JSON.stringify({ timestamps: [0], appVersion: '0.34.1' })),
+      writeFileSync: vi.fn(),
+      unlinkSync: vi.fn(),
+      ...over,
+    };
+  }
+
+  it('proceeds normally on non-win32', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn() };
+    const deps = makeDeps();
+    deps.platform = 'linux';
+    expect(handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' })).toBe(true);
+    expect(dialog.showMessageBoxSync).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when there is no crash marker', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn() };
+    const deps = makeDeps(); // default fs.readFileSync throws
+    expect(handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' })).toBe(true);
+    expect(dialog.showMessageBoxSync).not.toHaveBeenCalled();
+  });
+
+  it('confirmed + Repair success: removes ACE, deletes marker, relaunches', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn(() => 0) }; // Repair
+    const repaired = new Set();
+    const execFileSync = vi.fn((cmd, args) => {
+      const dir = args[0];
+      if (args.includes('/remove')) {
+        repaired.add(dir);
+        return;
+      }
+      if (dir === CONFIRMED_DIR && !repaired.has(dir)) return EXPLICIT_ORPHAN;
+      return CLEAN;
+    });
+    const fs = crashMarkerFs();
+    const deps = makeDeps({ execFileSync, fs });
+    const proceed = handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    expect(dialog.showMessageBoxSync.mock.calls[0][0].buttons[0]).toMatch(/Repair/);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'icacls',
+      [CONFIRMED_DIR, '/remove', `*${ORPHAN_A}`],
+      expect.objectContaining({ windowsHide: true })
+    );
+    expect(fs.writeFileSync).toHaveBeenCalled();
+    expect(fs.unlinkSync).toHaveBeenCalled();
+    expect(app.relaunch).toHaveBeenCalled();
+    expect(proceed).toBe(false);
+  });
+
+  it('confirmed + Continue without sandbox: writes fallback marker, relaunches', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn(() => 1) }; // Continue
+    const execFileSync = vi.fn((cmd, args) =>
+      args[0] === CONFIRMED_DIR ? EXPLICIT_ORPHAN : CLEAN
+    );
+    const fs = crashMarkerFs();
+    const deps = makeDeps({ execFileSync, fs });
+    const proceed = handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    const fallbackWrite = fs.writeFileSync.mock.calls.find((c) =>
+      String(c[0]).includes(FALLBACK_MARKER)
+    );
+    expect(fallbackWrite).toBeTruthy();
+    expect(JSON.parse(fallbackWrite[1])).toEqual({ appVersion: '0.34.1' });
+    expect(app.relaunch).toHaveBeenCalled();
+    expect(proceed).toBe(false);
+  });
+
+  it('confirmed + Quit: deletes marker, exits, no fallback written', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn(() => 2) }; // Quit
+    const execFileSync = vi.fn((cmd, args) =>
+      args[0] === CONFIRMED_DIR ? EXPLICIT_ORPHAN : CLEAN
+    );
+    const fs = crashMarkerFs();
+    const deps = makeDeps({ execFileSync, fs });
+    const proceed = handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    const fallbackWrite = fs.writeFileSync.mock.calls.find((c) =>
+      String(c[0]).includes(FALLBACK_MARKER)
+    );
+    expect(fallbackWrite).toBeFalsy();
+    expect(app.exit).toHaveBeenCalledWith(0);
+    expect(app.relaunch).not.toHaveBeenCalled();
+    expect(proceed).toBe(false);
+  });
+
+  it('confirmed + Repair fails: shows fallback dialog, then no-sandbox continue', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn() };
+    dialog.showMessageBoxSync.mockReturnValueOnce(0); // Repair
+    dialog.showMessageBoxSync.mockReturnValueOnce(0); // Continue without sandbox
+    const execFileSync = vi.fn((cmd, args) => {
+      if (args.includes('/remove')) throw new Error('Access is denied.');
+      return args[0] === CONFIRMED_DIR ? EXPLICIT_ORPHAN : CLEAN;
+    });
+    const fs = crashMarkerFs();
+    const deps = makeDeps({ execFileSync, fs });
+    const proceed = handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    expect(dialog.showMessageBoxSync).toHaveBeenCalledTimes(2);
+    const fallbackWrite = fs.writeFileSync.mock.calls.find((c) =>
+      String(c[0]).includes(FALLBACK_MARKER)
+    );
+    expect(fallbackWrite).toBeTruthy();
+    expect(app.relaunch).toHaveBeenCalled();
+    expect(proceed).toBe(false);
+  });
+
+  it('unconfirmed (clean scan): offers no Repair button', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn(() => 1) }; // Quit (index 1 of 2)
+    const execFileSync = vi.fn(() => CLEAN);
+    const fs = crashMarkerFs();
+    const deps = makeDeps({ execFileSync, fs });
+    const proceed = handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    const buttons = dialog.showMessageBoxSync.mock.calls[0][0].buttons;
+    expect(buttons.some((b) => /Repair/.test(b))).toBe(false);
+    expect(buttons).toHaveLength(2);
+    expect(app.exit).toHaveBeenCalledWith(0);
+    expect(proceed).toBe(false);
+  });
+
+  it('unconfirmed + Continue without sandbox: writes fallback, relaunches', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn(() => 0) }; // Continue (index 0 of 2)
+    const execFileSync = vi.fn(() => CLEAN);
+    const fs = crashMarkerFs();
+    const deps = makeDeps({ execFileSync, fs });
+    const proceed = handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    const fallbackWrite = fs.writeFileSync.mock.calls.find((c) =>
+      String(c[0]).includes(FALLBACK_MARKER)
+    );
+    expect(fallbackWrite).toBeTruthy();
+    expect(app.relaunch).toHaveBeenCalled();
+    expect(proceed).toBe(false);
   });
 });

--- a/electron/sandbox-recovery.test.js
+++ b/electron/sandbox-recovery.test.js
@@ -5,6 +5,9 @@ import {
   isGpuSandboxCrash,
   evaluateCrashRelaunch,
   evaluateNoSandbox,
+  scanDirectory,
+  repairDirectory,
+  buildBackupLog,
 } from './sandbox-recovery.js';
 
 // A realistic orphan AppContainer package SID: "S-1-15-2" followed by 7
@@ -216,5 +219,93 @@ describe('evaluateNoSandbox', () => {
       noSandbox: false,
       clearMarker: false,
     });
+  });
+});
+
+describe('scanDirectory', () => {
+  it('runs icacls on the directory and parses explicit orphan SIDs', () => {
+    const execFileSync = vi.fn(() => EXPLICIT_ORPHAN);
+    const result = scanDirectory('C:/SokujiSandboxTest', { execFileSync });
+    expect(execFileSync).toHaveBeenCalledWith(
+      'icacls',
+      ['C:/SokujiSandboxTest'],
+      expect.objectContaining({ windowsHide: true })
+    );
+    expect(result).toEqual({
+      dir: 'C:/SokujiSandboxTest',
+      sids: [ORPHAN_A],
+      rawOutput: EXPLICIT_ORPHAN,
+      error: null,
+    });
+  });
+
+  it('decodes a Buffer as latin1 (byte-safe against the OEM code page)', () => {
+    // Non-ASCII bytes around an ASCII SID must not corrupt SID extraction.
+    const buf = Buffer.from(EXPLICIT_ORPHAN, 'latin1');
+    const execFileSync = vi.fn(() => buf);
+    const result = scanDirectory('C:/x', { execFileSync });
+    expect(result.sids).toEqual([ORPHAN_A]);
+    expect(result.error).toBeNull();
+  });
+
+  it('returns an error record when icacls throws', () => {
+    const execFileSync = vi.fn(() => {
+      throw new Error('The system cannot find the path specified.');
+    });
+    const result = scanDirectory('C:/missing', { execFileSync });
+    expect(result.sids).toEqual([]);
+    expect(result.rawOutput).toBe('');
+    expect(result.error).toMatch(/cannot find the path/);
+  });
+});
+
+describe('repairDirectory', () => {
+  it('removes each orphan SID via icacls /remove "*<SID>"', () => {
+    const execFileSync = vi.fn();
+    const result = repairDirectory('C:/SokujiSandboxTest', [ORPHAN_A, ORPHAN_B], {
+      execFileSync,
+    });
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      1,
+      'icacls',
+      ['C:/SokujiSandboxTest', '/remove', `*${ORPHAN_A}`],
+      expect.objectContaining({ windowsHide: true })
+    );
+    expect(execFileSync).toHaveBeenNthCalledWith(
+      2,
+      'icacls',
+      ['C:/SokujiSandboxTest', '/remove', `*${ORPHAN_B}`],
+      expect.objectContaining({ windowsHide: true })
+    );
+    expect(result).toEqual({
+      dir: 'C:/SokujiSandboxTest',
+      removed: [ORPHAN_A, ORPHAN_B],
+      errors: [],
+    });
+  });
+
+  it('records per-SID errors without aborting the rest', () => {
+    const execFileSync = vi.fn((cmd, args) => {
+      if (args[2] === `*${ORPHAN_A}`) throw new Error('Access is denied.');
+    });
+    const result = repairDirectory('C:/x', [ORPHAN_A, ORPHAN_B], { execFileSync });
+    expect(result.removed).toEqual([ORPHAN_B]);
+    expect(result.errors).toEqual([
+      { sid: ORPHAN_A, error: expect.stringMatching(/Access is denied/) },
+    ]);
+  });
+});
+
+describe('buildBackupLog', () => {
+  it('records the directories, SIDs, raw output and issue URL', () => {
+    const scanResults = [
+      { dir: 'C:/SokujiSandboxTest', sids: [ORPHAN_A], rawOutput: EXPLICIT_ORPHAN, error: null },
+    ];
+    const log = buildBackupLog(scanResults, '2026-07-24T04-00-00-000Z');
+    expect(log).toContain('2026-07-24T04-00-00-000Z');
+    expect(log).toContain('C:/SokujiSandboxTest');
+    expect(log).toContain(ORPHAN_A);
+    expect(log).toContain('issues/352');
+    expect(log).toContain(EXPLICIT_ORPHAN);
   });
 });

--- a/electron/sandbox-recovery.test.js
+++ b/electron/sandbox-recovery.test.js
@@ -617,3 +617,104 @@ describe('handleRecoveryMode', () => {
     expect(proceed).toBe(false);
   });
 });
+
+describe('beforeExit cleanup hook (sidecar teardown before exit)', () => {
+  const gpuCrash = { type: 'GPU', reason: 'crashed', exitCode: -2147483645 };
+
+  it('runs beforeExit before app.exit on the passive crash relaunch', () => {
+    const app = makeApp();
+    const order = [];
+    app.relaunch = vi.fn(() => order.push('relaunch'));
+    app.exit = vi.fn(() => order.push('exit'));
+    const beforeExit = vi.fn(() => order.push('cleanup'));
+    const deps = makeDeps();
+    deps.beforeExit = beforeExit;
+    registerCrashDetection(app, { deps, userDataDir: 'C:/UD' });
+    app._handlers['child-process-gone']({}, gpuCrash);
+    expect(beforeExit).toHaveBeenCalledTimes(1);
+    expect(order).toEqual(['cleanup', 'relaunch', 'exit']);
+  });
+
+  it('runs beforeExit before app.exit on the recovery Quit path', () => {
+    const app = makeApp();
+    const order = [];
+    app.exit = vi.fn(() => order.push('exit'));
+    const beforeExit = vi.fn(() => order.push('cleanup'));
+    const dialog = { showMessageBoxSync: vi.fn(() => 2) }; // Quit (confirmed)
+    const execFileSync = vi.fn((cmd, args) =>
+      args[0] === CONFIRMED_DIR ? EXPLICIT_ORPHAN : CLEAN
+    );
+    const fs = {
+      readFileSync: vi.fn(() => JSON.stringify({ timestamps: [0], appVersion: '0.34.1' })),
+      writeFileSync: vi.fn(),
+      unlinkSync: vi.fn(),
+    };
+    const deps = makeDeps({ execFileSync, fs });
+    deps.beforeExit = beforeExit;
+    handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    expect(order).toEqual(['cleanup', 'exit']);
+  });
+
+  it('runs beforeExit before relaunch on the continue-without-sandbox path', () => {
+    const app = makeApp();
+    const order = [];
+    app.relaunch = vi.fn(() => order.push('relaunch'));
+    app.exit = vi.fn(() => order.push('exit'));
+    const beforeExit = vi.fn(() => order.push('cleanup'));
+    const dialog = { showMessageBoxSync: vi.fn(() => 0) }; // Continue (unconfirmed)
+    const execFileSync = vi.fn(() => CLEAN);
+    const fs = {
+      readFileSync: vi.fn(() => JSON.stringify({ timestamps: [0], appVersion: '0.34.1' })),
+      writeFileSync: vi.fn(),
+      unlinkSync: vi.fn(),
+    };
+    const deps = makeDeps({ execFileSync, fs });
+    deps.beforeExit = beforeExit;
+    handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    expect(order).toEqual(['cleanup', 'relaunch', 'exit']);
+  });
+});
+
+describe('repair-failed dialog does not overclaim a backup', () => {
+  it('omits the "saved to" line when the backup write failed', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn() };
+    dialog.showMessageBoxSync.mockReturnValueOnce(0); // Repair
+    dialog.showMessageBoxSync.mockReturnValueOnce(1); // Quit at repair-failed dialog
+    const execFileSync = vi.fn((cmd, args) => {
+      if (args.includes('/remove')) throw new Error('Access is denied.');
+      return args[0] === CONFIRMED_DIR ? EXPLICIT_ORPHAN : CLEAN;
+    });
+    const fs = {
+      readFileSync: vi.fn(() => JSON.stringify({ timestamps: [0], appVersion: '0.34.1' })),
+      writeFileSync: vi.fn(() => {
+        throw new Error('disk full');
+      }), // backup write fails
+      unlinkSync: vi.fn(),
+    };
+    const deps = makeDeps({ execFileSync, fs });
+    handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    const failDetail = dialog.showMessageBoxSync.mock.calls[1][0].detail;
+    expect(failDetail).not.toMatch(/was saved to/);
+  });
+
+  it('still reports the backup path when the backup write succeeded', () => {
+    const app = makeApp();
+    const dialog = { showMessageBoxSync: vi.fn() };
+    dialog.showMessageBoxSync.mockReturnValueOnce(0); // Repair
+    dialog.showMessageBoxSync.mockReturnValueOnce(1); // Quit at repair-failed dialog
+    const execFileSync = vi.fn((cmd, args) => {
+      if (args.includes('/remove')) throw new Error('Access is denied.');
+      return args[0] === CONFIRMED_DIR ? EXPLICIT_ORPHAN : CLEAN;
+    });
+    const fs = {
+      readFileSync: vi.fn(() => JSON.stringify({ timestamps: [0], appVersion: '0.34.1' })),
+      writeFileSync: vi.fn(), // backup write succeeds
+      unlinkSync: vi.fn(),
+    };
+    const deps = makeDeps({ execFileSync, fs });
+    handleRecoveryMode(app, dialog, { deps, userDataDir: 'C:/UD' });
+    const failDetail = dialog.showMessageBoxSync.mock.calls[1][0].detail;
+    expect(failDetail).toMatch(/was saved to/);
+  });
+});

--- a/electron/sandbox-recovery.test.js
+++ b/electron/sandbox-recovery.test.js
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  parseIcaclsAces,
+  findExplicitOrphanSids,
+} from './sandbox-recovery.js';
+
+// A realistic orphan AppContainer package SID: "S-1-15-2" followed by 7
+// sub-authority groups. Matches /S-1-15-2(?:-\d+){6,}/.
+const ORPHAN_A =
+  'S-1-15-2-1111111111-2222222222-3333333333-4444444444-5555555555-6666666666-7777777777';
+const ORPHAN_B =
+  'S-1-15-2-3624051433-2125758914-1423191267-1740899205-1073925389-3782572162-737981194';
+
+// A clean, healthy directory ACL — no AppContainer package SIDs at all.
+const CLEAN = [
+  'C:\\SokujiSandboxTest NT AUTHORITY\\SYSTEM:(OI)(CI)(F)',
+  '                     BUILTIN\\Administrators:(OI)(CI)(F)',
+  '                     CREATOR OWNER:(OI)(CI)(IO)(F)',
+  '                     BUILTIN\\Users:(OI)(CI)(RX)',
+  '',
+  'Successfully processed 1 files; Failed processing 0 files.',
+].join('\r\n');
+
+// An EXPLICIT orphan ACE (no "(I)" inherited flag) plus normal inherited ACEs.
+const EXPLICIT_ORPHAN = [
+  `C:\\SokujiSandboxTest ${ORPHAN_A}:(OI)(CI)(F)`,
+  '                     NT AUTHORITY\\SYSTEM:(I)(OI)(CI)(F)',
+  '                     BUILTIN\\Administrators:(I)(OI)(CI)(F)',
+  '',
+  'Successfully processed 1 files; Failed processing 0 files.',
+].join('\r\n');
+
+// The SAME orphan SID but INHERITED (has the "(I)" flag) — must be ignored,
+// because we only remove explicit ACEs at the directory that defines them.
+const INHERITED_ORPHAN = [
+  `C:\\Users\\jiang\\AppData\\Local\\Sokuji ${ORPHAN_A}:(I)(OI)(CI)(F)`,
+  '                                         NT AUTHORITY\\SYSTEM:(I)(OI)(CI)(F)',
+  '',
+  'Successfully processed 1 files; Failed processing 0 files.',
+].join('\r\n');
+
+// Legit AppContainer well-known SIDs shown as RAW SIDs must NOT match:
+// S-1-15-2-1 (ALL APPLICATION PACKAGES) and S-1-15-2-2 (ALL RESTRICTED
+// APPLICATION PACKAGES) each have only ONE sub-authority after S-1-15-2.
+const LEGIT_WELLKNOWN = [
+  'C:\\SokujiSandboxTest S-1-15-2-1:(OI)(CI)(RX)',
+  '                     S-1-15-2-2:(OI)(CI)(RX)',
+  '                     Everyone:(RX)',
+  '',
+  'Successfully processed 1 files; Failed processing 0 files.',
+].join('\r\n');
+
+// A non-English (Chinese) localized "account unknown" label wrapping an
+// explicit orphan SID. The account name is localized; the SID is stable. We
+// must extract by SID, never by name.
+const NON_ENGLISH_LOCALE = [
+  `C:\\SokujiSandboxTest 账户未知(${ORPHAN_B}):(OI)(CI)(F)`,
+  '                     NT AUTHORITY\\SYSTEM:(I)(OI)(CI)(F)',
+  '',
+  'Successfully processed 1 files; Failed processing 0 files.',
+].join('\r\n');
+
+describe('parseIcaclsAces', () => {
+  it('returns no ACEs for a clean directory', () => {
+    expect(parseIcaclsAces(CLEAN)).toEqual([]);
+  });
+
+  it('flags an explicit orphan ACE as not inherited', () => {
+    const aces = parseIcaclsAces(EXPLICIT_ORPHAN);
+    expect(aces).toEqual([{ sid: ORPHAN_A, inherited: false }]);
+  });
+
+  it('flags an inherited orphan ACE as inherited', () => {
+    const aces = parseIcaclsAces(INHERITED_ORPHAN);
+    expect(aces).toEqual([{ sid: ORPHAN_A, inherited: true }]);
+  });
+
+  it('ignores legit well-known S-1-15-2-1 / S-1-15-2-2 raw SIDs', () => {
+    expect(parseIcaclsAces(LEGIT_WELLKNOWN)).toEqual([]);
+  });
+
+  it('extracts the SID even when wrapped in a localized account name', () => {
+    const aces = parseIcaclsAces(NON_ENGLISH_LOCALE);
+    expect(aces).toEqual([{ sid: ORPHAN_B, inherited: false }]);
+  });
+});
+
+describe('findExplicitOrphanSids', () => {
+  it('returns [] for a clean directory', () => {
+    expect(findExplicitOrphanSids(CLEAN)).toEqual([]);
+  });
+
+  it('returns the explicit orphan SID', () => {
+    expect(findExplicitOrphanSids(EXPLICIT_ORPHAN)).toEqual([ORPHAN_A]);
+  });
+
+  it('does NOT return an inherited orphan SID', () => {
+    expect(findExplicitOrphanSids(INHERITED_ORPHAN)).toEqual([]);
+  });
+
+  it('does NOT return legit well-known SIDs', () => {
+    expect(findExplicitOrphanSids(LEGIT_WELLKNOWN)).toEqual([]);
+  });
+
+  it('deduplicates repeated explicit orphan SIDs', () => {
+    const doubled = [
+      `C:\\SokujiSandboxTest ${ORPHAN_A}:(OI)(F)`,
+      `                     ${ORPHAN_A}:(CI)(F)`,
+      '',
+    ].join('\r\n');
+    expect(findExplicitOrphanSids(doubled)).toEqual([ORPHAN_A]);
+  });
+});

--- a/electron/sandbox-recovery.test.js
+++ b/electron/sandbox-recovery.test.js
@@ -2,6 +2,9 @@ import { describe, it, expect, vi } from 'vitest';
 import {
   parseIcaclsAces,
   findExplicitOrphanSids,
+  isGpuSandboxCrash,
+  evaluateCrashRelaunch,
+  evaluateNoSandbox,
 } from './sandbox-recovery.js';
 
 // A realistic orphan AppContainer package SID: "S-1-15-2" followed by 7
@@ -109,5 +112,109 @@ describe('findExplicitOrphanSids', () => {
       '',
     ].join('\r\n');
     expect(findExplicitOrphanSids(doubled)).toEqual([ORPHAN_A]);
+  });
+});
+
+describe('isGpuSandboxCrash', () => {
+  const base = { type: 'GPU', reason: 'crashed', exitCode: -2147483645 };
+
+  it('matches a GPU crash with signed STATUS_BREAKPOINT exit code', () => {
+    expect(isGpuSandboxCrash({ ...base, exitCode: -2147483645 })).toBe(true);
+  });
+
+  it('matches a GPU crash with unsigned STATUS_BREAKPOINT exit code', () => {
+    expect(isGpuSandboxCrash({ ...base, exitCode: 2147483651 })).toBe(true);
+  });
+
+  it('matches reason "abnormal-exit"', () => {
+    expect(isGpuSandboxCrash({ ...base, reason: 'abnormal-exit' })).toBe(true);
+  });
+
+  it('rejects non-GPU process types', () => {
+    expect(isGpuSandboxCrash({ ...base, type: 'Utility' })).toBe(false);
+  });
+
+  it('rejects unrelated reasons like clean-exit', () => {
+    expect(isGpuSandboxCrash({ ...base, reason: 'clean-exit' })).toBe(false);
+  });
+
+  it('rejects a GPU crash with a different exit code', () => {
+    expect(isGpuSandboxCrash({ ...base, exitCode: 1 })).toBe(false);
+  });
+
+  it('rejects null/undefined details', () => {
+    expect(isGpuSandboxCrash(null)).toBe(false);
+    expect(isGpuSandboxCrash(undefined)).toBe(false);
+  });
+});
+
+describe('evaluateCrashRelaunch', () => {
+  const V = '0.34.1';
+
+  it('relaunches on the first crash (no prior marker)', () => {
+    const { marker, shouldRelaunch } = evaluateCrashRelaunch(null, 1000, V);
+    expect(shouldRelaunch).toBe(true);
+    expect(marker).toEqual({ timestamps: [1000], appVersion: V });
+  });
+
+  it('relaunches on the second crash within the hour', () => {
+    const prior = { timestamps: [1000], appVersion: V };
+    const { marker, shouldRelaunch } = evaluateCrashRelaunch(prior, 2000, V);
+    expect(shouldRelaunch).toBe(true);
+    expect(marker.timestamps).toEqual([1000, 2000]);
+  });
+
+  it('does NOT relaunch on the third crash within the hour', () => {
+    const prior = { timestamps: [1000, 2000], appVersion: V };
+    const { marker, shouldRelaunch } = evaluateCrashRelaunch(prior, 3000, V);
+    expect(shouldRelaunch).toBe(false);
+    // still records the crash so the next manual launch enters recovery
+    expect(marker.timestamps).toEqual([1000, 2000, 3000]);
+  });
+
+  it('drops timestamps older than one hour before counting', () => {
+    const now = 10_000_000;
+    const stale = now - 3_600_001; // just over an hour ago
+    const prior = { timestamps: [stale, stale], appVersion: V };
+    const { marker, shouldRelaunch } = evaluateCrashRelaunch(prior, now, V);
+    // both stale entries dropped -> this counts as the first fresh crash
+    expect(shouldRelaunch).toBe(true);
+    expect(marker.timestamps).toEqual([now]);
+  });
+
+  it('tolerates a malformed marker (missing timestamps array)', () => {
+    const { marker, shouldRelaunch } = evaluateCrashRelaunch({}, 5000, V);
+    expect(shouldRelaunch).toBe(true);
+    expect(marker.timestamps).toEqual([5000]);
+  });
+});
+
+describe('evaluateNoSandbox', () => {
+  it('does nothing when there is no fallback marker', () => {
+    expect(evaluateNoSandbox(null, '0.34.1')).toEqual({
+      noSandbox: false,
+      clearMarker: false,
+    });
+  });
+
+  it('applies no-sandbox when the marker version matches', () => {
+    expect(evaluateNoSandbox({ appVersion: '0.34.1' }, '0.34.1')).toEqual({
+      noSandbox: true,
+      clearMarker: false,
+    });
+  });
+
+  it('clears the marker and retries the sandbox when the version changed', () => {
+    expect(evaluateNoSandbox({ appVersion: '0.34.0' }, '0.34.1')).toEqual({
+      noSandbox: false,
+      clearMarker: true,
+    });
+  });
+
+  it('ignores a marker with no appVersion string', () => {
+    expect(evaluateNoSandbox({}, '0.34.1')).toEqual({
+      noSandbox: false,
+      clearMarker: false,
+    });
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -141,6 +141,7 @@ export default defineConfig(({ command, mode }) => {
             'sidecar-sku': 'electron/sidecar-sku.js',
             'sidecar-bundle': 'electron/sidecar-bundle.js',
             'pulseaudio-utils': 'electron/pulseaudio-utils.js',
+            'sandbox-recovery': 'electron/sandbox-recovery.js',
             'windows-audio-utils': 'electron/windows-audio-utils.js',
             'vb-cable-installer': 'electron/vb-cable-installer.js',
             'squirrel-events': 'electron/squirrel-events.js',


### PR DESCRIPTION
## Summary

Windows-only self-healing for the silent startup crash in #352. On some machines other software (OpenAI Codex CLI's elevated sandbox, Google Antigravity's Gemini sandbox, or MSIX installers that leave ACEs on uninstall) writes an **orphaned AppContainer SID ACE** onto `%LOCALAPPDATA%`/`%USERPROFILE%`, which Sokuji's install dir inherits. Chromium's restricted-token sandbox children (GPU/renderer) are then locked out of the install dir and die at `CHECK(InitializeICU())` while mmap'ing `icudtl.dat`; after 3 GPU crashes Chromium fatally kills the app → silent crash.

Removing just the explicit orphan ACE heals the whole inheritance chain, needs **no admin rights** (the user owns their profile dirs → implicit `WRITE_DAC`), and future Squirrel `app-x.y.z` dirs stay immune.

All logic lives in `electron/sandbox-recovery.js`; `main.js` gets three wiring points. **Everything is gated on `win32`; other platforms are unchanged.**

## How it works (three layers)

1. **Detection (dual-channel)**
   - *Passive:* `child-process-gone` filtered to GPU + `crashed`/`abnormal-exit` + `STATUS_BREAKPOINT` exit code (`-2147483645`/`2147483651`). First action writes a crash marker to `userData` (Roaming tree, unaffected by the Local-tree DACL), then relaunches — capped at 2 auto-relaunches/hour.
   - *Active:* on recovery, `icacls` scans the install dir, `%LOCALAPPDATA%`, `%USERPROFILE%` for **explicit** (non-`(I)`) ACEs matching `/S-1-15-2(?:-\d+){6,}/` (excludes legit `S-1-15-2-1`/`-2`; matches SIDs only, never localized account names; latin1-decoded, byte-safe).
2. **Recovery dialog** (native `showMessageBoxSync`, shown before the transparent main window exists). Two tiers:
   - *Confirmed* (scan found orphan ACEs): **[Repair permissions (recommended)] [Continue without sandbox] [Quit]**
   - *Unconfirmed* (crash signature but clean scan): **[Continue without sandbox] [Quit]** — no repair offered.
3. **Repair & fallback:** text backup → precise `icacls /remove "*<SID>"` (never `/reset`, never `/save`) → re-scan to verify → relaunch with sandbox. `Continue without sandbox` writes a persistent version-stamped fallback marker (applied at the top of `main.js`); a version change clears it to retry the sandbox (auto-regression probe).

**No silent operations:** every ACL write and every sandbox downgrade is behind a user button click.

## Testing

- **50 unit tests** (vitest, dependency-injected — runs on Linux + Windows, no real `icacls`): parser (real-shaped fixtures incl. inherited vs explicit, legit well-known SIDs, non-English locale), crash signature, marker state machines, scan/repair/backup, and every orchestration branch. Full suite green: **1436 passed** (1386 baseline + 50).
- **Windows E2E** on an isolated `C:\SokujiSandboxTest\` (never touching real profile dirs):
  - Real `icacls` output parsed correctly (explicit orphan flagged; inherited `(I)` in a subdir correctly ignored).
  - Real `icacls /remove` via `repairDirectory` removed the ACE; parent **and** subdir rescanned clean (inheritance self-heals).
  - Packaged app: baseline launches normally with the feature wired; the **confirmed recovery dialog renders correctly** (verified via UI Automation — correct title/body/affected-path from a real scan + all three buttons), with no main window created.
  - Caught & fixed a real packaging bug: `sandbox-recovery.js` had to be registered as a vite electron entry or the packaged app threw `Cannot find module './sandbox-recovery'`.
  - *Not reproduced here:* the runtime GPU crash did not trigger on this machine (Win11 26200) — the bug is environment-specific (reporter confirmed on theirs); trigger constants come from the reporter's symbolicated stack.

## Not in scope

No Chromium/Electron changes (upstream electron/electron#51761 is open; maintainers won't fix short-term). No silent auto-repair, no silent no-sandbox, no repair button when the scan is clean, no `icacls /reset`, no renderer i18n in the main process.

Refs #352, electron/electron#51761

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows-only Chromium sandbox crash self-healing, including permission scan/repair with user confirmation.
  * Automatically classifies relevant GPU crashes, records crash history, and relaunches with safeguards against repeated failures.
  * Provides a version-aware persistent no-sandbox fallback when repair can’t be completed.
  * Shows recovery/repair dialogs and creates backup logs of affected ACL data.
* **Tests**
  * Added extensive unit and orchestration-level tests covering crash detection, ACL parsing/repair, dialogs, backups, and fallback behavior.
* **Documentation**
  * Added/updated a Windows recovery implementation plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->