### PR TITLE
fix(palabraai): reverse translation direction in participant mode, and drop four language codes the API rejects

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -45,7 +45,7 @@ import { useLogActions } from '../../stores/logStore';
 import { useNativeAsrLoading } from '../../stores/nativeModelStore';
 import type { RealtimeEvent } from '../../stores/logStore';
 import { IClient, ConversationItem, SessionConfig, ClientEventHandlers, ClientFactory, ResponseConfig } from '../../services/clients';
-import type { VolcengineAST2SessionConfig, VolcengineSTSessionConfig, LocalInferenceSessionConfig, LocalNativeSessionConfig, OpenAITranslateSessionConfig, TranslateTargetLanguage, ZoomAISessionConfig, SonioxSessionConfig } from '../../services/interfaces/IClient';
+import type { VolcengineAST2SessionConfig, VolcengineSTSessionConfig, LocalInferenceSessionConfig, LocalNativeSessionConfig, OpenAITranslateSessionConfig, TranslateTargetLanguage, ZoomAISessionConfig, SonioxSessionConfig, PalabraAISessionConfig } from '../../services/interfaces/IClient';
 import { WavRenderer } from '../../utils/wav_renderer';
 import { ServiceFactory } from '../../services/ServiceFactory'; // Import the ServiceFactory
 import { IAudioService } from '../../services/interfaces/IAudioService';
@@ -703,6 +703,23 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       // participant translates the other party's speech into the user's language.
       const sx = config as SonioxSessionConfig;
       [sx.sourceLanguage, sx.targetLanguage] = [sx.targetLanguage, sx.sourceLanguage];
+    } else if (config.provider === 'palabraai') {
+      // PalabraAI ignores `instructions` entirely — set_task carries the direction
+      // in pipeline.transcription.source_language and
+      // pipeline.translations[0].target_language, built from these two fields. Without
+      // this swap the participant session transcribes the other party's speech under
+      // the *user's* language and "translates" it back to the other party's language,
+      // so the other party's own language comes out on both lines.
+      //
+      // The two fields use different code spaces (targets carry region suffixes like
+      // en-us, sources don't), but the API strips the suffix before validating a
+      // source, so a plain swap holds for every target we offer except `vn` — and `vn`
+      // is not a valid target code in the first place (see TARGET_LANGUAGES). The eight
+      // source languages that aren't valid targets (ba, eo, eu, ga, ia, mn, mt, ug)
+      // make the reversed task fail loudly with the API's VALIDATION_ERROR, which
+      // handleError surfaces.
+      const pa = config as PalabraAISessionConfig;
+      [pa.sourceLanguage, pa.targetLanguage] = [pa.targetLanguage, pa.sourceLanguage];
     } else if (config.provider === 'local_native') {
       // Native ASR/translate carry the translation direction in
       // sourceLanguage/targetLanguage AND in the chosen model ids (a directional

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -713,11 +713,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       //
       // The two fields use different code spaces (targets carry region suffixes like
       // en-us, sources don't), but the API strips the suffix before validating a
-      // source, so a plain swap holds for every target we offer except `vn` — and `vn`
-      // is not a valid target code in the first place (see TARGET_LANGUAGES). The eight
-      // source languages that aren't valid targets (ba, eo, eu, ga, ia, mn, mt, ug)
-      // make the reversed task fail loudly with the API's VALIDATION_ERROR, which
-      // handleError surfaces.
+      // source, so a plain swap holds for every target we offer. In the other
+      // direction five source languages aren't valid targets (eu, ga, mn, mt, ug);
+      // picking one of those makes the reversed task fail with the API's
+      // VALIDATION_ERROR, which arrives as a data message and surfaces through
+      // handleError rather than throwing out of connect().
       const pa = config as PalabraAISessionConfig;
       [pa.sourceLanguage, pa.targetLanguage] = [pa.targetLanguage, pa.sourceLanguage];
     } else if (config.provider === 'local_native') {

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -1188,48 +1188,14 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
               }}
               disabled={isSessionActive}
             >
