### PR TITLE
feat(palabraai): support platform API key auth alongside app credentials

### DIFF
--- a/docs/superpowers/plans/2026-07-30-palabra-platform-api-key.md
+++ b/docs/superpowers/plans/2026-07-30-palabra-platform-api-key.md
@@ -1,0 +1,844 @@
+# Palabra Platform API Key (Dual Auth Mode) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add platform.palabra.ai single-API-key auth as a second auth mode on the existing `palabraai` provider, alongside the legacy app Client ID/Secret pair, switchable without losing either credential.
+
+**Architecture:** Same provider, same client. `PalabraAIClient` takes a `PalabraCredentials` discriminated union and builds auth headers in one place (`authHeaders()`). The settings slice gains `authMode` + `apiKey` (flat fields; all three credential values persist independently). The descriptor maps platform mode into the existing shared `Credentials` contract as `{ ok, primary: apiKey }` with no `secret`; `createClient` branches on `secret` presence. Spec: `docs/superpowers/specs/2026-07-30-palabra-platform-api-key-design.md`.
+
+**Tech Stack:** TypeScript, React, Zustand, vitest. No new dependencies.
+
+## Global Constraints
+
+- `livekit-client` stays pinned to exact `2.18.7` — do not touch `package.json` dependencies.
+- Never fall back from one auth mode to the other automatically (spec: "A failing credential is never silently retried with the other kind").
+- All code and comments in English. Conventional commit messages.
+- The correctness gate is `npm run test` (vitest). `tsc` has ~113 pre-existing errors and is NOT a gate — do not try to make it clean, but do not add new errors in files you touch.
+- Do not `git push` or open PRs — the user approves publish actions separately.
+- Work on branch `feat/palabra-platform-auth` (already created; spec committed).
+- API keys/secrets must never be committed, echoed to logs, or pasted into files. Use environment variables for live tests.
+
+---
+
+### Task 1: Live Bearer smoke test (GATE — do this before any code)
+
+**Files:** none (scratch commands only; nothing committed)
+
+**Interfaces:**
+- Consumes: `PALABRA_API_KEY` env var (real platform key, ask the user to provide it in the shell); optionally `PALABRA_CLIENT_ID`/`PALABRA_CLIENT_SECRET` for the app-mode baseline.
+- Produces: go/no-go decision. If the Bearer POST fails, STOP the plan and report — the design needs re-evaluation (see spec §Testing).
+
+- [ ] **Step 1: Confirm the key is present without printing it**
+
+Run: `[ -n "$PALABRA_API_KEY" ] && echo "key present" || echo "MISSING - ask user"`
+Expected: `key present`. If missing, pause and ask the user to export it.
+
+- [ ] **Step 2: Create a session with Bearer auth**
+
+```bash
+curl -s -X POST "https://api.palabra.ai/session-storage/session" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $PALABRA_API_KEY" \
+  -d '{"data": {"intent": "api"}}' | tee /tmp/palabra-smoke.json | \
+  python3 -c "import json,sys; d=json.load(sys.stdin); print('ok:', d.get('ok')); print('fields:', sorted(d.get('data',{}).keys()))"
+```
+
+Expected: `ok: True` and fields including `id`, `publisher`, `webrtc_url`, `ws_url`. **Gate: if this fails (401/403/missing fields), STOP and report to the user.**
+
+- [ ] **Step 3: List sessions with Bearer auth (validation-endpoint check)**
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" "https://api.palabra.ai/session-storage/sessions" \
+  -H "Accept: application/json" -H "Authorization: Bearer $PALABRA_API_KEY"
+```
+
+Expected: `200`. This is the endpoint `validateApiKey` uses.
+
+- [ ] **Step 4: Delete the smoke-test session (cleanup)**
+
+```bash
+SESSION_ID=$(python3 -c "import json; print(json.load(open('/tmp/palabra-smoke.json'))['data']['id'])")
+curl -s -o /dev/null -w "%{http_code}\n" -X DELETE \
+  "https://api.palabra.ai/session-storage/sessions/$SESSION_ID" \
+  -H "Authorization: Bearer $PALABRA_API_KEY"
+rm /tmp/palabra-smoke.json
+```
+
+Expected: `204` (or `200`).
+
+- [ ] **Step 5: CORS preflight probe (informative, not a hard gate)**
+
+```bash
+curl -s -i -X OPTIONS "https://api.palabra.ai/session-storage/sessions" \
+  -H "Origin: chrome-extension://abcdefghijklmnop" \
+  -H "Access-Control-Request-Method: GET" \
+  -H "Access-Control-Request-Headers: authorization" | head -20
+```
+
+Expected: response headers contain `access-control-allow-headers` including `authorization` (case-insensitive). If OPTIONS is not answered meaningfully, note it — the definitive browser-context check happens in Task 7 acceptance. Record the result in the task report either way.
+
+---
+
+### Task 2: `PalabraAIClient` credential union + `authHeaders()`
+
+**Files:**
+- Modify: `src/services/clients/PalabraAIClient.ts` (constructor at lines ~140-145, static `validateApiKey` at ~150-201, `createSession` at ~404-438, `getUserSessions` at ~1064-1110, `deleteSession` at ~1115-1133)
+- Modify: `src/services/clients/PalabraAIClient.test.ts` (constructor call at line 44; new describe block)
+- Modify: `src/services/providers/PalabraAIProviderConfig.ts` (call-site adaptation only — `createClient` ~57-60, `validateAndFetchModels` ~73; platform branches come in Task 4)
+
+**Interfaces:**
+- Produces (Tasks 4+ rely on these exact shapes):
+
+```typescript
+// exported from src/services/clients/PalabraAIClient.ts
+export type PalabraCredentials =
+  | { kind: 'clientCredentials'; clientId: string; clientSecret: string }
+  | { kind: 'apiKey'; apiKey: string };
+
+// constructor
+constructor(credentials: PalabraCredentials)
+
+// static — same return type as before
+static async validateApiKey(credentials: PalabraCredentials): Promise<ApiKeyValidationResult>
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/services/clients/PalabraAIClient.test.ts`:
+
+```typescript
+describe('PalabraAIClient auth headers', () => {
+  it('builds ClientId/ClientSecret headers for app credentials', () => {
+    const c = new PalabraAIClient({ kind: 'clientCredentials', clientId: 'id-1', clientSecret: 'sec-1' });
+    expect((c as any).authHeaders()).toEqual({ ClientId: 'id-1', ClientSecret: 'sec-1' });
+  });
+
+  it('builds a Bearer Authorization header for a platform API key', () => {
+    const c = new PalabraAIClient({ kind: 'apiKey', apiKey: 'pk-123' });
+    expect((c as any).authHeaders()).toEqual({ Authorization: 'Bearer pk-123' });
+  });
+});
+
+describe('PalabraAIClient.validateApiKey empty-credential short-circuit', () => {
+  it('rejects an empty platform API key without a network call', async () => {
+    const result = await PalabraAIClient.validateApiKey({ kind: 'apiKey', apiKey: '  ' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects app credentials with a missing secret without a network call', async () => {
+    const result = await PalabraAIClient.validateApiKey({
+      kind: 'clientCredentials', clientId: 'id-1', clientSecret: '',
+    });
+    expect(result.valid).toBe(false);
+  });
+});
+```
+
+Also update the existing `beforeEach` (line 44):
+
+```typescript
+client = new PalabraAIClient({ kind: 'clientCredentials', clientId: 'test-id', clientSecret: 'test-secret' });
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+Run: `npm run test -- src/services/clients/PalabraAIClient.test.ts`
+Expected: new tests FAIL (constructor signature / `authHeaders` missing); pre-existing tests may fail to compile — that's fine at this step.
+
+- [ ] **Step 3: Implement the client changes**
+
+In `src/services/clients/PalabraAIClient.ts`:
+
+3a. Add the exported union type above the class and replace the two credential fields:
+
+```typescript
+/**
+ * Palabra has two credential systems: the legacy app.palabra.ai ClientId/ClientSecret
+ * header pair and the platform.palabra.ai single API key (Authorization: Bearer).
+ * Both hit the same endpoints; only the auth headers differ.
+ */
+export type PalabraCredentials =
+  | { kind: 'clientCredentials'; clientId: string; clientSecret: string }
+  | { kind: 'apiKey'; apiKey: string };
+```
+
+Replace `private clientId: string;` and `private clientSecret: string;` with `private credentials: PalabraCredentials;`, and the constructor:
+
+```typescript
+constructor(credentials: PalabraCredentials) {
+  this.credentials = credentials;
+  // Generate a unique instance ID that remains constant for this client instance
+  this.instanceId = `palabra_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+}
+```
+
+3b. Add the header builders (static so `validateApiKey` can share it):
+
+```typescript
+private static authHeadersFor(credentials: PalabraCredentials): Record<string, string> {
+  return credentials.kind === 'apiKey'
+    ? { 'Authorization': `Bearer ${credentials.apiKey}` }
+    : { 'ClientId': credentials.clientId, 'ClientSecret': credentials.clientSecret };
+}
+
+private authHeaders(): Record<string, string> {
+  return PalabraAIClient.authHeadersFor(this.credentials);
+}
+```
+
+3c. Rewrite `validateApiKey`'s signature and empty-check; keep the rest of its body (fetch of `/session-storage/sessions`, response handling, catch) unchanged except the headers:
+
+```typescript
+static async validateApiKey(credentials: PalabraCredentials): Promise<ApiKeyValidationResult> {
+  try {
+    const empty = credentials.kind === 'apiKey'
+      ? !credentials.apiKey || credentials.apiKey.trim() === ''
+      : !credentials.clientId || credentials.clientId.trim() === '' ||
+        !credentials.clientSecret || credentials.clientSecret.trim() === '';
+    if (empty) {
+      return {
+        valid: false,
+        message: i18n.t('settings.errorValidatingApiKey'),
+        validating: false
+      };
+    }
+
+    // Test credentials by getting user sessions
+    const response = await fetch(`${this.API_BASE_URL}/session-storage/sessions`, {
+      method: 'GET',
+      headers: {
+        'Accept': 'application/json',
+        ...PalabraAIClient.authHeadersFor(credentials),
+      }
+    });
+    // ... rest of the method body unchanged ...
+```
+
+3d. In `createSession`, `getUserSessions`, `deleteSession`: replace the two literal `'ClientId': this.clientId, 'ClientSecret': this.clientSecret,` header lines with `...this.authHeaders(),`. In `createSession` also replace the body — `subscriber_count` is no longer in Palabra's `CreateSessionRequestV2` schema:
+
+```typescript
+body: JSON.stringify({
+  data: {
+    intent: 'api'
+  }
+})
+```
+
+3e. In `src/services/providers/PalabraAIProviderConfig.ts`, adapt the two call sites (app-mode mapping only; platform branches come in Task 4):
+
+```typescript
+// createClient body (keep the existing secret guard for now):
+if (!creds.secret) throw new Error('Client secret is required for palabraai provider');
+return new PalabraAIClient({ kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret });
+```
+
+```typescript
+// validateAndFetchModels — replace the positional call:
+const validation = await PalabraAIClient.validateApiKey({
+  kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret,
+});
+```
+
+(That call sits behind the existing `if (!creds.secret)` guard, so `creds.secret` is a definite `string` there.)
+
+- [ ] **Step 4: Run the client tests, then the full suite**
+
+Run: `npm run test -- src/services/clients/PalabraAIClient.test.ts`
+Expected: PASS (all, including pre-existing).
+Run: `npm run test`
+Expected: PASS — descriptor registry and language tests must stay green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/clients/PalabraAIClient.ts src/services/clients/PalabraAIClient.test.ts src/services/providers/PalabraAIProviderConfig.ts
+git commit -m "refactor(palabraai): parameterize client auth via PalabraCredentials union"
+```
+
+---
+
+### Task 3: Settings fields + `authMode` migration
+
+**Files:**
+- Modify: `src/services/providers/PalabraAIProviderConfig.ts` (interface at lines 8-22, defaults at 24-38)
+- Modify: `src/stores/settingsStore.ts` (exported migration fn near `migrateRejectedPalabraLanguages`; wiring in the load path at ~1212)
+- Create: `src/stores/palabraAuthModeMigration.test.ts`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks.
+- Produces:
+
+```typescript
+// PalabraAISettings gains (Task 4 + 5 read these):
+authMode: 'app' | 'platform';   // default 'platform'
+apiKey: string;                  // default ''
+
+// exported from src/stores/settingsStore.ts (mirrors migrateRejectedPalabraLanguages):
+export function migratePalabraAuthMode(
+  storedAuthMode: string,
+  slice: Pick<PalabraAISettings, 'clientId' | 'clientSecret'>
+): Partial<Pick<PalabraAISettings, 'authMode'>>
+```
+
+**Why the extra `storedAuthMode` parameter:** `loadProviderSettings` fills every missing key with its default, per key. After loading, `authMode === 'platform'` is ambiguous — stored choice or injected default. The migration therefore probes the raw stored value separately with an empty-string sentinel default; `''` means "never stored".
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/stores/palabraAuthModeMigration.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { migratePalabraAuthMode } from './settingsStore';
+
+describe('migratePalabraAuthMode', () => {
+  it('keeps an explicitly stored app mode', () => {
+    expect(migratePalabraAuthMode('app', { clientId: '', clientSecret: '' })).toEqual({});
+  });
+
+  it('keeps an explicitly stored platform mode even when legacy credentials exist', () => {
+    expect(migratePalabraAuthMode('platform', { clientId: 'id', clientSecret: 'sec' })).toEqual({});
+  });
+
+  it('pins a legacy user (stored credentials, never chose a mode) to app', () => {
+    expect(migratePalabraAuthMode('', { clientId: 'id', clientSecret: 'sec' })).toEqual({ authMode: 'app' });
+  });
+
+  it('pins to app when only one legacy field is present', () => {
+    expect(migratePalabraAuthMode('', { clientId: 'id', clientSecret: '' })).toEqual({ authMode: 'app' });
+    expect(migratePalabraAuthMode('', { clientId: '', clientSecret: 'sec' })).toEqual({ authMode: 'app' });
+  });
+
+  it('leaves a fresh install on the platform default', () => {
+    expect(migratePalabraAuthMode('', { clientId: '', clientSecret: '' })).toEqual({ authMode: 'platform' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npm run test -- src/stores/palabraAuthModeMigration.test.ts`
+Expected: FAIL — `migratePalabraAuthMode` is not exported.
+
+- [ ] **Step 3: Implement**
+
+3a. `src/services/providers/PalabraAIProviderConfig.ts` — extend the interface and defaults:
+
+```typescript
+export interface PalabraAISettings {
+  authMode: 'app' | 'platform';
+  apiKey: string;
+  clientId: string;
+  clientSecret: string;
+  // ... existing fields unchanged ...
+}
+
+export const defaultPalabraAISettings: PalabraAISettings = {
+  authMode: 'platform',
+  apiKey: '',
+  clientId: '',
+  clientSecret: '',
+  // ... existing defaults unchanged ...
+};
+```
+
+3b. `src/stores/settingsStore.ts` — add next to `migrateRejectedPalabraLanguages`:
+
+```typescript
+/**
+ * Decide the auth mode for a persisted Palabra slice that predates authMode.
+ * storedAuthMode is the RAW stored value probed with an empty-string sentinel
+ * (loadProviderSettings merges defaults per key, so the merged slice cannot
+ * distinguish "never stored" from "stored 'platform'"). A user with legacy
+ * credentials who never chose a mode keeps working in app mode; everyone
+ * else gets the platform default.
+ */
+export function migratePalabraAuthMode(
+  storedAuthMode: string,
+  slice: Pick<PalabraAISettings, 'clientId' | 'clientSecret'>
+): Partial<Pick<PalabraAISettings, 'authMode'>> {
+  if (storedAuthMode === 'app' || storedAuthMode === 'platform') return {};
+  if (slice.clientId || slice.clientSecret) return { authMode: 'app' };
+  return { authMode: 'platform' };
+}
+```
+
+3c. Wire it into the load path — the existing palabra block becomes:
+
+```typescript
+// Drop persisted PalabraAI language codes the API rejects, so an existing
+// user isn't left on a pair whose set_task fails validation.
+const palabraSlice = loadedSlices.palabraai as PalabraAISettings | undefined;
+if (palabraSlice) {
+  Object.assign(palabraSlice, migrateRejectedPalabraLanguages(palabraSlice));
+  // authMode predates some persisted slices; probe the raw stored value so a
+  // default-injected 'platform' isn't mistaken for a user choice.
+  const storedAuthMode = await service.getSetting('settings.palabraai.authMode', '');
+  Object.assign(palabraSlice, migratePalabraAuthMode(storedAuthMode, palabraSlice));
+}
+```
+
+- [ ] **Step 4: Run the migration tests, then the full suite**
+
+Run: `npm run test -- src/stores/palabraAuthModeMigration.test.ts src/stores/palabraLanguageMigration.test.ts`
+Expected: PASS.
+Run: `npm run test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/providers/PalabraAIProviderConfig.ts src/stores/settingsStore.ts src/stores/palabraAuthModeMigration.test.ts
+git commit -m "feat(palabraai): add authMode/apiKey settings with legacy-user migration"
+```
+
+---
+
+### Task 4: Descriptor platform credential flow
+
+**Files:**
+- Modify: `src/services/providers/PalabraAIProviderConfig.ts` (`extractCredentials`, `peekPrimaryCredential`, `createClient`, `validateAndFetchModels`)
+- Create: `src/services/providers/PalabraAIProviderConfig.test.ts`
+
+**Interfaces:**
+- Consumes: `PalabraCredentials` union and `validateApiKey(credentials)` from Task 2; `authMode`/`apiKey` settings fields from Task 3.
+- Produces: descriptor behavior the UI (Task 5) relies on — `peekPrimaryCredential` returns the active mode's credential; `extractCredentials` encodes platform as `{ ok: true, primary: apiKey }` with **no** `secret` key.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/services/providers/PalabraAIProviderConfig.test.ts`:
+
+```typescript
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../locales', () => ({
+  default: { t: (key: string) => key }
+}));
+vi.mock('livekit-client', () => ({
+  setLogLevel: vi.fn(),
+  Room: class {}, RoomEvent: {}, TrackPublication: class {},
+  RemoteParticipant: class {}, RemoteTrack: class {},
+  RemoteAudioTrack: class {}, LocalAudioTrack: class {},
+}));
+
+const { PalabraAIProviderConfig, defaultPalabraAISettings } = await import('./PalabraAIProviderConfig');
+const { PalabraAIClient } = await import('../clients/PalabraAIClient');
+
+const descriptor = new PalabraAIProviderConfig();
+const appSlice = { ...defaultPalabraAISettings, authMode: 'app' as const, clientId: 'id-1', clientSecret: 'sec-1' };
+const platformSlice = { ...defaultPalabraAISettings, authMode: 'platform' as const, apiKey: 'pk-1' };
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('extractCredentials', () => {
+  it('maps platform mode to primary-only credentials (no secret key)', async () => {
+    const creds = await descriptor.extractCredentials(platformSlice, {});
+    expect(creds).toEqual({ ok: true, primary: 'pk-1' });
+    expect('secret' in creds).toBe(false);
+  });
+
+  it('rejects platform mode without an API key', async () => {
+    const creds = await descriptor.extractCredentials({ ...platformSlice, apiKey: '' }, {});
+    expect(creds.ok).toBe(false);
+  });
+
+  it('maps app mode to primary+secret', async () => {
+    expect(await descriptor.extractCredentials(appSlice, {}))
+      .toEqual({ ok: true, primary: 'id-1', secret: 'sec-1' });
+  });
+
+  it('rejects app mode with a missing half of the pair', async () => {
+    expect((await descriptor.extractCredentials({ ...appSlice, clientSecret: '' }, {})).ok).toBe(false);
+    expect((await descriptor.extractCredentials({ ...appSlice, clientId: '' }, {})).ok).toBe(false);
+  });
+
+  it('app mode ignores a stale apiKey value; platform mode ignores stale clientId/clientSecret', async () => {
+    expect(await descriptor.extractCredentials({ ...appSlice, apiKey: 'stale' }, {}))
+      .toEqual({ ok: true, primary: 'id-1', secret: 'sec-1' });
+    expect(await descriptor.extractCredentials({ ...platformSlice, clientId: 'stale', clientSecret: 'stale' }, {}))
+      .toEqual({ ok: true, primary: 'pk-1' });
+  });
+});
+
+describe('peekPrimaryCredential', () => {
+  it('returns the active mode credential', () => {
+    expect(descriptor.peekPrimaryCredential(appSlice)).toBe('id-1');
+    expect(descriptor.peekPrimaryCredential(platformSlice)).toBe('pk-1');
+  });
+});
+
+describe('createClient', () => {
+  it('builds an app-credential client when secret is present', () => {
+    const client = descriptor.createClient({ ok: true, primary: 'id-1', secret: 'sec-1' }, { transport: 'websocket' } as any);
+    expect((client as any).credentials).toEqual({ kind: 'clientCredentials', clientId: 'id-1', clientSecret: 'sec-1' });
+  });
+
+  it('builds a platform-key client when secret is absent', () => {
+    const client = descriptor.createClient({ ok: true, primary: 'pk-1' }, { transport: 'websocket' } as any);
+    expect((client as any).credentials).toEqual({ kind: 'apiKey', apiKey: 'pk-1' });
+  });
+});
+
+describe('validateAndFetchModels', () => {
+  it('validates a platform key (no secret) instead of demanding a client secret', async () => {
+    const spy = vi.spyOn(PalabraAIClient, 'validateApiKey').mockResolvedValue({
+      valid: true, message: 'ok', validating: false,
+    });
+    const result = await descriptor.validateAndFetchModels({ ok: true, primary: 'pk-1' });
+    expect(spy).toHaveBeenCalledWith({ kind: 'apiKey', apiKey: 'pk-1' });
+    expect(result.validation.valid).toBe(true);
+    expect(result.models).toHaveLength(1);
+  });
+
+  it('validates app credentials as before', async () => {
+    const spy = vi.spyOn(PalabraAIClient, 'validateApiKey').mockResolvedValue({
+      valid: true, message: 'ok', validating: false,
+    });
+    await descriptor.validateAndFetchModels({ ok: true, primary: 'id-1', secret: 'sec-1' });
+    expect(spy).toHaveBeenCalledWith({ kind: 'clientCredentials', clientId: 'id-1', clientSecret: 'sec-1' });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the platform-path ones fail**
+
+Run: `npm run test -- src/services/providers/PalabraAIProviderConfig.test.ts`
+Expected: FAIL on platform-mode cases ("Both Client ID and Client Secret..." / secret guard throw); app-mode cases pass.
+
+- [ ] **Step 3: Implement the descriptor branches**
+
+In `src/services/providers/PalabraAIProviderConfig.ts` (import `PalabraCredentials` from the client module):
+
+```typescript
+async extractCredentials(slice: unknown, _ctx: CredentialCtx): Promise<Credentials> {
+  const s = slice as PalabraAISettings;
+  if (s?.authMode === 'platform') {
+    if (!s.apiKey || s.apiKey.trim() === '') {
+      return { ok: false, missing: 'API Key is required for Palabra AI' };
+    }
+    // No `secret` key: createClient/validateAndFetchModels decode its absence
+    // as platform mode. Both ends of that convention live in Palabra's own files.
+    return { ok: true, primary: s.apiKey };
+  }
+  if (!s?.clientId || !s?.clientSecret) {
+    return { ok: false, missing: 'Both Client ID and Client Secret are required for Palabra AI' };
+  }
+  return { ok: true, primary: s.clientId, secret: s.clientSecret };
+}
+
+peekPrimaryCredential(slice: unknown): string {
+  const s = slice as PalabraAISettings;
+  return s?.authMode === 'platform' ? (s?.apiKey ?? '') : (s?.clientId ?? '');
+}
+
+createClient(creds: Credentials & { ok: true }, _options: ClientOptions): IClient {
+  return new PalabraAIClient(PalabraAIProviderConfig.toPalabraCredentials(creds));
+}
+
+async validateAndFetchModels(creds: Credentials): Promise<{
+  validation: ApiKeyValidationResult; models: FilteredModel[];
+}> {
+  if (!creds.ok) {
+    return { validation: { valid: false, message: creds.missing, validating: false }, models: [] };
+  }
+  const validation = await PalabraAIClient.validateApiKey(
+    PalabraAIProviderConfig.toPalabraCredentials(creds)
+  );
+  return {
+    validation,
+    models: [{ id: 'realtime-translation', type: 'realtime', created: Date.now() / 1000 }],
+  };
+}
+
+/**
+ * secret present = app pair, absent = platform key. A deprecated-façade caller
+ * passing a clientId without its secret now gets a Bearer 401 from validation
+ * instead of the old tailored both-required message — acceptable degradation;
+ * the live path (extractCredentials) always sets secret for app mode.
+ */
+private static toPalabraCredentials(creds: Credentials & { ok: true }): PalabraCredentials {
+  return creds.secret !== undefined
+    ? { kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret }
+    : { kind: 'apiKey', apiKey: creds.primary };
+}
+```
+
+This **deletes** the old `if (!creds.secret) throw` guard in `createClient` and the `if (!creds.secret) return "Both required"` legacy guard in `validateAndFetchModels`.
+
+- [ ] **Step 4: Run the descriptor tests, then the full suite**
+
+Run: `npm run test -- src/services/providers/PalabraAIProviderConfig.test.ts`
+Expected: PASS.
+Run: `npm run test`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/providers/PalabraAIProviderConfig.ts src/services/providers/PalabraAIProviderConfig.test.ts
+git commit -m "feat(palabraai): route platform API keys through the descriptor credential flow"
+```
+
+---
+
+### Task 5: Settings UI + English locale keys
+
+**Files:**
+- Modify: `src/components/Settings/sections/ProviderSection.tsx` (Palabra block at ~758-795; `updateApiKey` switch case at ~305)
+- Modify: `src/components/SettingsInitializer/SettingsInitializer.tsx` (validation-effect deps at ~117)
+- Modify: `src/components/Settings/Settings.scss` (inside `.palabraai-credentials-group` at ~1217)
+- Modify: `src/locales/en/translation.json` (`providers.palabraai` block at ~369)
+
+**Interfaces:**
+- Consumes: `authMode`/`apiKey` fields (Task 3); mode-aware `peekPrimaryCredential` (Task 4) — `getCurrentApiKey` needs no change, it already delegates to the descriptor.
+- Produces: locale keys Task 6 replicates: `providers.palabraai.apiKeyPlaceholder`, `.authModePlatform`, `.authModeApp`.
+
+- [ ] **Step 1: Replace the Palabra credential block in `ProviderSection.tsx`**
+
+The existing block (two unconditional inputs) becomes:
+
+```tsx
+) : provider === Provider.PALABRA_AI ? (
+  // PalabraAI has two auth systems: platform API key (Bearer) or the legacy
+  // app Client ID/Secret pair. All three values persist; the toggle only
+  // selects which are used.
+  <div className="palabraai-credentials-group">
+    <div className="palabraai-auth-mode">
+      <label className="auth-mode-option">
+        <input
+          type="radio"
+          name="palabraai-auth-mode"
+          checked={palabraAISettings.authMode === 'platform'}
+          onChange={() => updatePalabraAISettings({ authMode: 'platform' })}
+          disabled={isSessionActive}
+        />
+        {t('providers.palabraai.authModePlatform', 'Platform API Key')}
+      </label>
+      <label className="auth-mode-option">
+        <input
+          type="radio"
+          name="palabraai-auth-mode"
+          checked={palabraAISettings.authMode === 'app'}
+          onChange={() => updatePalabraAISettings({ authMode: 'app' })}
+          disabled={isSessionActive}
+        />
+        {t('providers.palabraai.authModeApp', 'App Client ID/Secret')}
+      </label>
+    </div>
+    {palabraAISettings.authMode === 'platform' ? (
+      <div className="api-key-input-group">
+        <input
+          type="password"
+          value={palabraAISettings.apiKey}
+          onChange={(e) => updatePalabraAISettings({ apiKey: e.target.value })}
+          placeholder={t('providers.palabraai.apiKeyPlaceholder', 'API Key')}
+          className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
+          disabled={isSessionActive}
+        />
+        <button
+          className="validate-button"
+          onClick={handleValidateApiKey}
+          disabled={!palabraAISettings.apiKey || isValidating || isSessionActive}
+          title={t('simpleSettings.validate')}
+        >
+          {isValidating ? <span className="spinner" /> : isApiKeyValid ? <CheckCircle size={16} /> : t('simpleSettings.validate')}
+        </button>
+      </div>
+    ) : (
+      <>
+        <div className="api-key-input-group">
+          <input
+            type="password"
+            value={palabraAISettings.clientId}
+            onChange={(e) => updatePalabraAISettings({ clientId: e.target.value })}
+            placeholder={t('providers.palabraai.clientIdPlaceholder', 'Client ID')}
+            className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
+            disabled={isSessionActive}
+          />
+        </div>
+        <div className="api-key-input-group">
+          <input
+            type="password"
+            value={palabraAISettings.clientSecret}
+            onChange={(e) => updatePalabraAISettings({ clientSecret: e.target.value })}
+            placeholder={t('providers.palabraai.clientSecretPlaceholder', 'Client Secret')}
+            className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
+            disabled={isSessionActive}
+          />
+          <button
+            className="validate-button"
+            onClick={handleValidateApiKey}
+            disabled={!palabraAISettings.clientId || !palabraAISettings.clientSecret || isValidating || isSessionActive}
+            title={t('simpleSettings.validate')}
+          >
+            {isValidating ? (
+              <span className="spinner" />
+            ) : isApiKeyValid ? (
+              <CheckCircle size={16} />
+            ) : (
+              t('simpleSettings.validate')
+            )}
+          </button>
+        </div>
+      </>
+    )}
+  </div>
+) : (
+```
+
+- [ ] **Step 2: Make the `updateApiKey` switch mode-aware**
+
+Replace the `Provider.PALABRA_AI` case (~line 305):
+
+```typescript
+case Provider.PALABRA_AI:
+  if (palabraAISettings.authMode === 'platform') {
+    updatePalabraAISettings({ apiKey: value });
+  } else {
+    updatePalabraAISettings({ clientId: value });
+  }
+  break;
+```
+
+- [ ] **Step 3: Extend the auto-validation deps in `SettingsInitializer.tsx`**
+
+In the deps array of the API-provider validation effect (~line 117), replace
+`palabraAISettings.clientId, palabraAISettings.clientSecret,` with:
+
+```typescript
+palabraAISettings.authMode, palabraAISettings.apiKey,
+palabraAISettings.clientId, palabraAISettings.clientSecret,
+```
+
+- [ ] **Step 4: Add the radio-row styles**
+
+Inside `.palabraai-credentials-group` in `src/components/Settings/Settings.scss` (block starts ~line 1217), add:
+
+```scss
+.palabraai-auth-mode {
+  display: flex;
+  gap: 16px;
+
+  .auth-mode-option {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    font-size: 13px;
+
+    input[type='radio'] {
+      accent-color: #10a37f;
+      margin: 0;
+      cursor: pointer;
+    }
+  }
+}
+```
+
+(Inherit text colors from the surrounding theme; `#10a37f` is the app's primary action color.)
+
+- [ ] **Step 5: Add the English locale keys**
+
+In `src/locales/en/translation.json`, extend the `providers.palabraai` block:
+
+```json
+"palabraai": {
+  "name": "Palabra AI",
+  "description": "Specialized translation AI",
+  "clientIdPlaceholder": "Client ID",
+  "clientSecretPlaceholder": "Client Secret",
+  "apiKeyPlaceholder": "API Key",
+  "authModePlatform": "Platform API Key",
+  "authModeApp": "App Client ID/Secret"
+}
+```
+
+- [ ] **Step 6: Run the full suite and a production build**
+
+Run: `npm run test`
+Expected: PASS.
+Run: `npm run build`
+Expected: builds without new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/Settings/sections/ProviderSection.tsx src/components/SettingsInitializer/SettingsInitializer.tsx src/components/Settings/Settings.scss src/locales/en/translation.json
+git commit -m "feat(palabraai): auth mode toggle UI with per-mode credential inputs"
+```
+
+---
+
+### Task 6: Locale sweep (all remaining locales)
+
+**Files:**
+- Modify: every `src/locales/<lng>/translation.json` except `en` that has a `providers.palabraai` block (30 of 32 locales have `clientIdPlaceholder` today — match that distribution; skip a locale only if it has no `providers.palabraai` block at all).
+
+**Interfaces:**
+- Consumes: the three key names from Task 5: `apiKeyPlaceholder`, `authModePlatform`, `authModeApp`.
+
+- [ ] **Step 1: Add the three keys to each locale**
+
+For each locale file, add translated values inside `providers.palabraai`, keeping key order consistent with `en`. Translation guidance: "API Key" is a product noun — most locales keep it as "API Key"/local transliteration (follow how each locale already translates `soniox.apiKeyPlaceholder` or `simpleSettings.apiKeyPlaceholder`); "Platform" and "App" refer to Palabra's product names and stay untranslated in most languages. Examples:
+
+- `zh`: `"apiKeyPlaceholder": "API 密钥"`, `"authModePlatform": "Platform API 密钥"`, `"authModeApp": "App Client ID/Secret"`
+- `ja`: `"apiKeyPlaceholder": "APIキー"`, `"authModePlatform": "Platform APIキー"`, `"authModeApp": "App Client ID/Secret"`
+- `de`: `"apiKeyPlaceholder": "API-Schlüssel"`, `"authModePlatform": "Platform-API-Schlüssel"`, `"authModeApp": "App Client-ID/Secret"`
+
+- [ ] **Step 2: Verify coverage and JSON validity**
+
+```bash
+for f in src/locales/*/translation.json; do
+  python3 -c "import json;json.load(open('$f'))" || echo "INVALID: $f"
+done
+grep -rl "authModePlatform" src/locales/ | wc -l
+grep -rl "clientIdPlaceholder" src/locales/ | wc -l
+```
+
+Expected: no `INVALID` lines; the two counts are equal (new keys everywhere the old palabra keys exist).
+
+- [ ] **Step 3: Run the full suite**
+
+Run: `npm run test`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/locales
+git commit -m "chore(i18n): add Palabra auth mode keys to all locales"
+```
+
+---
+
+### Task 7: Full verification + live acceptance (user in the loop)
+
+**Files:** none (verification only)
+
+**Interfaces:**
+- Consumes: everything above; real credentials from the user (both kinds — confirmed available).
+
+- [ ] **Step 1: Full suite + build from a clean state**
+
+Run: `npm run test` then `npm run build`
+Expected: all green, build succeeds.
+
+- [ ] **Step 2: Migration spot-check in dev**
+
+Run `npm run dev`, and with the user (or via devtools console against the running app):
+1. Simulate a legacy user: with stored `clientId`/`clientSecret` and no stored `authMode`, reload — the Palabra settings must open in **App** mode with both values intact.
+2. Toggle to Platform, reload — must stay Platform (choice persisted), and clientId/clientSecret must still be present when toggling back.
+
+- [ ] **Step 3: Live acceptance — platform mode (user performs)**
+
+Ask the user to: enter the platform API key, validate (expect green check), start a session, and speak a few sentences. Checklist to confirm together:
+- transcriptions AND translated audio arrive (Palabra's known regression mode is "connected but zero transcriptions" — an idle-looking session is a FAIL, not a pass);
+- no repeating `NegotiationError: negotiation timed out` in the console;
+- the one expected harmless log: a failed WebSocket + 404 on `/rtc/v1` before the v0 fallback on first connect.
+
+- [ ] **Step 4: Live acceptance — app mode regression (user performs)**
+
+Switch to App mode with the legacy credentials and repeat the same checklist. Both modes passing is the acceptance bar.
+
+- [ ] **Step 5: Report results**
+
+Summarize both live runs (pass/fail per checklist item) to the user. Do NOT push or open a PR — the user decides the next step.

--- a/docs/superpowers/specs/2026-07-30-palabra-platform-api-key-design.md
+++ b/docs/superpowers/specs/2026-07-30-palabra-platform-api-key-design.md
@@ -1,0 +1,100 @@
+# Palabra Platform API Key (Dual Auth Mode) — Design
+
+**Date**: 2026-07-30
+**Status**: Approved (brainstormed with user; protocol facts verified against Palabra docs + OpenAPI spec, live smoke test pending)
+
+## Summary
+
+Palabra split its developer offering into the legacy **app** (app.palabra.ai, `ClientId`/`ClientSecret` header pair) and the new **platform** (platform.palabra.ai, single API key via `Authorization: Bearer`). Sokuji currently supports only app credentials. This design adds platform API key support as a second auth mode on the existing `palabraai` provider — same client, same provider, only the auth header construction is parameterized. Users holding both credential kinds can switch freely; all three credential values persist independently.
+
+Out of scope: voice selection ([#367](https://github.com/kizuna-ai-lab/sokuji/issues/367)), the WebSocket streaming transport, clone-upload UI, removing app mode.
+
+## Verified protocol facts (2026-07-30)
+
+Verified against `platform.palabra.ai/docs` and `https://api.palabra.ai/docs/openapi.json` (spec saved during research). Live verification with a real key is the first implementation step.
+
+- Both auth modes hit the **same host and endpoints**: `POST/GET/DELETE https://api.palabra.ai/session-storage/session[s]`. Only the auth headers differ:
+  - app: `ClientId: <id>` + `ClientSecret: <secret>` (spec's securitySchemes still declare these)
+  - platform: `Authorization: Bearer <API_KEY>` (all platform docs; old docs site pages are being migrated to Bearer too)
+- Session create response (`CreateSessionResponseDataV2`) carries exactly the fields the client already reads: `publisher` (JWT), `webrtc_url`, `ws_url`, `webrtc_room_name`, `intent`, `id`. The `subscriber` field is deprecated upstream; we never used it.
+- Session create request schema (`CreateSessionRequestV2`) now only accepts `intent` and `aggregation_id`. Our `subscriber_count: 0` is a dead field (ignored server-side).
+- Everything after session creation — LiveKit room join with `webrtc_url` + `publisher` JWT, `set_task` / `end_task` over the data channel, all transcription message types — is byte-identical between the two modes. The `livekit-client` 2.18.7 exact pin stays untouched.
+- Palabra does not document an API key format/prefix; auth mode cannot be inferred from the key's shape.
+- Dual-auth coexistence on api.palabra.ai is current fact, not a documented commitment. Whichever side Palabra sunsets, this design only loses one branch.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Provider shape | Same provider, same client. Auth header construction parameterized. New provider/client rejected: protocols are identical, splitting doubles language-enum/swap-chain/locale maintenance. |
+| Credential UI | Explicit auth mode toggle (Platform API Key / App Client ID+Secret), conditional inputs. Auto-detection rejected: no key format to detect on, muddy error messages. |
+| Storage | Flat fields: `authMode` + `apiKey` added; `clientId`/`clientSecret` kept. All three values persist; the toggle only selects which are read. Nested per-mode object rejected (all slices are flat; shallow-merge updates). |
+| Default mode | New users: `'platform'`. Existing users: migration pins `'app'` (see below). |
+| Descriptor contract | Approach A — reuse the shared `Credentials` type as-is. Platform mode → `{ ok: true, primary: apiKey }` with no `secret`; `createClient` branches on `secret` presence. Widening the shared type with a `variant` discriminator rejected (only Palabra would use it). |
+| Cross-mode fallback | Never. A failing credential is never silently retried with the other kind. |
+
+## Data model & migration
+
+`PalabraAISettings` gains:
+
+```typescript
+authMode: 'app' | 'platform';  // default 'platform'
+apiKey: string;                 // default ''
+```
+
+**Migration (required, not optional):** defaults shallow-merge into persisted slices, so an existing user's slice (no `authMode`) would silently become `'platform'` and break them. In the settingsStore load path (near the existing `palabraLanguageMigration` precedent):
+
+- persisted slice has no `authMode` AND (`clientId` or `clientSecret` non-empty) → set `authMode: 'app'`
+- persisted slice has no `authMode` and both empty → leave default `'platform'`
+- persisted slice already has `authMode` → untouched
+
+## Credential flow (descriptor)
+
+`PalabraAIProviderConfig`:
+
+- `extractCredentials`: branch on `authMode`. Platform requires non-empty `apiKey` → `{ ok: true, primary: apiKey }`. App requires both → unchanged `{ ok: true, primary: clientId, secret: clientSecret }`.
+- `peekPrimaryCredential`: returns `apiKey` or `clientId` per mode.
+- `createClient`: `creds.secret !== undefined` → app branch, else platform branch; builds the `PalabraCredentials` discriminated union and passes it to the client.
+- `validateAndFetchModels`: **delete** the legacy "Both Client ID and Client Secret are required" guard for missing `secret`. It only served the deprecated `ClientOperations` façade (live validation goes `settingsStore.validateApiKey → descriptor.extractCredentials`). Degradation: a hypothetical legacy caller passing a clientId without secret now gets a Bearer 401 instead of the tailored message — acceptable; documented in a comment.
+
+## Client changes
+
+`PalabraAIClient`:
+
+```typescript
+type PalabraCredentials =
+  | { kind: 'clientCredentials'; clientId: string; clientSecret: string }
+  | { kind: 'apiKey'; apiKey: string };
+```
+
+- Constructor takes `PalabraCredentials` instead of two positional strings.
+- New private `authHeaders(): Record<string, string>` — the single place both header shapes are built.
+- Four REST call sites switch to it: static `validateApiKey` (signature also takes the union), `createSession`, `getUserSessions`, `deleteSession`.
+- Session create body cleanup: `{ data: { intent: 'api' } }` (drop the dead `subscriber_count`).
+- LiveKit pipeline, `set_task` payload, audio worklets, message handling: untouched.
+
+## UI & i18n
+
+- `ProviderSection.tsx` (Palabra block, currently lines ~760–783): add an auth mode toggle; render one API key input (platform) or the existing two inputs (app); validate button disabled per mode (`!apiKey` vs `!clientId || !clientSecret`).
+- `SettingsInitializer.tsx` auto-validation effect deps: add `palabraAISettings.authMode` and `palabraAISettings.apiKey`.
+- i18n: new keys for the mode labels, API key placeholder, and per-mode required-field error. Repo convention (verified): provider keys are added to all locale files — `providers.palabraai.clientIdPlaceholder` exists in 30 of 32 locales — so the new keys get translated entries in every locale, same as the existing Palabra keys.
+
+## Error handling
+
+- Per-mode required-field messages ("API Key is required for Palabra AI" vs the existing both-required message).
+- HTTP errors surfaced exactly as today (`errors[0].detail` parsing).
+- No silent cross-mode retry, ever.
+
+## Testing & verification (risk-first)
+
+1. **Smoke test before any UI work** (user has both credential kinds):
+   - `curl` with `Authorization: Bearer <platform key>` → `POST /session-storage/session` must return 201 with `publisher`/`webrtc_url` present.
+   - A fetch from the extension context to confirm the `Authorization` header passes CORS preflight.
+   - If this fails, stop and re-evaluate (e.g. proxy fallback) before building anything.
+2. Unit tests:
+   - `extractCredentials`: both modes × (complete / missing fields).
+   - `createClient` union mapping (secret present/absent).
+   - `authHeaders()` both shapes.
+   - Migration: three cases (old creds → `'app'`; empty slice → `'platform'`; existing `authMode` untouched).
+   - Update `PalabraAIClient.test.ts` constructor call sites.
+3. Acceptance: one **real translation session per mode**. Watch for Palabra's signature silent failure — "connected" UI with zero transcriptions — which unit tests cannot catch.

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1229,6 +1229,25 @@
       }
     }
   }
+
+  .palabraai-auth-mode {
+    display: flex;
+    gap: 16px;
+
+    .auth-mode-option {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      cursor: pointer;
+      font-size: 13px;
+
+      input[type='radio'] {
+        accent-color: #10a37f;
+        margin: 0;
+        cursor: pointer;
+      }
+    }
+  }
 }
 
 // API key info/warning styles

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1230,21 +1230,49 @@
     }
   }
 
-  .palabraai-auth-mode {
-    display: flex;
-    gap: 16px;
+  // Mirrors the app's segmented-control archetype (ModePicker.scss and the
+  // noise-suppression control further down this file — both scope their rules
+  // to their own section, hence this local copy). Active = fill, per the
+  // state-selected-fill convention in _variables.scss. Like ModePicker, no
+  // font-weight change on active: the two labels differ in width and the
+  // control must not resize when the user switches modes.
+  .segmented-control {
+    display: inline-flex;
+    align-items: stretch;
+    align-self: flex-start;
+    height: 28px;
+    border: 1px solid vars.$border-default;
+    border-radius: vars.$radius-md;
+    overflow: hidden;
 
-    .auth-mode-option {
-      display: flex;
+    .segmented-option {
+      display: inline-flex;
       align-items: center;
-      gap: 6px;
+      padding: 0 12px;
+      font-size: vars.$font-caption;
+      line-height: 1;
+      border: none;
+      background: vars.$bg-control;
+      color: #aaa;
       cursor: pointer;
-      font-size: 13px;
+      transition: all 0.15s ease;
 
-      input[type='radio'] {
-        accent-color: #10a37f;
-        margin: 0;
-        cursor: pointer;
+      &:not(:last-child) {
+        border-right: 1px solid vars.$border-default;
+      }
+
+      &:hover:not(.active):not(:disabled) {
+        background: vars.$bg-hover;
+      }
+
+      &.active {
+        background: vars.$color-primary;
+        color: #fff;
+      }
+
+      &:disabled {
+        opacity: vars.$disabled-opacity;
+        cursor: not-allowed;
       }
     }
   }

--- a/src/components/Settings/sections/ProviderSection.palabraai.test.tsx
+++ b/src/components/Settings/sections/ProviderSection.palabraai.test.tsx
@@ -69,13 +69,13 @@ describe('ProviderSection — PalabraAI auth mode toggle', () => {
   it('switching modes swaps the inputs and never clears any credential', () => {
     render(<ProviderSection isSessionActive={false} />);
 
-    fireEvent.click(screen.getByRole('radio', { name: 'App Client ID/Secret' }));
+    fireEvent.click(screen.getByRole('button', { name: 'App Client ID/Secret' }));
     expect(useSettingsStore.getState().palabraai.authMode).toBe('app');
     expect((screen.getByPlaceholderText('Client ID') as HTMLInputElement).value).toBe('id-existing');
     expect((screen.getByPlaceholderText('Client Secret') as HTMLInputElement).value).toBe('sec-existing');
     expect(useSettingsStore.getState().palabraai.apiKey).toBe('pk-existing');
 
-    fireEvent.click(screen.getByRole('radio', { name: 'Platform API Key' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Platform API Key' }));
     expect(useSettingsStore.getState().palabraai.authMode).toBe('platform');
     expect((screen.getByPlaceholderText('API Key') as HTMLInputElement).value).toBe('pk-existing');
     expect(useSettingsStore.getState().palabraai.clientId).toBe('id-existing');

--- a/src/components/Settings/sections/ProviderSection.palabraai.test.tsx
+++ b/src/components/Settings/sections/ProviderSection.palabraai.test.tsx
@@ -1,0 +1,84 @@
+/**
+ * Coverage for the PalabraAI auth-mode toggle (final-review follow-up,
+ * feat/palabra-platform-auth): the radio pair only selects which credential
+ * inputs render — switching modes must never clear or overwrite any of the
+ * three stored credential values (apiKey / clientId / clientSecret).
+ *
+ * Mounts the real component against the real settingsStore, mirroring
+ * ProviderSection.soniox.test.tsx: everything else ProviderSection touches
+ * (auth, analytics, settings service) is mocked to keep the test focused.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+vi.mock('react-i18next', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-i18next')>();
+  return {
+    ...actual,
+    useTranslation: () => ({
+      t: (_k: string, def?: string) => def ?? _k,
+    }),
+    Trans: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  };
+});
+
+vi.mock('../../../lib/analytics', () => ({
+  useAnalytics: () => ({ trackEvent: vi.fn() }),
+}));
+
+vi.mock('../../../lib/auth/hooks', () => ({
+  useAuth: () => ({ isSignedIn: false, getToken: undefined }),
+}));
+
+vi.mock('../../../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: async (_k: string, d: unknown) => d,
+      setSetting: async () => undefined,
+    }),
+  },
+}));
+
+const { default: useSettingsStore } = await import('../../../stores/settingsStore');
+const { Provider } = await import('../../../types/Provider');
+const { default: ProviderSection } = await import('./ProviderSection');
+
+describe('ProviderSection — PalabraAI auth mode toggle', () => {
+  beforeEach(() => {
+    useSettingsStore.setState((s: any) => ({
+      provider: Provider.PALABRA_AI,
+      palabraai: {
+        ...s.palabraai,
+        authMode: 'platform',
+        apiKey: 'pk-existing',
+        clientId: 'id-existing',
+        clientSecret: 'sec-existing',
+      },
+    }));
+  });
+
+  it('renders the platform input and writes typed input to apiKey', () => {
+    render(<ProviderSection isSessionActive={false} />);
+    const input = screen.getByPlaceholderText('API Key') as HTMLInputElement;
+    expect(input.value).toBe('pk-existing');
+    fireEvent.change(input, { target: { value: 'pk-new' } });
+    expect(useSettingsStore.getState().palabraai.apiKey).toBe('pk-new');
+  });
+
+  it('switching modes swaps the inputs and never clears any credential', () => {
+    render(<ProviderSection isSessionActive={false} />);
+
+    fireEvent.click(screen.getByRole('radio', { name: 'App Client ID/Secret' }));
+    expect(useSettingsStore.getState().palabraai.authMode).toBe('app');
+    expect((screen.getByPlaceholderText('Client ID') as HTMLInputElement).value).toBe('id-existing');
+    expect((screen.getByPlaceholderText('Client Secret') as HTMLInputElement).value).toBe('sec-existing');
+    expect(useSettingsStore.getState().palabraai.apiKey).toBe('pk-existing');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Platform API Key' }));
+    expect(useSettingsStore.getState().palabraai.authMode).toBe('platform');
+    expect((screen.getByPlaceholderText('API Key') as HTMLInputElement).value).toBe('pk-existing');
+    expect(useSettingsStore.getState().palabraai.clientId).toBe('id-existing');
+    expect(useSettingsStore.getState().palabraai.clientSecret).toBe('sec-existing');
+  });
+});

--- a/src/components/Settings/sections/ProviderSection.tsx
+++ b/src/components/Settings/sections/ProviderSection.tsx
@@ -302,7 +302,11 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
         updateOpenAICompatibleSettings({ apiKey: value });
         break;
       case Provider.PALABRA_AI:
-        updatePalabraAISettings({ clientId: value });
+        if (palabraAISettings.authMode === 'platform') {
+          updatePalabraAISettings({ apiKey: value });
+        } else {
+          updatePalabraAISettings({ clientId: value });
+        }
         break;
       case Provider.OPENAI_TRANSLATE:
         updateOpenAITranslateSettings({ apiKey: value });
@@ -756,42 +760,89 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
             </div>
           </div>
         ) : provider === Provider.PALABRA_AI ? (
-          // PalabraAI requires both Client ID and Client Secret
+          // PalabraAI has two auth systems: platform API key (Bearer) or the legacy
+          // app Client ID/Secret pair. All three values persist; the toggle only
+          // selects which are used.
           <div className="palabraai-credentials-group">
-            <div className="api-key-input-group">
-              <input
-                type="password"
-                value={palabraAISettings.clientId}
-                onChange={(e) => updatePalabraAISettings({ clientId: e.target.value })}
-                placeholder={t('providers.palabraai.clientIdPlaceholder', 'Client ID')}
-                className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
-                disabled={isSessionActive}
-              />
+            <div className="palabraai-auth-mode">
+              <label className="auth-mode-option">
+                <input
+                  type="radio"
+                  name="palabraai-auth-mode"
+                  checked={palabraAISettings.authMode === 'platform'}
+                  onChange={() => updatePalabraAISettings({ authMode: 'platform' })}
+                  disabled={isSessionActive}
+                />
+                {t('providers.palabraai.authModePlatform', 'Platform API Key')}
+              </label>
+              <label className="auth-mode-option">
+                <input
+                  type="radio"
+                  name="palabraai-auth-mode"
+                  checked={palabraAISettings.authMode === 'app'}
+                  onChange={() => updatePalabraAISettings({ authMode: 'app' })}
+                  disabled={isSessionActive}
+                />
+                {t('providers.palabraai.authModeApp', 'App Client ID/Secret')}
+              </label>
             </div>
-            <div className="api-key-input-group">
-              <input
-                type="password"
-                value={palabraAISettings.clientSecret}
-                onChange={(e) => updatePalabraAISettings({ clientSecret: e.target.value })}
-                placeholder={t('providers.palabraai.clientSecretPlaceholder', 'Client Secret')}
-                className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
-                disabled={isSessionActive}
-              />
-              <button
-                className="validate-button"
-                onClick={handleValidateApiKey}
-                disabled={!palabraAISettings.clientId || !palabraAISettings.clientSecret || isValidating || isSessionActive}
-                title={t('simpleSettings.validate')}
-              >
-                {isValidating ? (
-                  <span className="spinner" />
-                ) : isApiKeyValid ? (
-                  <CheckCircle size={16} />
-                ) : (
-                  t('simpleSettings.validate')
-                )}
-              </button>
-            </div>
+            {palabraAISettings.authMode === 'platform' ? (
+              <div className="api-key-input-group">
+                <input
+                  type="password"
+                  value={palabraAISettings.apiKey}
+                  onChange={(e) => updatePalabraAISettings({ apiKey: e.target.value })}
+                  placeholder={t('providers.palabraai.apiKeyPlaceholder', 'API Key')}
+                  className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
+                  disabled={isSessionActive}
+                />
+                <button
+                  className="validate-button"
+                  onClick={handleValidateApiKey}
+                  disabled={!palabraAISettings.apiKey || isValidating || isSessionActive}
+                  title={t('simpleSettings.validate')}
+                >
+                  {isValidating ? <span className="spinner" /> : isApiKeyValid ? <CheckCircle size={16} /> : t('simpleSettings.validate')}
+                </button>
+              </div>
+            ) : (
+              <>
+                <div className="api-key-input-group">
+                  <input
+                    type="password"
+                    value={palabraAISettings.clientId}
+                    onChange={(e) => updatePalabraAISettings({ clientId: e.target.value })}
+                    placeholder={t('providers.palabraai.clientIdPlaceholder', 'Client ID')}
+                    className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
+                    disabled={isSessionActive}
+                  />
+                </div>
+                <div className="api-key-input-group">
+                  <input
+                    type="password"
+                    value={palabraAISettings.clientSecret}
+                    onChange={(e) => updatePalabraAISettings({ clientSecret: e.target.value })}
+                    placeholder={t('providers.palabraai.clientSecretPlaceholder', 'Client Secret')}
+                    className={`api-key-input ${isApiKeyValid === true ? 'valid' : isApiKeyValid === false ? 'invalid' : ''}`}
+                    disabled={isSessionActive}
+                  />
+                  <button
+                    className="validate-button"
+                    onClick={handleValidateApiKey}
+                    disabled={!palabraAISettings.clientId || !palabraAISettings.clientSecret || isValidating || isSessionActive}
+                    title={t('simpleSettings.validate')}
+                  >
+                    {isValidating ? (
+                      <span className="spinner" />
+                    ) : isApiKeyValid ? (
+                      <CheckCircle size={16} />
+                    ) : (
+                      t('simpleSettings.validate')
+                    )}
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         ) : (
           // Standard API key input for other providers

--- a/src/components/Settings/sections/ProviderSection.tsx
+++ b/src/components/Settings/sections/ProviderSection.tsx
@@ -764,27 +764,23 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
           // app Client ID/Secret pair. All three values persist; the toggle only
           // selects which are used.
           <div className="palabraai-credentials-group">
-            <div className="palabraai-auth-mode">
-              <label className="auth-mode-option">
-                <input
-                  type="radio"
-                  name="palabraai-auth-mode"
-                  checked={palabraAISettings.authMode === 'platform'}
-                  onChange={() => updatePalabraAISettings({ authMode: 'platform' })}
-                  disabled={isSessionActive}
-                />
+            <div className="segmented-control">
+              <button
+                type="button"
+                className={`segmented-option ${palabraAISettings.authMode === 'platform' ? 'active' : ''}`}
+                onClick={() => updatePalabraAISettings({ authMode: 'platform' })}
+                disabled={isSessionActive}
+              >
                 {t('providers.palabraai.authModePlatform', 'Platform API Key')}
-              </label>
-              <label className="auth-mode-option">
-                <input
-                  type="radio"
-                  name="palabraai-auth-mode"
-                  checked={palabraAISettings.authMode === 'app'}
-                  onChange={() => updatePalabraAISettings({ authMode: 'app' })}
-                  disabled={isSessionActive}
-                />
+              </button>
+              <button
+                type="button"
+                className={`segmented-option ${palabraAISettings.authMode === 'app' ? 'active' : ''}`}
+                onClick={() => updatePalabraAISettings({ authMode: 'app' })}
+                disabled={isSessionActive}
+              >
                 {t('providers.palabraai.authModeApp', 'App Client ID/Secret')}
-              </label>
+              </button>
             </div>
             {palabraAISettings.authMode === 'platform' ? (
               <div className="api-key-input-group">

--- a/src/components/SettingsInitializer/SettingsInitializer.tsx
+++ b/src/components/SettingsInitializer/SettingsInitializer.tsx
@@ -114,6 +114,7 @@ export function SettingsInitializer() {
     }
   }, [settingsLoaded, provider, openAISettings.apiKey, geminiSettings.apiKey,
       openAICompatibleSettings.apiKey,
+      palabraAISettings.authMode, palabraAISettings.apiKey,
       palabraAISettings.clientId, palabraAISettings.clientSecret,
       volcengineSTSettings.accessKeyId, volcengineSTSettings.secretAccessKey,
       volcengineAST2Settings.appId, volcengineAST2Settings.accessToken,

--- a/src/components/SettingsInitializer/SettingsInitializer.tsx
+++ b/src/components/SettingsInitializer/SettingsInitializer.tsx
@@ -35,6 +35,9 @@ export function SettingsInitializer() {
   // Track previous provider to detect changes (null initially to trigger validation on mount)
   const prevProviderRef = useRef<typeof provider | null>(null);
   const isValidatingRef = useRef(false);
+  // Set when a credential/provider change lands mid-validation; consumed by
+  // the API-provider effect below to run one follow-up validation.
+  const pendingRevalidateRef = useRef(false);
 
   // Get all provider settings to monitor credential changes
   const openAISettings = useOpenAISettings();
@@ -105,12 +108,24 @@ export function SettingsInitializer() {
 
     // Always call validateApiKey — it handles empty credentials internally
     // (sets isApiKeyValid to null, clears availableModels).
-    if (!isValidatingRef.current) {
+    // Changes that arrive while a validation is in flight queue exactly one
+    // rerun: validateApiKey reads the latest store state at call time, so the
+    // follow-up run covers the final values instead of dropping them.
+    const runValidation = () => {
       isValidatingRef.current = true;
-      console.log('[SettingsInitializer] Validating API provider:', provider);
       validateApiKey().finally(() => {
         isValidatingRef.current = false;
+        if (pendingRevalidateRef.current) {
+          pendingRevalidateRef.current = false;
+          runValidation();
+        }
       });
+    };
+    if (isValidatingRef.current) {
+      pendingRevalidateRef.current = true;
+    } else {
+      console.log('[SettingsInitializer] Validating API provider:', provider);
+      runValidation();
     }
   }, [settingsLoaded, provider, openAISettings.apiKey, geminiSettings.apiKey,
       openAICompatibleSettings.apiKey,

--- a/src/components/SettingsInitializer/SettingsInitializer.validationQueue.test.tsx
+++ b/src/components/SettingsInitializer/SettingsInitializer.validationQueue.test.tsx
@@ -1,0 +1,75 @@
+/**
+ * Regression test for a bot-review finding on PR #369: credential changes
+ * arriving while a validation is already in flight were silently dropped by
+ * the isValidatingRef guard — the finally callback only cleared the ref and
+ * never re-validated, so isApiKeyValid could reflect a stale key or auth
+ * mode until the user clicked Validate manually. The initializer must queue
+ * exactly one rerun; validateApiKey reads the latest store state at call
+ * time, so the follow-up run covers the final values.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, act } from '@testing-library/react';
+
+vi.mock('../../lib/auth/hooks', () => ({
+  useAuth: () => ({ isSignedIn: false, getToken: undefined }),
+}));
+
+vi.mock('../../lib/edge-tts/voiceList', () => ({
+  getEdgeTtsVoices: async () => [],
+  filterVoicesByLanguage: () => [],
+}));
+
+const { default: useSettingsStore } = await import('../../stores/settingsStore');
+const { Provider } = await import('../../types/Provider');
+const { SettingsInitializer } = await import('./SettingsInitializer');
+
+describe('SettingsInitializer — validation rerun queue', () => {
+  let resolveFirst: (() => void) | undefined;
+  let validateMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    resolveFirst = undefined;
+    validateMock = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          if (!resolveFirst) {
+            resolveFirst = resolve; // first call stays pending until the test releases it
+          } else {
+            resolve();
+          }
+        }),
+    );
+    useSettingsStore.setState({
+      settingsLoaded: true,
+      provider: Provider.OPENAI,
+      validateApiKey: validateMock,
+    } as never);
+  });
+
+  it('re-validates once more when credentials change during an in-flight validation', async () => {
+    render(<SettingsInitializer />);
+    expect(validateMock).toHaveBeenCalledTimes(1);
+
+    // Credential change while the first validation is still pending
+    act(() => {
+      useSettingsStore.setState((s: any) => ({ openai: { ...s.openai, apiKey: 'sk-new' } }));
+    });
+    expect(validateMock).toHaveBeenCalledTimes(1); // guarded — must be queued, not run concurrently
+
+    await act(async () => {
+      resolveFirst!();
+    });
+    expect(validateMock).toHaveBeenCalledTimes(2); // queued rerun fired with the latest state
+  });
+
+  it('does not rerun when nothing changed during the validation', async () => {
+    render(<SettingsInitializer />);
+    expect(validateMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFirst!();
+    });
+    expect(validateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "ذكاء اصطناعي متخصص في الترجمة",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "مفتاح API",
+      "authModePlatform": "مفتاح Platform API",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine ترجمة الكلام",

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "বিশেষায়িত অনুবাদ AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API কী",
+      "authModePlatform": "Platform API কী",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine স্পিচ ট্রান্সলেট",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Spezialisierte Übersetzungs-AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API-Schlüssel",
+      "authModePlatform": "Platform-API-Schlüssel",
+      "authModeApp": "App Client-ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Sprachübersetzung",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Specialized translation AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API Key",
+      "authModePlatform": "Platform API Key",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Speech Translate",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI de traducción especializada",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Clave API",
+      "authModePlatform": "Clave API de Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Traducción de Voz",

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "هوش مصنوعی تخصصی ترجمه",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "کلید API",
+      "authModePlatform": "کلید Platform API",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine ترجمه گفتار",

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Erikoistunut käännöstekoäly",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API-avain",
+      "authModePlatform": "Platform-API-avain",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Puheenkääntäjä",

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Specialized na translation AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API Key",
+      "authModePlatform": "Platform API Key",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Pagsasalin ng Pananalita",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "IA de traduction spécialisée",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Clé API",
+      "authModePlatform": "Clé API Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Traduction Vocale",

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "בינה מלאכותית מתמחה בתרגום",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "מפתח API",
+      "authModePlatform": "מפתח API של Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine תרגום דיבור",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "विशिष्ट अनुवाद AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API कुंजी",
+      "authModePlatform": "Platform API कुंजी",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine स्पीच ट्रांसलेट",

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI terjemahan khusus",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API Key",
+      "authModePlatform": "Platform API Key",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Terjemahan Ucapan",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI specializzata in traduzione",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Chiave API",
+      "authModePlatform": "Chiave API Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Traduzione Vocale",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "専門翻訳AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "APIキー",
+      "authModePlatform": "Platform APIキー",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine 音声翻訳",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "전문 번역 AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API 키",
+      "authModePlatform": "Platform API 키",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine 음성 번역",

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI terjemahan khusus",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Kunci API",
+      "authModePlatform": "Kunci API Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Terjemahan Pertuturan",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Gespecialiseerde vertaal AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API-sleutel",
+      "authModePlatform": "Platform-API-sleutel",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Spraakvertaling",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Wyspecjalizowane AI do tłumaczeń",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Klucz API",
+      "authModePlatform": "Klucz API Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Tłumaczenie Mowy",

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "IA especializada em tradução",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Chave de API",
+      "authModePlatform": "Chave de API do Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Tradução de Fala",

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI de tradução especializada",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "Chave API",
+      "authModePlatform": "Chave API do Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Tradução de Voz",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Специализированный переводческий ИИ",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API-ключ",
+      "authModePlatform": "API-ключ Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Голосовой Перевод",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Specialiserad översättnings AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API-nyckel",
+      "authModePlatform": "Platform API-nyckel",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Röstöversättning",

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "நியங்களித்த மோழிபெயர்ப்பு AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API விசை",
+      "authModePlatform": "Platform API விசை",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine பேச்சு மொழிபெயர்ப்பு",

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "ప్రత్యేక అనువాద AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API కీ",
+      "authModePlatform": "Platform API కీ",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine స్పీచ్ ట్రాన్స్‌లేట్",

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI แปลภาษาเฉพาะทาง",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "คีย์ API",
+      "authModePlatform": "คีย์ API Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine การแปลเสียงพูด",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Uzmanlaşmış çeviri AI'si",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API Anahtarı",
+      "authModePlatform": "Platform API Anahtarı",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Konuşma Çevirisi",

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "Спеціалізований ШІ для перекладу",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API-ключ",
+      "authModePlatform": "API-ключ Platform",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Голосовий Переклад",

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "AI dịch chuyên biệt",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API Key",
+      "authModePlatform": "Platform API Key",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "Volcengine Dịch Giọng Nói",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "专业翻译AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API 密钥",
+      "authModePlatform": "Platform API 密钥",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "火山引擎语音翻译",

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -370,7 +370,10 @@
       "name": "Palabra AI",
       "description": "專精翻譯的 AI",
       "clientIdPlaceholder": "Client ID",
-      "clientSecretPlaceholder": "Client Secret"
+      "clientSecretPlaceholder": "Client Secret",
+      "apiKeyPlaceholder": "API 金鑰",
+      "authModePlatform": "Platform API 金鑰",
+      "authModeApp": "App Client ID/Secret"
     },
     "volcengine_st": {
       "name": "火山引擎語音翻譯",

--- a/src/services/clients/PalabraAIClient.test.ts
+++ b/src/services/clients/PalabraAIClient.test.ts
@@ -139,14 +139,26 @@ describe('PalabraAIClient.validateApiKey error surfacing', () => {
 
 describe('PalabraAIClient.validateApiKey empty-credential short-circuit', () => {
   it('rejects an empty platform API key without a network call', async () => {
-    const result = await PalabraAIClient.validateApiKey({ kind: 'apiKey', apiKey: '  ' });
-    expect(result.valid).toBe(false);
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    try {
+      const result = await PalabraAIClient.validateApiKey({ kind: 'apiKey', apiKey: '  ' });
+      expect(result.valid).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 
   it('rejects app credentials with a missing secret without a network call', async () => {
-    const result = await PalabraAIClient.validateApiKey({
-      kind: 'clientCredentials', clientId: 'id-1', clientSecret: '',
-    });
-    expect(result.valid).toBe(false);
+    const fetchSpy = vi.spyOn(global, 'fetch');
+    try {
+      const result = await PalabraAIClient.validateApiKey({
+        kind: 'clientCredentials', clientId: 'id-1', clientSecret: '',
+      });
+      expect(result.valid).toBe(false);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    } finally {
+      fetchSpy.mockRestore();
+    }
   });
 });

--- a/src/services/clients/PalabraAIClient.test.ts
+++ b/src/services/clients/PalabraAIClient.test.ts
@@ -112,6 +112,31 @@ describe('PalabraAIClient auth headers', () => {
   });
 });
 
+describe('PalabraAIClient.validateApiKey error surfacing', () => {
+  it('surfaces the API error detail from a 401 response instead of the generic message', async () => {
+    // Real Palabra error shape: { ok: false, errors: [{ title, detail, ... }] }
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({
+        ok: false,
+        errors: [{
+          title: 'Unauthorized',
+          detail: 'Unauthorized access is denied due to invalid credentials.',
+          status: 401,
+        }],
+      }),
+    } as unknown as Response);
+    try {
+      const result = await PalabraAIClient.validateApiKey({ kind: 'apiKey', apiKey: 'wrong-key' });
+      expect(result.valid).toBe(false);
+      expect(result.message).toContain('Unauthorized access is denied');
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});
+
 describe('PalabraAIClient.validateApiKey empty-credential short-circuit', () => {
   it('rejects an empty platform API key without a network call', async () => {
     const result = await PalabraAIClient.validateApiKey({ kind: 'apiKey', apiKey: '  ' });

--- a/src/services/clients/PalabraAIClient.test.ts
+++ b/src/services/clients/PalabraAIClient.test.ts
@@ -41,7 +41,7 @@ describe('PalabraAIClient data message handling', () => {
   let events: RealtimeEvent[];
 
   beforeEach(() => {
-    client = new PalabraAIClient('test-id', 'test-secret');
+    client = new PalabraAIClient({ kind: 'clientCredentials', clientId: 'test-id', clientSecret: 'test-secret' });
     events = [];
     client.setEventHandlers({
       onRealtimeEvent: (event) => { events.push(event); },
@@ -97,5 +97,31 @@ describe('PalabraAIClient data message handling', () => {
 
     expect(errorEvents()).toEqual([]);
     expect(updated).toContain('Hello there');
+  });
+});
+
+describe('PalabraAIClient auth headers', () => {
+  it('builds ClientId/ClientSecret headers for app credentials', () => {
+    const c = new PalabraAIClient({ kind: 'clientCredentials', clientId: 'id-1', clientSecret: 'sec-1' });
+    expect((c as any).authHeaders()).toEqual({ ClientId: 'id-1', ClientSecret: 'sec-1' });
+  });
+
+  it('builds a Bearer Authorization header for a platform API key', () => {
+    const c = new PalabraAIClient({ kind: 'apiKey', apiKey: 'pk-123' });
+    expect((c as any).authHeaders()).toEqual({ Authorization: 'Bearer pk-123' });
+  });
+});
+
+describe('PalabraAIClient.validateApiKey empty-credential short-circuit', () => {
+  it('rejects an empty platform API key without a network call', async () => {
+    const result = await PalabraAIClient.validateApiKey({ kind: 'apiKey', apiKey: '  ' });
+    expect(result.valid).toBe(false);
+  });
+
+  it('rejects app credentials with a missing secret without a network call', async () => {
+    const result = await PalabraAIClient.validateApiKey({
+      kind: 'clientCredentials', clientId: 'id-1', clientSecret: '',
+    });
+    expect(result.valid).toBe(false);
   });
 });

--- a/src/services/clients/PalabraAIClient.ts
+++ b/src/services/clients/PalabraAIClient.ts
@@ -102,14 +102,22 @@ interface PalabraAISessionData {
 }
 
 /**
+ * Palabra has two credential systems: the legacy app.palabra.ai ClientId/ClientSecret
+ * header pair and the platform.palabra.ai single API key (Authorization: Bearer).
+ * Both hit the same endpoints; only the auth headers differ.
+ */
+export type PalabraCredentials =
+  | { kind: 'clientCredentials'; clientId: string; clientSecret: string }
+  | { kind: 'apiKey'; apiKey: string };
+
+/**
  * PalabraAI WebRTC client adapter
  * Implements the IClient interface for PalabraAI's WebRTC API
  */
 export class PalabraAIClient implements IClient {
   private static readonly API_BASE_URL = 'https://api.palabra.ai';
-  
-  private clientId: string;
-  private clientSecret: string;
+
+  private credentials: PalabraCredentials;
   private room: Room | null = null;
   private eventHandlers: ClientEventHandlers = {};
   private conversationItems: ConversationItem[] = [];
@@ -137,20 +145,33 @@ export class PalabraAIClient implements IClient {
   private remoteAudioBufferLength: number = 0;
   private remoteAudioFlushTimer: ReturnType<typeof setTimeout> | null = null;
 
-  constructor(clientId: string, clientSecret: string) {
-    this.clientId = clientId;
-    this.clientSecret = clientSecret;
+  constructor(credentials: PalabraCredentials) {
+    this.credentials = credentials;
     // Generate a unique instance ID that remains constant for this client instance
     this.instanceId = `palabra_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+  }
+
+  private static authHeadersFor(credentials: PalabraCredentials): Record<string, string> {
+    return credentials.kind === 'apiKey'
+      ? { 'Authorization': `Bearer ${credentials.apiKey}` }
+      : { 'ClientId': credentials.clientId, 'ClientSecret': credentials.clientSecret };
+  }
+
+  private authHeaders(): Record<string, string> {
+    return PalabraAIClient.authHeadersFor(this.credentials);
   }
 
   /**
    * Validate API credentials by checking user sessions
    */
-  static async validateApiKey(clientId: string, clientSecret: string): Promise<ApiKeyValidationResult> {
+  static async validateApiKey(credentials: PalabraCredentials): Promise<ApiKeyValidationResult> {
     try {
       // Check if credentials are empty
-      if (!clientId || clientId.trim() === '' || !clientSecret || clientSecret.trim() === '') {
+      const empty = credentials.kind === 'apiKey'
+        ? !credentials.apiKey || credentials.apiKey.trim() === ''
+        : !credentials.clientId || credentials.clientId.trim() === '' ||
+          !credentials.clientSecret || credentials.clientSecret.trim() === '';
+      if (empty) {
         return {
           valid: false,
           message: i18n.t('settings.errorValidatingApiKey'),
@@ -163,8 +184,7 @@ export class PalabraAIClient implements IClient {
         method: 'GET',
         headers: {
           'Accept': 'application/json',
-          'ClientId': clientId,
-          'ClientSecret': clientSecret,
+          ...PalabraAIClient.authHeadersFor(credentials),
         }
       });
 
@@ -406,12 +426,10 @@ export class PalabraAIClient implements IClient {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'ClientId': this.clientId,
-        'ClientSecret': this.clientSecret,
+        ...this.authHeaders(),
       },
       body: JSON.stringify({
         data: {
-          subscriber_count: 0,
           intent: 'api'
         }
       })
@@ -1067,8 +1085,7 @@ export class PalabraAIClient implements IClient {
         method: 'GET',
         headers: {
           'Accept': 'application/json',
-          'ClientId': this.clientId,
-          'ClientSecret': this.clientSecret,
+          ...this.authHeaders(),
         }
       });
 
@@ -1117,8 +1134,7 @@ export class PalabraAIClient implements IClient {
       const response = await fetch(`${PalabraAIClient.API_BASE_URL}/session-storage/sessions/${sessionId}`, {
         method: 'DELETE',
         headers: {
-          'ClientId': this.clientId,
-          'ClientSecret': this.clientSecret,
+          ...this.authHeaders(),
         }
       });
 

--- a/src/services/clients/PalabraAIClient.ts
+++ b/src/services/clients/PalabraAIClient.ts
@@ -193,9 +193,12 @@ export class PalabraAIClient implements IClient {
       if (!response.ok) {
         const errorData = await response.json().catch(() => ({}));
         console.warn("[Sokuji] [PalabraAIClient] Validation failed:", errorData);
+        // Palabra's error shape is { ok: false, errors: [{ title, detail, ... }] };
+        // the flat error.message form is kept as a fallback for older responses.
+        const firstError = errorData?.errors?.[0];
         return {
           valid: false,
-          message: errorData.error?.message || i18n.t('settings.errorValidatingApiKey'),
+          message: firstError?.detail || firstError?.title || errorData.error?.message || i18n.t('settings.errorValidatingApiKey'),
           validating: false
         };
       }

--- a/src/services/providers/PalabraAIProviderConfig.test.ts
+++ b/src/services/providers/PalabraAIProviderConfig.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+vi.mock('../../locales', () => ({
+  default: { t: (key: string) => key }
+}));
+vi.mock('livekit-client', () => ({
+  setLogLevel: vi.fn(),
+  Room: class {}, RoomEvent: {}, TrackPublication: class {},
+  RemoteParticipant: class {}, RemoteTrack: class {},
+  RemoteAudioTrack: class {}, LocalAudioTrack: class {},
+}));
+
+const { PalabraAIProviderConfig, defaultPalabraAISettings } = await import('./PalabraAIProviderConfig');
+const { PalabraAIClient } = await import('../clients/PalabraAIClient');
+
+const descriptor = new PalabraAIProviderConfig();
+const appSlice = { ...defaultPalabraAISettings, authMode: 'app' as const, clientId: 'id-1', clientSecret: 'sec-1' };
+const platformSlice = { ...defaultPalabraAISettings, authMode: 'platform' as const, apiKey: 'pk-1' };
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('extractCredentials', () => {
+  it('maps platform mode to primary-only credentials (no secret key)', async () => {
+    const creds = await descriptor.extractCredentials(platformSlice, {});
+    expect(creds).toEqual({ ok: true, primary: 'pk-1' });
+    expect('secret' in creds).toBe(false);
+  });
+
+  it('rejects platform mode without an API key', async () => {
+    const creds = await descriptor.extractCredentials({ ...platformSlice, apiKey: '' }, {});
+    expect(creds.ok).toBe(false);
+  });
+
+  it('maps app mode to primary+secret', async () => {
+    expect(await descriptor.extractCredentials(appSlice, {}))
+      .toEqual({ ok: true, primary: 'id-1', secret: 'sec-1' });
+  });
+
+  it('rejects app mode with a missing half of the pair', async () => {
+    expect((await descriptor.extractCredentials({ ...appSlice, clientSecret: '' }, {})).ok).toBe(false);
+    expect((await descriptor.extractCredentials({ ...appSlice, clientId: '' }, {})).ok).toBe(false);
+  });
+
+  it('app mode ignores a stale apiKey value; platform mode ignores stale clientId/clientSecret', async () => {
+    expect(await descriptor.extractCredentials({ ...appSlice, apiKey: 'stale' }, {}))
+      .toEqual({ ok: true, primary: 'id-1', secret: 'sec-1' });
+    expect(await descriptor.extractCredentials({ ...platformSlice, clientId: 'stale', clientSecret: 'stale' }, {}))
+      .toEqual({ ok: true, primary: 'pk-1' });
+  });
+});
+
+describe('peekPrimaryCredential', () => {
+  it('returns the active mode credential', () => {
+    expect(descriptor.peekPrimaryCredential(appSlice)).toBe('id-1');
+    expect(descriptor.peekPrimaryCredential(platformSlice)).toBe('pk-1');
+  });
+});
+
+describe('createClient', () => {
+  it('builds an app-credential client when secret is present', () => {
+    const client = descriptor.createClient({ ok: true, primary: 'id-1', secret: 'sec-1' }, { transport: 'websocket' } as any);
+    expect((client as any).credentials).toEqual({ kind: 'clientCredentials', clientId: 'id-1', clientSecret: 'sec-1' });
+  });
+
+  it('builds a platform-key client when secret is absent', () => {
+    const client = descriptor.createClient({ ok: true, primary: 'pk-1' }, { transport: 'websocket' } as any);
+    expect((client as any).credentials).toEqual({ kind: 'apiKey', apiKey: 'pk-1' });
+  });
+});
+
+describe('validateAndFetchModels', () => {
+  it('validates a platform key (no secret) instead of demanding a client secret', async () => {
+    const spy = vi.spyOn(PalabraAIClient, 'validateApiKey').mockResolvedValue({
+      valid: true, message: 'ok', validating: false,
+    });
+    const result = await descriptor.validateAndFetchModels({ ok: true, primary: 'pk-1' });
+    expect(spy).toHaveBeenCalledWith({ kind: 'apiKey', apiKey: 'pk-1' });
+    expect(result.validation.valid).toBe(true);
+    expect(result.models).toHaveLength(1);
+  });
+
+  it('validates app credentials as before', async () => {
+    const spy = vi.spyOn(PalabraAIClient, 'validateApiKey').mockResolvedValue({
+      valid: true, message: 'ok', validating: false,
+    });
+    await descriptor.validateAndFetchModels({ ok: true, primary: 'id-1', secret: 'sec-1' });
+    expect(spy).toHaveBeenCalledWith({ kind: 'clientCredentials', clientId: 'id-1', clientSecret: 'sec-1' });
+  });
+});

--- a/src/services/providers/PalabraAIProviderConfig.test.ts
+++ b/src/services/providers/PalabraAIProviderConfig.test.ts
@@ -41,6 +41,18 @@ describe('extractCredentials', () => {
     expect((await descriptor.extractCredentials({ ...appSlice, clientId: '' }, {})).ok).toBe(false);
   });
 
+  it('trims surrounding whitespace from credentials in both modes', async () => {
+    expect(await descriptor.extractCredentials({ ...platformSlice, apiKey: '  pk-1  ' }, {}))
+      .toEqual({ ok: true, primary: 'pk-1' });
+    expect(await descriptor.extractCredentials({ ...appSlice, clientId: ' id-1 ', clientSecret: ' sec-1\n' }, {}))
+      .toEqual({ ok: true, primary: 'id-1', secret: 'sec-1' });
+  });
+
+  it('rejects whitespace-only credentials in both modes', async () => {
+    expect((await descriptor.extractCredentials({ ...platformSlice, apiKey: '   ' }, {})).ok).toBe(false);
+    expect((await descriptor.extractCredentials({ ...appSlice, clientSecret: '   ' }, {})).ok).toBe(false);
+  });
+
   it('app mode ignores a stale apiKey value; platform mode ignores stale clientId/clientSecret', async () => {
     expect(await descriptor.extractCredentials({ ...appSlice, apiKey: 'stale' }, {}))
       .toEqual({ ok: true, primary: 'id-1', secret: 'sec-1' });

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -2,7 +2,7 @@ import { ProviderConfig, LanguageOption, VoiceOption, ModelOption } from './Prov
 import { BaseProviderDescriptor, Credentials, CredentialCtx, ClientOptions } from './ProviderDescriptor';
 import { IClient, FilteredModel, SessionConfig, PalabraAISessionConfig } from '../interfaces/IClient';
 import { ApiKeyValidationResult } from '../interfaces/ISettingsService';
-import { PalabraAIClient } from '../clients/PalabraAIClient';
+import { PalabraAIClient, PalabraCredentials } from '../clients/PalabraAIClient';
 
 // PalabraAI Settings
 export interface PalabraAISettings {
@@ -47,6 +47,14 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
 
   async extractCredentials(slice: unknown, _ctx: CredentialCtx): Promise<Credentials> {
     const s = slice as PalabraAISettings;
+    if (s?.authMode === 'platform') {
+      if (!s.apiKey || s.apiKey.trim() === '') {
+        return { ok: false, missing: 'API Key is required for Palabra AI' };
+      }
+      // No `secret` key: createClient/validateAndFetchModels decode its absence
+      // as platform mode. Both ends of that convention live in Palabra's own files.
+      return { ok: true, primary: s.apiKey };
+    }
     if (!s?.clientId || !s?.clientSecret) {
       return { ok: false, missing: 'Both Client ID and Client Secret are required for Palabra AI' };
     }
@@ -54,13 +62,12 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
   }
 
   peekPrimaryCredential(slice: unknown): string {
-    return (slice as PalabraAISettings)?.clientId ?? '';
+    const s = slice as PalabraAISettings;
+    return s?.authMode === 'platform' ? (s?.apiKey ?? '') : (s?.clientId ?? '');
   }
 
-  // creds.secret is guaranteed by extractCredentials (Task 5).
   createClient(creds: Credentials & { ok: true }, _options: ClientOptions): IClient {
-    if (!creds.secret) throw new Error('Client secret is required for palabraai provider');
-    return new PalabraAIClient({ kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret });
+    return new PalabraAIClient(PalabraAIProviderConfig.toPalabraCredentials(creds));
   }
 
   async validateAndFetchModels(creds: Credentials): Promise<{
@@ -69,18 +76,25 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     if (!creds.ok) {
       return { validation: { valid: false, message: creds.missing, validating: false }, models: [] };
     }
-    if (!creds.secret) {
-      // Legacy façade callers pass raw positional args and skip
-      // extractCredentials — keep the old required-field contract here.
-      return { validation: { valid: false, message: 'Both Client ID and Client Secret are required for Palabra AI', validating: false }, models: [] };
-    }
-    const validation = await PalabraAIClient.validateApiKey({
-      kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret,
-    });
+    const validation = await PalabraAIClient.validateApiKey(
+      PalabraAIProviderConfig.toPalabraCredentials(creds)
+    );
     return {
       validation,
       models: [{ id: 'realtime-translation', type: 'realtime', created: Date.now() / 1000 }],
     };
+  }
+
+  /**
+   * secret present = app pair, absent = platform key. A deprecated-façade caller
+   * passing a clientId without its secret now gets a Bearer 401 from validation
+   * instead of the old tailored both-required message — acceptable degradation;
+   * the live path (extractCredentials) always sets secret for app mode.
+   */
+  private static toPalabraCredentials(creds: Credentials & { ok: true }): PalabraCredentials {
+    return creds.secret !== undefined
+      ? { kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret }
+      : { kind: 'apiKey', apiKey: creds.primary };
   }
 
   buildSessionConfig(slice: unknown, systemInstructions: string): SessionConfig {

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -6,6 +6,8 @@ import { PalabraAIClient } from '../clients/PalabraAIClient';
 
 // PalabraAI Settings
 export interface PalabraAISettings {
+  authMode: 'app' | 'platform';
+  apiKey: string;
   clientId: string;
   clientSecret: string;
   sourceLanguage: string;
@@ -22,6 +24,8 @@ export interface PalabraAISettings {
 }
 
 export const defaultPalabraAISettings: PalabraAISettings = {
+  authMode: 'platform',
+  apiKey: '',
   clientId: '',
   clientSecret: '',
   sourceLanguage: 'en',

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -48,17 +48,20 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
   async extractCredentials(slice: unknown, _ctx: CredentialCtx): Promise<Credentials> {
     const s = slice as PalabraAISettings;
     if (s?.authMode === 'platform') {
-      if (!s.apiKey || s.apiKey.trim() === '') {
+      const apiKey = s.apiKey?.trim();
+      if (!apiKey) {
         return { ok: false, missing: 'API Key is required for Palabra AI' };
       }
       // No `secret` key: createClient/validateAndFetchModels decode its absence
       // as platform mode. Both ends of that convention live in Palabra's own files.
-      return { ok: true, primary: s.apiKey };
+      return { ok: true, primary: apiKey };
     }
-    if (!s?.clientId || !s?.clientSecret) {
+    const clientId = s?.clientId?.trim();
+    const clientSecret = s?.clientSecret?.trim();
+    if (!clientId || !clientSecret) {
       return { ok: false, missing: 'Both Client ID and Client Secret are required for Palabra AI' };
     }
-    return { ok: true, primary: s.clientId, secret: s.clientSecret };
+    return { ok: true, primary: clientId, secret: clientSecret };
   }
 
   peekPrimaryCredential(slice: unknown): string {

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -56,7 +56,7 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
   // creds.secret is guaranteed by extractCredentials (Task 5).
   createClient(creds: Credentials & { ok: true }, _options: ClientOptions): IClient {
     if (!creds.secret) throw new Error('Client secret is required for palabraai provider');
-    return new PalabraAIClient(creds.primary, creds.secret);
+    return new PalabraAIClient({ kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret });
   }
 
   async validateAndFetchModels(creds: Credentials): Promise<{
@@ -70,7 +70,9 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
       // extractCredentials — keep the old required-field contract here.
       return { validation: { valid: false, message: 'Both Client ID and Client Secret are required for Palabra AI', validating: false }, models: [] };
     }
-    const validation = await PalabraAIClient.validateApiKey(creds.primary, creds.secret);
+    const validation = await PalabraAIClient.validateApiKey({
+      kind: 'clientCredentials', clientId: creds.primary, clientSecret: creds.secret,
+    });
     return {
       validation,
       models: [{ id: 'realtime-translation', type: 'realtime', created: Date.now() / 1000 }],

--- a/src/services/providers/descriptorRegistry.test.ts
+++ b/src/services/providers/descriptorRegistry.test.ts
@@ -336,7 +336,6 @@ describe('legacy façade credential guards (deprecated ClientOperations/ClientFa
   it('two-field providers reject a filled primary with a missing secret', async () => {
     const { ClientOperations } = await import('../ClientOperations');
     const cases: Array<[Provider, RegExp]> = [
-      [Provider.PALABRA_AI, /Client ID and Client Secret/],
       [Provider.VOLCENGINE_ST, /Access Key ID and Secret Access Key/],
       [Provider.VOLCENGINE_AST2, /APP ID and Access Token/],
       [Provider.ZOOM_AI, /API Key and API Secret/],
@@ -347,6 +346,28 @@ describe('legacy façade credential guards (deprecated ClientOperations/ClientFa
       expect(r.validation.message, id).toMatch(msg);
       expect(r.models, id).toEqual([]);
     }
+  });
+
+  // PalabraAI is no longer a synchronous two-field guard: a missing `secret` is
+  // the documented signal for platform-mode (API key) credentials (see
+  // PalabraAIProviderConfig.toPalabraCredentials), so a legacy caller passing
+  // only a primary now reaches the real validateApiKey network call instead of
+  // being rejected up front. Mock fetch so that call still fails deterministically.
+  it('PalabraAI treats a missing secret as a platform API key, not a guard failure', async () => {
+    const fetchSpy = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({ error: { message: 'Unauthorized' } }),
+    } as unknown as Response);
+    const { ClientOperations } = await import('../ClientOperations');
+    const r = await ClientOperations.validateApiKeyAndFetchModels('primary-only', Provider.PALABRA_AI);
+    expect(fetchSpy).toHaveBeenCalled();
+    expect(r.validation.valid).toBe(false);
+    // Unlike the guard-rejection cases above, credential *shape* was accepted
+    // (creds.ok === true), so validateAndFetchModels still returns the static
+    // model list — only `validation` reflects the failed network check.
+    expect(r.models).toHaveLength(1);
+    fetchSpy.mockRestore();
   });
 
   it('ClientFactory.createClient rejects an empty apiKey for credentialed providers', async () => {

--- a/src/services/providers/descriptorRegistry.test.ts
+++ b/src/services/providers/descriptorRegistry.test.ts
@@ -359,15 +359,20 @@ describe('legacy façade credential guards (deprecated ClientOperations/ClientFa
       status: 401,
       json: async () => ({ error: { message: 'Unauthorized' } }),
     } as unknown as Response);
-    const { ClientOperations } = await import('../ClientOperations');
-    const r = await ClientOperations.validateApiKeyAndFetchModels('primary-only', Provider.PALABRA_AI);
-    expect(fetchSpy).toHaveBeenCalled();
-    expect(r.validation.valid).toBe(false);
-    // Unlike the guard-rejection cases above, credential *shape* was accepted
-    // (creds.ok === true), so validateAndFetchModels still returns the static
-    // model list — only `validation` reflects the failed network check.
-    expect(r.models).toHaveLength(1);
-    fetchSpy.mockRestore();
+    try {
+      const { ClientOperations } = await import('../ClientOperations');
+      const r = await ClientOperations.validateApiKeyAndFetchModels('primary-only', Provider.PALABRA_AI);
+      expect(fetchSpy).toHaveBeenCalled();
+      expect(r.validation.valid).toBe(false);
+      // Unlike the guard-rejection cases above, credential *shape* was accepted
+      // (creds.ok === true), so validateAndFetchModels still returns the static
+      // model list — only `validation` reflects the failed network check.
+      expect(r.models).toHaveLength(1);
+    } finally {
+      // Without the finally, a failing expect leaks the global fetch mock into
+      // every later test in this file.
+      fetchSpy.mockRestore();
+    }
   });
 
   it('ClientFactory.createClient rejects an empty apiKey for credentialed providers', async () => {

--- a/src/stores/palabraAuthModeMigration.test.ts
+++ b/src/stores/palabraAuthModeMigration.test.ts
@@ -22,4 +22,10 @@ describe('migratePalabraAuthMode', () => {
   it('leaves a fresh install on the platform default', () => {
     expect(migratePalabraAuthMode('', { clientId: '', clientSecret: '' })).toEqual({ authMode: 'platform' });
   });
+
+  it('treats an unrecognized stored value as never stored', () => {
+    // e.g. corrupted storage or a foreign value like 'Platform' (wrong case)
+    expect(migratePalabraAuthMode('Platform', { clientId: 'id', clientSecret: 'sec' })).toEqual({ authMode: 'app' });
+    expect(migratePalabraAuthMode('garbage', { clientId: '', clientSecret: '' })).toEqual({ authMode: 'platform' });
+  });
 });

--- a/src/stores/palabraAuthModeMigration.test.ts
+++ b/src/stores/palabraAuthModeMigration.test.ts
@@ -23,6 +23,13 @@ describe('migratePalabraAuthMode', () => {
     expect(migratePalabraAuthMode('', { clientId: '', clientSecret: '' })).toEqual({ authMode: 'platform' });
   });
 
+  it('treats whitespace-only legacy credentials as absent', () => {
+    // extractCredentials trims and rejects whitespace-only values, so pinning
+    // such a slice to app mode would strand the user on unusable credentials.
+    expect(migratePalabraAuthMode('', { clientId: '   ', clientSecret: '' })).toEqual({ authMode: 'platform' });
+    expect(migratePalabraAuthMode('', { clientId: '', clientSecret: '  ' })).toEqual({ authMode: 'platform' });
+  });
+
   it('treats an unrecognized stored value as never stored', () => {
     // e.g. corrupted storage or a foreign value like 'Platform' (wrong case)
     expect(migratePalabraAuthMode('Platform', { clientId: 'id', clientSecret: 'sec' })).toEqual({ authMode: 'app' });

--- a/src/stores/palabraAuthModeMigration.test.ts
+++ b/src/stores/palabraAuthModeMigration.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { migratePalabraAuthMode } from './settingsStore';
+
+describe('migratePalabraAuthMode', () => {
+  it('keeps an explicitly stored app mode', () => {
+    expect(migratePalabraAuthMode('app', { clientId: '', clientSecret: '' })).toEqual({});
+  });
+
+  it('keeps an explicitly stored platform mode even when legacy credentials exist', () => {
+    expect(migratePalabraAuthMode('platform', { clientId: 'id', clientSecret: 'sec' })).toEqual({});
+  });
+
+  it('pins a legacy user (stored credentials, never chose a mode) to app', () => {
+    expect(migratePalabraAuthMode('', { clientId: 'id', clientSecret: 'sec' })).toEqual({ authMode: 'app' });
+  });
+
+  it('pins to app when only one legacy field is present', () => {
+    expect(migratePalabraAuthMode('', { clientId: 'id', clientSecret: '' })).toEqual({ authMode: 'app' });
+    expect(migratePalabraAuthMode('', { clientId: '', clientSecret: 'sec' })).toEqual({ authMode: 'app' });
+  });
+
+  it('leaves a fresh install on the platform default', () => {
+    expect(migratePalabraAuthMode('', { clientId: '', clientSecret: '' })).toEqual({ authMode: 'platform' });
+  });
+});

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -343,6 +343,23 @@ export function migrateRejectedPalabraLanguages(
   };
 }
 
+/**
+ * Decide the auth mode for a persisted Palabra slice that predates authMode.
+ * storedAuthMode is the RAW stored value probed with an empty-string sentinel
+ * (loadProviderSettings merges defaults per key, so the merged slice cannot
+ * distinguish "never stored" from "stored 'platform'"). A user with legacy
+ * credentials who never chose a mode keeps working in app mode; everyone
+ * else gets the platform default.
+ */
+export function migratePalabraAuthMode(
+  storedAuthMode: string,
+  slice: Pick<PalabraAISettings, 'clientId' | 'clientSecret'>
+): Partial<Pick<PalabraAISettings, 'authMode'>> {
+  if (storedAuthMode === 'app' || storedAuthMode === 'platform') return {};
+  if (slice.clientId || slice.clientSecret) return { authMode: 'app' };
+  return { authMode: 'platform' };
+}
+
 /** Migrate a persisted deprecated OpenAI voice-agent realtime model id to its
  *  current replacement. OpenAI notified (2026-07-20) that the pre-2.1 realtime
  *  and audio model families/snapshots are removed from the API on 2027-01-20;
@@ -1212,6 +1229,10 @@ const useSettingsStore = create<SettingsStore>()(
         const palabraSlice = loadedSlices.palabraai as PalabraAISettings | undefined;
         if (palabraSlice) {
           Object.assign(palabraSlice, migrateRejectedPalabraLanguages(palabraSlice));
+          // authMode predates some persisted slices; probe the raw stored value so a
+          // default-injected 'platform' isn't mistaken for a user choice.
+          const storedAuthMode = await service.getSetting('settings.palabraai.authMode', '');
+          Object.assign(palabraSlice, migratePalabraAuthMode(storedAuthMode, palabraSlice));
         }
 
         set({

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -356,7 +356,9 @@ export function migratePalabraAuthMode(
   slice: Pick<PalabraAISettings, 'clientId' | 'clientSecret'>
 ): Partial<Pick<PalabraAISettings, 'authMode'>> {
   if (storedAuthMode === 'app' || storedAuthMode === 'platform') return {};
-  if (slice.clientId || slice.clientSecret) return { authMode: 'app' };
+  // Trimmed, to mirror extractCredentials: whitespace-only credentials are
+  // rejected there, so pinning them to app mode would strand the user.
+  if (slice.clientId?.trim() || slice.clientSecret?.trim()) return { authMode: 'app' };
   return { authMode: 'platform' };
 }
 


### PR DESCRIPTION
## Summary

Palabra split its developer offering into the legacy **app** (app.palabra.ai, `ClientId`/`ClientSecret` header pair) and the new **platform** (platform.palabra.ai, single API key via `Authorization: Bearer`). This PR adds platform API key support as a second auth mode on the existing `palabraai` provider — same client, same provider, same LiveKit pipeline; only the auth header construction is parameterized.

Both credential systems hit the same endpoints (`api.palabra.ai/session-storage/*`), verified against Palabra's OpenAPI spec and a live smoke test (Bearer 201/200/204, CORS preflight `allow-headers: *`, app credentials still returning 200).

## Key changes

- **`PalabraAIClient`**: constructor takes a `PalabraCredentials` discriminated union (`clientCredentials` | `apiKey`); all four REST call sites build headers through a single `authHeaders()` helper. Session-create body drops the dead `subscriber_count` field (no longer in `CreateSessionRequestV2`). `validateApiKey` now surfaces Palabra's real error shape (`errors[0].detail`) instead of a generic message.
- **Settings**: `palabraai` slice gains `authMode: 'app' | 'platform'` (new installs default to `platform`) and `apiKey`. All three credential values persist independently — the toggle only selects which are used, never clears anything.
- **Migration**: legacy users (stored `clientId`/`clientSecret`, never chose a mode) are pinned to app mode. The migration probes the raw stored `authMode` with an empty-string sentinel because `loadProviderSettings` injects defaults per key, making a merged slice unable to distinguish "never stored" from "stored 'platform'".
- **Descriptor**: platform mode encodes into the shared `Credentials` contract as `{ ok, primary }` with no `secret`; secret-presence is the discriminator on decode. Credentials are trimmed in both modes. No automatic fallback between modes, ever.
- **UI**: auth mode segmented control (same archetype as ModePicker / noise suppression / native device selection) with per-mode credential inputs; auto-validation reacts to `authMode`/`apiKey` changes.
- **i18n**: three new keys (`apiKeyPlaceholder`, `authModePlatform`, `authModeApp`) across all 30 locales.

## Verification

- 1717/1717 vitest tests green (new coverage: auth header shapes, descriptor credential flow both modes, migration cases incl. corrupted values, UI toggle credential persistence); production build succeeds.
- Live acceptance on the real API with both credential kinds: validation and full translation sessions (transcriptions + translated audio) pass in both modes.
- `livekit-client` stays pinned at exact 2.18.7 (Palabra's server-side LiveKit version ceiling).

Design doc: `docs/superpowers/specs/2026-07-30-palabra-platform-api-key-design.md` · Plan: `docs/superpowers/plans/2026-07-30-palabra-platform-api-key.md`

Related: #367 (voice selection — the voice endpoints accept both credential styles, so it can reuse the `authHeaders()` helper introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Platform API Key authentication for Palabra AI alongside existing App Client ID/Secret authentication.
  * Added an authentication-mode switch in settings with mode-specific credential fields and validation.
  * New installations default to Platform mode; existing configurations are preserved via migration.
* **Bug Fixes**
  * Improved settings validation so changes during an in-progress check trigger an additional revalidation when needed.
* **Localization**
  * Added authentication-mode labels and API key placeholders across supported languages.
* **Tests**
  * Expanded coverage for credential handling, auth headers, migration, settings UI behavior, and validation flows.
* **Style**
  * Added segmented-control styling for the auth-mode selector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->