### PR TITLE
feat(soniox): 28-voice catalog + session background (context.text)

### DIFF
--- a/docs/superpowers/plans/2026-07-31-soniox-voices-context-text.md
+++ b/docs/superpowers/plans/2026-07-31-soniox-voices-context-text.md
@@ -1,0 +1,452 @@
+# Soniox Voices + Session Background Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand the Soniox TTS voice catalog from 12 to the official 28, and expose STT `context.text` as an optional "Session Background" setting folded into the serialized-context budget (text trimmed first).
+
+**Architecture:** Pure additions along the established Soniox chain: settings field → `buildSessionConfig` (budget guard grows a `text` argument with character-level first-priority truncation) → `SonioxSessionConfig.context.text` → client passthrough → wire `context.text` (default-neutral omission). One new UI section reusing the vocabulary-textarea pattern. Spec: `docs/superpowers/specs/2026-07-31-soniox-voices-context-text-design.md`.
+
+**Tech Stack:** TypeScript, Vitest, i18next (30 locales).
+
+## Global Constraints
+
+- **Branch/worktree:** `feat/soniox-voices-context-text` in `.claude/worktrees/soniox-voices-text` (off origin/main). Never push, never open a PR, no bare `git stash`.
+- **Default-neutral wire:** `context.text` appears only when the trimmed setting is non-empty; with defaults the wire is byte-identical to today (existing omission tests must pass unedited).
+- **Length policy (exact):** textarea `maxLength={4000}`; `fitContextToBudget` budgets the WIRE-shaped serialization at 9,000 chars and trims in order — truncate `text` (character-level) first, then `translation_terms` tail, then `terms` tail; `console.warn` on any trim.
+- **Vitest is the gate:** `npx vitest run <path>`; not tsc (~113 pre-existing errors). This worktree shares the known environmental "Denied ID …?url" failures (no own node_modules) — not regressions.
+- **All comments/code in English.** Conventional commits, one per task, ending with `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+
+---
+
+### Task 1: Voice catalog 12 → 28
+
+**Files:**
+- Modify: `src/services/providers/SonioxProviderConfig.ts` (`VOICES` at :259, stale comments at :257 and :295)
+- Test: `src/services/providers/SonioxProviderConfig.test.ts`
+
+**Interfaces:** none new — `VoiceOption[]` shape unchanged; managed twin inherits via `super.getConfig()`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append a new describe at the end of `src/services/providers/SonioxProviderConfig.test.ts`:
+
+```typescript
+describe('SonioxProviderConfig voices', () => {
+  it('exposes the full 28-voice catalog, unique, including the original twelve', () => {
+    const voices = new SonioxProviderConfig().getConfig().voices.map((v) => v.value);
+    expect(voices).toHaveLength(28);
+    expect(new Set(voices).size).toBe(28);
+    for (const original of ['Adrian', 'Claire', 'Daniel', 'Emma', 'Grace', 'Jack', 'Kenji', 'Maya', 'Mina', 'Nina', 'Noah', 'Owen']) {
+      expect(voices).toContain(original);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/services/providers/SonioxProviderConfig.test.ts`
+Expected: FAIL — length 12 ≠ 28.
+
+- [ ] **Step 3: Implement**
+
+Replace the comment at :257-258 and extend the `VOICES` table (keep the original 12 entries first, verbatim):
+
+```typescript
+  // Every voice is multilingual — any voice speaks any language (official
+  // catalog, 2026-07-31; zh/ja/en live-verified 2026-07-18 for the original
+  // twelve) — so one voice serves both two_way directions.
+  private static readonly VOICES: VoiceOption[] = [
+    { name: 'Adrian', value: 'Adrian' },
+    { name: 'Claire', value: 'Claire' },
+    { name: 'Daniel', value: 'Daniel' },
+    { name: 'Emma', value: 'Emma' },
+    { name: 'Grace', value: 'Grace' },
+    { name: 'Jack', value: 'Jack' },
+    { name: 'Kenji', value: 'Kenji' },
+    { name: 'Maya', value: 'Maya' },
+    { name: 'Mina', value: 'Mina' },
+    { name: 'Nina', value: 'Nina' },
+    { name: 'Noah', value: 'Noah' },
+    { name: 'Owen', value: 'Owen' },
+    // Accented additions (official catalog, 2026-07-31):
+    { name: 'Rafael', value: 'Rafael' },     // Spanish accent
+    { name: 'Mateo', value: 'Mateo' },       // Spanish accent
+    { name: 'Lucia', value: 'Lucia' },       // Spanish accent
+    { name: 'Sofia', value: 'Sofia' },       // Spanish accent
+    { name: 'Oliver', value: 'Oliver' },     // British accent
+    { name: 'Arthur', value: 'Arthur' },     // British accent
+    { name: 'Isla', value: 'Isla' },         // British accent
+    { name: 'Victoria', value: 'Victoria' }, // British accent
+    { name: 'Cooper', value: 'Cooper' },     // Australian accent
+    { name: 'Mason', value: 'Mason' },       // Australian accent
+    { name: 'Ruby', value: 'Ruby' },         // Australian accent
+    { name: 'Elise', value: 'Elise' },       // Australian accent
+    { name: 'Arjun', value: 'Arjun' },       // Indian accent
+    { name: 'Rohan', value: 'Rohan' },       // Indian accent
+    { name: 'Priya', value: 'Priya' },       // Indian accent
+    { name: 'Meera', value: 'Meera' },       // Indian accent
+  ];
+```
+
+Update the capability comment at :295 from `// TTS voice dropdown (12 multilingual voices)` to `// TTS voice dropdown (28 multilingual voices)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run src/services/providers/SonioxProviderConfig.test.ts src/services/providers/descriptorRegistry.test.ts`
+Expected: PASS (descriptorRegistry has one known environmental failure in this worktree — everything else green, no assertion touches voices).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/providers/SonioxProviderConfig.ts src/services/providers/SonioxProviderConfig.test.ts
+git commit -m "feat(soniox): expand the TTS voice catalog to the official 28 voices
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Provider layer — `contextText` setting, budget with text-first trimming
+
+**Files:**
+- Modify: `src/services/providers/SonioxProviderConfig.ts` (`SonioxSettings`/defaults ~:9-40, `fitContextToBudget` ~:80-107, `buildSessionConfig` ~:155-175)
+- Modify: `src/services/interfaces/IClient.ts` (`SonioxSessionConfig.context` at ~:196)
+- Test: `src/services/providers/SonioxProviderConfig.test.ts`
+
+**Interfaces:**
+- Produces: `SonioxSettings.contextText: string` (default `''`); `fitContextToBudget(terms, translationTerms, text)` returning `{ terms, translationTerms, text }`; `SonioxSessionConfig.context` gains `text?: string`. Tasks 3-4 rely on these names.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append inside the existing `describe('SonioxProviderConfig.buildSessionConfig', ...)` block (reuse its `build` helper):
+
+```typescript
+  it('passes trimmed background text through as context.text', () => {
+    const cfg = build({ contextText: '  Quarterly review of the Sokuji roadmap. ' });
+    expect(cfg.context).toEqual({ text: 'Quarterly review of the Sokuji roadmap.' });
+  });
+
+  it('omits context entirely for whitespace-only background text', () => {
+    const cfg = build({ contextText: '   \n\t ' });
+    expect(cfg.context).toBeUndefined();
+  });
+
+  it('truncates the background text first when the serialized context overflows, keeping vocabulary intact', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // ~200 translation pairs (~6.4 KB serialized) + 4000-char text → overflow
+    // where text absorbs the whole cut and translations survive untouched.
+    const lines = Array.from({ length: 200 }, (_, i) => `src${String(i).padStart(3, '0')}=tgt${i}`);
+    const cfg = build({ vocabularyTranslations: lines.join('\n'), contextText: 'x'.repeat(4000) });
+    expect(cfg.context!.translationTerms).toHaveLength(200);
+    const text = cfg.context!.text!;
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThan(4000);
+    const serialized = JSON.stringify({
+      translation_terms: cfg.context!.translationTerms,
+      text,
+    }).length;
+    expect(serialized).toBeLessThanOrEqual(9000);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('sacrifices the text entirely before touching vocabulary on extreme overflow', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // 700 pairs (~22 KB serialized) — text goes to zero, then translations trim.
+    const lines = Array.from({ length: 700 }, (_, i) => `s${String(i).padStart(3, '0')}=t${i}`);
+    const cfg = build({ vocabularyTranslations: lines.join('\n'), contextText: 'y'.repeat(4000) });
+    expect(cfg.context!.text).toBeUndefined();          // fully truncated → omitted
+    expect(cfg.context!.translationTerms!.length).toBeGreaterThan(0);
+    expect(cfg.context!.translationTerms!.length).toBeLessThan(700);
+    warn.mockRestore();
+  });
+```
+
+Also extend the existing legacy-slice test: add `delete legacy.contextText;` alongside the other deletes and assert nothing throws (the existing assertions suffice).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/services/providers/SonioxProviderConfig.test.ts`
+Expected: the four new tests FAIL (`contextText` unknown / `context.text` missing).
+
+- [ ] **Step 3: Implement**
+
+**(a)** `SonioxSettings` gains (after `vocabularyTranslations`):
+
+```typescript
+  /** Free-form session background (agenda/topic/notes) → wire context.text. */
+  contextText: string;
+```
+
+and `defaultSonioxSettings` gains `contextText: '',`.
+
+**(b)** Replace `fitContextToBudget` with the three-argument version (same constant, text truncated first):
+
+```typescript
+function fitContextToBudget(
+  terms: string[],
+  translationTerms: Array<{ source: string; target: string }>,
+  text: string
+): { terms: string[]; translationTerms: Array<{ source: string; target: string }>; text: string } {
+  const serializedSize = (): number =>
+    JSON.stringify({
+      ...(terms.length ? { terms } : {}),
+      ...(translationTerms.length ? { translation_terms: translationTerms } : {}),
+      ...(text ? { text } : {}),
+    }).length;
+  const dropped = { terms: 0, translationTerms: 0, textChars: 0 };
+  // Background text is the weakest context evidence: truncate it first,
+  // character-wise (removing k chars shrinks the serialization by >= k, so
+  // one cut computed from the overflow is always sufficient — or empties it).
+  if (text) {
+    const over = serializedSize() - SONIOX_CONTEXT_CHAR_BUDGET;
+    if (over > 0) {
+      const keep = Math.max(0, text.length - over);
+      dropped.textChars = text.length - keep;
+      text = text.slice(0, keep);
+    }
+  }
+  while (serializedSize() > SONIOX_CONTEXT_CHAR_BUDGET && translationTerms.length) {
+    translationTerms = translationTerms.slice(0, -1);
+    dropped.translationTerms++;
+  }
+  while (serializedSize() > SONIOX_CONTEXT_CHAR_BUDGET && terms.length) {
+    terms = terms.slice(0, -1);
+    dropped.terms++;
+  }
+  if (dropped.terms || dropped.translationTerms || dropped.textChars) {
+    console.warn(
+      `[SonioxProviderConfig] Custom vocabulary/background exceeds the Soniox context size limit — ` +
+      `truncated ${dropped.textChars} background char(s), dropped ${dropped.translationTerms} translation(s) ` +
+      `and ${dropped.terms} term(s) from the end`
+    );
+  }
+  return { terms, translationTerms, text };
+}
+```
+
+**(c)** `buildSessionConfig`: feed the trimmed setting and emit `text`:
+
+```typescript
+    const { terms, translationTerms, text } = fitContextToBudget(
+      parseVocabularyTerms(settings.vocabularyTerms ?? ''),
+      parseVocabularyTranslations(settings.vocabularyTranslations ?? ''),
+      (settings.contextText ?? '').trim()
+    );
+```
+
+and in the returned object replace the context spread with:
+
+```typescript
+      ...(terms.length || translationTerms.length || text
+        ? {
+            context: {
+              ...(terms.length ? { terms } : {}),
+              ...(translationTerms.length ? { translationTerms } : {}),
+              ...(text ? { text } : {}),
+            },
+          }
+        : {}),
+```
+
+**(d)** `src/services/interfaces/IClient.ts` — `SonioxSessionConfig.context` (at ~:196) gains a third optional member:
+
+```typescript
+  context?: {
+    terms?: string[];
+    translationTerms?: Array<{ source: string; target: string }>;
+    /** Free-form background text (wire: context.text); absent when empty. */
+    text?: string;
+  };
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/services/providers/SonioxProviderConfig.test.ts src/services/clients/SonioxClient.test.ts`
+Expected: PASS — all pre-existing budget/vocabulary tests unedited (two-argument call sites no longer exist; only `buildSessionConfig` calls the guard).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/providers/SonioxProviderConfig.ts src/services/providers/SonioxProviderConfig.test.ts src/services/interfaces/IClient.ts
+git commit -m "feat(soniox): session background setting with text-first context budgeting
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Wire + client passthrough for `context.text`
+
+**Files:**
+- Modify: `src/services/clients/SonioxSttStream.ts` (wire context type at :52-55)
+- Modify: `src/services/clients/SonioxClient.ts` (`sttContext` mapping at ~:267-273)
+- Test: `src/services/clients/SonioxSttStream.test.ts`, `src/services/clients/SonioxClient.test.ts`
+
+**Interfaces:** `SonioxSttConfig.context` gains `text?: string` (wire name identical — no renaming needed).
+
+- [ ] **Step 1: Write the failing tests**
+
+`SonioxSttStream.test.ts` — extend the existing context presence test's config (the one asserting `first.context`) with `text: 'Quarterly sync'` in the passed context and `expect(first.context.text).toBe('Quarterly sync')`; the existing defaults-omission test already proves absence.
+
+`SonioxClient.test.ts` — extend the passthrough describe:
+
+```typescript
+  it('passes background text through to the STT wire context', async () => {
+    const { stt } = await connectedClient({ context: { text: 'Quarterly sync' } });
+    expect((stt.config as { context?: { text?: string } }).context).toEqual({ text: 'Quarterly sync' });
+  });
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run src/services/clients/SonioxSttStream.test.ts src/services/clients/SonioxClient.test.ts`
+Expected: the extended/new cases FAIL (type error / missing text on the wire).
+
+- [ ] **Step 3: Implement**
+
+`SonioxSttStream.ts` context type:
+
+```typescript
+  context?: {
+    terms?: string[];
+    translation_terms?: Array<{ source: string; target: string }>;
+    text?: string;
+  };
+```
+
+`SonioxClient.ts` — extend the `sttContext` construction with a third spread:
+
+```typescript
+          ...(cfg.context.text ? { text: cfg.context.text } : {}),
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/services/clients/`
+Expected: ALL PASS (including the wire-neutrality omission tests, unedited).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/services/clients/SonioxSttStream.ts src/services/clients/SonioxSttStream.test.ts src/services/clients/SonioxClient.ts src/services/clients/SonioxClient.test.ts
+git commit -m "feat(soniox): send context.text in the STT config frame
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: UI — Session Background section
+
+**Files:**
+- Modify: `src/components/Settings/sections/ProviderSpecificSettings.tsx` (insert between the vocabulary section's closing `</div>` at ~:1806 and the endpoint section opening at :1807)
+- Test: `src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx`
+
+**Interfaces:** DOM id `soniox-context-text` for tests; three `t()` keys with inline defaults that Task 5's locale table must match byte-for-byte.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to the existing soniox wiring describe:
+
+```typescript
+  it('writes the background textarea to soniox.contextText and caps it at 4000 chars', () => {
+    const { container } = mount();
+    const el = container.querySelector('#soniox-context-text') as HTMLTextAreaElement;
+    expect(el.getAttribute('maxlength')).toBe('4000');
+    fireEvent.change(el, { target: { value: 'Quarterly roadmap sync' } });
+    expect(useSettingsStore.getState().soniox.contextText).toBe('Quarterly roadmap sync');
+  });
+```
+
+(The `beforeEach` slice reset object gains `contextText: '',`.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx`
+Expected: FAIL — `#soniox-context-text` not found.
+
+- [ ] **Step 3: Implement**
+
+Insert a new section between the vocabulary and endpoint sections:
+
+```tsx
+        <div className="settings-section" id="soniox-background-section">
+          <h2>
+            {t('settings.sonioxBackground', 'Session Background')}
+            <Tooltip
+              content={t('settings.sonioxBackgroundTooltip', 'Free-form background for the next session — agenda, topic, or reference notes. Helps recognition and translation follow the domain. Trimmed first if the combined context exceeds the size limit.')}
+              position="top"
+            >
+              <CircleHelp className="tooltip-trigger" size={14} style={{ marginLeft: '8px' }} />
+            </Tooltip>
+          </h2>
+          <div className="setting-item">
+            <textarea
+              id="soniox-context-text"
+              aria-label={t('settings.sonioxBackground', 'Session Background')}
+              className="system-instructions"
+              placeholder={t('settings.sonioxBackgroundPlaceholder', 'Paste an agenda, topic, or background notes (optional)')}
+              maxLength={4000}
+              value={activeSonioxSettings.contextText}
+              onChange={(e) => updateActiveSonioxSettings({ contextText: e.target.value })}
+              disabled={isSessionActive}
+            />
+          </div>
+        </div>
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx`
+Expected: ALL PASS (including the pre-existing wiring cases).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/Settings/sections/ProviderSpecificSettings.tsx src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
+git commit -m "feat(soniox): session background settings section
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Locales — 3 new keys × 30 files
+
+**Files:** `src/locales/<locale>/translation.json` × 30.
+
+The 3 keys (under `settings`, en values byte-identical to Task 4's inline defaults):
+
+| Key | en value |
+|---|---|
+| `sonioxBackground` | `Session Background` |
+| `sonioxBackgroundTooltip` | `Free-form background for the next session — agenda, topic, or reference notes. Helps recognition and translation follow the domain. Trimmed first if the combined context exceeds the size limit.` |
+| `sonioxBackgroundPlaceholder` | `Paste an agenda, topic, or background notes (optional)` |
+
+- [ ] **Step 1:** Add the 3 keys to `en/translation.json` immediately after `"sonioxLatencyLevelMost"` (:236); run the locale consistency test (find via `ls src/locales/*.test.ts`) → expect FAIL (29 locales missing keys).
+- [ ] **Step 2:** Translate into the 29 non-en locales (native-quality de/ja/zh_CN/zh_TW; reuse each locale's established register from the neighboring soniox* keys), insert after the same anchor via a job-tmp script (the #368 `insert-soniox-keys.mjs` pattern; job tmp dir: `/home/jiangzhuo/.claude/jobs/6639a1cc/tmp/`).
+- [ ] **Step 3:** Consistency test → PASS; `git diff --stat src/locales/` = exactly 30 files.
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/locales
+git commit -m "feat(soniox): locale strings for the session background section
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Full-suite verification
+
+- [ ] **Step 1:** `npx vitest run` — expected: only the known environmental "Denied ID …?url" failures (verify any unexpected failure against the branch base `97045697` with an in-place `git checkout <sha> -q` round-trip; tree is clean).
+- [ ] **Step 2:** `npm run build` — passes.
+- [ ] **Step 3:** `npx vitest run src/services/clients/ src/services/providers/SonioxProviderConfig.test.ts src/locales/` — wire-neutrality + budget + locale lockstep re-check.
+- [ ] **Step 4:** Commit only if fixes were needed (`fix(soniox): full-suite fixes for voices/background`, same footer).
+
+## Out of scope
+
+- `language_hints_strict` (probed: zero delta), `context.general` (user decision), any cross-provider auto-detect changes.
+- Pushing / PR — user approval required per action.

--- a/docs/superpowers/specs/2026-07-31-soniox-voices-context-text-design.md
+++ b/docs/superpowers/specs/2026-07-31-soniox-voices-context-text-design.md
@@ -1,0 +1,83 @@
+# Soniox Voice Catalog Expansion + Session Background (context.text) — Design
+
+**Date**: 2026-07-31
+**Status**: Approved (brainstormed with user; SDK/docs facts verified 2026-07-31)
+**Tracking**: follow-up to issue #342 (API-surface audit)
+
+## Summary
+
+Two additive Soniox provider changes: (1) expand the built-in TTS voice list
+from the original 12 to the current official 28, and (2) expose the STT
+`context.text` field as an optional "Session Background" free-text setting,
+folded into the existing serialized-context budget with text as the first
+thing trimmed. Explicitly **not** included, with reasons on record:
+`language_hints_strict` (live-probed: zero measurable delta over the hints we
+already send — four accent/ambiguity materials behaved byte-identically with
+and without it) and `context.general` (free-form `{key, value}` pairs per
+both official SDKs — no enum or schema; user chose `text` as the single
+context extension).
+
+## Verified facts (2026-07-31)
+
+- Official voice catalog (https://soniox.com/docs/tts/voices): 28 voices —
+  the original 12 (Adrian, Claire, Daniel, Emma, Grace, Jack, Kenji, Maya,
+  Mina, Nina, Noah, Owen) all still listed, plus 16 accented ones in four
+  groups of four: Spanish (Rafael, Mateo, Lucia, Sofia), British (Oliver,
+  Arthur, Isla, Victoria), Australian (Cooper, Mason, Ruby, Elise), Indian
+  (Arjun, Rohan, Priya, Meera). Any voice works with any language.
+- No test or code depends on the voice count or the exact set (audited);
+  `defaultSonioxSettings.voice = 'Maya'` unaffected; the Kizuna managed twin
+  inherits `voices` via `super.getConfig()`.
+- `context.text` is a single free-form string (docs + both official SDKs:
+  `@soniox/client` 2.2.0 `TranscriptionContext.text?: string`, Python
+  `soniox` 2.8.0 `StructuredContext.text: str | None`). Documented influence
+  ranks below `general`/`terms`. The whole `context` object shares one
+  ~8,000-token (~10,000-char) limit.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Voice list | Static table 12 → 28; update the two stale "12 voices" comments; no dynamic fetching (single-model era, YAGNI) |
+| context.text setting | `contextText: string` (default `''`) on `SonioxSettings`; own settings section "Session Background" with one textarea; disabled while a session is active; editable on the managed twin |
+| Wire | `context.text` sent only when non-empty after trim (default-neutral: existing users' wire unchanged) |
+| Length policy | Textarea `maxLength={4000}` (consistent with the two vocabulary textareas). The serialized-context budget guard (`fitContextToBudget`, 9,000 chars over the wire shape) now includes `text`, and trims in this order: **truncate `text` first** (character-level, weakest evidence), then drop `translation_terms` from the tail, then `terms` from the tail; console.warn on any trim. A session always starts; vocabulary survives preferentially |
+| i18n | ~4 new keys (section title, tooltip, placeholder — plus label if the markup needs one) × 30 locales; #339 convention (machine translate + native pass for de/ja/zh_CN/zh_TW) |
+| Not doing | `language_hints_strict` (probe: no delta vs existing hints); `context.general` (user decision; free-form pairs add nothing over `text` for our UX) |
+
+## Architecture
+
+- `SonioxProviderConfig`: `contextText` field + default; `buildSessionConfig`
+  passes the trimmed text through `fitContextToBudget` (now
+  `(terms, translationTerms, text)`) and emits
+  `context: { terms?, translationTerms?, text? }` — the whole `context` key
+  still omitted when all three are empty.
+- `SonioxSessionConfig.context` gains `text?: string`.
+- `SonioxSttStream`'s wire-shaped `context` type gains `text?: string`;
+  `SonioxClient` maps it through alongside the camel→snake term mapping
+  (text needs no rename).
+- UI: new section after Custom Vocabulary, same textarea pattern
+  (`system-instructions` class, aria-label, maxLength, `disabled={isSessionActive}`),
+  writes via `updateActiveSonioxSettings`.
+
+## Testing
+
+- Voices: `getConfig().voices` has 28 unique entries and still contains the
+  original 12 (guards accidental deletion).
+- Budget guard: text-first truncation (oversized text truncated, vocab
+  untouched); combined overflow (all three large → text truncated, then
+  translations tail-dropped); under-budget untouched; whitespace-only text →
+  no `context.text` key.
+- Wire: `context.text` present when set, absent otherwise (existing
+  presence/omission pattern).
+- `buildSessionConfig` mapping and legacy-slice (missing field) tolerance.
+- UI wiring: mutation-verified store write + maxLength attribute + managed
+  twin routing (existing harness).
+
+## Known limitations
+
+- Trimming the background text is silent apart from a console warning —
+  acceptable: the session must always start, and `text` is the least
+  load-bearing context field.
+- Like all Soniox settings, applies from the next session (connect-time
+  config).

--- a/src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
@@ -72,6 +72,7 @@ describe('ProviderSpecificSettings — Soniox advanced settings wiring (#342)', 
         ...s.soniox,
         vocabularyTerms: '',
         vocabularyTranslations: '',
+        contextText: '',
         endpointSensitivity: 0,
         endpointLatencyAdjustmentLevel: 0,
         ttsSpeed: 1.0,
@@ -116,6 +117,14 @@ describe('ProviderSpecificSettings — Soniox advanced settings wiring (#342)', 
     expect(el.getAttribute('max')).toBe('1.3');
     fireEvent.change(el, { target: { value: '0.8' } });
     expect(useSettingsStore.getState().soniox.ttsSpeed).toBe(0.8);
+  });
+
+  it('writes the background textarea to soniox.contextText and caps it at 4000 chars', () => {
+    const { container } = mount();
+    const el = container.querySelector('#soniox-context-text') as HTMLTextAreaElement;
+    expect(el.getAttribute('maxlength')).toBe('4000');
+    fireEvent.change(el, { target: { value: 'Quarterly roadmap sync' } });
+    expect(useSettingsStore.getState().soniox.contextText).toBe('Quarterly roadmap sync');
   });
 
   it('renders no model dropdown for Soniox (fixed stt-rt-v5 + tts-rt-v1 pipeline, nothing to choose)', () => {

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -1804,6 +1804,30 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
           </div>
         </div>
 
+        <div className="settings-section" id="soniox-background-section">
+          <h2>
+            {t('settings.sonioxBackground', 'Session Background')}
+            <Tooltip
+              content={t('settings.sonioxBackgroundTooltip', 'Free-form background for the next session — agenda, topic, or reference notes. Helps recognition and translation follow the domain. Trimmed first if the combined context exceeds the size limit.')}
+              position="top"
+            >
+              <CircleHelp className="tooltip-trigger" size={14} style={{ marginLeft: '8px' }} />
+            </Tooltip>
+          </h2>
+          <div className="setting-item">
+            <textarea
+              id="soniox-context-text"
+              aria-label={t('settings.sonioxBackground', 'Session Background')}
+              className="system-instructions"
+              placeholder={t('settings.sonioxBackgroundPlaceholder', 'Paste an agenda, topic, or background notes (optional)')}
+              maxLength={4000}
+              value={activeSonioxSettings.contextText}
+              onChange={(e) => updateActiveSonioxSettings({ contextText: e.target.value })}
+              disabled={isSessionActive}
+            />
+          </div>
+        </div>
+
         <div className="settings-section" id="soniox-endpoint-section">
           <h2>{t('settings.sonioxEndpointTuning', 'Endpoint Detection Tuning')}</h2>
           <div className="setting-item">

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "افتراضي",
     "sonioxLatencyLevelLower": "تأخير أقل",
     "sonioxLatencyLevelEvenLower": "تأخير أقل من ذلك",
-    "sonioxLatencyLevelMost": "الأكثر قوة"
+    "sonioxLatencyLevelMost": "الأكثر قوة",
+    "sonioxBackground": "خلفية الجلسة",
+    "sonioxBackgroundTooltip": "خلفية حرة الصياغة للجلسة القادمة — جدول الأعمال، الموضوع، أو ملاحظات مرجعية. تساعد على أن يواكب التعرف والترجمة المجال المطلوب. تُقتطع أولاً إذا تجاوز السياق المجمّع الحد الأقصى للحجم.",
+    "sonioxBackgroundPlaceholder": "الصق جدول الأعمال أو الموضوع أو ملاحظات خلفية (اختياري)"
   },
   "simpleSettings": {
     "autoAuthenticated": "تمت المصادقة تلقائيًا عبر حسابك",

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "ডিফল্ট",
     "sonioxLatencyLevelLower": "কম বিলম্ব",
     "sonioxLatencyLevelEvenLower": "আরও কম বিলম্ব",
-    "sonioxLatencyLevelMost": "সবচেয়ে আক্রমণাত্মক"
+    "sonioxLatencyLevelMost": "সবচেয়ে আক্রমণাত্মক",
+    "sonioxBackground": "সেশনের পটভূমি",
+    "sonioxBackgroundTooltip": "পরবর্তী সেশনের জন্য মুক্ত-বিন্যাসের পটভূমি — আলোচ্যসূচি, বিষয়, বা তথ্যসূত্র নোট। এটি শনাক্তকরণ ও অনুবাদকে সংশ্লিষ্ট বিষয়ক্ষেত্র অনুসরণ করতে সাহায্য করে। সম্মিলিত প্রসঙ্গ আকারের সীমা অতিক্রম করলে এটি সবার আগে ছাঁটা হয়।",
+    "sonioxBackgroundPlaceholder": "একটি আলোচ্যসূচি, বিষয়, বা পটভূমির নোট পেস্ট করুন (ঐচ্ছিক)"
   },
   "simpleSettings": {
     "autoAuthenticated": "আপনার অ্যাকাউন্টের মাধ্যমে স্বয়ংক্রিয়ভাবে প্রমাণীকৃত",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Standard",
     "sonioxLatencyLevelLower": "Geringere Latenz",
     "sonioxLatencyLevelEvenLower": "Noch geringere Latenz",
-    "sonioxLatencyLevelMost": "Am aggressivsten"
+    "sonioxLatencyLevelMost": "Am aggressivsten",
+    "sonioxBackground": "Sitzungshintergrund",
+    "sonioxBackgroundTooltip": "Freier Hintergrundtext für die nächste Sitzung – Agenda, Thema oder Referenznotizen. Hilft dabei, dass Erkennung und Übersetzung dem Fachgebiet folgen. Wird bei Überschreitung der Größenbegrenzung des kombinierten Kontexts zuerst gekürzt.",
+    "sonioxBackgroundPlaceholder": "Agenda, Thema oder Hintergrundnotizen einfügen (optional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Automatisch über Ihr Konto authentifiziert",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Default",
     "sonioxLatencyLevelLower": "Lower latency",
     "sonioxLatencyLevelEvenLower": "Even lower latency",
-    "sonioxLatencyLevelMost": "Most aggressive"
+    "sonioxLatencyLevelMost": "Most aggressive",
+    "sonioxBackground": "Session Background",
+    "sonioxBackgroundTooltip": "Free-form background for the next session — agenda, topic, or reference notes. Helps recognition and translation follow the domain. Trimmed first if the combined context exceeds the size limit.",
+    "sonioxBackgroundPlaceholder": "Paste an agenda, topic, or background notes (optional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Automatically authenticated via your account",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -234,9 +234,9 @@
     "sonioxLatencyLevelLower": "Menor latencia",
     "sonioxLatencyLevelEvenLower": "Latencia aún menor",
     "sonioxLatencyLevelMost": "Más agresivo",
-    "sonioxBackground": "Antecedentes de la sesión",
-    "sonioxBackgroundTooltip": "Antecedentes de formato libre para la próxima sesión — agenda, tema o notas de referencia. Ayuda a que el reconocimiento y la traducción se ajusten al ámbito. Se recorta primero si el contexto combinado supera el límite de tamaño.",
-    "sonioxBackgroundPlaceholder": "Pega una agenda, un tema o notas de antecedentes (opcional)"
+    "sonioxBackground": "Contexto de la sesión",
+    "sonioxBackgroundTooltip": "Contexto de formato libre para la próxima sesión — agenda, tema o notas de referencia. Ayuda a que el reconocimiento y la traducción se ajusten al ámbito. Se recorta primero si el contexto combinado supera el límite de tamaño.",
+    "sonioxBackgroundPlaceholder": "Pega una agenda, un tema o notas de contexto (opcional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Autenticado automáticamente a través de tu cuenta",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Predeterminado",
     "sonioxLatencyLevelLower": "Menor latencia",
     "sonioxLatencyLevelEvenLower": "Latencia aún menor",
-    "sonioxLatencyLevelMost": "Más agresivo"
+    "sonioxLatencyLevelMost": "Más agresivo",
+    "sonioxBackground": "Antecedentes de la sesión",
+    "sonioxBackgroundTooltip": "Antecedentes de formato libre para la próxima sesión — agenda, tema o notas de referencia. Ayuda a que el reconocimiento y la traducción se ajusten al ámbito. Se recorta primero si el contexto combinado supera el límite de tamaño.",
+    "sonioxBackgroundPlaceholder": "Pega una agenda, un tema o notas de antecedentes (opcional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Autenticado automáticamente a través de tu cuenta",

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "پیش‌فرض",
     "sonioxLatencyLevelLower": "تأخیر کمتر",
     "sonioxLatencyLevelEvenLower": "تأخیر حتی کمتر",
-    "sonioxLatencyLevelMost": "تهاجمی‌ترین"
+    "sonioxLatencyLevelMost": "تهاجمی‌ترین",
+    "sonioxBackground": "پیش‌زمینه نشست",
+    "sonioxBackgroundTooltip": "پیش‌زمینه آزاد برای نشست بعدی — دستور کار، موضوع یا یادداشت‌های مرجع. به تشخیص و ترجمه کمک می‌کند تا با حوزه موضوع همسو بمانند. اگر زمینه ترکیبی از حد اندازه فراتر رود، ابتدا همین بخش کوتاه می‌شود.",
+    "sonioxBackgroundPlaceholder": "دستور کار، موضوع یا یادداشت‌های پیش‌زمینه را جای‌گذاری کنید (اختیاری)"
   },
   "simpleSettings": {
     "autoAuthenticated": "به طور خودکار از طریق حساب کاربری شما احراز هویت شده",

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Oletus",
     "sonioxLatencyLevelLower": "Pienempi viive",
     "sonioxLatencyLevelEvenLower": "Vielä pienempi viive",
-    "sonioxLatencyLevelMost": "Aggressiivisin"
+    "sonioxLatencyLevelMost": "Aggressiivisin",
+    "sonioxBackground": "Istunnon tausta",
+    "sonioxBackgroundTooltip": "Vapaamuotoinen tausta seuraavaa istuntoa varten — asialista, aihe tai viitemuistiinpanot. Auttaa tunnistusta ja käännöstä pysymään aihealueessa. Lyhennetään ensin, jos yhdistetty konteksti ylittää kokorajan.",
+    "sonioxBackgroundPlaceholder": "Liitä asialista, aihe tai taustatiedot (valinnainen)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Automaattisesti todennettu tilisi kautta",

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -234,9 +234,9 @@
     "sonioxLatencyLevelLower": "Mas mababang latency",
     "sonioxLatencyLevelEvenLower": "Mas mababa pang latency",
     "sonioxLatencyLevelMost": "Pinaka-agresibo",
-    "sonioxBackground": "Background ng Session",
-    "sonioxBackgroundTooltip": "Malayang background para sa susunod na session — agenda, paksa, o mga tala sanggunian. Tumutulong ito para sumunod sa larangan ang pagkilala at pagsasalin. Ito ang unang puputulin kung lumampas sa limitasyon ng sukat ang pinagsamang konteksto.",
-    "sonioxBackgroundPlaceholder": "I-paste ang agenda, paksa, o mga tala ng background (opsyonal)"
+    "sonioxBackground": "Konteksto ng Session",
+    "sonioxBackgroundTooltip": "Malayang konteksto para sa susunod na session — agenda, paksa, o mga tala sanggunian. Tumutulong ito para sumunod sa larangan ang pagkilala at pagsasalin. Ito ang unang puputulin kung lumampas sa limitasyon ng sukat ang pinagsamang konteksto.",
+    "sonioxBackgroundPlaceholder": "I-paste ang agenda, paksa, o mga tala ng konteksto (opsyonal)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Awtomatikong na-authenticate sa pamamagitan ng iyong account",

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Default",
     "sonioxLatencyLevelLower": "Mas mababang latency",
     "sonioxLatencyLevelEvenLower": "Mas mababa pang latency",
-    "sonioxLatencyLevelMost": "Pinaka-agresibo"
+    "sonioxLatencyLevelMost": "Pinaka-agresibo",
+    "sonioxBackground": "Background ng Session",
+    "sonioxBackgroundTooltip": "Malayang background para sa susunod na session — agenda, paksa, o mga tala sanggunian. Tumutulong ito para sumunod sa larangan ang pagkilala at pagsasalin. Ito ang unang puputulin kung lumampas sa limitasyon ng sukat ang pinagsamang konteksto.",
+    "sonioxBackgroundPlaceholder": "I-paste ang agenda, paksa, o mga tala ng background (opsyonal)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Awtomatikong na-authenticate sa pamamagitan ng iyong account",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Par défaut",
     "sonioxLatencyLevelLower": "Latence réduite",
     "sonioxLatencyLevelEvenLower": "Latence encore plus réduite",
-    "sonioxLatencyLevelMost": "Le plus agressif"
+    "sonioxLatencyLevelMost": "Le plus agressif",
+    "sonioxBackground": "Contexte de la session",
+    "sonioxBackgroundTooltip": "Contexte libre pour la prochaine session — ordre du jour, sujet ou notes de référence. Aide la reconnaissance et la traduction à suivre le domaine. Réduit en premier si le contexte combiné dépasse la limite de taille.",
+    "sonioxBackgroundPlaceholder": "Collez un ordre du jour, un sujet ou des notes de contexte (facultatif)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Authentifié automatiquement via votre compte",

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "ברירת מחדל",
     "sonioxLatencyLevelLower": "השהייה נמוכה יותר",
     "sonioxLatencyLevelEvenLower": "השהייה נמוכה עוד יותר",
-    "sonioxLatencyLevelMost": "הכי אגרסיבי"
+    "sonioxLatencyLevelMost": "הכי אגרסיבי",
+    "sonioxBackground": "רקע המפגש",
+    "sonioxBackgroundTooltip": "רקע חופשי למפגש הבא — סדר יום, נושא או הערות התייחסות. עוזר לזיהוי ולתרגום לעקוב אחר התחום. יקוצץ ראשון אם ההקשר המשולב חורג ממגבלת הגודל.",
+    "sonioxBackgroundPlaceholder": "הדבק סדר יום, נושא או הערות רקע (אופציונלי)"
   },
   "simpleSettings": {
     "autoAuthenticated": "אומת אוטומטית דרך החשבון שלך",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "डिफ़ॉल्ट",
     "sonioxLatencyLevelLower": "कम विलंबता",
     "sonioxLatencyLevelEvenLower": "और भी कम विलंबता",
-    "sonioxLatencyLevelMost": "सबसे आक्रामक"
+    "sonioxLatencyLevelMost": "सबसे आक्रामक",
+    "sonioxBackground": "सत्र पृष्ठभूमि",
+    "sonioxBackgroundTooltip": "अगले सत्र के लिए मुक्त-रूप पृष्ठभूमि — एजेंडा, विषय, या संदर्भ नोट्स। यह पहचान और अनुवाद को क्षेत्र के अनुरूप रहने में मदद करता है। यदि संयुक्त संदर्भ आकार सीमा से अधिक हो जाए, तो इसे सबसे पहले छोटा किया जाता है।",
+    "sonioxBackgroundPlaceholder": "एजेंडा, विषय, या पृष्ठभूमि नोट्स पेस्ट करें (वैकल्पिक)"
   },
   "simpleSettings": {
     "autoAuthenticated": "आपके खाते के माध्यम से स्वचालित रूप से प्रमाणित",

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Default",
     "sonioxLatencyLevelLower": "Latensi lebih rendah",
     "sonioxLatencyLevelEvenLower": "Latensi lebih rendah lagi",
-    "sonioxLatencyLevelMost": "Paling agresif"
+    "sonioxLatencyLevelMost": "Paling agresif",
+    "sonioxBackground": "Latar Belakang Sesi",
+    "sonioxBackgroundTooltip": "Latar belakang bebas format untuk sesi berikutnya — agenda, topik, atau catatan referensi. Membantu pengenalan dan terjemahan mengikuti domain. Dipangkas lebih dulu jika konteks gabungan melebihi batas ukuran.",
+    "sonioxBackgroundPlaceholder": "Tempel agenda, topik, atau catatan latar belakang (opsional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Otomatis terautentikasi melalui akun Anda",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Predefinito",
     "sonioxLatencyLevelLower": "Latenza inferiore",
     "sonioxLatencyLevelEvenLower": "Latenza ancora più bassa",
-    "sonioxLatencyLevelMost": "Più aggressivo"
+    "sonioxLatencyLevelMost": "Più aggressivo",
+    "sonioxBackground": "Contesto della sessione",
+    "sonioxBackgroundTooltip": "Contesto libero per la prossima sessione — ordine del giorno, argomento o note di riferimento. Aiuta il riconoscimento e la traduzione a seguire l'ambito. Viene troncato per primo se il contesto complessivo supera il limite di dimensione.",
+    "sonioxBackgroundPlaceholder": "Incolla un ordine del giorno, un argomento o note di contesto (facoltativo)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Autenticato automaticamente tramite il tuo account",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "標準",
     "sonioxLatencyLevelLower": "遅延を低減",
     "sonioxLatencyLevelEvenLower": "さらに遅延を低減",
-    "sonioxLatencyLevelMost": "最も積極的"
+    "sonioxLatencyLevelMost": "最も積極的",
+    "sonioxBackground": "セッションの背景",
+    "sonioxBackgroundTooltip": "次回のセッション用の自由形式の背景情報です——議題、トピック、参考メモなど。認識と翻訳が話題の分野に沿うようになります。結合した文脈がサイズ上限を超える場合、最初に削られます。",
+    "sonioxBackgroundPlaceholder": "議題やトピック、背景メモを貼り付けてください（任意）"
   },
   "simpleSettings": {
     "autoAuthenticated": "アカウントで自動的に認証されました",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "기본값",
     "sonioxLatencyLevelLower": "지연 시간 감소",
     "sonioxLatencyLevelEvenLower": "지연 시간 더 감소",
-    "sonioxLatencyLevelMost": "가장 적극적"
+    "sonioxLatencyLevelMost": "가장 적극적",
+    "sonioxBackground": "세션 배경",
+    "sonioxBackgroundTooltip": "다음 세션을 위한 자유 형식 배경 정보입니다 — 안건, 주제 또는 참고 메모. 인식과 번역이 해당 분야를 따르도록 돕습니다. 결합된 문맥이 크기 제한을 초과하면 이 항목이 가장 먼저 잘립니다.",
+    "sonioxBackgroundPlaceholder": "안건, 주제 또는 배경 메모를 붙여넣으세요 (선택 사항)"
   },
   "simpleSettings": {
     "autoAuthenticated": "계정을 통해 자동으로 인증됨",

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Lalai",
     "sonioxLatencyLevelLower": "Kependaman lebih rendah",
     "sonioxLatencyLevelEvenLower": "Kependaman lebih rendah lagi",
-    "sonioxLatencyLevelMost": "Paling agresif"
+    "sonioxLatencyLevelMost": "Paling agresif",
+    "sonioxBackground": "Latar Belakang Sesi",
+    "sonioxBackgroundTooltip": "Latar belakang bebas format untuk sesi seterusnya — agenda, topik, atau nota rujukan. Membantu pengecaman dan terjemahan mengikuti bidang tersebut. Dipotong dahulu jika konteks gabungan melebihi had saiz.",
+    "sonioxBackgroundPlaceholder": "Tampal agenda, topik, atau nota latar belakang (pilihan)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Disahkan secara automatik melalui akaun anda",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Standaard",
     "sonioxLatencyLevelLower": "Lagere latentie",
     "sonioxLatencyLevelEvenLower": "Nog lagere latentie",
-    "sonioxLatencyLevelMost": "Meest agressief"
+    "sonioxLatencyLevelMost": "Meest agressief",
+    "sonioxBackground": "Sessieachtergrond",
+    "sonioxBackgroundTooltip": "Vrije achtergrondinformatie voor de volgende sessie — agenda, onderwerp of referentienotities. Helpt herkenning en vertaling het domein te volgen. Wordt als eerste ingekort als de gecombineerde context de groottelimiet overschrijdt.",
+    "sonioxBackgroundPlaceholder": "Plak een agenda, onderwerp of achtergrondnotities (optioneel)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Automatisch geauthenticeerd via uw account",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Domyślny",
     "sonioxLatencyLevelLower": "Niższe opóźnienie",
     "sonioxLatencyLevelEvenLower": "Jeszcze niższe opóźnienie",
-    "sonioxLatencyLevelMost": "Najbardziej agresywny"
+    "sonioxLatencyLevelMost": "Najbardziej agresywny",
+    "sonioxBackground": "Tło sesji",
+    "sonioxBackgroundTooltip": "Dowolny opis tła dla następnej sesji — agenda, temat lub notatki referencyjne. Pomaga rozpoznawaniu i tłumaczeniu podążać za dziedziną. Jest przycinane jako pierwsze, gdy połączony kontekst przekroczy limit rozmiaru.",
+    "sonioxBackgroundPlaceholder": "Wklej agendę, temat lub notatki dotyczące tła (opcjonalnie)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Automatycznie uwierzytelniono za pomocą konta",

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Padrão",
     "sonioxLatencyLevelLower": "Menor latência",
     "sonioxLatencyLevelEvenLower": "Latência ainda menor",
-    "sonioxLatencyLevelMost": "Mais agressivo"
+    "sonioxLatencyLevelMost": "Mais agressivo",
+    "sonioxBackground": "Contexto da sessão",
+    "sonioxBackgroundTooltip": "Contexto livre para a próxima sessão — pauta, tópico ou notas de referência. Ajuda o reconhecimento e a tradução a acompanhar o domínio. É cortado primeiro se o contexto combinado exceder o limite de tamanho.",
+    "sonioxBackgroundPlaceholder": "Cole uma pauta, tópico ou notas de contexto (opcional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Autenticado automaticamente através da sua conta",

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Predefinido",
     "sonioxLatencyLevelLower": "Latência mais baixa",
     "sonioxLatencyLevelEvenLower": "Latência ainda mais baixa",
-    "sonioxLatencyLevelMost": "Mais agressivo"
+    "sonioxLatencyLevelMost": "Mais agressivo",
+    "sonioxBackground": "Contexto da sessão",
+    "sonioxBackgroundTooltip": "Contexto livre para a próxima sessão — agenda, tópico ou notas de referência. Ajuda o reconhecimento e a tradução a acompanhar o domínio. É cortado primeiro se o contexto combinado exceder o limite de tamanho.",
+    "sonioxBackgroundPlaceholder": "Cole uma agenda, um tópico ou notas de contexto (opcional)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Autenticado automaticamente através da sua conta",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "По умолчанию",
     "sonioxLatencyLevelLower": "Меньшая задержка",
     "sonioxLatencyLevelEvenLower": "Ещё меньшая задержка",
-    "sonioxLatencyLevelMost": "Максимально агрессивный"
+    "sonioxLatencyLevelMost": "Максимально агрессивный",
+    "sonioxBackground": "Контекст сеанса",
+    "sonioxBackgroundTooltip": "Произвольный контекст для следующего сеанса — повестка, тема или справочные заметки. Помогает распознаванию и переводу соответствовать предметной области. Обрезается первым, если объединённый контекст превышает лимит размера.",
+    "sonioxBackgroundPlaceholder": "Вставьте повестку, тему или справочные заметки (необязательно)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Автоматически аутентифицирован через вашу учетную запись",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Standard",
     "sonioxLatencyLevelLower": "Lägre latens",
     "sonioxLatencyLevelEvenLower": "Ännu lägre latens",
-    "sonioxLatencyLevelMost": "Mest aggressiv"
+    "sonioxLatencyLevelMost": "Mest aggressiv",
+    "sonioxBackground": "Sessionsbakgrund",
+    "sonioxBackgroundTooltip": "Fri bakgrundsinformation för nästa session — agenda, ämne eller referensanteckningar. Hjälper igenkänning och översättning att följa området. Trunkeras först om det kombinerade sammanhanget överskrider storleksgränsen.",
+    "sonioxBackgroundPlaceholder": "Klistra in en agenda, ett ämne eller bakgrundsanteckningar (valfritt)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Automatiskt autentiserad via ditt konto",

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "இயல்புநிலை",
     "sonioxLatencyLevelLower": "குறைந்த தாமதம்",
     "sonioxLatencyLevelEvenLower": "இன்னும் குறைந்த தாமதம்",
-    "sonioxLatencyLevelMost": "மிக ஆக்ரோஷமானது"
+    "sonioxLatencyLevelMost": "மிக ஆக்ரோஷமானது",
+    "sonioxBackground": "அமர்வு பின்னணி",
+    "sonioxBackgroundTooltip": "அடுத்த அமர்வுக்கான சுதந்திரமான பின்னணி தகவல் — நிகழ்ச்சி நிரல், தலைப்பு, அல்லது குறிப்பு விவரங்கள். இது அடையாளம் காணுதலும் மொழிபெயர்ப்பும் தொடர்புடைய துறையைப் பின்பற்ற உதவுகிறது. இணைந்த சூழல் அளவு வரம்பைத் தாண்டினால், இது முதலில் குறைக்கப்படும்.",
+    "sonioxBackgroundPlaceholder": "நிகழ்ச்சி நிரல், தலைப்பு அல்லது பின்னணிக் குறிப்புகளை ஒட்டவும் (விருப்பமானது)"
   },
   "simpleSettings": {
     "autoAuthenticated": "உங்கள் கணக்கு மூலம் தானாக அங்கீகரிக்கப்பட்டது",

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "డిఫాల్ట్",
     "sonioxLatencyLevelLower": "తక్కువ జాప్యం",
     "sonioxLatencyLevelEvenLower": "మరింత తక్కువ జాప్యం",
-    "sonioxLatencyLevelMost": "అత్యంత దూకుడైనది"
+    "sonioxLatencyLevelMost": "అత్యంత దూకుడైనది",
+    "sonioxBackground": "సెషన్ నేపథ్యం",
+    "sonioxBackgroundTooltip": "తదుపరి సెషన్ కోసం స్వేచ్ఛా-రూప నేపథ్యం — ఎజెండా, అంశం, లేదా సూచన గమనికలు. ఇది గుర్తింపు మరియు అనువాదం సంబంధిత రంగాన్ని అనుసరించడానికి సహాయపడుతుంది. మిళిత సందర్భం పరిమాణ పరిమితిని మించితే, దీన్ని మొదట కుదిస్తారు.",
+    "sonioxBackgroundPlaceholder": "ఎజెండా, అంశం, లేదా నేపథ్య గమనికలను అతికించండి (ఐచ్ఛికం)"
   },
   "simpleSettings": {
     "autoAuthenticated": "మీ ఖాతా ద్వారా స్వయంచాలకంగా ప్రామాణీకరించబడింది",

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "ค่าเริ่มต้น",
     "sonioxLatencyLevelLower": "ความหน่วงต่ำลง",
     "sonioxLatencyLevelEvenLower": "ความหน่วงต่ำลงอีก",
-    "sonioxLatencyLevelMost": "รุนแรงที่สุด"
+    "sonioxLatencyLevelMost": "รุนแรงที่สุด",
+    "sonioxBackground": "พื้นหลังเซสชัน",
+    "sonioxBackgroundTooltip": "ข้อมูลพื้นหลังแบบอิสระสำหรับเซสชันถัดไป — วาระ หัวข้อ หรือบันทึกอ้างอิง ช่วยให้การจดจำและการแปลติดตามสาขาที่เกี่ยวข้อง จะถูกตัดออกก่อนหากบริบทที่รวมกันเกินขีดจำกัดขนาด",
+    "sonioxBackgroundPlaceholder": "วางวาระ หัวข้อ หรือบันทึกพื้นหลัง (ไม่บังคับ)"
   },
   "simpleSettings": {
     "autoAuthenticated": "ตรวจสอบสิทธิ์อัตโนมัติผ่านบัญชีของคุณ",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Varsayılan",
     "sonioxLatencyLevelLower": "Daha düşük gecikme",
     "sonioxLatencyLevelEvenLower": "Daha da düşük gecikme",
-    "sonioxLatencyLevelMost": "En agresif"
+    "sonioxLatencyLevelMost": "En agresif",
+    "sonioxBackground": "Oturum Arka Planı",
+    "sonioxBackgroundTooltip": "Bir sonraki oturum için serbest biçimli arka plan — gündem, konu veya referans notları. Tanımanın ve çevirinin alana uygun kalmasına yardımcı olur. Birleşik bağlam boyut sınırını aşarsa önce bu kısaltılır.",
+    "sonioxBackgroundPlaceholder": "Bir gündem, konu veya arka plan notu yapıştırın (isteğe bağlı)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Hesabınız üzerinden otomatik olarak doğrulandı",

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "За замовчуванням",
     "sonioxLatencyLevelLower": "Нижча затримка",
     "sonioxLatencyLevelEvenLower": "Ще нижча затримка",
-    "sonioxLatencyLevelMost": "Найагресивніший"
+    "sonioxLatencyLevelMost": "Найагресивніший",
+    "sonioxBackground": "Тло сеансу",
+    "sonioxBackgroundTooltip": "Довільний опис тла для наступного сеансу — порядок денний, тема або довідкові нотатки. Допомагає розпізнаванню та перекладу відповідати предметній галузі. Обрізається першим, якщо об'єднаний контекст перевищує ліміт розміру.",
+    "sonioxBackgroundPlaceholder": "Вставте порядок денний, тему або нотатки щодо тла (необов'язково)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Автоматично автентифіковано через ваш обліковий запис",

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "Mặc định",
     "sonioxLatencyLevelLower": "Độ trễ thấp hơn",
     "sonioxLatencyLevelEvenLower": "Độ trễ thấp hơn nữa",
-    "sonioxLatencyLevelMost": "Mạnh nhất"
+    "sonioxLatencyLevelMost": "Mạnh nhất",
+    "sonioxBackground": "Bối cảnh phiên",
+    "sonioxBackgroundTooltip": "Bối cảnh tự do cho phiên tiếp theo — chương trình nghị sự, chủ đề, hoặc ghi chú tham khảo. Giúp việc nhận diện và dịch bám sát lĩnh vực. Sẽ bị cắt bớt trước tiên nếu ngữ cảnh kết hợp vượt quá giới hạn kích thước.",
+    "sonioxBackgroundPlaceholder": "Dán chương trình nghị sự, chủ đề, hoặc ghi chú bối cảnh (tùy chọn)"
   },
   "simpleSettings": {
     "autoAuthenticated": "Tự động xác thực qua tài khoản của bạn",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "默认",
     "sonioxLatencyLevelLower": "更低延迟",
     "sonioxLatencyLevelEvenLower": "进一步降低延迟",
-    "sonioxLatencyLevelMost": "最积极"
+    "sonioxLatencyLevelMost": "最积极",
+    "sonioxBackground": "会话背景",
+    "sonioxBackgroundTooltip": "为下一次会话提供的自由格式背景信息——议程、主题或参考笔记。有助于识别和翻译贴合相关领域。如果合并后的上下文超出大小限制，会首先裁剪这部分内容。",
+    "sonioxBackgroundPlaceholder": "粘贴议程、主题或背景笔记（可选）"
   },
   "simpleSettings": {
     "autoAuthenticated": "已通过您的账户自动认证",

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -233,7 +233,10 @@
     "sonioxLatencyLevelDefault": "預設",
     "sonioxLatencyLevelLower": "較低延遲",
     "sonioxLatencyLevelEvenLower": "更低延遲",
-    "sonioxLatencyLevelMost": "最積極"
+    "sonioxLatencyLevelMost": "最積極",
+    "sonioxBackground": "工作階段背景",
+    "sonioxBackgroundTooltip": "為下一個工作階段提供的自由格式背景資訊——議程、主題或參考筆記。有助於辨識與翻譯貼合相關領域。若合併後的上下文超出大小限制，會優先裁剪這部分內容。",
+    "sonioxBackgroundPlaceholder": "貼上議程、主題或背景筆記（可選）"
   },
   "simpleSettings": {
     "autoAuthenticated": "已通過您的帳戶自動認證",

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -654,6 +654,11 @@ describe('SonioxClient advanced-feature passthrough (#342)', () => {
     });
   });
 
+  it('passes background text through to the STT wire context', async () => {
+    const { stt } = await connectedClient({ context: { text: 'Quarterly sync' } });
+    expect((stt.config as { context?: { text?: string } }).context).toEqual({ text: 'Quarterly sync' });
+  });
+
   it('sends no context when the session config has none', async () => {
     const { stt } = await connectedClient();
     expect((stt.config as { context?: unknown }).context).toBeUndefined();

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -270,6 +270,7 @@ export class SonioxClient implements IClient {
           ...(cfg.context.translationTerms?.length
             ? { translation_terms: cfg.context.translationTerms }
             : {}),
+          ...(cfg.context.text ? { text: cfg.context.text } : {}),
         }
       : undefined;
     await this.stt.connect({

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -263,7 +263,8 @@ export class SonioxClient implements IClient {
       onTick: () => this.costMeter?.tick(Date.now()),
     });
     // Map the session config's camelCase context to the wire's snake_case.
-    // buildSessionConfig only sets `context` when at least one list is non-empty.
+    // buildSessionConfig only sets `context` when at least one of
+    // terms/translations/background text is non-empty.
     const sttContext = cfg.context
       ? {
           ...(cfg.context.terms?.length ? { terms: cfg.context.terms } : {}),

--- a/src/services/clients/SonioxSttStream.test.ts
+++ b/src/services/clients/SonioxSttStream.test.ts
@@ -168,6 +168,7 @@ describe('SonioxSttStream', () => {
       context: {
         terms: ['Sokuji'],
         translation_terms: [{ source: 'Kizuna AI', target: '絆愛' }],
+        text: 'Quarterly sync',
       },
       endpointSensitivity: -0.5,
       endpointLatencyAdjustmentLevel: 2,
@@ -176,7 +177,9 @@ describe('SonioxSttStream', () => {
     expect(first.context).toEqual({
       terms: ['Sokuji'],
       translation_terms: [{ source: 'Kizuna AI', target: '絆愛' }],
+      text: 'Quarterly sync',
     });
+    expect(first.context.text).toBe('Quarterly sync');
     expect(first.endpoint_sensitivity).toBe(-0.5);
     expect(first.endpoint_latency_adjustment_level).toBe(2);
   });

--- a/src/services/clients/SonioxSttStream.ts
+++ b/src/services/clients/SonioxSttStream.ts
@@ -48,7 +48,7 @@ export interface SonioxSttConfig {
   sampleRate: number;
   languageHints?: string[];
   translation: SonioxTranslationConfig;
-  /** Custom vocabulary, wire-shaped (snake_case). Omitted from the config frame when absent. */
+  /** Custom vocabulary and background text, wire-shaped (snake_case). Omitted from the config frame when absent. */
   context?: {
     terms?: string[];
     translation_terms?: Array<{ source: string; target: string }>;

--- a/src/services/clients/SonioxSttStream.ts
+++ b/src/services/clients/SonioxSttStream.ts
@@ -52,6 +52,7 @@ export interface SonioxSttConfig {
   context?: {
     terms?: string[];
     translation_terms?: Array<{ source: string; target: string }>;
+    text?: string;
   };
   /** endpoint_sensitivity, -1.0..1.0. 0/undefined = omit (server default). v5-only. */
   endpointSensitivity?: number;

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -196,6 +196,8 @@ export interface SonioxSessionConfig extends BaseSessionConfig {
   context?: {
     terms?: string[];
     translationTerms?: Array<{ source: string; target: string }>;
+    /** Free-form background text (wire: context.text); absent when empty. */
+    text?: string;
   };
   /** Clamped -1.0..1.0; 0 (default) is omitted from the wire. */
   endpointSensitivity?: number;

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -192,7 +192,7 @@ export interface SonioxSessionConfig extends BaseSessionConfig {
   targetLanguage: string; // ISO code
   /** True only for Both mode with a shared single session (set by MainPanel). Drives two_way vs one_way. */
   bidirectional: boolean;
-  /** Custom vocabulary parsed from settings; absent when both lists are empty. */
+  /** Custom vocabulary parsed from settings; absent when all three parts are empty. */
   context?: {
     terms?: string[];
     translationTerms?: Array<{ source: string; target: string }>;

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -198,19 +198,43 @@ describe('SonioxProviderConfig.buildSessionConfig', () => {
       translation_terms: cfg.context!.translationTerms,
       text,
     }).length;
-    expect(serialized).toBeLessThanOrEqual(9005);
+    expect(serialized).toBeLessThanOrEqual(9000);
     expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('cuts escape-heavy background text exactly instead of over-truncating', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // Newline-rich agenda: every second character serializes as a 2-unit
+    // escape, so raw-length arithmetic would empty the text entirely; the
+    // exact (binary-search) cut keeps everything that actually fits.
+    const lines = Array.from({ length: 200 }, (_, i) => `src${String(i).padStart(3, '0')}=tgt${i}`);
+    const cfg = build({ vocabularyTranslations: lines.join('\n'), contextText: 'a\n'.repeat(2000) });
+    expect(cfg.context!.translationTerms).toHaveLength(200);
+    const text = cfg.context!.text!;
+    expect(text.length).toBeGreaterThan(0); // the naive over-cut would have emptied it
+    const serialized = JSON.stringify({
+      translation_terms: cfg.context!.translationTerms,
+      text,
+    }).length;
+    expect(serialized).toBeLessThanOrEqual(9000);
+    expect(serialized).toBeGreaterThan(8990); // maximal: the cut wastes no meaningful capacity
     warn.mockRestore();
   });
 });
 
 describe('SonioxProviderConfig voices', () => {
-  it('exposes the full 28-voice catalog, unique, including the original twelve', () => {
+  it('exposes exactly the official 28-voice catalog (originals first, accented additions after)', () => {
     const voices = new SonioxProviderConfig().getConfig().voices.map((v) => v.value);
-    expect(voices).toHaveLength(28);
-    expect(new Set(voices).size).toBe(28);
-    for (const original of ['Adrian', 'Claire', 'Daniel', 'Emma', 'Grace', 'Jack', 'Kenji', 'Maya', 'Mina', 'Nina', 'Noah', 'Owen']) {
-      expect(voices).toContain(original);
-    }
+    expect(voices).toEqual([
+      // Original twelve (order preserved — existing users' stored values):
+      'Adrian', 'Claire', 'Daniel', 'Emma', 'Grace', 'Jack',
+      'Kenji', 'Maya', 'Mina', 'Nina', 'Noah', 'Owen',
+      // Accented additions (official catalog, 2026-07-31):
+      'Rafael', 'Mateo', 'Lucia', 'Sofia',        // Spanish
+      'Oliver', 'Arthur', 'Isla', 'Victoria',     // British
+      'Cooper', 'Mason', 'Ruby', 'Elise',         // Australian
+      'Arjun', 'Rohan', 'Priya', 'Meera',         // Indian
+    ]);
   });
 });

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -128,11 +128,52 @@ describe('SonioxProviderConfig.buildSessionConfig', () => {
     delete legacy.endpointSensitivity;
     delete legacy.endpointLatencyAdjustmentLevel;
     delete legacy.ttsSpeed;
+    delete legacy.contextText;
     const cfg = descriptor.buildSessionConfig(legacy, '') as SonioxSessionConfig;
     expect(cfg.context).toBeUndefined();
     expect(cfg.endpointSensitivity).toBe(0);
     expect(cfg.endpointLatencyAdjustmentLevel).toBe(0);
     expect(cfg.ttsSpeed).toBe(1.0);
+  });
+
+  it('passes trimmed background text through as context.text', () => {
+    const cfg = build({ contextText: '  Quarterly review of the Sokuji roadmap. ' });
+    expect(cfg.context).toEqual({ text: 'Quarterly review of the Sokuji roadmap.' });
+  });
+
+  it('omits context entirely for whitespace-only background text', () => {
+    const cfg = build({ contextText: '   \n\t ' });
+    expect(cfg.context).toBeUndefined();
+  });
+
+  it('truncates the background text first when the serialized context overflows, keeping vocabulary intact', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // ~200 translation pairs (~6.4 KB serialized) + 4000-char text → overflow
+    // where text absorbs the whole cut and translations survive untouched.
+    const lines = Array.from({ length: 200 }, (_, i) => `src${String(i).padStart(3, '0')}=tgt${i}`);
+    const cfg = build({ vocabularyTranslations: lines.join('\n'), contextText: 'x'.repeat(4000) });
+    expect(cfg.context!.translationTerms).toHaveLength(200);
+    const text = cfg.context!.text!;
+    expect(text.length).toBeGreaterThan(0);
+    expect(text.length).toBeLessThan(4000);
+    const serialized = JSON.stringify({
+      translation_terms: cfg.context!.translationTerms,
+      text,
+    }).length;
+    expect(serialized).toBeLessThanOrEqual(9000);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
+
+  it('sacrifices the text entirely before touching vocabulary on extreme overflow', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // 700 pairs (~22 KB serialized) — text goes to zero, then translations trim.
+    const lines = Array.from({ length: 700 }, (_, i) => `s${String(i).padStart(3, '0')}=t${i}`);
+    const cfg = build({ vocabularyTranslations: lines.join('\n'), contextText: 'y'.repeat(4000) });
+    expect(cfg.context!.text).toBeUndefined();          // fully truncated → omitted
+    expect(cfg.context!.translationTerms!.length).toBeGreaterThan(0);
+    expect(cfg.context!.translationTerms!.length).toBeLessThan(700);
+    warn.mockRestore();
   });
 });
 

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -175,6 +175,33 @@ describe('SonioxProviderConfig.buildSessionConfig', () => {
     expect(cfg.context!.translationTerms!.length).toBeLessThan(700);
     warn.mockRestore();
   });
+
+  it('strips a trailing lone surrogate when the truncation cut lands mid-emoji', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // 100 CJK chars + 1950 emoji (each a surrogate pair) = 4000 UTF-16 code
+    // units of background text, plus 200 translation pairs to force overflow
+    // (same generator as the test above). With these exact counts the
+    // computed cut (keep=1477) lands 1,377 code units into the emoji run —
+    // an odd offset into 2-unit pairs, i.e. mid-pair — which exercises the
+    // lone-surrogate strip. (Verified numerically; adjust the pair count if
+    // this ever stops landing mid-pair.)
+    const lines = Array.from({ length: 200 }, (_, i) => `src${String(i).padStart(3, '0')}=tgt${i}`);
+    const cfg = build({
+      vocabularyTranslations: lines.join('\n'),
+      contextText: '好'.repeat(100) + '😀'.repeat(1950),
+    });
+    expect(cfg.context!.translationTerms).toHaveLength(200);
+    const text = cfg.context!.text!;
+    expect(text.length).toBeGreaterThan(0);
+    expect(/[\uD800-\uDBFF]$/.test(text)).toBe(false);
+    const serialized = JSON.stringify({
+      translation_terms: cfg.context!.translationTerms,
+      text,
+    }).length;
+    expect(serialized).toBeLessThanOrEqual(9005);
+    expect(warn).toHaveBeenCalledTimes(1);
+    warn.mockRestore();
+  });
 });
 
 describe('SonioxProviderConfig voices', () => {

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -135,3 +135,14 @@ describe('SonioxProviderConfig.buildSessionConfig', () => {
     expect(cfg.ttsSpeed).toBe(1.0);
   });
 });
+
+describe('SonioxProviderConfig voices', () => {
+  it('exposes the full 28-voice catalog, unique, including the original twelve', () => {
+    const voices = new SonioxProviderConfig().getConfig().voices.map((v) => v.value);
+    expect(voices).toHaveLength(28);
+    expect(new Set(voices).size).toBe(28);
+    for (const original of ['Adrian', 'Claire', 'Daniel', 'Emma', 'Grace', 'Jack', 'Kenji', 'Maya', 'Mina', 'Nina', 'Noah', 'Owen']) {
+      expect(voices).toContain(original);
+    }
+  });
+});

--- a/src/services/providers/SonioxProviderConfig.ts
+++ b/src/services/providers/SonioxProviderConfig.ts
@@ -254,8 +254,9 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
     { name: 'Cymraeg', value: 'cy', englishName: 'Welsh' },
   ];
 
-  // All 12 voices are multilingual (zh/ja/en verified live 2026-07-18):
-  // one voice serves both two_way directions.
+  // Every voice is multilingual — any voice speaks any language (official
+  // catalog, 2026-07-31; zh/ja/en live-verified 2026-07-18 for the original
+  // twelve) — so one voice serves both two_way directions.
   private static readonly VOICES: VoiceOption[] = [
     { name: 'Adrian', value: 'Adrian' },
     { name: 'Claire', value: 'Claire' },
@@ -269,6 +270,23 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
     { name: 'Nina', value: 'Nina' },
     { name: 'Noah', value: 'Noah' },
     { name: 'Owen', value: 'Owen' },
+    // Accented additions (official catalog, 2026-07-31):
+    { name: 'Rafael', value: 'Rafael' },     // Spanish accent
+    { name: 'Mateo', value: 'Mateo' },       // Spanish accent
+    { name: 'Lucia', value: 'Lucia' },       // Spanish accent
+    { name: 'Sofia', value: 'Sofia' },       // Spanish accent
+    { name: 'Oliver', value: 'Oliver' },     // British accent
+    { name: 'Arthur', value: 'Arthur' },     // British accent
+    { name: 'Isla', value: 'Isla' },         // British accent
+    { name: 'Victoria', value: 'Victoria' }, // British accent
+    { name: 'Cooper', value: 'Cooper' },     // Australian accent
+    { name: 'Mason', value: 'Mason' },       // Australian accent
+    { name: 'Ruby', value: 'Ruby' },         // Australian accent
+    { name: 'Elise', value: 'Elise' },       // Australian accent
+    { name: 'Arjun', value: 'Arjun' },       // Indian accent
+    { name: 'Rohan', value: 'Rohan' },       // Indian accent
+    { name: 'Priya', value: 'Priya' },       // Indian accent
+    { name: 'Meera', value: 'Meera' },       // Indian accent
   ];
 
   private static readonly MODELS: ModelOption[] = [
@@ -292,7 +310,7 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
       capabilities: {
         hasTemplateMode: false, // dedicated translation service — no prompt templates
         hasTurnDetection: false, // server-side endpoint detection, not user-configurable
-        hasVoiceSettings: true, // TTS voice dropdown (12 multilingual voices)
+        hasVoiceSettings: true, // TTS voice dropdown (28 multilingual voices)
         hasNoiseReduction: false,
         hasModelConfiguration: false,
         textOnlyCapability: 'optional', // toggle: subtitles-only vs spoken translation

--- a/src/services/providers/SonioxProviderConfig.ts
+++ b/src/services/providers/SonioxProviderConfig.ts
@@ -94,21 +94,28 @@ function fitContextToBudget(
       ...(text ? { text } : {}),
     }).length;
   const dropped = { terms: 0, translationTerms: 0, textChars: 0 };
-  // Background text is the weakest context evidence: truncate it first,
-  // character-wise (removing k chars shrinks the serialization by >= k, so
-  // one cut computed from the overflow is always sufficient — or empties it —
-  // a trailing lone surrogate from a mid-pair cut is stripped below; the
-  // remaining ≤5-char excess in the no-vocab case sits well inside the
-  // 1,000-char headroom).
-  if (text) {
-    const over = serializedSize() - SONIOX_CONTEXT_CHAR_BUDGET;
-    if (over > 0) {
-      const keep = Math.max(0, text.length - over);
-      dropped.textChars = text.length - keep;
-      // A cut landing mid-surrogate-pair would leave a lone high surrogate
-      // (serializes as a 6-char escape and renders as U+FFFD downstream).
-      text = text.slice(0, keep).replace(/[\uD800-\uDBFF]$/, '');
+  // Background text is the weakest context evidence: truncate it first.
+  // Raw-length arithmetic misjudges the cut when characters JSON-escape to
+  // 2-6 output units (newlines and quotes are certain in pasted agendas), so
+  // binary-search the longest prefix whose actual serialization fits the
+  // budget (~12 stringify probes at connect time, once per session).
+  if (text && serializedSize() > SONIOX_CONTEXT_CHAR_BUDGET) {
+    const full = text;
+    const fits = (keep: number): boolean => {
+      text = full.slice(0, keep);
+      return serializedSize() <= SONIOX_CONTEXT_CHAR_BUDGET;
+    };
+    let lo = 0;
+    let hi = full.length;
+    while (lo < hi) {
+      const mid = Math.ceil((lo + hi) / 2);
+      if (fits(mid)) lo = mid;
+      else hi = mid - 1;
     }
+    // A cut landing mid-surrogate-pair would leave a lone high surrogate
+    // (serializes as a 6-char escape and renders as U+FFFD downstream).
+    text = full.slice(0, lo).replace(/[\uD800-\uDBFF]$/, '');
+    dropped.textChars = full.length - text.length;
   }
   while (serializedSize() > SONIOX_CONTEXT_CHAR_BUDGET && translationTerms.length) {
     translationTerms = translationTerms.slice(0, -1);

--- a/src/services/providers/SonioxProviderConfig.ts
+++ b/src/services/providers/SonioxProviderConfig.ts
@@ -96,13 +96,18 @@ function fitContextToBudget(
   const dropped = { terms: 0, translationTerms: 0, textChars: 0 };
   // Background text is the weakest context evidence: truncate it first,
   // character-wise (removing k chars shrinks the serialization by >= k, so
-  // one cut computed from the overflow is always sufficient — or empties it).
+  // one cut computed from the overflow is always sufficient — or empties it —
+  // a trailing lone surrogate from a mid-pair cut is stripped below; the
+  // remaining ≤5-char excess in the no-vocab case sits well inside the
+  // 1,000-char headroom).
   if (text) {
     const over = serializedSize() - SONIOX_CONTEXT_CHAR_BUDGET;
     if (over > 0) {
       const keep = Math.max(0, text.length - over);
       dropped.textChars = text.length - keep;
-      text = text.slice(0, keep);
+      // A cut landing mid-surrogate-pair would leave a lone high surrogate
+      // (serializes as a 6-char escape and renders as U+FFFD downstream).
+      text = text.slice(0, keep).replace(/[\uD800-\uDBFF]$/, '');
     }
   }
   while (serializedSize() > SONIOX_CONTEXT_CHAR_BUDGET && translationTerms.length) {

--- a/src/services/providers/SonioxProviderConfig.ts
+++ b/src/services/providers/SonioxProviderConfig.ts
@@ -18,6 +18,8 @@ export interface SonioxSettings {
   vocabularyTerms: string;
   /** Preferred translations, one "source=target" per line (→ context.translation_terms). */
   vocabularyTranslations: string;
+  /** Free-form session background (agenda/topic/notes) → wire context.text. */
+  contextText: string;
   /** Soniox endpoint_sensitivity, -1.0..1.0; 0 = server default. */
   endpointSensitivity: number;
   /** Soniox endpoint_latency_adjustment_level, 0..3; 0 = server default. */
@@ -35,6 +37,7 @@ export const defaultSonioxSettings: SonioxSettings = {
   model: 'stt-rt-v5',
   vocabularyTerms: '',
   vocabularyTranslations: '',
+  contextText: '',
   endpointSensitivity: 0,
   endpointLatencyAdjustmentLevel: 0,
   ttsSpeed: 1.0,
@@ -81,14 +84,27 @@ const SONIOX_CONTEXT_CHAR_BUDGET = 9000;
 
 function fitContextToBudget(
   terms: string[],
-  translationTerms: Array<{ source: string; target: string }>
-): { terms: string[]; translationTerms: Array<{ source: string; target: string }> } {
+  translationTerms: Array<{ source: string; target: string }>,
+  text: string
+): { terms: string[]; translationTerms: Array<{ source: string; target: string }>; text: string } {
   const serializedSize = (): number =>
     JSON.stringify({
       ...(terms.length ? { terms } : {}),
       ...(translationTerms.length ? { translation_terms: translationTerms } : {}),
+      ...(text ? { text } : {}),
     }).length;
-  const dropped = { terms: 0, translationTerms: 0 };
+  const dropped = { terms: 0, translationTerms: 0, textChars: 0 };
+  // Background text is the weakest context evidence: truncate it first,
+  // character-wise (removing k chars shrinks the serialization by >= k, so
+  // one cut computed from the overflow is always sufficient — or empties it).
+  if (text) {
+    const over = serializedSize() - SONIOX_CONTEXT_CHAR_BUDGET;
+    if (over > 0) {
+      const keep = Math.max(0, text.length - over);
+      dropped.textChars = text.length - keep;
+      text = text.slice(0, keep);
+    }
+  }
   while (serializedSize() > SONIOX_CONTEXT_CHAR_BUDGET && translationTerms.length) {
     translationTerms = translationTerms.slice(0, -1);
     dropped.translationTerms++;
@@ -97,13 +113,14 @@ function fitContextToBudget(
     terms = terms.slice(0, -1);
     dropped.terms++;
   }
-  if (dropped.terms || dropped.translationTerms) {
+  if (dropped.terms || dropped.translationTerms || dropped.textChars) {
     console.warn(
-      `[SonioxProviderConfig] Custom vocabulary exceeds the Soniox context size limit — ` +
-      `dropped ${dropped.translationTerms} translation(s) and ${dropped.terms} term(s) from the end`
+      `[SonioxProviderConfig] Custom vocabulary/background exceeds the Soniox context size limit — ` +
+      `truncated ${dropped.textChars} background char(s), dropped ${dropped.translationTerms} translation(s) ` +
+      `and ${dropped.terms} term(s) from the end`
     );
   }
-  return { terms, translationTerms };
+  return { terms, translationTerms, text };
 }
 
 // The managed start floor lives in its own import-free module so the Start
@@ -156,9 +173,10 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
 
   buildSessionConfig(slice: unknown, systemInstructions: string): SessionConfig {
     const settings = slice as SonioxSettings;
-    const { terms, translationTerms } = fitContextToBudget(
+    const { terms, translationTerms, text } = fitContextToBudget(
       parseVocabularyTerms(settings.vocabularyTerms ?? ''),
-      parseVocabularyTranslations(settings.vocabularyTranslations ?? '')
+      parseVocabularyTranslations(settings.vocabularyTranslations ?? ''),
+      (settings.contextText ?? '').trim()
     );
     return {
       provider: 'soniox',
@@ -170,11 +188,12 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
       // Direction is derived from You/Others/Both at connect time; default one_way.
       // MainPanel sets bidirectional:true only for the shared-Both single-session path.
       bidirectional: false,
-      ...(terms.length || translationTerms.length
+      ...(terms.length || translationTerms.length || text
         ? {
             context: {
               ...(terms.length ? { terms } : {}),
               ...(translationTerms.length ? { translationTerms } : {}),
+              ...(text ? { text } : {}),
             },
           }
         : {}),


### PR DESCRIPTION
## Summary

Two additive Soniox provider features from the post-#342 API-surface audit:

1. **Voice catalog 12 → 28** — the 16 newer official voices in four accent groups (Spanish: Rafael/Mateo/Lucia/Sofia, British: Oliver/Arthur/Isla/Victoria, Australian: Cooper/Mason/Ruby/Elise, Indian: Arjun/Rohan/Priya/Meera), verified against the live official catalog on 2026-07-31. A guard test pins 28 + uniqueness + the original twelve; the Kizuna managed twin inherits structurally.
2. **Session Background** — exposes STT `context.text`: a free-form textarea (agenda/topic/notes) that biases recognition and translation toward the session's domain. The serialized-context budget guard now takes all three context parts and trims in evidence-strength order: **background text is truncated first** (character-level, with a lone-surrogate strip at the cut), then translation pairs, then terms — so a session always starts and vocabulary survives preferentially. Wire stays default-neutral: empty background sends nothing.

Deliberately not included, with evidence on record: `language_hints_strict` (live-probed across four accent/ambiguity materials — byte-identical behavior vs the `[a,b]` hints we already send, while single-language strict measurably corrupts `token.language`) and `context.general` (both official SDKs type it as free-form `{key, value}` pairs — nothing it expresses that `text` doesn't).

## Testing

- New: voice-catalog guard; budget tests for trimmed passthrough, whitespace omission, partial text truncation (vocabulary intact, serialized ≤ budget), extreme overflow (text sacrificed before any vocabulary), and a mid-emoji-cut surrogate-boundary case; wire presence/omission; client passthrough; mutation-verified UI wiring incl. maxLength.
- Locale consistency 88/88 (3 new keys × 30 locales, native-quality de/ja/zh_CN/zh_TW).
- Full suite: zero regressions vs base (remaining failures are the known worktree-environment Vite `fs.allow` class, byte-identical at base); `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded Soniox text-to-speech voice selection from 12 to 28 voices.
  * Added an optional Session Background field for Soniox speech recognition, with a 4,000-character limit.
  * Background text is included in session context when provided and automatically trimmed to fit context limits.
* **Localization**
  * Added translated labels, guidance, and placeholders across supported languages.
* **Bug Fixes**
  * Preserved compatibility with existing saved Soniox settings and default session output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->