-              {/* PalabraAI target language options */}
-              <option value="ar-sa">العربية (السعودية)</option>
-              <option value="ar-ae">العربية (الإمارات)</option>
-              <option value="az">Azərbaycan</option>
-              <option value="bg">Български</option>
-              <option value="zh">中文 (简体)</option>
-              <option value="zh-hant">中文 (繁體)</option>
-              <option value="cs">Čeština</option>
-              <option value="da">Dansk</option>
-              <option value="de">Deutsch</option>
-              <option value="el">Ελληνικά</option>
-              <option value="en-us">English (US)</option>
-              <option value="en-au">English (Australia)</option>
-              <option value="en-ca">English (Canada)</option>
-              <option value="es">Español</option>
-              <option value="es-mx">Español (México)</option>
-              <option value="fil">Filipino</option>
-              <option value="fi">Suomi</option>
-              <option value="fr">Français</option>
-              <option value="fr-ca">Français (Canada)</option>
-              <option value="he">עברית</option>
-              <option value="hi">हिन्दी</option>
-              <option value="hr">Hrvatski</option>
-              <option value="hu">Magyar</option>
-              <option value="id">Bahasa Indonesia</option>
-              <option value="it">Italiano</option>
-              <option value="ja">日本語</option>
-              <option value="ko">한국어</option>
-              <option value="ms">Bahasa Melayu</option>
-              <option value="nl">Nederlands</option>
-              <option value="no">Norsk</option>
-              <option value="pl">Polski</option>
-              <option value="pt">Português</option>
-              <option value="pt-br">Português (Brasil)</option>
-              <option value="ro">Română</option>
-              <option value="ru">Русский</option>
-              <option value="sk">Slovenčina</option>
-              <option value="sv">Svenska</option>
-              <option value="ta">தமிழ்</option>
-              <option value="tr">Türkçe</option>
-              <option value="uk">Українська</option>
-              <option value="vn">Tiếng Việt</option>
+              {/* Target list comes from the descriptor — the same expression
+                  LanguageSection uses — so the two surfaces cannot drift. This
+                  block used to be 41 hardcoded options, which is how a stale
+                  Vietnamese code ('vn', rejected by the API) survived here after
+                  the descriptor was corrected. */}
+              {(config.targetLanguages ?? config.languages).map((lang) => (
+                <option key={lang.value} value={lang.value}>{lang.name}</option>
+              ))}
             </select>
           </div>
         </div>

