### PR TITLE
fix(palabraai): pin livekit-client to 2.18.7 — Palabra's LiveKit server breaks 2.18.8+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,3 +121,10 @@ __pycache__/
 
 # Architecture-review screenshots (scratch, same batch as .playwright-mcp/)
 /arch-review-*.png
+
+# Manual PalabraAI probe harness — drives the real PalabraAIClient against the
+# live API in a browser and tees the LiveKit signalling socket to print each
+# offer/answer SessionDescription.id. Kept locally for re-testing whenever
+# Palabra upgrades their LiveKit server (which is what pins livekit-client to an
+# exact version); takes credentials via query string, so never commit it.
+/palabra-probe/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -219,10 +219,32 @@ useSettingsStore.subscribe(
 - **i18next & react-i18next**: Internationalization framework
 - **openai-realtime-api**: OpenAI real-time API client (strongly-typed fork)
 - **@google/genai**: Google Gemini SDK
-- **livekit-client**: LiveKit SDK for Palabra AI WebRTC integration
+- **livekit-client**: LiveKit SDK for Palabra AI WebRTC integration — **pinned to an exact version, do not upgrade** (see below)
 - **better-auth**: Authentication library for user sessions
 - **lucide-react**: Icon library
 - **ws**: WebSocket client for real-time communication
+
+### livekit-client is version-capped by Palabra's server
+
+`livekit-client` is pinned to an **exact** version (currently `2.18.7`) — never widen it to a
+caret range and never bump it without a live Palabra session test. Palabra runs LiveKit server
+**1.8.4 / protocol 15**, whose answers carry `SessionDescription.id = 0` because the server
+doesn't echo the offer's id. livekit-client **2.18.8+** gates negotiation completion on
+`offerId > checkpoint`, so `negotiate()` never resolves, times out after 15s, and the engine
+escalates to a full reconnect — forever. Palabra's own SDK (`@palabra-ai/translator`) pins
+`livekit-client` `2.13.0` for the same reason.
+
+This regression is **silent**: `connect()` still resolves, the UI still says "connected", and
+the entire vitest suite still passes — nothing covers real WebRTC negotiation. The only signal
+is a live session producing zero transcriptions plus a `NegotiationError: negotiation timed out`
+every ~17s.
+
+One related symptom is expected and harmless: Palabra only serves `/rtc`, so every connect logs
+a failed WebSocket and a 404 on `/rtc/v1` (a path added in client 2.17.0) before LiveKit's
+automatic v0 fallback, costing ~1s on first connect.
+
+Before lifting the pin, confirm the server echoes the id — join a room and check that the
+inbound `answer` has a non-zero `SessionDescription.id`.
 
 ### Internationalization
 - Complete translations for 35+ languages

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "i18next-browser-languagedetector": "^8.1.0",
         "idb": "^8.0.3",
         "jsdom": "^24.0.0",
-        "livekit-client": "^2.15.2",
+        "livekit-client": "2.18.7",
         "lucide-react": "^0.515.0",
         "mpg123-decoder": "^1.0.3",
         "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
@@ -2933,9 +2933,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@livekit/protocol": {
-      "version": "1.45.8",
-      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.45.8.tgz",
-      "integrity": "sha512-Q+l57E7w/xxOBFVWzdX5rkAZO7ffyF+rlDzNUYq2SU114+5aTyCq+PK4unaEVDNd4952Af7wteKr3sOgasGuaA==",
+      "version": "1.45.3",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.45.3.tgz",
+      "integrity": "sha512-WmMxBTsy4dRBqcrswFwUUlgq3Z0nnhOqKR6tX749Rb/PcB1yBMUtrHxZvcsS6qi3/5+86zHeVG+exmu1sZqfJg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9621,14 +9621,14 @@
       }
     },
     "node_modules/livekit-client": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.19.0.tgz",
