### PR TITLE
fix(openai): honor Realtime voice selection across transports

### DIFF
--- a/src/services/EphemeralTokenService.test.ts
+++ b/src/services/EphemeralTokenService.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EphemeralTokenService } from './EphemeralTokenService';
+
+describe('EphemeralTokenService Realtime GA client secrets', () => {
+  afterEach(() => {
+    EphemeralTokenService.clearCache();
+    vi.unstubAllGlobals();
+  });
+
+  it('mints an Ash client secret with the current GA endpoint and body', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        value: 'ek_test_ash',
+        expires_at: Math.floor(Date.now() / 1000) + 60
+      })
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const token = await EphemeralTokenService.getToken(
+      'sk-test',
+      'gpt-realtime-2.1',
+      'ash'
+    );
+
+    expect(token).toBe('ek_test_ash');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const [url, options] = fetchMock.mock.calls[0];
+    expect(url).toBe('https://api.openai.com/v1/realtime/client_secrets');
+    expect(JSON.parse(options.body)).toEqual({
+      session: {
+        type: 'realtime',
+        model: 'gpt-realtime-2.1',
+        audio: {
+          output: { voice: 'ash' }
+        }
+      }
+    });
+  });
+
+  it('continues to accept the legacy nested client-secret response shape', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        client_secret: {
+          value: 'ek_legacy',
+          expires_at: Math.floor(Date.now() / 1000) + 60
+        }
+      })
+    }));
+
+    await expect(EphemeralTokenService.getToken(
+      'sk-test',
+      'gpt-realtime',
+      'ash'
+    )).resolves.toBe('ek_legacy');
+  });
+});

