### PR TITLE
fix(audio): don't drop the device list when the default-mic warm-up fails

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -765,9 +765,13 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     // teardown. Without this, closing and quickly reopening can leave the mic
     // stranded and the next launch's getUserMedia fails with
     // "NotReadableError: Could not start audio source" (Windows especially).
-    // `pagehide` is more reliable than `beforeunload` for this and also fires
-    // on Electron window close.
-    const releaseMic = () => {
+    // `pagehide` fires on window close / navigation / reload — but NOT on
+    // minimize/hide (that's `visibilitychange`), so this never releases the mic
+    // while the app is merely hidden. Guard against the bfcache case
+    // (event.persisted) where the page is frozen and may be restored via
+    // `pageshow` rather than torn down.
+    const releaseMic = (event?: PageTransitionEvent) => {
+      if (event?.persisted) return;
       audioServiceRef.current?.releaseMicrophone?.();
     };
     window.addEventListener('pagehide', releaseMic);

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -759,10 +759,23 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     };
     
     initAudioService();
-    
+
+    // Release the microphone the instant the window/page is going away, so the
+    // OS capture endpoint is freed cleanly rather than on abrupt process
+    // teardown. Without this, closing and quickly reopening can leave the mic
+    // stranded and the next launch's getUserMedia fails with
+    // "NotReadableError: Could not start audio source" (Windows especially).
+    // `pagehide` is more reliable than `beforeunload` for this and also fires
+    // on Electron window close.
+    const releaseMic = () => {
+      audioServiceRef.current?.releaseMicrophone?.();
+    };
+    window.addEventListener('pagehide', releaseMic);
+
     // Clean up function
     return () => {
-      // Any cleanup needed for the audio service
+      window.removeEventListener('pagehide', releaseMic);
+      releaseMic();
     };
   }, []);
 

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -776,10 +776,12 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     };
     window.addEventListener('pagehide', releaseMic);
 
-    // Clean up function
+    // Cleanup only detaches the listener. Do NOT release the mic on unmount:
+    // real teardown already goes through the non-persisted `pagehide` above,
+    // and releasing here would stop capture during a StrictMode remount or any
+    // future transition that unmounts MainPanel while a session is live.
     return () => {
       window.removeEventListener('pagehide', releaseMic);
-      releaseMic();
     };
   }, []);
 

--- a/src/lib/modern-audio/BaseAudioRecorder.ts
+++ b/src/lib/modern-audio/BaseAudioRecorder.ts
@@ -54,6 +54,25 @@ export abstract class BaseAudioRecorder {
   }
 
   /**
+   * Immediately release the microphone device by stopping all live tracks.
+   *
+   * This is a synchronous best-effort teardown for page/window close: it frees
+   * the OS capture endpoint right away instead of waiting for the (async)
+   * end()/cleanup() path or for process teardown. On Windows, closing the app
+   * without cleanly stopping the mic tracks can leave the WASAPI capture
+   * endpoint stranded, so the next launch's getUserMedia fails with
+   * "NotReadableError: Could not start audio source". Stopping the tracks here
+   * makes the release deterministic. Full graph cleanup still happens in
+   * cleanup(); this only guarantees the device itself is let go.
+   */
+  releaseStream(): void {
+    if (this.stream) {
+      this.stream.getTracks().forEach((track) => track.stop());
+      this.stream = null;
+    }
+  }
+
+  /**
    * Get the URL for the AudioWorklet processor
    * Handles both extension and regular web/Electron environments
    */