-      "integrity": "sha512-aolY1XDAtx0nHKBNm29W9OhzBnSz1CP5kq3phvRhFfi1NbvMXs8tcACjAkZTnIKgihkp+BiJScZZ3tZv0Gz8sA==",
+      "version": "2.18.7",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.18.7.tgz",
+      "integrity": "sha512-8mMNfJ9sPTWT9W5CsV23yJhut4vtw0M4c/AR5diRvLn6XsUDij7Odr6GrI9Oj5/T5vDis4y2JTumMiTweGlqMA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@livekit/mutex": "1.1.1",
-        "@livekit/protocol": "1.45.8",
+        "@livekit/protocol": "1.45.3",
         "events": "^3.3.0",
         "jose": "^6.1.0",
         "loglevel": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "i18next-browser-languagedetector": "^8.1.0",
     "idb": "^8.0.3",
     "jsdom": "^24.0.0",
-    "livekit-client": "^2.15.2",
+    "livekit-client": "2.18.7",
     "lucide-react": "^0.515.0",
     "mpg123-decoder": "^1.0.3",
     "onnxruntime-web": "1.26.0-dev.20260416-b7804b056c",
@@ -183,8 +183,8 @@
     "vite-plugin-electron-renderer": "^1.0.0",
     "vitest": "^4.0.18",
     "web-vitals": "^2.1.4",