--- a/src/services/EphemeralTokenService.ts
+++ b/src/services/EphemeralTokenService.ts
@@ -7,7 +7,9 @@
  */
 
 interface EphemeralTokenResponse {
-  client_secret: {
+  value?: string;
+  expires_at?: number;
+  client_secret?: string | {
     value: string;
     expires_at: number; // Unix timestamp
   };
@@ -71,7 +73,7 @@ export class EphemeralTokenService {
     apiHost?: string
   ): Promise<string> {
     const host = apiHost || this.OPENAI_API_HOST;
-    const endpoint = `${host.replace(/\/$/, '')}/v1/realtime/sessions`;
+    const endpoint = `${host.replace(/\/$/, '')}/v1/realtime/client_secrets`;
 
     try {
       const response = await fetch(endpoint, {
@@ -81,8 +83,13 @@ export class EphemeralTokenService {
           'Content-Type': 'application/json'
         },
         body: JSON.stringify({
-          model,
-          voice
+          session: {
+            type: 'realtime',
+            model,
+            audio: {
+              output: { voice }
+            }
+          }
         })
       });
 
@@ -93,22 +100,30 @@ export class EphemeralTokenService {
       }
 
       const data: EphemeralTokenResponse = await response.json();
+      const nestedSecret = typeof data.client_secret === 'string'
+        ? data.client_secret
+        : data.client_secret?.value;
+      const tokenValue = data.value ?? nestedSecret;
+      const nestedExpiresAt = typeof data.client_secret === 'object'
+        ? data.client_secret.expires_at
+        : undefined;
+      const expiresAt = data.expires_at ?? nestedExpiresAt ?? Math.floor(Date.now() / 1000) + 60;
 
-      if (!data.client_secret?.value) {
+      if (!tokenValue) {
         throw new Error('Invalid token response: missing client_secret');
       }
 
       // Cache the token
       const cacheKey = `${host}:${model}:${voice}`;
       tokenCache.set(cacheKey, {
-        value: data.client_secret.value,
-        expiresAt: data.client_secret.expires_at * 1000 // Convert to milliseconds
+        value: tokenValue,
+        expiresAt: expiresAt * 1000 // Convert to milliseconds
       });
 
       console.debug('[EphemeralTokenService] Obtained new ephemeral token, expires at:',
-        new Date(data.client_secret.expires_at * 1000).toISOString());
+        new Date(expiresAt * 1000).toISOString());
 
-      return data.client_secret.value;
+      return tokenValue;
     } catch (error) {
       console.error('[EphemeralTokenService] Error fetching ephemeral token:', error);
       throw error;

--- a/src/services/EphemeralTokenService.ts
+++ b/src/services/EphemeralTokenService.ts
@@ -1,3 +1,5 @@
+import useLogStore from '../stores/logStore';
+
 /**
  * EphemeralTokenService
  *
@@ -126,6 +128,8 @@ export class EphemeralTokenService {
       return tokenValue;
     } catch (error) {
       console.error('[EphemeralTokenService] Error fetching ephemeral token:', error);
+      const message = error instanceof Error ? error.message : String(error);
+      useLogStore.getState().addLog(`Failed to fetch OpenAI Realtime client secret: ${message}`, 'error');
       throw error;
     }
   }

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -24,6 +24,10 @@ import type { EventData } from '../../stores/logStore';
 import { Provider, ProviderType } from '../../types/Provider';
 import { unwrapTranslationText } from '../../utils/textUtils';
 import { OpenAIClient } from './OpenAIClient';
+import {
+  buildOpenAIRealtimeResponseEvent,
+  buildOpenAIRealtimeSession
+} from './openAIRealtimeSession';
 
 /**
  * OpenAI Realtime API client using the official SDK (GA protocol)
@@ -620,76 +624,11 @@ export class OpenAIGAClient implements IClient {
   private sendSessionUpdate(config: OpenAISessionConfig): void {
     if (!this.rt) return;
 
-    // GA API session parameters differ from beta:
-    // - 'modalities' → 'output_modalities' (only ['text'] or ['audio'], not both)
-    // - 'max_response_output_tokens' → 'max_output_tokens'
-    // - 'input_audio_format'/'output_audio_format' → nested 'audio' config
-    // - 'temperature' → removed (not a GA session param)
-    // - 'voice' → set at connection time, can only be updated if no audio output yet
-    const session: any = {
-      type: 'realtime',
-      output_modalities: config.textOnly ? ['text'] : ['audio'],
-      instructions: config.instructions,
-      max_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
-      // Explicitly disable tools to prevent model drift from translator role
-      tool_choice: 'none',
-      tools: []
-    };
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
+    this.turnDetectionDisabled = turnDetectionDisabled;
 
-    // Reasoning effort: only `gpt-realtime-2` accepts this; older models reject the field.
-    if (config.model?.startsWith('gpt-realtime-2') && config.reasoningEffort) {
-      session.reasoning = { effort: config.reasoningEffort };
+    if (session.reasoning) {
       console.info('[Sokuji] [OpenAIGAClient] reasoning.effort applied:', config.reasoningEffort);
-    }
-
-    // GA API nests turn_detection, transcription, noise_reduction under audio.input
-    const audioInput: any = {};
-    let hasAudioInput = false;
-
-    // Turn detection → audio.input.turn_detection
-    if (config.turnDetection) {
-      if (config.turnDetection.type === 'none') {
-        audioInput.turn_detection = null;
-        this.turnDetectionDisabled = true;
-      } else {
-        this.turnDetectionDisabled = false;
-        const td: any = {
-          type: config.turnDetection.type,
-          create_response: config.turnDetection.createResponse ?? true,
-          interrupt_response: config.turnDetection.interruptResponse ?? false
-        };
-
-        if (config.turnDetection.type === 'server_vad') {
-          if (config.turnDetection.threshold !== undefined) td.threshold = config.turnDetection.threshold;
-          if (config.turnDetection.prefixPadding !== undefined) td.prefix_padding_ms = Math.round(config.turnDetection.prefixPadding * 1000);
-          if (config.turnDetection.silenceDuration !== undefined) td.silence_duration_ms = Math.round(config.turnDetection.silenceDuration * 1000);
-        } else if (config.turnDetection.type === 'semantic_vad' && config.turnDetection.eagerness) {
-          td.eagerness = config.turnDetection.eagerness.toLowerCase();
-        }
-
-        audioInput.turn_detection = td;
-      }
-      hasAudioInput = true;
-    }
-
-    // Input audio transcription → audio.input.transcription
-    if (config.inputAudioTranscription?.model) {
-      audioInput.transcription = {
-        model: config.inputAudioTranscription.model
-      };
-      hasAudioInput = true;
-    }
-
-    // Noise reduction → audio.input.noise_reduction
-    if (config.inputAudioNoiseReduction?.type) {
-      audioInput.noise_reduction = {
-        type: config.inputAudioNoiseReduction.type
-      };
-      hasAudioInput = true;
-    }
-
-    if (hasAudioInput) {
-      session.audio = { input: audioInput };
     }
 
     this.rt.send({
@@ -826,24 +765,7 @@ export class OpenAIGAClient implements IClient {
     }
 
     if (config) {
-      const responseEvent: any = {
-        type: 'response.create',
-        response: {}
-      };
-
-      if (config.instructions) {
-        responseEvent.response.instructions = config.instructions;
-      }
-      if (config.conversation) {
-        responseEvent.response.conversation = config.conversation;
-      }
-      // GA API uses 'output_modalities' instead of 'modalities' in response.create
-      if (config.modalities) {
-        responseEvent.response.output_modalities = config.modalities;
-      }
-      if (config.metadata) {
-        responseEvent.response.metadata = config.metadata;
-      }
+      const responseEvent = buildOpenAIRealtimeResponseEvent(config);
 
       if (config.conversation === 'none') {
         console.debug('[OpenAIGAClient] Sending out-of-band response:', {
@@ -864,7 +786,7 @@ export class OpenAIGAClient implements IClient {
         }
       });
     } else {
-      this.rt.send({ type: 'response.create' } as any);
+      this.rt.send(buildOpenAIRealtimeResponseEvent() as any);
 
       this.eventHandlers.onRealtimeEvent?.({
         source: 'client',

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -621,10 +621,12 @@ export class OpenAIGAClient implements IClient {
   /**
    * Send session.update event with configuration
    */
-  private sendSessionUpdate(config: OpenAISessionConfig): void {
+  private sendSessionUpdate(config: OpenAISessionConfig, partial = false): void {
     if (!this.rt) return;
 
-    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config, {
+      includeDefaultVoice: !partial
+    });
     this.turnDetectionDisabled = turnDetectionDisabled;
 
     if (session.reasoning) {
@@ -676,7 +678,7 @@ export class OpenAIGAClient implements IClient {
 
   updateSession(config: Partial<SessionConfig>): void {
     if (isOpenAISessionConfig(config as SessionConfig)) {
-      this.sendSessionUpdate(config as OpenAISessionConfig);
+      this.sendSessionUpdate(config as OpenAISessionConfig, true);
     }
   }
 
@@ -776,7 +778,7 @@ export class OpenAIGAClient implements IClient {
         });
       }
 
-      this.rt.send(responseEvent);
+      this.rt.send(responseEvent as any);
 
       this.eventHandlers.onRealtimeEvent?.({
         source: 'client',

--- a/src/services/clients/OpenAIGAClient.ts
+++ b/src/services/clients/OpenAIGAClient.ts
@@ -26,7 +26,8 @@ import { unwrapTranslationText } from '../../utils/textUtils';
 import { OpenAIClient } from './OpenAIClient';
 import {
   buildOpenAIRealtimeResponseEvent,
-  buildOpenAIRealtimeSession
+  buildOpenAIRealtimeSession,
+  buildOpenAIRealtimeSessionUpdate
 } from './openAIRealtimeSession';
 
 /**
@@ -621,12 +622,10 @@ export class OpenAIGAClient implements IClient {
   /**
    * Send session.update event with configuration
    */
-  private sendSessionUpdate(config: OpenAISessionConfig, partial = false): void {
+  private sendSessionUpdate(config: OpenAISessionConfig): void {
     if (!this.rt) return;
 
-    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config, {
-      includeDefaultVoice: !partial
-    });
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
     this.turnDetectionDisabled = turnDetectionDisabled;
 
     if (session.reasoning) {
@@ -639,6 +638,29 @@ export class OpenAIGAClient implements IClient {
     } as any);
 
     // Forward as client event for logging
+    this.eventHandlers.onRealtimeEvent?.({
+      source: 'client',
+      event: {
+        type: 'session.update',
+        data: { session }
+      }
+    });
+  }
+
+  private sendPartialSessionUpdate(config: Partial<OpenAISessionConfig>): void {
+    if (!this.rt) return;
+
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSessionUpdate(config);
+    if (turnDetectionDisabled !== undefined) {
+      this.turnDetectionDisabled = turnDetectionDisabled;
+    }
+    if (Object.keys(session).length === 1) return;
+
+    this.rt.send({
+      type: 'session.update',
+      session
+    } as any);
+
     this.eventHandlers.onRealtimeEvent?.({
       source: 'client',
       event: {
@@ -677,8 +699,8 @@ export class OpenAIGAClient implements IClient {
   }
 
   updateSession(config: Partial<SessionConfig>): void {
-    if (isOpenAISessionConfig(config as SessionConfig)) {
-      this.sendSessionUpdate(config as OpenAISessionConfig, true);
+    if (isOpenAISessionConfig(config)) {
+      this.sendPartialSessionUpdate(config);
     }
   }
 

--- a/src/services/clients/OpenAIWebRTCClient.ts
+++ b/src/services/clients/OpenAIWebRTCClient.ts
@@ -20,7 +20,7 @@ import {
   isOpenAISessionConfig,
   ResponseConfig
 } from '../interfaces/IClient';
-import { RealtimeEvent } from '../../stores/logStore';
+import useLogStore, { RealtimeEvent } from '../../stores/logStore';
 import { Provider, ProviderType } from '../../types/Provider';
 import { unwrapTranslationText } from '../../utils/textUtils';
 import { EphemeralTokenService } from '../EphemeralTokenService';
@@ -53,6 +53,7 @@ interface ServerEvent {
  */
 export class OpenAIWebRTCClient implements IClient {
   private static readonly DEFAULT_API_HOST = 'https://api.openai.com';
+  private static readonly CALLS_REQUEST_TIMEOUT_MS = 15000;
 
   private apiKey: string;
   private apiHost: string;
@@ -276,20 +277,27 @@ export class OpenAIWebRTCClient implements IClient {
   ): Promise<string> {
     const endpoint = `${this.apiHost}/v1/realtime/calls`;
 
-    const response = await fetch(endpoint, {
-      method: 'POST',
-      headers: {
-        'Authorization': `Bearer ${token}`
-      },
-      body: buildOpenAIRealtimeCallForm(sdp, config)
-    });
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: {
+          'Authorization': `Bearer ${token}`
+        },
+        body: buildOpenAIRealtimeCallForm(sdp, config),
+        signal: AbortSignal.timeout(OpenAIWebRTCClient.CALLS_REQUEST_TIMEOUT_MS)
+      });
 
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(`Failed to establish WebRTC connection: ${response.status} ${errorText}`);
+      if (!response.ok) {
+        const errorText = await response.text();
+        throw new Error(`Failed to establish WebRTC connection: ${response.status} ${errorText}`);
+      }
+
+      return await response.text();
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      useLogStore.getState().addLog(`OpenAI WebRTC connection failed: ${message}`, 'error');
+      throw error;
     }
-
-    return await response.text();
   }
 
   /**
@@ -517,8 +525,10 @@ export class OpenAIWebRTCClient implements IClient {
   /**
    * Send session.update event to configure the session
    */
-  private sendSessionUpdate(config: OpenAISessionConfig): void {
-    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
+  private sendSessionUpdate(config: OpenAISessionConfig, partial = false): void {
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config, {
+      includeDefaultVoice: !partial
+    });
     this.turnDetectionDisabled = turnDetectionDisabled;
 
     if (session.reasoning) {
@@ -604,7 +614,7 @@ export class OpenAIWebRTCClient implements IClient {
    */
   updateSession(config: Partial<SessionConfig>): void {
     if (isOpenAISessionConfig(config as SessionConfig)) {
-      this.sendSessionUpdate(config as OpenAISessionConfig);
+      this.sendSessionUpdate(config as OpenAISessionConfig, true);
     }
   }
 

--- a/src/services/clients/OpenAIWebRTCClient.ts
+++ b/src/services/clients/OpenAIWebRTCClient.ts
@@ -28,7 +28,8 @@ import { WebRTCAudioBridge, BufferedAudioMetadata } from '../../lib/modern-audio
 import {
   buildOpenAIRealtimeCallForm,
   buildOpenAIRealtimeResponseEvent,
-  buildOpenAIRealtimeSession
+  buildOpenAIRealtimeSession,
+  buildOpenAIRealtimeSessionUpdate
 } from './openAIRealtimeSession';
 
 interface WebRTCClientOptions {
@@ -525,15 +526,26 @@ export class OpenAIWebRTCClient implements IClient {
   /**
    * Send session.update event to configure the session
    */
-  private sendSessionUpdate(config: OpenAISessionConfig, partial = false): void {
-    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config, {
-      includeDefaultVoice: !partial
-    });
+  private sendSessionUpdate(config: OpenAISessionConfig): void {
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
     this.turnDetectionDisabled = turnDetectionDisabled;
 
     if (session.reasoning) {
       console.info('[Sokuji] [OpenAIWebRTCClient] reasoning.effort applied:', config.reasoningEffort);
     }
+
+    this.sendEvent({
+      type: 'session.update',
+      session
+    });
+  }
+
+  private sendPartialSessionUpdate(config: Partial<OpenAISessionConfig>): void {
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSessionUpdate(config);
+    if (turnDetectionDisabled !== undefined) {
+      this.turnDetectionDisabled = turnDetectionDisabled;
+    }
+    if (Object.keys(session).length === 1) return;
 
     this.sendEvent({
       type: 'session.update',
@@ -613,8 +625,8 @@ export class OpenAIWebRTCClient implements IClient {
    * Update session configuration
    */
   updateSession(config: Partial<SessionConfig>): void {
-    if (isOpenAISessionConfig(config as SessionConfig)) {
-      this.sendSessionUpdate(config as OpenAISessionConfig, true);
+    if (isOpenAISessionConfig(config)) {
+      this.sendPartialSessionUpdate(config);
     }
   }
 

--- a/src/services/clients/OpenAIWebRTCClient.ts
+++ b/src/services/clients/OpenAIWebRTCClient.ts
@@ -25,6 +25,11 @@ import { Provider, ProviderType } from '../../types/Provider';
 import { unwrapTranslationText } from '../../utils/textUtils';
 import { EphemeralTokenService } from '../EphemeralTokenService';
 import { WebRTCAudioBridge, BufferedAudioMetadata } from '../../lib/modern-audio/WebRTCAudioBridge';
+import {
+  buildOpenAIRealtimeCallForm,
+  buildOpenAIRealtimeResponseEvent,
+  buildOpenAIRealtimeSession
+} from './openAIRealtimeSession';
 
 interface WebRTCClientOptions {
   /** User's API key for ephemeral token generation */
@@ -184,7 +189,8 @@ export class OpenAIWebRTCClient implements IClient {
       // Send offer to OpenAI and get answer via REST API
       const answer = await this.sendOfferToOpenAI(
         this.pc.localDescription!.sdp,
-        ephemeralToken
+        ephemeralToken,
+        config
       );
 
       // Set remote description
@@ -263,16 +269,19 @@ export class OpenAIWebRTCClient implements IClient {
   /**
    * Send SDP offer to OpenAI and receive answer
    */
-  private async sendOfferToOpenAI(sdp: string, token: string): Promise<string> {
-    const endpoint = `${this.apiHost}/v1/realtime?model=${encodeURIComponent(this.currentModel)}`;
+  private async sendOfferToOpenAI(
+    sdp: string,
+    token: string,
+    config: OpenAISessionConfig
+  ): Promise<string> {
+    const endpoint = `${this.apiHost}/v1/realtime/calls`;
 
     const response = await fetch(endpoint, {
       method: 'POST',
       headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/sdp'
+        'Authorization': `Bearer ${token}`
       },
-      body: sdp
+      body: buildOpenAIRealtimeCallForm(sdp, config)
     });
 
     if (!response.ok) {
@@ -509,70 +518,17 @@ export class OpenAIWebRTCClient implements IClient {
    * Send session.update event to configure the session
    */
   private sendSessionUpdate(config: OpenAISessionConfig): void {
-    const sessionUpdate: any = {
-      type: 'session.update',
-      session: {
-        modalities: config.textOnly ? ['text'] : ['text', 'audio'],
-        voice: config.voice || 'alloy',
-        instructions: config.instructions,
-        input_audio_format: 'pcm16',
-        output_audio_format: 'pcm16',
-        temperature: config.temperature ?? 0.8,
-        max_response_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
-        // Explicitly disable tools to prevent model drift from translator role
-        tool_choice: 'none',
-        tools: []
-      }
-    };
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
+    this.turnDetectionDisabled = turnDetectionDisabled;
 
-    // Add turn detection config and track if disabled
-    if (config.turnDetection) {
-      if (config.turnDetection.type === 'none') {
-        sessionUpdate.session.turn_detection = null;
-        this.turnDetectionDisabled = true;
-      } else {
-        this.turnDetectionDisabled = false;
-        sessionUpdate.session.turn_detection = {
-          type: config.turnDetection.type,
-          threshold: config.turnDetection.threshold,
-          prefix_padding_ms: config.turnDetection.prefixPadding
-            ? Math.round(config.turnDetection.prefixPadding * 1000)
-            : undefined,
-          silence_duration_ms: config.turnDetection.silenceDuration
-            ? Math.round(config.turnDetection.silenceDuration * 1000)
-            : undefined,
-          create_response: config.turnDetection.createResponse ?? true,
-          interrupt_response: config.turnDetection.interruptResponse ?? false
-        };
-
-        if (config.turnDetection.type === 'semantic_vad' && config.turnDetection.eagerness) {
-          sessionUpdate.session.turn_detection.eagerness =
-            config.turnDetection.eagerness.toLowerCase();
-        }
-      }
-    }
-
-    // Add input audio transcription
-    if (config.inputAudioTranscription?.model) {
-      sessionUpdate.session.input_audio_transcription = {
-        model: config.inputAudioTranscription.model
-      };
-    }
-
-    // Add noise reduction
-    if (config.inputAudioNoiseReduction?.type) {
-      sessionUpdate.session.input_audio_noise_reduction = {
-        type: config.inputAudioNoiseReduction.type
-      };
-    }
-
-    // Reasoning effort: only `gpt-realtime-2` accepts this; older models reject the field.
-    if (config.model?.startsWith('gpt-realtime-2') && config.reasoningEffort) {
-      sessionUpdate.session.reasoning = { effort: config.reasoningEffort };
+    if (session.reasoning) {
       console.info('[Sokuji] [OpenAIWebRTCClient] reasoning.effort applied:', config.reasoningEffort);
     }
 
-    this.sendEvent(sessionUpdate);
+    this.sendEvent({
+      type: 'session.update',
+      session
+    });
   }
 
   /**
@@ -713,31 +669,7 @@ export class OpenAIWebRTCClient implements IClient {
     }
 
     if (config) {
-      // Send response.create event with per-turn configuration
-      const responseEvent: any = {
-        type: 'response.create',
-        response: {}
-      };
-
-      // Add per-turn instructions if provided (key mechanism for preventing drift)
-      if (config.instructions) {
-        responseEvent.response.instructions = config.instructions;
-      }
-
-      // Add conversation mode if specified
-      if (config.conversation) {
-        responseEvent.response.conversation = config.conversation;
-      }
-
-      // Add modalities if specified
-      if (config.modalities) {
-        responseEvent.response.modalities = config.modalities;
-      }
-
-      // Add metadata if specified (for tracking/filtering purposes)
-      if (config.metadata) {
-        responseEvent.response.metadata = config.metadata;
-      }
+      const responseEvent = buildOpenAIRealtimeResponseEvent(config);
 
       // Log out-of-band anchor requests for debugging
       if (config.conversation === 'none') {
@@ -751,7 +683,7 @@ export class OpenAIWebRTCClient implements IClient {
 
       this.sendEvent(responseEvent);
     } else {
-      this.sendEvent({ type: 'response.create' });
+      this.sendEvent(buildOpenAIRealtimeResponseEvent());
     }
   }
 

--- a/src/services/clients/openAIRealtimeSession.test.ts
+++ b/src/services/clients/openAIRealtimeSession.test.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { OpenAISessionConfig } from '../interfaces/IClient';
+import { isOpenAISessionConfig, OpenAISessionConfig } from '../interfaces/IClient';
 import {
   buildOpenAIRealtimeCallForm,
   buildOpenAIRealtimeResponseEvent,
-  buildOpenAIRealtimeSession
+  buildOpenAIRealtimeSession,
+  buildOpenAIRealtimeSessionUpdate
 } from './openAIRealtimeSession';
 
 const config: OpenAISessionConfig = {
@@ -38,12 +39,39 @@ describe('OpenAI Realtime GA session payload', () => {
   });
 
   it('preserves the current voice for partial updates that omit voice', () => {
-    const { session } = buildOpenAIRealtimeSession(
-      { ...config, voice: undefined },
-      { includeDefaultVoice: false }
-    );
+    const { session } = buildOpenAIRealtimeSessionUpdate({
+      provider: 'openai',
+      instructions: 'Updated instructions.'
+    });
 
-    expect(session.audio.output).toBeUndefined();
+    expect(session).toEqual({
+      type: 'realtime',
+      instructions: 'Updated instructions.'
+    });
+    expect(session.audio).toBeUndefined();
+    expect(session.output_modalities).toBeUndefined();
+    expect(session.tool_choice).toBeUndefined();
+    expect(session.tools).toBeUndefined();
+  });
+
+  it('only changes push-to-talk state when turn detection is supplied', () => {
+    expect(buildOpenAIRealtimeSessionUpdate({
+      provider: 'openai',
+      instructions: 'Keep translating.'
+    }).turnDetectionDisabled).toBeUndefined();
+
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSessionUpdate({
+      provider: 'openai',
+      turnDetection: { type: 'none' }
+    });
+
+    expect(turnDetectionDisabled).toBe(true);
+    expect(session).toEqual({
+      type: 'realtime',
+      audio: {
+        input: { turn_detection: null }
+      }
+    });
   });
 
   it('omits reasoning for models that do not support it', () => {
@@ -115,5 +143,16 @@ describe('OpenAI Realtime GA session payload', () => {
       }
     });
     expect(event.response.modalities).toBeUndefined();
+  });
+});
+
+describe('OpenAI session config guard', () => {
+  it('accepts sparse OpenAI configs and rejects non-object values', () => {
+    expect(isOpenAISessionConfig({ provider: 'openai' })).toBe(true);
+    expect(isOpenAISessionConfig({ provider: 'cometapi' })).toBe(true);
+    expect(isOpenAISessionConfig({ provider: 'gemini' })).toBe(false);
+    expect(isOpenAISessionConfig(null)).toBe(false);
+    expect(isOpenAISessionConfig('openai')).toBe(false);
+    expect(isOpenAISessionConfig(42)).toBe(false);
   });
 });

--- a/src/services/clients/openAIRealtimeSession.test.ts
+++ b/src/services/clients/openAIRealtimeSession.test.ts
@@ -37,6 +37,24 @@ describe('OpenAI Realtime GA session payload', () => {
     expect(turnDetectionDisabled).toBe(false);
   });
 
+  it('preserves the current voice for partial updates that omit voice', () => {
+    const { session } = buildOpenAIRealtimeSession(
+      { ...config, voice: undefined },
+      { includeDefaultVoice: false }
+    );
+
+    expect(session.audio.output).toBeUndefined();
+  });
+
+  it('omits reasoning for models that do not support it', () => {
+    const { session } = buildOpenAIRealtimeSession({
+      ...config,
+      model: 'gpt-realtime'
+    });
+
+    expect(session.reasoning).toBeUndefined();
+  });
+
   it('uses GA nested audio input fields', () => {
     const { session } = buildOpenAIRealtimeSession(config);
 

--- a/src/services/clients/openAIRealtimeSession.test.ts
+++ b/src/services/clients/openAIRealtimeSession.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { OpenAISessionConfig } from '../interfaces/IClient';
+import {
+  buildOpenAIRealtimeCallForm,
+  buildOpenAIRealtimeResponseEvent,
+  buildOpenAIRealtimeSession
+} from './openAIRealtimeSession';
+
+const config: OpenAISessionConfig = {
+  provider: 'openai',
+  model: 'gpt-realtime-2.1',
+  voice: 'ash',
+  instructions: 'Translate only.',
+  maxTokens: 'inf',
+  reasoningEffort: 'low',
+  turnDetection: {
+    type: 'server_vad',
+    threshold: 0.5,
+    prefixPadding: 0.3,
+    silenceDuration: 0.8,
+    createResponse: true,
+    interruptResponse: false
+  },
+  inputAudioTranscription: { model: 'gpt-4o-transcribe' },
+  inputAudioNoiseReduction: { type: 'near_field' }
+};
+
+describe('OpenAI Realtime GA session payload', () => {
+  it('places the selected voice under audio.output for every transport', () => {
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession(config);
+
+    expect(session.audio.output.voice).toBe('ash');
+    expect(session.voice).toBeUndefined();
+    expect(session.output_modalities).toEqual(['audio']);
+    expect(session.max_output_tokens).toBe('inf');
+    expect(session.reasoning).toEqual({ effort: 'low' });
+    expect(turnDetectionDisabled).toBe(false);
+  });
+
+  it('uses GA nested audio input fields', () => {
+    const { session } = buildOpenAIRealtimeSession(config);
+
+    expect(session.audio.input).toEqual({
+      turn_detection: {
+        type: 'server_vad',
+        threshold: 0.5,
+        prefix_padding_ms: 300,
+        silence_duration_ms: 800,
+        create_response: true,
+        interrupt_response: false
+      },
+      transcription: { model: 'gpt-4o-transcribe' },
+      noise_reduction: { type: 'near_field' }
+    });
+    expect(session.turn_detection).toBeUndefined();
+    expect(session.input_audio_transcription).toBeUndefined();
+  });
+
+  it('embeds the same Ash session in the WebRTC call form', () => {
+    const form = buildOpenAIRealtimeCallForm('offer-sdp', config);
+    const callSession = JSON.parse(String(form.get('session')));
+
+    expect(form.get('sdp')).toBe('offer-sdp');
+    expect(callSession.model).toBe('gpt-realtime-2.1');
+    expect(callSession.audio.output.voice).toBe('ash');
+    expect(callSession.output_modalities).toEqual(['audio']);
+  });
+
+  it('tracks push-to-talk and omits output voice for text-only mode', () => {
+    const { session, turnDetectionDisabled } = buildOpenAIRealtimeSession({
+      ...config,
+      textOnly: true,
+      turnDetection: { type: 'none' }
+    });
+
+    expect(turnDetectionDisabled).toBe(true);
+    expect(session.output_modalities).toEqual(['text']);
+    expect(session.audio.output).toBeUndefined();
+    expect(session.audio.input.turn_detection).toBeNull();
+  });
+
+  it('uses output_modalities in GA response.create events', () => {
+    const event = buildOpenAIRealtimeResponseEvent({
+      conversation: 'none',
+      modalities: ['text'],
+      instructions: 'Anchor translator behavior.',
+      metadata: { purpose: 'anchor' }
+    });
+
+    expect(event).toEqual({
+      type: 'response.create',
+      response: {
+        conversation: 'none',
+        output_modalities: ['text'],
+        instructions: 'Anchor translator behavior.',
+        metadata: { purpose: 'anchor' }
+      }
+    });
+    expect(event.response.modalities).toBeUndefined();
+  });
+});

--- a/src/services/clients/openAIRealtimeSession.ts
+++ b/src/services/clients/openAIRealtimeSession.ts
@@ -1,0 +1,126 @@
+import { OpenAISessionConfig, ResponseConfig } from '../interfaces/IClient';
+
+export interface OpenAIRealtimeSessionBuildResult {
+  session: Record<string, any>;
+  turnDetectionDisabled: boolean;
+}
+
+/**
+ * Build the GA Realtime session shape shared by the WebSocket and WebRTC
+ * transports. Keeping this in one place prevents transport fallback from
+ * silently changing session settings such as the selected voice.
+ */
+export function buildOpenAIRealtimeSession(
+  config: OpenAISessionConfig
+): OpenAIRealtimeSessionBuildResult {
+  const session: Record<string, any> = {
+    type: 'realtime',
+    output_modalities: config.textOnly ? ['text'] : ['audio'],
+    instructions: config.instructions,
+    max_output_tokens: config.maxTokens === 'inf' ? 'inf' : config.maxTokens,
+    tool_choice: 'none',
+    tools: []
+  };
+
+  const audio: Record<string, any> = {};
+  const audioInput: Record<string, any> = {};
+  let turnDetectionDisabled = false;
+
+  // Voice is nested under audio.output in the GA protocol. This must be sent
+  // before the first audio response because the API locks the voice afterward.
+  if (!config.textOnly) {
+    audio.output = {
+      voice: config.voice || 'alloy'
+    };
+  }
+
+  if (config.turnDetection) {
+    if (config.turnDetection.type === 'none') {
+      audioInput.turn_detection = null;
+      turnDetectionDisabled = true;
+    } else {
+      const turnDetection: Record<string, any> = {
+        type: config.turnDetection.type,
+        create_response: config.turnDetection.createResponse ?? true,
+        interrupt_response: config.turnDetection.interruptResponse ?? false
+      };
+
+      if (config.turnDetection.type === 'server_vad') {
+        if (config.turnDetection.threshold !== undefined) {
+          turnDetection.threshold = config.turnDetection.threshold;
+        }
+        if (config.turnDetection.prefixPadding !== undefined) {
+          turnDetection.prefix_padding_ms = Math.round(config.turnDetection.prefixPadding * 1000);
+        }
+        if (config.turnDetection.silenceDuration !== undefined) {
+          turnDetection.silence_duration_ms = Math.round(config.turnDetection.silenceDuration * 1000);
+        }
+      } else if (config.turnDetection.eagerness) {
+        turnDetection.eagerness = config.turnDetection.eagerness.toLowerCase();
+      }
+
+      audioInput.turn_detection = turnDetection;
+    }
+  }
+
+  if (config.inputAudioTranscription?.model) {
+    audioInput.transcription = {
+      model: config.inputAudioTranscription.model
+    };
+  }
+
+  if (config.inputAudioNoiseReduction?.type) {
+    audioInput.noise_reduction = {
+      type: config.inputAudioNoiseReduction.type
+    };
+  }
+
+  if (Object.keys(audioInput).length > 0) {
+    audio.input = audioInput;
+  }
+
+  if (Object.keys(audio).length > 0) {
+    session.audio = audio;
+  }
+
+  if (config.model?.startsWith('gpt-realtime-2') && config.reasoningEffort) {
+    session.reasoning = { effort: config.reasoningEffort };
+  }
+
+  return { session, turnDetectionDisabled };
+}
+
+/** Build the multipart request used by POST /v1/realtime/calls. */
+export function buildOpenAIRealtimeCallForm(
+  sdp: string,
+  config: OpenAISessionConfig
+): FormData {
+  const { session } = buildOpenAIRealtimeSession(config);
+  const form = new FormData();
+  form.set('sdp', sdp);
+  form.set('session', JSON.stringify({
+    ...session,
+    model: config.model
+  }));
+  return form;
+}
+
+/** Build the GA response.create shape shared by both Realtime transports. */
+export function buildOpenAIRealtimeResponseEvent(
+  config?: ResponseConfig
+): Record<string, any> {
+  if (!config) {
+    return { type: 'response.create' };
+  }
+
+  const response: Record<string, any> = {};
+  if (config.instructions) response.instructions = config.instructions;
+  if (config.conversation) response.conversation = config.conversation;
+  if (config.modalities) response.output_modalities = config.modalities;
+  if (config.metadata) response.metadata = config.metadata;
+
+  return {
+    type: 'response.create',
+    response
+  };
+}

--- a/src/services/clients/openAIRealtimeSession.ts
+++ b/src/services/clients/openAIRealtimeSession.ts
@@ -5,13 +5,23 @@ export interface OpenAIRealtimeSessionBuildResult {
   turnDetectionDisabled: boolean;
 }
 
+export interface OpenAIRealtimeSessionBuildOptions {
+  /**
+   * Initial session creation should fall back to Alloy when no voice is set.
+   * Partial session updates must disable this so they preserve the server's
+   * current voice instead of silently resetting it.
+   */
+  includeDefaultVoice?: boolean;
+}
+
 /**
  * Build the GA Realtime session shape shared by the WebSocket and WebRTC
  * transports. Keeping this in one place prevents transport fallback from
  * silently changing session settings such as the selected voice.
  */
 export function buildOpenAIRealtimeSession(
-  config: OpenAISessionConfig
+  config: OpenAISessionConfig,
+  options: OpenAIRealtimeSessionBuildOptions = {}
 ): OpenAIRealtimeSessionBuildResult {
   const session: Record<string, any> = {
     type: 'realtime',
@@ -28,9 +38,10 @@ export function buildOpenAIRealtimeSession(
 
   // Voice is nested under audio.output in the GA protocol. This must be sent
   // before the first audio response because the API locks the voice afterward.
-  if (!config.textOnly) {
+  const outputVoice = config.voice || (options.includeDefaultVoice === false ? undefined : 'alloy');
+  if (!config.textOnly && outputVoice) {
     audio.output = {
-      voice: config.voice || 'alloy'
+      voice: outputVoice
     };
   }
 

--- a/src/services/clients/openAIRealtimeSession.ts
+++ b/src/services/clients/openAIRealtimeSession.ts
@@ -5,13 +5,9 @@ export interface OpenAIRealtimeSessionBuildResult {
   turnDetectionDisabled: boolean;
 }
 
-export interface OpenAIRealtimeSessionBuildOptions {
-  /**
-   * Initial session creation should fall back to Alloy when no voice is set.
-   * Partial session updates must disable this so they preserve the server's
-   * current voice instead of silently resetting it.
-   */
-  includeDefaultVoice?: boolean;
+export interface OpenAIRealtimeSessionUpdateBuildResult {
+  session: Record<string, any>;
+  turnDetectionDisabled?: boolean;
 }
 
 /**
@@ -20,8 +16,7 @@ export interface OpenAIRealtimeSessionBuildOptions {
  * silently changing session settings such as the selected voice.
  */
 export function buildOpenAIRealtimeSession(
-  config: OpenAISessionConfig,
-  options: OpenAIRealtimeSessionBuildOptions = {}
+  config: OpenAISessionConfig
 ): OpenAIRealtimeSessionBuildResult {
   const session: Record<string, any> = {
     type: 'realtime',
@@ -38,10 +33,9 @@ export function buildOpenAIRealtimeSession(
 
   // Voice is nested under audio.output in the GA protocol. This must be sent
   // before the first audio response because the API locks the voice afterward.
-  const outputVoice = config.voice || (options.includeDefaultVoice === false ? undefined : 'alloy');
-  if (!config.textOnly && outputVoice) {
+  if (!config.textOnly) {
     audio.output = {
-      voice: outputVoice
+      voice: config.voice || 'alloy'
     };
   }
 
@@ -90,6 +84,88 @@ export function buildOpenAIRealtimeSession(
     audio.input = audioInput;
   }
 
+  if (Object.keys(audio).length > 0) {
+    session.audio = audio;
+  }
+
+  if (config.model?.startsWith('gpt-realtime-2') && config.reasoningEffort) {
+    session.reasoning = { effort: config.reasoningEffort };
+  }
+
+  return { session, turnDetectionDisabled };
+}
+
+/**
+ * Build a sparse GA session.update payload. Only explicitly supplied settings
+ * are emitted so a runtime update cannot reset unrelated server state.
+ */
+export function buildOpenAIRealtimeSessionUpdate(
+  config: Partial<OpenAISessionConfig>
+): OpenAIRealtimeSessionUpdateBuildResult {
+  const session: Record<string, any> = { type: 'realtime' };
+  const audio: Record<string, any> = {};
+  const audioInput: Record<string, any> = {};
+  let turnDetectionDisabled: boolean | undefined;
+
+  if (config.textOnly !== undefined) {
+    session.output_modalities = config.textOnly ? ['text'] : ['audio'];
+  }
+  if (config.instructions !== undefined) {
+    session.instructions = config.instructions;
+  }
+  if (config.maxTokens !== undefined) {
+    session.max_output_tokens = config.maxTokens === 'inf' ? 'inf' : config.maxTokens;
+  }
+
+  if (config.voice !== undefined && config.textOnly !== true) {
+    audio.output = { voice: config.voice };
+  }
+
+  if (config.turnDetection !== undefined) {
+    if (config.turnDetection.type === 'none') {
+      audioInput.turn_detection = null;
+      turnDetectionDisabled = true;
+    } else {
+      const turnDetection: Record<string, any> = {
+        type: config.turnDetection.type,
+        create_response: config.turnDetection.createResponse ?? true,
+        interrupt_response: config.turnDetection.interruptResponse ?? false
+      };
+
+      if (config.turnDetection.type === 'server_vad') {
+        if (config.turnDetection.threshold !== undefined) {
+          turnDetection.threshold = config.turnDetection.threshold;
+        }
+        if (config.turnDetection.prefixPadding !== undefined) {
+          turnDetection.prefix_padding_ms = Math.round(config.turnDetection.prefixPadding * 1000);
+        }
+        if (config.turnDetection.silenceDuration !== undefined) {
+          turnDetection.silence_duration_ms = Math.round(config.turnDetection.silenceDuration * 1000);
+        }
+      } else if (config.turnDetection.eagerness) {
+        turnDetection.eagerness = config.turnDetection.eagerness.toLowerCase();
+      }
+
+      audioInput.turn_detection = turnDetection;
+      turnDetectionDisabled = false;
+    }
+  }
+
+  if (config.inputAudioTranscription?.model) {
+    audioInput.transcription = {
+      model: config.inputAudioTranscription.model
+    };
+  }
+
+  if (config.inputAudioNoiseReduction?.type) {
+    audioInput.noise_reduction = {
+      type: config.inputAudioNoiseReduction.type
+    };
+  }
+
+  if (Object.keys(audioInput).length > 0) {
+    audio.input = audioInput;
+  }
   if (Object.keys(audio).length > 0) {
     session.audio = audio;
   }

--- a/src/services/clients/openAIRealtimeSession.ts
+++ b/src/services/clients/openAIRealtimeSession.ts
@@ -10,6 +10,49 @@ export interface OpenAIRealtimeSessionUpdateBuildResult {
   turnDetectionDisabled?: boolean;
 }
 
+function buildTurnDetectionPayload(
+  turnDetection: NonNullable<OpenAISessionConfig['turnDetection']>
+): { payload: Record<string, any> | null; disabled: boolean } {
+  if (turnDetection.type === 'none') {
+    return { payload: null, disabled: true };
+  }
+
+  const payload: Record<string, any> = {
+    type: turnDetection.type,
+    create_response: turnDetection.createResponse ?? true,
+    interrupt_response: turnDetection.interruptResponse ?? false
+  };
+
+  if (turnDetection.type === 'server_vad') {
+    if (turnDetection.threshold !== undefined) {
+      payload.threshold = turnDetection.threshold;
+    }
+    if (turnDetection.prefixPadding !== undefined) {
+      payload.prefix_padding_ms = Math.round(turnDetection.prefixPadding * 1000);
+    }
+    if (turnDetection.silenceDuration !== undefined) {
+      payload.silence_duration_ms = Math.round(turnDetection.silenceDuration * 1000);
+    }
+  } else if (turnDetection.eagerness) {
+    payload.eagerness = turnDetection.eagerness.toLowerCase();
+  }
+
+  return { payload, disabled: false };
+}
+
+function attachAudioConfig(
+  session: Record<string, any>,
+  audio: Record<string, any>,
+  audioInput: Record<string, any>
+): void {
+  if (Object.keys(audioInput).length > 0) {
+    audio.input = audioInput;
+  }
+  if (Object.keys(audio).length > 0) {
+    session.audio = audio;
+  }
+}
+
 /**
  * Build the GA Realtime session shape shared by the WebSocket and WebRTC
  * transports. Keeping this in one place prevents transport fallback from
@@ -40,32 +83,9 @@ export function buildOpenAIRealtimeSession(
   }
 
   if (config.turnDetection) {
-    if (config.turnDetection.type === 'none') {
-      audioInput.turn_detection = null;
-      turnDetectionDisabled = true;
-    } else {
-      const turnDetection: Record<string, any> = {
-        type: config.turnDetection.type,
-        create_response: config.turnDetection.createResponse ?? true,
-        interrupt_response: config.turnDetection.interruptResponse ?? false
-      };
-
-      if (config.turnDetection.type === 'server_vad') {
-        if (config.turnDetection.threshold !== undefined) {
-          turnDetection.threshold = config.turnDetection.threshold;
-        }
-        if (config.turnDetection.prefixPadding !== undefined) {
-          turnDetection.prefix_padding_ms = Math.round(config.turnDetection.prefixPadding * 1000);
-        }
-        if (config.turnDetection.silenceDuration !== undefined) {
-          turnDetection.silence_duration_ms = Math.round(config.turnDetection.silenceDuration * 1000);
-        }
-      } else if (config.turnDetection.eagerness) {
-        turnDetection.eagerness = config.turnDetection.eagerness.toLowerCase();
-      }
-
-      audioInput.turn_detection = turnDetection;
-    }
+    const { payload, disabled } = buildTurnDetectionPayload(config.turnDetection);
+    audioInput.turn_detection = payload;
+    turnDetectionDisabled = disabled;
   }
 
   if (config.inputAudioTranscription?.model) {
@@ -80,13 +100,7 @@ export function buildOpenAIRealtimeSession(
     };
   }
 
-  if (Object.keys(audioInput).length > 0) {
-    audio.input = audioInput;
-  }
-
-  if (Object.keys(audio).length > 0) {
-    session.audio = audio;
-  }
+  attachAudioConfig(session, audio, audioInput);
 
   if (config.model?.startsWith('gpt-realtime-2') && config.reasoningEffort) {
     session.reasoning = { effort: config.reasoningEffort };
@@ -122,33 +136,9 @@ export function buildOpenAIRealtimeSessionUpdate(
   }
 
   if (config.turnDetection !== undefined) {
-    if (config.turnDetection.type === 'none') {
-      audioInput.turn_detection = null;
-      turnDetectionDisabled = true;
-    } else {
-      const turnDetection: Record<string, any> = {
-        type: config.turnDetection.type,
-        create_response: config.turnDetection.createResponse ?? true,
-        interrupt_response: config.turnDetection.interruptResponse ?? false
-      };
-
-      if (config.turnDetection.type === 'server_vad') {
-        if (config.turnDetection.threshold !== undefined) {
-          turnDetection.threshold = config.turnDetection.threshold;
-        }
-        if (config.turnDetection.prefixPadding !== undefined) {
-          turnDetection.prefix_padding_ms = Math.round(config.turnDetection.prefixPadding * 1000);
-        }
-        if (config.turnDetection.silenceDuration !== undefined) {
-          turnDetection.silence_duration_ms = Math.round(config.turnDetection.silenceDuration * 1000);
-        }
-      } else if (config.turnDetection.eagerness) {
-        turnDetection.eagerness = config.turnDetection.eagerness.toLowerCase();
-      }
-
-      audioInput.turn_detection = turnDetection;
-      turnDetectionDisabled = false;
-    }
+    const { payload, disabled } = buildTurnDetectionPayload(config.turnDetection);
+    audioInput.turn_detection = payload;
+    turnDetectionDisabled = disabled;
   }
 
   if (config.inputAudioTranscription?.model) {
@@ -163,12 +153,7 @@ export function buildOpenAIRealtimeSessionUpdate(
     };
   }
 
-  if (Object.keys(audioInput).length > 0) {
-    audio.input = audioInput;
-  }
-  if (Object.keys(audio).length > 0) {
-    session.audio = audio;
-  }
+  attachAudioConfig(session, audio, audioInput);
 
   if (config.model?.startsWith('gpt-realtime-2') && config.reasoningEffort) {
     session.reasoning = { effort: config.reasoningEffort };

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -274,8 +274,11 @@ export type SessionConfig = OpenAISessionConfig | OpenAITranslateSessionConfig |
 /**
  * Type guards for session configurations
  */
-export function isOpenAISessionConfig(config: SessionConfig): config is OpenAISessionConfig {
-  return config.provider === 'openai' || config.provider === 'cometapi';
+export function isOpenAISessionConfig(config: unknown): config is OpenAISessionConfig {
+  if (typeof config !== 'object' || config === null) return false;
+
+  const provider = (config as { provider?: unknown }).provider;
+  return provider === 'openai' || provider === 'cometapi';
 }
 
 export function isOpenAITranslateSessionConfig(config: SessionConfig): config is OpenAITranslateSessionConfig {
@@ -449,9 +452,9 @@ export interface IClientStatic {
     validation: ApiKeyValidationResult;
     models: FilteredModel[];
   }>;
-  
+
   /**
    * Get the latest realtime model ID
    */
   getLatestRealtimeModel(models: FilteredModel[]): string;
-} 
+}


### PR DESCRIPTION
## Summary

- migrate OpenAI Realtime WebRTC authentication to `/v1/realtime/client_secrets`
- exchange WebRTC SDP through `/v1/realtime/calls` with the GA multipart session payload
- share the GA session and `response.create` builders across WebSocket and WebRTC
- send the selected voice as `audio.output.voice` and use GA `output_modalities`
- retain compatibility with the legacy nested client-secret response shape

## Root cause

The WebSocket client never included the selected voice in its GA `session.update`, while the WebRTC client still used legacy endpoints and beta-shaped top-level fields such as `voice`, `turn_detection`, and `modalities`. As a result, OpenAI could keep its default voice even when users selected Ash or another voice, making every selection sound the same. The transports could also behave differently when WebRTC fell back to WebSocket.

## Impact

Voice selection and per-turn output modality now remain consistent across both OpenAI Realtime transports and transport fallback. The server-confirmed session reflects the voice selected in Sokuji.

## Validation

- `vitest --run src/services/clients/openAIRealtimeSession.test.ts src/services/EphemeralTokenService.test.ts` — 11 tests passed
- `vite build` — passed
- live OpenAI Realtime smoke tests for WebSocket and WebRTC with `gpt-realtime-2.1` — both server `session.updated` events reported `audio.output.voice: "ash"`



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for OpenAI Realtime GA sessions over WebSocket and WebRTC.
  - Expanded realtime audio options, including voice selection, transcription, noise reduction, turn detection, and reasoning settings.
  - Added text-only push-to-talk sessions and configurable response behavior.
  - Improved WebRTC realtime session setup and configuration updates.

- **Bug Fixes**
  - Improved handling of realtime client-secret responses and expiration values.
  - Preserved compatibility with legacy client-secret response formats.
  - Improved error logging and validation for realtime session requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->