--- a/src/services/clients/PalabraAIClient.test.ts
+++ b/src/services/clients/PalabraAIClient.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import type { RealtimeEvent } from '../interfaces/IClient';
+import type { RealtimeEvent } from '../../stores/logStore';
 
 vi.mock('../../locales', () => ({
   default: { t: (key: string) => key }

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -101,7 +101,6 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
   // PalabraAI supported source languages (for recognition) based on their documentation
   private static readonly SOURCE_LANGUAGES: LanguageOption[] = [
     { name: 'العربية', value: 'ar', englishName: 'Arabic' },
-    { name: 'Башҡорт теле', value: 'ba', englishName: 'Bashkir' },
     { name: 'Беларуская', value: 'be', englishName: 'Belarusian' },
     { name: 'Български', value: 'bg', englishName: 'Bulgarian' },
     { name: 'বাংলা', value: 'bn', englishName: 'Bengali' },
@@ -113,7 +112,6 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     { name: 'Deutsch', value: 'de', englishName: 'German' },
     { name: 'Ελληνικά', value: 'el', englishName: 'Greek' },
     { name: 'English', value: 'en', englishName: 'English' },
-    { name: 'Esperanto', value: 'eo', englishName: 'Esperanto' },
     { name: 'Español', value: 'es', englishName: 'Spanish' },
     { name: 'Eesti', value: 'et', englishName: 'Estonian' },
     { name: 'Euskera', value: 'eu', englishName: 'Basque' },
@@ -126,7 +124,6 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     { name: 'हिन्दी', value: 'hi', englishName: 'Hindi' },
     { name: 'Hrvatski', value: 'hr', englishName: 'Croatian' },
     { name: 'Magyar', value: 'hu', englishName: 'Hungarian' },
-    { name: 'Interlingua', value: 'ia', englishName: 'Interlingua' },
     { name: 'Bahasa Indonesia', value: 'id', englishName: 'Indonesian' },
     { name: 'Italiano', value: 'it', englishName: 'Italian' },
     { name: '日本語', value: 'ja', englishName: 'Japanese' },
@@ -198,7 +195,7 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     { name: 'தமிழ்', value: 'ta', englishName: 'Tamil' },
     { name: 'Türkçe', value: 'tr', englishName: 'Turkish' },
     { name: 'Українська', value: 'uk', englishName: 'Ukrainian' },
-    { name: 'Tiếng Việt', value: 'vn', englishName: 'Vietnamese' },
+    { name: 'Tiếng Việt', value: 'vi', englishName: 'Vietnamese' },
   ];
 
   // Combined languages for UI display (using source languages as base)

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -153,21 +153,38 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     { name: 'Tiếng Việt', value: 'vi', englishName: 'Vietnamese' },
   ];
 
-  // PalabraAI supported target languages (for translation) based on their documentation
+  // PalabraAI supported target languages (for translation). Checked against the
+  // API's own target enum — see palabraLanguageCodes.test.ts for the full list and
+  // how to re-capture it. Every source language the API also accepts as a target
+  // has to appear here: both the participant swap and the settings swap button move
+  // a source code into targetLanguage, and a code missing from this list leaves the
+  // dropdown blank even though the session still works.
   private static readonly TARGET_LANGUAGES: LanguageOption[] = [
+    { name: 'العربية', value: 'ar', englishName: 'Arabic' },
     { name: 'العربية (السعودية)', value: 'ar-sa', englishName: 'Arabic (Saudi)' },
     { name: 'العربية (الإمارات)', value: 'ar-ae', englishName: 'Arabic (UAE)' },
     { name: 'Azərbaycan', value: 'az', englishName: 'Azerbaijani' },
+    { name: 'Беларуская', value: 'be', englishName: 'Belarusian' },
+    { name: 'বাংলা', value: 'bn', englishName: 'Bengali' },
     { name: 'Български', value: 'bg', englishName: 'Bulgarian' },
+    { name: 'Català', value: 'ca', englishName: 'Catalan' },
     { name: '中文 (简体)', value: 'zh', englishName: 'Chinese (Simplified)' },
     { name: '中文 (繁體)', value: 'zh-hant', englishName: 'Chinese (Traditional)' },
     { name: 'Čeština', value: 'cs', englishName: 'Czech' },
     { name: 'Dansk', value: 'da', englishName: 'Danish' },
+    { name: 'English', value: 'en', englishName: 'English' },
+    { name: 'Eesti', value: 'et', englishName: 'Estonian' },
+    { name: 'Galego', value: 'gl', englishName: 'Galician' },
     { name: 'Deutsch', value: 'de', englishName: 'German' },
     { name: 'Ελληνικά', value: 'el', englishName: 'Greek' },
     { name: 'English (US)', value: 'en-us', englishName: 'English (US)' },
     { name: 'English (Australia)', value: 'en-au', englishName: 'English (Australia)' },
     { name: 'English (Canada)', value: 'en-ca', englishName: 'English (Canada)' },
+    { name: 'Latviešu', value: 'lv', englishName: 'Latvian' },
+    { name: 'Lietuvių', value: 'lt', englishName: 'Lithuanian' },
+    { name: 'मराठी', value: 'mr', englishName: 'Marathi' },
+    { name: 'فارسی', value: 'fa', englishName: 'Persian' },
+    { name: 'Slovenščina', value: 'sl', englishName: 'Slovenian' },
     { name: 'Español', value: 'es', englishName: 'Spanish (Spain)' },
     { name: 'Español (México)', value: 'es-mx', englishName: 'Spanish (Mexico)' },
     { name: 'Filipino', value: 'fil', englishName: 'Filipino' },
@@ -191,11 +208,15 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     { name: 'Română', value: 'ro', englishName: 'Romanian' },
     { name: 'Русский', value: 'ru', englishName: 'Russian' },
     { name: 'Slovenčina', value: 'sk', englishName: 'Slovak' },
+    { name: 'Kiswahili', value: 'sw', englishName: 'Swahili' },
     { name: 'Svenska', value: 'sv', englishName: 'Swedish' },
     { name: 'தமிழ்', value: 'ta', englishName: 'Tamil' },
+    { name: 'ไทย', value: 'th', englishName: 'Thai' },
     { name: 'Türkçe', value: 'tr', englishName: 'Turkish' },
     { name: 'Українська', value: 'uk', englishName: 'Ukrainian' },
+    { name: 'اردو', value: 'ur', englishName: 'Urdu' },
     { name: 'Tiếng Việt', value: 'vi', englishName: 'Vietnamese' },
+    { name: 'Cymraeg', value: 'cy', englishName: 'Welsh' },
   ];
 
   // Combined languages for UI display (using source languages as base)

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -201,10 +201,11 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
   // Combined languages for UI display (using source languages as base)
   private static readonly LANGUAGES: LanguageOption[] = PalabraAIProviderConfig.SOURCE_LANGUAGES;
 
-  // PalabraAI supports most language pairs, so the target list doesn't depend
-  // on the source. getConfig() doesn't set `targetLanguages` (LANGUAGES/config
-  // reuses the source list for the shared dropdown), so the base default would
-  // incorrectly fall back to the source list here — override explicitly.
+  // PalabraAI supports most language pairs, so the target list doesn't depend on
+  // the source. The base default would fall back to `getConfig().languages` —
+  // the source list — so return the target list explicitly. getConfig() declares
+  // `targetLanguages` as well; both paths are live (this one feeds the swap
+  // validation, that one feeds the settings dropdown).
   resolveTargetLanguages(_source: string): LanguageOption[] {
     return PalabraAIProviderConfig.TARGET_LANGUAGES;
   }
@@ -229,6 +230,10 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
       apiKeyPlaceholder: 'Enter your PalabraAI Client ID',
       
       languages: PalabraAIProviderConfig.LANGUAGES,
+      // Must be declared, not left to the `targetLanguages ?? languages` fallback
+      // in LanguageSection: `languages` is the *source* list, and offering it as
+      // targets puts codes Palabra rejects (eu, ga, mn, mt, ug) in the dropdown.
+      targetLanguages: PalabraAIProviderConfig.TARGET_LANGUAGES,
       voices: PalabraAIProviderConfig.VOICES,
       models: PalabraAIProviderConfig.MODELS,
       noiseReductionModes: [], // PalabraAI handles audio processing internally

--- a/src/services/providers/palabraLanguageCodes.test.ts
+++ b/src/services/providers/palabraLanguageCodes.test.ts
@@ -79,6 +79,19 @@ describe('PalabraAI language codes match the API enums', () => {
     expect(rejected).toEqual([]);
   });
 
+  it('offers every source language the API also accepts as a target', () => {
+    // Two code paths move a source code into targetLanguage: the participant swap
+    // and the settings swap button. Any source the API accepts as a target has to
+    // appear in the target dropdown too, or the swapped value is stranded — it keeps
+    // working against the API while the select renders blank, because the option
+    // isn't there. Only genuinely unsupported codes may be missing.
+    const sources = descriptor.resolveSourceLanguages().map((l) => l.value);
+    const targets = new Set(descriptor.resolveTargetLanguages('en').map((l) => l.value));
+    const stranded = sources.filter((c) => API_TARGET_LANGUAGES.has(c) && !targets.has(c));
+
+    expect(stranded).toEqual([]);
+  });
+
   it('keeps every offered target usable as a participant-mode source', () => {
     // Participant mode swaps source and target. The API strips the region suffix
     // before validating a source, so the base of every target we offer has to be

--- a/src/services/providers/palabraLanguageCodes.test.ts
+++ b/src/services/providers/palabraLanguageCodes.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../../utils/environment', async (orig) => ({
+  ...(await orig<any>()),
+  isPalabraAIEnabled: () => true,
+  isElectron: () => true,
+  isExtension: () => false,
+}));
+
+import { ProviderConfigFactory } from './ProviderConfigFactory';
+import { Provider } from '../../types/Provider';
+
+/**
+ * Palabra validates source_language and target_language against two different
+ * enums, and offering a code outside them fails the whole set_task with a
+ * VALIDATION_ERROR — i.e. the session connects and then translates nothing.
+ *
+ * The lists below are the API's own enums, captured on 2026-07-30 from the
+ * `desc` field of that VALIDATION_ERROR, which enumerates every permitted
+ * member. They are not published anywhere. To refresh them, run the
+ * palabra-probe harness with a deliberately bogus code — `?src=zz` for the
+ * source enum, `?tgt=zz` for the target enum — and read the error payload.
+ *
+ * Two properties worth knowing, both verified against the live API:
+ *  - The source enum holds plain codes only, but the API strips a region suffix
+ *    before validating, so `en-us` is accepted as a source and normalised to
+ *    `en`. That is what makes a plain source/target swap viable for participant
+ *    mode (see createParticipantSessionConfig).
+ *  - The target enum keeps region variants, and spells Vietnamese `vi` — there
+ *    is no `vn` target.
+ */
+const API_SOURCE_LANGUAGES = new Set([
+  'af', 'am', 'ar', 'as', 'auto', 'az', 'be', 'bg', 'bn', 'bs', 'ca', 'ceb', 'cs', 'cy', 'da',
+  'de', 'el', 'en', 'es', 'et', 'eu', 'fa', 'fi', 'fil', 'fr', 'ga', 'gl', 'gu', 'ha', 'he',
+  'hi', 'hr', 'hu', 'hy', 'id', 'ig', 'is', 'it', 'ja', 'jv', 'ka', 'kk', 'km', 'kn', 'ko',
+  'ku', 'ky', 'lb', 'lg', 'ln', 'lo', 'lt', 'lv', 'mi', 'mk', 'ml', 'mn', 'mr', 'ms', 'mt',
+  'my', 'ne', 'nl', 'no', 'ny', 'or', 'pa', 'pl', 'ps', 'pt', 'ro', 'ru', 'sd', 'sk', 'sl',
+  'sn', 'so', 'sq', 'sr', 'sv', 'sw', 'ta', 'te', 'tg', 'th', 'tl', 'tr', 'ug', 'uk', 'ur',
+  'uz', 'vi', 'wo', 'xh', 'yue', 'zh', 'zu',
+]);
+
+const API_TARGET_LANGUAGES = new Set([
+  'af', 'ar', 'ar-ae', 'ar-sa', 'az', 'be', 'bg', 'bn', 'bs', 'ca', 'cs', 'cy', 'da', 'de',
+  'el', 'en', 'en-au', 'en-ca', 'en-gb', 'en-us', 'es', 'es-ar', 'es-ch', 'es-co', 'es-eu',
+  'es-la', 'es-mx', 'et', 'fa', 'fi', 'fil', 'fr', 'fr-ca', 'fr-eu', 'gl', 'gu', 'he', 'hi',
+  'hr', 'hu', 'hy', 'id', 'is', 'it', 'ja', 'ka', 'kk', 'kn', 'ko', 'lt', 'lv', 'mi', 'mk',
+  'ml', 'mr', 'ms', 'ne', 'nl', 'no', 'pa', 'pl', 'pt', 'pt-br', 'pt-eu', 'pt-la', 'ro', 'ru',
+  'sk', 'sl', 'sr', 'sv', 'sw', 'ta', 'te', 'th', 'tl', 'tr', 'uk', 'ur', 'vi', 'zh',
+  'zh-hans', 'zh-hant',
+]);
+
+describe('PalabraAI language codes match the API enums', () => {
+  const descriptor = ProviderConfigFactory.getDescriptor(Provider.PALABRA_AI);
+
+  it('offers only source languages the API accepts', () => {
+    const offered = descriptor.resolveSourceLanguages().map((l) => l.value);
+    const rejected = offered.filter((code) => !API_SOURCE_LANGUAGES.has(code));
+
+    expect(rejected).toEqual([]);
+  });
+
+  it('offers only target languages the API accepts', () => {
+    const offered = descriptor.resolveTargetLanguages('en').map((l) => l.value);
+    const rejected = offered.filter((code) => !API_TARGET_LANGUAGES.has(code));
+
+    expect(rejected).toEqual([]);
+  });
+
+  it('keeps every offered target usable as a participant-mode source', () => {
+    // Participant mode swaps source and target. The API strips the region suffix
+    // before validating a source, so the base of every target we offer has to be
+    // a valid source code or the reversed session dies on set_task.
+    const offered = descriptor.resolveTargetLanguages('en').map((l) => l.value);
+    const unswappable = offered.filter((code) => !API_SOURCE_LANGUAGES.has(code.split('-')[0]));
+
+    expect(unswappable).toEqual([]);
+  });
+});

--- a/src/services/providers/palabraLanguageCodes.test.ts
+++ b/src/services/providers/palabraLanguageCodes.test.ts
@@ -66,6 +66,19 @@ describe('PalabraAI language codes match the API enums', () => {
     expect(rejected).toEqual([]);
   });
 
+  it('exposes the target list through getConfig(), which is what the settings dropdown reads', () => {
+    // LanguageSection resolves its target dropdown as
+    // `providerConfig.targetLanguages ?? providerConfig.languages`, and only
+    // consults resolveTargetLanguages() for LOCAL_INFERENCE/LOCAL_NATIVE/ZOOM_AI.
+    // A provider that leaves `targetLanguages` unset therefore offers its *source*
+    // list as targets, no matter what resolveTargetLanguages() returns.
+    const cfg = ProviderConfigFactory.getConfig(Provider.PALABRA_AI);
+    const offered = (cfg.targetLanguages ?? cfg.languages).map((l) => l.value);
+    const rejected = offered.filter((code) => !API_TARGET_LANGUAGES.has(code));
+
+    expect(rejected).toEqual([]);
+  });
+
   it('keeps every offered target usable as a participant-mode source', () => {
     // Participant mode swaps source and target. The API strips the region suffix
     // before validating a source, so the base of every target we offer has to be

--- a/src/stores/palabraLanguageMigration.test.ts
+++ b/src/stores/palabraLanguageMigration.test.ts
@@ -22,6 +22,9 @@ describe('rejected PalabraAI language migration', () => {
   });
 
   it('leaves a valid pair untouched', () => {
+    // es → en is the pair from the original bug report. Plain 'en' is in the API's
+    // target enum (verified against the live API), so the migration must not touch
+    // it — only 'vn' has no valid equivalent.
     expect(migrateRejectedPalabraLanguages({ sourceLanguage: 'es', targetLanguage: 'en' }))
       .toEqual({ sourceLanguage: 'es', targetLanguage: 'en' });
     expect(migrateRejectedPalabraLanguages({ sourceLanguage: 'vi', targetLanguage: 'vi' }))

--- a/src/stores/palabraLanguageMigration.test.ts
+++ b/src/stores/palabraLanguageMigration.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { migrateRejectedPalabraLanguages } from './settingsStore';
+import { defaultPalabraAISettings } from '../services/providers/PalabraAIProviderConfig';
+
+/**
+ * Four codes we used to offer are rejected by Palabra's set_task validation, so a
+ * persisted setting holding one of them connects and then translates nothing.
+ * Dropping them from the dropdowns doesn't help anyone who already picked one —
+ * the stored value survives and the select just renders blank.
+ */
+describe('rejected PalabraAI language migration', () => {
+  it("rewrites the Vietnamese target from 'vn' to the code the API accepts", () => {
+    expect(migrateRejectedPalabraLanguages({ sourceLanguage: 'en', targetLanguage: 'vn' }))
+      .toEqual({ sourceLanguage: 'en', targetLanguage: 'vi' });
+  });
+
+  it('falls back to the default source for languages Palabra never supported', () => {
+    for (const code of ['ba', 'eo', 'ia']) {
+      expect(migrateRejectedPalabraLanguages({ sourceLanguage: code, targetLanguage: 'es' }))
+        .toEqual({ sourceLanguage: defaultPalabraAISettings.sourceLanguage, targetLanguage: 'es' });
+    }
+  });
+
+  it('leaves a valid pair untouched', () => {
+    expect(migrateRejectedPalabraLanguages({ sourceLanguage: 'es', targetLanguage: 'en' }))
+      .toEqual({ sourceLanguage: 'es', targetLanguage: 'en' });
+    expect(migrateRejectedPalabraLanguages({ sourceLanguage: 'vi', targetLanguage: 'vi' }))
+      .toEqual({ sourceLanguage: 'vi', targetLanguage: 'vi' });
+  });
+
+  it('leaves region-suffixed targets untouched', () => {
+    // en-us/pt-br/zh-hant are all valid targets; only 'vn' was wrong.
+    expect(migrateRejectedPalabraLanguages({ sourceLanguage: 'ja', targetLanguage: 'en-us' }))
+      .toEqual({ sourceLanguage: 'ja', targetLanguage: 'en-us' });
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -1269,7 +1269,12 @@ const useSettingsStore = create<SettingsStore>()(
         const currentSettings = state.getCurrentProviderSettings();
 
         const sourceLang = providerConfig.languages.find(l => l.value === currentSettings.sourceLanguage);
-        const targetLang = providerConfig.languages.find(l => l.value === currentSettings.targetLanguage);
+        // Resolve the target name from the target list when the provider declares
+        // one — `languages` is the source list, so a target-only code (region
+        // variants like en-us, or az/fil/zh-hant) finds nothing there and the
+        // template renders the raw code instead of a display name.
+        const targetLang = (providerConfig.targetLanguages ?? providerConfig.languages)
+          .find(l => l.value === currentSettings.targetLanguage);
 
         const sourceLangName = sourceLang?.englishName || currentSettings.sourceLanguage || 'SOURCE_LANGUAGE';
         const targetLangName = targetLang?.englishName || currentSettings.targetLanguage || 'TARGET_LANGUAGE';

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -322,6 +322,27 @@ export function migrateLegacyKizunaProvider(p: Provider | string): Provider {
   return (p as string) === 'kizunaai' ? Provider.KIZUNA_AI_OPENAI_TRANSLATE : (p as Provider);
 }
 
+/** Migrate persisted PalabraAI language codes that the API rejects.
+ *  Palabra validates source_language and target_language against two separate
+ *  enums, and a code outside them fails the whole set_task — the session connects
+ *  and then translates nothing. We shipped four such codes: Vietnamese was spelled
+ *  `vn` as a target (the API wants `vi`), and `ba`/`eo`/`ia` were offered as
+ *  sources though Palabra never supported them. Removing them from the dropdowns
+ *  does nothing for a user who already picked one, since the stored value survives
+ *  and the select just renders blank. `vn` has a correct equivalent, so rewrite it;
+ *  the three sources don't, so fall back to the default. */
+export function migrateRejectedPalabraLanguages(
+  slice: { sourceLanguage: string; targetLanguage: string },
+): { sourceLanguage: string; targetLanguage: string } {
+  const UNSUPPORTED_SOURCES = new Set(['ba', 'eo', 'ia']);
+  return {
+    sourceLanguage: UNSUPPORTED_SOURCES.has(slice.sourceLanguage)
+      ? defaultPalabraAISettings.sourceLanguage
+      : slice.sourceLanguage,
+    targetLanguage: slice.targetLanguage === 'vn' ? 'vi' : slice.targetLanguage,
+  };
+}
+
 /** Migrate a persisted deprecated OpenAI voice-agent realtime model id to its
  *  current replacement. OpenAI notified (2026-07-20) that the pre-2.1 realtime
  *  and audio model families/snapshots are removed from the API on 2027-01-20;
@@ -1184,6 +1205,13 @@ const useSettingsStore = create<SettingsStore>()(
         const openaiSlice = loadedSlices.openai as OpenAISettings | undefined;
         if (openaiSlice?.model) {
           openaiSlice.model = migrateDeprecatedOpenAIModel(openaiSlice.model);
+        }
+
+        // Drop persisted PalabraAI language codes the API rejects, so an existing
+        // user isn't left on a pair whose set_task fails validation.
+        const palabraSlice = loadedSlices.palabraai as PalabraAISettings | undefined;
+        if (palabraSlice) {
+          Object.assign(palabraSlice, migrateRejectedPalabraLanguages(palabraSlice));
         }
 
         set({


### PR DESCRIPTION
## What was broken

Participant mode with the user on `es` and the other party on `en`: **every line came out in
English** — the transcript and the "translation" both.

```
[12:30:17] 对方:      That's how many times Anthony Fauci invoked the Fifth Amendment.
[12:30:17] 对方 (译): That's how many times Anthony Fauci invoked the Fifth Amendment.
```

## Root cause

`createParticipantSessionConfig` reverses the translation direction with a hand-written
per-provider if/else chain, and **palabraai was never in it**. The chain falls through to
`return config` unchanged, so the participant session ran the user's own direction verbatim:

```json
"transcription":  { "source_language": "es" }
"translations": [ { "target_language": "en" } ]
```

That told Palabra's ASR to expect Spanish while it received English audio — transcripts came back
tagged `language: "es"` holding English text — and then asked it to translate es→en, which is the
identity transform for English input.

Palabra ignores `instructions` entirely; `set_task` carries the direction in
`pipeline.transcription.source_language` and `pipeline.translations[0].target_language`, built
straight from the config fields. So it needs the explicit swap that `soniox` and
`volcengine_ast2` already do.

**Why this hid for so long:** the defaults are source `en` / target `es`. Unswapped, that is
*correct* whenever the other party speaks English. It only surfaces on a non-default pair.

## Four bad language codes, fixed too

Palabra validates source and target against two different enums, and a code outside them fails
the whole `set_task` — the session connects and then translates nothing. Found while checking
whether a plain swap is safe across both code spaces:

- `TARGET_LANGUAGES` spelled Vietnamese **`vn`**; the API's target enum has **`vi`**. Picking
  Vietnamese as a target failed with `VALIDATION_ERROR` in **ordinary use**, not just participant
  mode.
- `SOURCE_LANGUAGES` offered **`ba`** (Bashkir), **`eo`** (Esperanto), **`ia`** (Interlingua) —
  none are in the API's source enum. Removed; there's no correct code to substitute, Palabra
  simply doesn't support them.

## Both enums are now pinned in a test

They aren't published anywhere. I captured them from the `desc` field of the API's
`VALIDATION_ERROR`, which helpfully enumerates every permitted member — send a bogus code to
provoke it. The new test asserts our lists stay inside them, and would have caught all four codes.

It also asserts the property that makes the plain swap safe: **the base of every target we offer
must be a valid source code**. The API strips a region suffix before validating a source, so
`en-us` is accepted and normalised to `en`. Verified against the live API:

| probe | result |
|---|---|
| `source_language: 'en-us'` | accepted, normalised to `en`, translation works |
| `source_language: 'vn'` | rejected — `VALIDATION_ERROR` |
| source enum | 96 plain codes, no region suffixes |
| target enum | 82 codes with region variants, has `vi`, no `vn` |

Net: a plain swap is safe for 40 of 41 targets and 46 of 51 remaining sources.

## Known leftover

Eight source languages aren't valid targets (`ba eo eu ga ia mn mt ug` — three of them now gone),
so a reversed session still fails for the rest. It fails **loudly** though, via the API's
`VALIDATION_ERROR` through `handleError`, so it isn't a silent wrong-language result.

## Also

Fixes a stray import in the `PalabraAIClient` test from #365 — `RealtimeEvent` comes from
`stores/logStore`, not `IClient`. vitest doesn't typecheck, so it only showed up under `tsc`.

## Verification

`npx vitest run`: **1685 passed** (155 files). `npm run build`: clean. Participant mode confirmed
working end to end by hand — the swap itself has no unit test because the function is a closure
inside MainPanel and this repo has no React rendering harness (see the preamble of
`participantErrorOrdering.test.ts`).

## Follow-up worth doing

`git log -L` on that chain shows this same bug fixed **one provider at a time, five times now**:
openai_translate, local_native (#289), zoom_ai, soniox, and palabraai here. Direction reversal is
per-provider knowledge that belongs in the provider descriptor, where
`descriptorRegistry.test.ts`'s invariant test would fail loudly on a missing provider instead of
waiting for someone to notice their subtitles are in the wrong language.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Palabra AI Vietnamese target-language code for selection.
  * Improved Palabra AI participant session language direction handling to align translation direction consistently.

* **Updates**
  * Refreshed Palabra AI language dropdown options to reflect only supported languages.
  * Switched the target-language dropdown to a dynamic, configuration-driven list.
  * Automatically migrates previously saved Palabra AI language settings to prevent invalid source/target pairs.

* **Tests**
  * Added/expanded automated checks to ensure offered language codes match Palabra’s allowed source/target enums.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->