--- a/src/lib/modern-audio/ModernBrowserAudioService.test.ts
+++ b/src/lib/modern-audio/ModernBrowserAudioService.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { ModernBrowserAudioService } from './ModernBrowserAudioService';
+
+// Regression tests for the reported failure: on a single fresh launch the UI
+// reported "no audio devices", after a ~20s freeze, with:
+//   [ModernBrowserAudio] Microphone permission denied:
+//   NotReadableError: Could not start audio source
+//
+// Root cause (captured from the packaged app's logs): enumerateDevices()
+// SUCCEEDS and returns every device, but getDevices() then ran a
+// getUserMedia({ audio: true }) "permission warm-up" that opens the system
+// DEFAULT input. On this machine the default was a stale/phantom "3- ZUM-2"
+// that hangs ~20s and rejects with NotReadableError. The old code let that
+// warm-up failure DISCARD the good enumerated list and return empty.
+//
+// The fix: enumerate first; skip the warm-up entirely when labels are already
+// present (permission granted); and never let a warm-up failure wipe the
+// enumerated device list.
+
+type FakeTrack = { stop: ReturnType<typeof vi.fn> };
+
+function makeStream(): { getTracks: () => FakeTrack[] } {
+  const track: FakeTrack = { stop: vi.fn() };
+  return { getTracks: () => [track] };
+}
+
+function setMediaDevices(getUserMedia: any, enumerateDevices: any) {
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia, enumerateDevices },
+  });
+}
+
+const LABELED = [
+  { deviceId: 'mic-1', kind: 'audioinput', label: 'Anker Powerconf C200', groupId: 'g1' },
+  { deviceId: 'spk-1', kind: 'audiooutput', label: 'WR44-PLUS', groupId: 'g2' },
+];
+const UNLABELED = [
+  { deviceId: 'mic-1', kind: 'audioinput', label: '', groupId: 'g1' },
+  { deviceId: 'spk-1', kind: 'audiooutput', label: '', groupId: 'g2' },
+];
+
+describe('ModernBrowserAudioService.getDevices', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('returns devices WITHOUT opening the mic when labels are already present', async () => {
+    const getUserMedia = vi.fn(async () => makeStream());
+    const enumerateDevices = vi.fn(async () => LABELED);
+    setMediaDevices(getUserMedia, enumerateDevices);
+
+    const service = new ModernBrowserAudioService();
+    const devices = await service.getDevices();
+
+    // The core fix: no unnecessary getUserMedia (which is what hung ~20s and
+    // failed on the broken default device).
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(devices.inputs.map(d => d.deviceId)).toEqual(['mic-1']);
+    expect(devices.outputs.map(d => d.deviceId)).toEqual(['spk-1']);
+  });
+
+  it('still returns the enumerated devices when the warm-up mic fails (broken default device)', async () => {
+    const notReadable = Object.assign(new Error('Could not start audio source'), {
+      name: 'NotReadableError',
+    });
+    // Labels missing -> warm-up attempted -> default device fails.
+    const getUserMedia = vi.fn(() => Promise.reject(notReadable));
+    const enumerateDevices = vi.fn(async () => UNLABELED);
+    setMediaDevices(getUserMedia, enumerateDevices);
+
+    const service = new ModernBrowserAudioService();
+    const devices = await service.getDevices();
+
+    // The bug was returning { inputs: [], outputs: [] } here. It must NOT.
+    expect(getUserMedia).toHaveBeenCalled();
+    expect(devices.inputs.map(d => d.deviceId)).toEqual(['mic-1']);
+    expect(devices.outputs.map(d => d.deviceId)).toEqual(['spk-1']);
+  });
+
+  it('opens the mic only once for concurrent getDevices() when a warm-up is needed', async () => {
+    const streams: Array<{ getTracks: () => FakeTrack[] }> = [];
+    const getUserMedia = vi.fn(
+      () => new Promise((resolve) => setTimeout(() => { const s = makeStream(); streams.push(s); resolve(s); }, 5))
+    );
+    // First enumerate has no labels (forces warm-up); after warm-up, labels appear.
+    let calls = 0;
+    const enumerateDevices = vi.fn(async () => (++calls === 1 ? UNLABELED : LABELED));
+    setMediaDevices(getUserMedia, enumerateDevices);
+
+    const service = new ModernBrowserAudioService();
+    await Promise.all([service.getDevices(), service.getDevices()]);
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    // Warm-up stream is released immediately (no leaked open source).
+    expect(streams).toHaveLength(1);
+    expect(streams[0].getTracks()[0].stop).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ModernBrowserAudioService.releaseMicrophone', () => {
+  it('stops the recorder capture stream so the device is freed on close', () => {
+    const service = new ModernBrowserAudioService();
+    const recorder = service.getRecorder();
+    const spy = vi.spyOn(recorder, 'releaseStream');
+
+    service.releaseMicrophone();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('actually stops live capture tracks via the recorder', () => {
+    const service = new ModernBrowserAudioService();
+    const recorder = service.getRecorder();
+    const track: FakeTrack = { stop: vi.fn() };
+    (recorder as unknown as { stream: unknown }).stream = { getTracks: () => [track] };
+
+    service.releaseMicrophone();
+
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect((recorder as unknown as { stream: unknown }).stream).toBeNull();
+  });
+});

--- a/src/lib/modern-audio/ModernBrowserAudioService.test.ts
+++ b/src/lib/modern-audio/ModernBrowserAudioService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { ModernBrowserAudioService } from './ModernBrowserAudioService';
 
 // Regression tests for the reported failure: on a single fresh launch the UI
@@ -39,6 +39,12 @@ const UNLABELED = [
   { deviceId: 'mic-1', kind: 'audioinput', label: '', groupId: 'g1' },
   { deviceId: 'spk-1', kind: 'audiooutput', label: '', groupId: 'g2' },
 ];
+// A labeled OUTPUT must not mask an unlabeled INPUT: the warm-up unlocks mic
+// (input) labels, so it must still run here.
+const LABELED_OUTPUT_UNLABELED_INPUT = [
+  { deviceId: 'mic-1', kind: 'audioinput', label: '', groupId: 'g1' },
+  { deviceId: 'spk-1', kind: 'audiooutput', label: 'WR44-PLUS', groupId: 'g2' },
+];
 
 describe('ModernBrowserAudioService.getDevices', () => {
   afterEach(() => vi.restoreAllMocks());
@@ -74,6 +80,21 @@ describe('ModernBrowserAudioService.getDevices', () => {
     expect(getUserMedia).toHaveBeenCalled();
     expect(devices.inputs.map(d => d.deviceId)).toEqual(['mic-1']);
     expect(devices.outputs.map(d => d.deviceId)).toEqual(['spk-1']);
+  });
+
+  it('warms up when an input lacks a label even if an output is labeled', async () => {
+    const getUserMedia = vi.fn(async () => makeStream());
+    let calls = 0;
+    const enumerateDevices = vi.fn(async () =>
+      ++calls === 1 ? LABELED_OUTPUT_UNLABELED_INPUT : LABELED
+    );
+    setMediaDevices(getUserMedia, enumerateDevices);
+
+    const service = new ModernBrowserAudioService();
+    await service.getDevices();
+
+    // Output label must not mask the unlabeled input — warm-up must still run.
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
   });
 
   it('opens the mic only once for concurrent getDevices() when a warm-up is needed', async () => {

--- a/src/lib/modern-audio/ModernBrowserAudioService.ts
+++ b/src/lib/modern-audio/ModernBrowserAudioService.ts
@@ -146,15 +146,19 @@ export class ModernBrowserAudioService implements IAudioService {
       // source of truth for the device list; the warm-up is best-effort.
       let devices = await navigator.mediaDevices.enumerateDevices();
 
-      const hasAudioLabels = devices.some(
-        d => (d.kind === 'audioinput' || d.kind === 'audiooutput') && d.label !== ''
+      // The warm-up exists to unlock MICROPHONE (input) labels, so key the
+      // decision on inputs only. A labeled audiooutput can otherwise mask
+      // unlabeled inputs and skip a warm-up the mic picker still needs. If
+      // there are no inputs at all, there is nothing to warm up.
+      const needsMicrophoneWarmup = devices.some(
+        d => d.kind === 'audioinput' && d.label === ''
       );
 
-      if (!hasAudioLabels) {
-        // Labels missing => permission not yet granted this session. Warm up to
-        // unlock them, but if the warm-up fails (e.g. broken default device),
-        // fall through with whatever enumerate already gave us instead of
-        // wiping the list.
+      if (needsMicrophoneWarmup) {
+        // Input labels missing => mic permission not yet granted this session.
+        // Warm up to unlock them, but if the warm-up fails (e.g. broken default
+        // device), fall through with whatever enumerate already gave us instead
+        // of wiping the list.
         try {
           await this.ensureMicrophonePermission();
           devices = await navigator.mediaDevices.enumerateDevices();

--- a/src/lib/modern-audio/ModernBrowserAudioService.ts
+++ b/src/lib/modern-audio/ModernBrowserAudioService.ts
@@ -23,6 +23,11 @@ export class ModernBrowserAudioService implements IAudioService {
   private targetTabId: number | null = null;
   private interruptedTrackIds: { [key: string]: boolean } = {};
   private initialized: boolean = false;
+  // In-flight guards: collapse concurrent initialize() / permission warm-up
+  // calls into a single run so we never open the microphone twice at once
+  // (which fails with NotReadableError on drivers that can't share a device).
+  private initPromise: Promise<void> | null = null;
+  private permissionWarmupPromise: Promise<void> | null = null;
   private recordingCallback: AudioRecordingCallback | null = null;
   private currentRecordingDeviceId: string | undefined = undefined;
 
@@ -66,12 +71,29 @@ export class ModernBrowserAudioService implements IAudioService {
    * Initialize the modern audio service
    */
   async initialize(): Promise<void> {
-    // Make initialization idempotent
+    // Make initialization idempotent AND concurrency-safe. Two effects mount at
+    // startup — Home's initializeAudioService and MainPanel's initAudioService —
+    // and React StrictMode double-invokes each in dev, so up to four
+    // initialize() calls race on this singleton. The `initialized` flag alone is
+    // not enough because it is only set at the very end (after several awaits),
+    // so every overlapping caller passes the guard below and each would run
+    // detectAndSetVirtualSpeaker() -> getDevices() -> getUserMedia() on the mic
+    // concurrently, tripping "NotReadableError: Could not start audio source".
+    // Caching the in-flight promise makes all callers share one initialization.
     if (this.initialized) {
       console.info('[Sokuji] [ModernBrowserAudio] Audio service already initialized');
       return;
     }
+    if (!this.initPromise) {
+      this.initPromise = this.doInitialize().catch((err) => {
+        this.initPromise = null; // allow a retry after a failed initialization
+        throw err;
+      });
+    }
+    return this.initPromise;
+  }
 
+  private async doInitialize(): Promise<void> {
     // Connect the player
     await this.player.connect();
 
@@ -108,21 +130,40 @@ export class ModernBrowserAudioService implements IAudioService {
    */
   async getDevices(): Promise<AudioDevices> {
     try {
-      // Request permission to access media devices
-      try {
-        await navigator.mediaDevices.getUserMedia({ audio: true });
-      } catch (permissionError: any) {
-        console.error('[Sokuji] [ModernBrowserAudio] Microphone permission denied:', permissionError);
-        
-        // Show user-friendly error message
-        this.showPermissionError(permissionError);
-        
-        // Return empty device lists
-        return { inputs: [], outputs: [] };
+      // Enumerate FIRST. Once microphone permission has been granted for this
+      // origin (always the case in Electron after the first run), enumerate
+      // returns fully-labeled devices WITHOUT needing an active stream — so the
+      // getUserMedia({ audio: true }) warm-up is only needed to unlock labels
+      // the very first time.
+      //
+      // Crucially, the warm-up opens the system DEFAULT input device. If that
+      // default is broken — e.g. a stale/phantom "3- ZUM-2" left by a
+      // replugged USB mic — getUserMedia hangs ~20s and then throws
+      // NotReadableError, even though every real device enumerates fine and the
+      // user's *selected* mic works. The old code let that warm-up failure
+      // discard the entire (good) device list and return empty, so the UI
+      // reported "no audio devices". We must never do that: enumerate is the
+      // source of truth for the device list; the warm-up is best-effort.
+      let devices = await navigator.mediaDevices.enumerateDevices();
+
+      const hasAudioLabels = devices.some(
+        d => (d.kind === 'audioinput' || d.kind === 'audiooutput') && d.label !== ''
+      );
+
+      if (!hasAudioLabels) {
+        // Labels missing => permission not yet granted this session. Warm up to
+        // unlock them, but if the warm-up fails (e.g. broken default device),
+        // fall through with whatever enumerate already gave us instead of
+        // wiping the list.
+        try {
+          await this.ensureMicrophonePermission();
+          devices = await navigator.mediaDevices.enumerateDevices();
+        } catch (permissionError: any) {
+          console.error('[Sokuji] [ModernBrowserAudio] Microphone permission warm-up failed; returning enumerated devices anyway:', permissionError);
+          this.showPermissionError(permissionError);
+        }
       }
-      
-      const devices = await navigator.mediaDevices.enumerateDevices();
-      
+
       const inputs = devices
         .filter(device => device.kind === 'audioinput')
         .filter(device => device.deviceId !== 'default')
@@ -152,6 +193,59 @@ export class ModernBrowserAudioService implements IAudioService {
     } catch (error) {
       console.error('[Sokuji] [ModernBrowserAudio] Failed to get audio devices:', error);
       return { inputs: [], outputs: [] };
+    }
+  }
+
+  /**
+   * Warm up microphone permission so enumerateDevices() returns labeled
+   * devices, then release the stream immediately.
+   *
+   * Serialized via a shared in-flight promise: at startup getDevices() is
+   * called from several overlapping paths (initialize()'s
+   * detectAndSetVirtualSpeaker + the store's refreshDevices, each doubled by
+   * React StrictMode). Without this guard they fire concurrent
+   * getUserMedia({ audio: true }) on the same physical mic, and drivers that
+   * cannot open one device twice reject the losers with
+   * "NotReadableError: Could not start audio source". Sharing one warm-up
+   * collapses them into a single open. The stream is stopped right away
+   * because enumerateDevices() only needs permission to have been granted, not
+   * a live track (leaving it open would leak an audio source that is only
+   * released on process teardown — abrupt on Windows and prone to stranding
+   * the capture endpoint for the next launch).
+   * @private
+   */
+  private ensureMicrophonePermission(): Promise<void> {
+    if (!this.permissionWarmupPromise) {
+      this.permissionWarmupPromise = (async () => {
+        const permStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        permStream.getTracks().forEach(track => track.stop());
+      })().finally(() => {
+        // Clear once settled so a later refresh can re-warm; concurrent callers
+        // still share this single in-flight open.
+        this.permissionWarmupPromise = null;
+      });
+    }
+    return this.permissionWarmupPromise;
+  }
+
+  /**
+   * Synchronously release the microphone device on page/window close.
+   *
+   * The renderer holds the mic through the recorder's capture stream (and the
+   * warm-up stream, already stopped). Nothing stops these when the window
+   * closes — the empty MainPanel cleanup and the analytics-only beforeunload
+   * handler leave the OS to reclaim the device on process teardown. On Windows
+   * that teardown is abrupt and can strand the WASAPI capture endpoint, so the
+   * next launch's getUserMedia fails with
+   * "NotReadableError: Could not start audio source" until the endpoint resets
+   * (often only after a reboot). Stopping the tracks here, wired to `pagehide`,
+   * makes the release clean and deterministic on every close.
+   */
+  public releaseMicrophone(): void {
+    try {
+      this.recorder.releaseStream();
+    } catch (error) {
+      console.warn('[Sokuji] [ModernBrowserAudio] Error releasing microphone on close:', error);
     }
   }
 

--- a/src/services/interfaces/IAudioService.ts
+++ b/src/services/interfaces/IAudioService.ts
@@ -129,6 +129,13 @@ export interface IAudioService {
   stopRecording(): Promise<void>;
 
   /**
+   * Synchronously release the microphone device (stop capture tracks).
+   * Intended for page/window close so the OS capture endpoint is freed cleanly
+   * instead of on abrupt process teardown.
+   */
+  releaseMicrophone?(): void;
+
+  /**
    * Pause recording (keeps resources allocated)
    */
   pauseRecording(): Promise<void>;


### PR DESCRIPTION
## Problem

On a single fresh launch (no repeated open/close needed), Sokuji intermittently reported **"no audio devices"** after a **~20s freeze**, with:

```
[ModernBrowserAudio] Microphone permission denied: NotReadableError: Could not start audio source
```

A reboot temporarily fixed it.

## Root cause (captured from the packaged app's own logs)

`enumerateDevices()` **succeeds** and returns every device. But `getDevices()` then ran a `getUserMedia({ audio: true })` permission *warm-up* that opens the **system DEFAULT input**. On the affected machine the default was a **stale/phantom `3- ZUM-2`** device (left by a replugged USB mic) that hangs ~20s and then rejects with `NotReadableError`.

The old code let that warm-up failure **discard the entire enumerated device list** and return `{ inputs: [], outputs: [] }` — so the UI showed "no audio devices" even though every real device (and the user's *selected* mic) was fine. A reboot only helped because it cleared the phantom default.

## Fix

`getDevices()` is restructured to:
1. **Enumerate first.**
2. **Skip the warm-up entirely when labels are already present** (permission granted — the normal case), so we never open the broken default device and never hang.
3. **Never let a warm-up failure wipe the enumerated list** — enumerate is the source of truth; the warm-up is best-effort.

Recording already uses the user's *selected* device (not the default), so it keeps working even when the default is broken.

### Same-path hardening
- Stop the warm-up stream's tracks immediately instead of leaking a live mic.
- Make `initialize()` concurrency-safe (dev React StrictMode double-invokes the mount effects, firing concurrent `getUserMedia` on one device).
- Release the microphone on window close via `pagehide` (guarded against the bfcache `persisted` case; does **not** fire on minimize/hide) so the OS capture endpoint is freed cleanly rather than on abrupt process teardown.

## Verification

Ran the fix (dev build) against the **same broken machine state** (phantom default still set):

| | Before (broken) | After (fix) |
|---|---|---|
| Audio init | ~20s hang → `NotReadableError` | **~470ms**, `Audio service initialized` |
| Device list | empty ("no audio devices") | fully populated, monitor device connected |
| Errors | `Microphone permission denied` | none |

Added `ModernBrowserAudioService.test.ts` (5 tests), including the exact regression: **enumerate succeeds but the warm-up mic fails → devices are still returned, not dropped.** Full audio suite: 29 passing.

## Notes
- The phantom `3- ZUM-2` default device is an environmental issue (can also be resolved by removing it in Windows sound settings), but the app is now resilient to it.
- Packaged builds need a rebuild to include this fix; the dev path is verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Ensures microphone capture is cleanly stopped when closing, navigating away from, or reloading the page.
  - Prevents microphone warm-up/open races when audio features are started or devices are queried concurrently.
  - Improves device listing behavior when microphone permission/warm-up fails (devices are still returned).
- **Tests**
  - Added regression tests covering device enumeration, microphone release behavior, and concurrency handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->