-    "zustand": "^5.0.8",
-    "ws": "^8.19.0"
+    "ws": "^8.19.0",
+    "zustand": "^5.0.8"
   },
   "scripts": {
     "dev": "vite",

--- a/src/services/clients/PalabraAIClient.test.ts
+++ b/src/services/clients/PalabraAIClient.test.ts
@@ -59,6 +59,14 @@ describe('PalabraAIClient data message handling', () => {
     expect(errorEvents()).toEqual([]);
   });
 
+  it('reports an empty array as an error rather than mistaking it for a queue status map', () => {
+    // Object.keys([]) is also empty, so the empty-map shortcut must not swallow a
+    // JSON array — the queue status is always a map.
+    receiveDataMessage(client, []);
+
+    expect(errorEvents()).toHaveLength(1);
+  });
+
   it('ignores a populated queue status map', () => {
     receiveDataMessage(client, { es: { current_queue_level_ms: 0, max_queue_level_ms: 24000 } });
 

--- a/src/services/clients/PalabraAIClient.test.ts
+++ b/src/services/clients/PalabraAIClient.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { RealtimeEvent } from '../interfaces/IClient';
+
+vi.mock('../../locales', () => ({
+  default: { t: (key: string) => key }
+}));
+
+// PalabraAIClient calls setLogLevel() at module load and only touches the rest of
+// livekit-client once a room exists, so a surface-level stub is enough here.
+vi.mock('livekit-client', () => ({
+  setLogLevel: vi.fn(),
+  Room: class {},
+  RoomEvent: {
+    TrackSubscribed: 'trackSubscribed',
+    DataReceived: 'dataReceived',
+    Connected: 'connected',
+    Disconnected: 'disconnected',
+  },
+  TrackPublication: class {},
+  RemoteParticipant: class {},
+  RemoteTrack: class {},
+  RemoteAudioTrack: class {},
+  LocalAudioTrack: class {},
+}));
+
+const { PalabraAIClient } = await import('./PalabraAIClient');
+
+/**
+ * Feed a JSON payload through the room's data-message path, exactly as the
+ * RoomEvent.DataReceived handler registered in connectToRoom() would. The
+ * handler is private, so we reach it directly rather than standing up a full
+ * WebRTC room just to classify one message.
+ */
+function receiveDataMessage(client: unknown, message: unknown): void {
+  const payload = new TextEncoder().encode(JSON.stringify(message));
+  (client as any).handleDataReceived(payload);
+}
+
+describe('PalabraAIClient data message handling', () => {
+  let client: InstanceType<typeof PalabraAIClient>;
+  let events: RealtimeEvent[];
+
+  beforeEach(() => {
+    client = new PalabraAIClient('test-id', 'test-secret');
+    events = [];
+    client.setEventHandlers({
+      onRealtimeEvent: (event) => { events.push(event); },
+    });
+  });
+
+  const errorEvents = () => events.filter((e) => e.event.type === 'error');
+
+  it('ignores an empty queue status map instead of reporting it as an error', () => {
+    // Palabra emits the queue status roughly once a second. Before any
+    // translation is queued the map is empty, and an empty map is still a queue
+    // status message — not something to surface to the user as an error.
+    receiveDataMessage(client, {});
+
+    expect(errorEvents()).toEqual([]);
+  });
+
+  it('ignores a populated queue status map', () => {
+    receiveDataMessage(client, { es: { current_queue_level_ms: 0, max_queue_level_ms: 24000 } });
+
+    expect(errorEvents()).toEqual([]);
+  });
+
+  it('reports a genuinely unrecognized message as an error', () => {
+    receiveDataMessage(client, { message_type: 'something_new', data: { foo: 1 } });
+
+    expect(errorEvents()).toHaveLength(1);
+    expect(errorEvents()[0].event.data).toMatchObject({ message_type: 'something_new' });
+  });
+
+  it('routes a transcription message to the conversation instead of the error path', () => {
+    const updated: string[] = [];
+    client.setEventHandlers({
+      onRealtimeEvent: (event) => { events.push(event); },
+      onConversationUpdated: ({ item }) => {
+        const text = item.formatted?.transcript ?? item.formatted?.text ?? '';
+        if (text) updated.push(text);
+      },
+    });
+
+    receiveDataMessage(client, {
+      message_type: 'validated_transcription',
+      data: { transcription: { transcription_id: 'abc123', language: 'en', text: 'Hello there' } },
+    });
+
+    expect(errorEvents()).toEqual([]);
+    expect(updated).toContain('Hello there');
+  });
+});

--- a/src/services/clients/PalabraAIClient.ts
+++ b/src/services/clients/PalabraAIClient.ts
@@ -712,17 +712,22 @@ export class PalabraAIClient implements IClient {
 
   /**
    * Check if the received data is a queue status message
-   * Queue status messages have language codes as keys with queue level information
+   * Queue status messages have language codes as keys with queue level information,
+   * or no keys at all when nothing is queued yet
    */
   private isQueueStatusMessage(data: any): boolean {
     if (!data || typeof data !== 'object') {
       return false;
     }
-    
+
     // Check if it's a simple object with language code keys
     const keys = Object.keys(data);
     if (keys.length === 0) {
-      return false;
+      // An empty map is the queue status with nothing queued — Palabra emits one
+      // about once a second, starting before the first translation is queued. It
+      // carries no information, and treating it as unknown surfaced a stream of
+      // bogus `{"type":"error","data":{}}` entries in the user-facing log panel.
+      return true;
     }
     
     // Check if all keys are potential language codes (2-3 letter codes or locale format like en-us)

--- a/src/services/clients/PalabraAIClient.ts
+++ b/src/services/clients/PalabraAIClient.ts
@@ -716,7 +716,9 @@ export class PalabraAIClient implements IClient {
    * or no keys at all when nothing is queued yet
    */
   private isQueueStatusMessage(data: any): boolean {
-    if (!data || typeof data !== 'object') {
+    // The queue status is always a map, never an array — Object.keys([]) is empty
+    // too, so arrays have to be rejected before the empty-map shortcut below.
+    if (!data || typeof data !== 'object' || Array.isArray(data)) {
       return false;
     }
 


### PR DESCRIPTION
## What was broken

Palabra AI translation has been completely dead: `connect()` resolves, the UI says
"connected", and then nothing arrives. The room reconnects every ~17s and produces zero
transcriptions.

The trigger was **dependency drift on our side**, not a Palabra API change — their session
REST contract is byte-for-byte unchanged. `"livekit-client": "^2.15.2"` floated us up to
2.19.0.

## Root cause

Palabra runs **LiveKit server 1.8.4 / protocol 15**. Its answers carry
`SessionDescription.id = 0` — the field exists in the proto, but the server never echoes the
offer's id:

```
WS<in JOIN    server=1.8.4 protocol=15 subscriberPrimary=true fastPublish=true
WS>out OFFER  SessionDescription.id=1
WS<in ANSWER  SessionDescription.id=0     <-- id not echoed
```

livekit-client **2.18.8** (2026-04-30) started gating negotiation completion on
`offerId > checkpoint`, comparing the answer's id against the id it sent. `0 > 1` is never
true, so `negotiate()` never resolves, times out after 15s, and `RTCEngine` escalates to a
full reconnect — forever. 2.18.7 is the last release without that gate (bisected across
published builds).

Palabra's own SDK, `@palabra-ai/translator`, pins `livekit-client` to `2.13.0` for the same
reason.

Two things made this nasty:

- `connect()` still **resolves**, so the UI reports success while the connection is dead.
- The **entire test suite still passes** — nothing covers real WebRTC negotiation, so the
  only signal is a live session.

## Changes

1. **`livekit-client` pinned to `2.18.7` exact** (no caret). A caret here re-breaks Palabra
   silently on any future bump.
2. **CLAUDE.md** documents the ceiling, the silent-failure mode, and how to verify before
   ever lifting the pin.
3. **Empty queue status map is no longer reported as an error.** Palabra emits its queue
   status about once a second and the map is empty before anything is queued;
   `isQueueStatusMessage()` rejected `{}`, so it fell through to the unknown-message branch
   and hit the user-facing log panel as `{"type":"error","data":{}}` every second. That spam
   was the visible face of the negotiation bug, and classifying it correctly is worth doing
   on its own.
4. **First `PalabraAIClient` test file** — covers the empty map plus the neighbouring
   branches it must not disturb (populated queue map still ignored, genuinely unknown message
   still an error, transcription still routed to the conversation).

## Verification

Driven against the **live Palabra API in a real browser**, using the production
`PalabraAIClient` with a 24kHz speech clip — not a mock:

| | before (2.19.0) | after (2.18.7) |
|---|---|---|
| `connect()` | 25.4s | 10.7s |
| JOINs in ~130s | 8+ (reconnect loop) | 1 |
| negotiation errors | one every ~17s | 0 |
| transcriptions | **0** | 106 partial / 22 validated / 11 translated |
| `error {}` log spam | one per second | 0 |

Translation output verified in three language pairs: en→es
(`"No pregunte qué puede hacer su país por usted."`), en→ja
(`"国があなたに何をしてくれるかを問うのではなく。"`), en→zh
(`"不要问您的国家能为您做些什么。"`). partial→validated→translated conversation items all
transition correctly.

`npx vitest run`: **1681 passed** (154 files).

## Known leftover (unchanged, harmless)

Palabra only serves `/rtc`, so every connect logs a failed WebSocket plus a 404 on `/rtc/v1`
(a path added in client 2.17.0) before LiveKit's automatic v0 fallback. Costs ~1s on first
connect. Only client 2.16.1 and older skip that probe, which isn't worth giving up two years
of fixes for.

## Follow-up

This fix's shelf life depends on Palabra. Once they upgrade their LiveKit server and start
echoing `SessionDescription.id`, the pin can and should be lifted — check that an inbound
`answer` has a non-zero id before doing so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty queue-status updates are now handled quietly instead of triggering unexpected message errors.
  * Array-shaped payloads are no longer misclassified as queue-status messages.
  * Validated transcription messages continue updating conversation transcripts correctly.
* **Tests**
  * Added Vitest coverage for queue-status handling, transcription routing, and unrecognized message-type error behavior.
* **Maintenance**
  * Pinned `livekit-client` to version `2.18.7` for consistent WebRTC behavior.
* **Documentation**
  * Updated dependency guidance to prevent widening the `livekit-client` version range.
* **Chores**
  * Updated `.gitignore` to exclude a local-only probe harness directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->