### PR TITLE
feat(soniox): auto-resume the STT stream after a transient 503

### DIFF
--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -1225,6 +1225,22 @@ describe('SonioxClient STT 503 auto-resume (transient service-unavailable, not f
     expect(items.filter((i) => i.role === 'assistant')).toHaveLength(1);
     expect(items.find((i) => i.role === 'assistant')!.id).toBe(assistantId);
   });
+
+  // The abandon path must END the interrupted utterance's TTS stream just
+  // like <end> does: the TTS socket survives the STT swap, and an un-ended
+  // utterance stream would absorb the resumed stream's next utterance text
+  // into one combined synthesis.
+  it('abandoning an interrupted utterance ends its TTS utterance stream', async () => {
+    const { stt, tts } = await connectedClient({ textOnly: false });
+    stt.emit({ tokens: [tok('Hello', { is_final: true, translation_status: 'translation', language: 'en', source_language: 'zh' })] });
+    expect(tts!.utteranceEnds).toBe(0); // no <end> yet — the TTS utterance is open
+
+    stt.handlers.onError?.('503', 'temporarily unavailable');
+    stt.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+    await flush();
+
+    expect(tts!.utteranceEnds).toBe(1); // abandon closed it, exactly as <end> would
+  });
 });
 
 describe('SonioxClient STT 503 auto-resume: all attempts fail', () => {

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -3,6 +3,7 @@ import { SonioxClient } from './SonioxClient';
 import { SonioxSessionConfig, ConversationItem } from '../interfaces/IClient';
 import { Provider } from '../../types/Provider';
 import type { SonioxSttMessage, SonioxSttStreamHandlers, SonioxSttConfig } from './SonioxSttStream';
+import { SonioxSideTracker } from './SonioxSideTracker';
 
 // --- Mock both wire components; capture instances for driving the client ---
 const sttInstances: MockStt[] = [];
@@ -12,9 +13,16 @@ class MockStt {
   sentAudio: Int16Array[] = [];
   ended = false;
   closed = false;
+  // Used by the 503-resume "all attempts fail" tests to make every
+  // subsequent reconnect attempt's connect() reject.
+  static failConnect = false;
   constructor() { sttInstances.push(this); }
   setHandlers(h: SonioxSttStreamHandlers) { this.handlers = h; }
-  connect(config: SonioxSttConfig) { this.config = config; return Promise.resolve(); }
+  connect(config: SonioxSttConfig) {
+    this.config = config;
+    if (MockStt.failConnect) return Promise.reject(new Error('stt connect failed'));
+    return Promise.resolve();
+  }
   sendAudio(a: Int16Array) { this.sentAudio.push(a); }
   finalize() {}
   end() { this.ended = true; }
@@ -79,6 +87,7 @@ beforeEach(() => {
   ttsInstances.length = 0;
   MockTts.failConnect = false;
   MockTts.gate = null;
+  MockStt.failConnect = false;
 });
 
 describe('SonioxClient connect', () => {
@@ -930,5 +939,216 @@ describe('SonioxClient diarization attribution (#342)', () => {
     // fallback (zh == source → speaker), not the stale participant memory.
     stt2.emit({ tokens: [tok('好', { is_final: true, translation_status: 'original', language: 'zh', speaker: '2' })] });
     expect(updates.at(-1)!.item.source).toBe('speaker');
+  });
+});
+
+describe('SonioxClient STT 503 auto-resume (transient service-unavailable, not fatal)', () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it('a 503 error frame + close resumes silently: no error item, no onError/onClose, onReconnected fires, and new audio reaches the fresh stream', async () => {
+    const { client, updates } = await connectedClient();
+    const stt0 = sttInstances.at(-1)!;
+    const errors: any[] = [];
+    const closeEvents: any[] = [];
+    const reconnected = vi.fn();
+    client.setEventHandlers({
+      onConversationUpdated: (d) => updates.push(d),
+      onError: (e) => errors.push(e),
+      onClose: (e) => closeEvents.push(e),
+      onReconnected: reconnected,
+    });
+
+    stt0.handlers.onError?.('503', 'temporarily unavailable');
+    stt0.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+    await flush(); // let the immediate (0ms) resume attempt settle
+
+    expect(errors).toHaveLength(0);
+    expect(closeEvents).toHaveLength(0);
+    expect(client.getConversationItems().some((i) => i.type === 'error')).toBe(false);
+    expect(reconnected).toHaveBeenCalledTimes(1);
+
+    const stt1 = sttInstances.at(-1)!;
+    expect(stt1).not.toBe(stt0);
+    expect(client.isConnected()).toBe(true);
+
+    const pcm = new Int16Array([9, 9]);
+    client.appendInputAudio(pcm);
+    expect(stt1.sentAudio).toEqual([pcm]);
+  });
+
+  it('onReconnecting fires synchronously as soon as the post-503 close lands', async () => {
+    const { client } = await connectedClient();
+    const stt0 = sttInstances.at(-1)!;
+    const reconnecting = vi.fn();
+    client.setEventHandlers({ onReconnecting: reconnecting });
+
+    stt0.handlers.onError?.('503', 'temporarily unavailable');
+    stt0.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+
+    expect(reconnecting).toHaveBeenCalledTimes(1);
+  });
+
+  it('a 413 error frame is unaffected: generic error item + onError, no resume attempted', async () => {
+    const { client, updates } = await connectedClient();
+    const stt0 = sttInstances.at(-1)!;
+    const errors: any[] = [];
+    const closeEvents: any[] = [];
+    client.setEventHandlers({
+      onConversationUpdated: (d) => updates.push(d),
+      onError: (e) => errors.push(e),
+      onClose: (e) => closeEvents.push(e),
+    });
+
+    stt0.handlers.onError?.('413', 'payload too large');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('413');
+    expect(client.getConversationItems().some((i) => i.type === 'error')).toBe(true);
+
+    // The close that follows a 413 is a normal close — not swallowed for a resume.
+    stt0.handlers.onClose?.({ code: 1000, reason: '' });
+    await flush();
+    expect(closeEvents).toHaveLength(1);
+    expect(sttInstances).toHaveLength(1); // no resume attempt opened a new stream
+  });
+
+  it('an utterance interrupted mid-flight is completed on resume; the next utterance mints a fresh item id', async () => {
+    const { client, stt } = await connectedClient();
+    // Seed mid-utterance state: a final user token with no <end> yet.
+    stt.emit({ tokens: [tok('Hel', { is_final: true, translation_status: 'original', language: 'zh' })] });
+    const interruptedId = client.getConversationItems().find((i) => i.role === 'user')!.id;
+    expect(client.getConversationItems().find((i) => i.id === interruptedId)!.status).toBe('in_progress');
+
+    stt.handlers.onError?.('503', 'temporarily unavailable');
+    stt.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+    await flush();
+
+    const interruptedItem = client.getConversationItems().find((i) => i.id === interruptedId)!;
+    expect(interruptedItem.status).toBe('completed');
+    expect(interruptedItem.formatted?.text).toBe('Hel');
+
+    const stt1 = sttInstances.at(-1)!;
+    expect(stt1).not.toBe(stt);
+    stt1.emit({ tokens: [tok('Next', { is_final: true, translation_status: 'original', language: 'zh' })] });
+    const nextItem = client.getConversationItems().find((i) => i.role === 'user' && i.id !== interruptedId);
+    expect(nextItem).toBeDefined();
+    expect(nextItem!.formatted?.text).toBe('Next');
+  });
+
+  it('bidirectional: the side tracker is reset on resume (stale labels/timeline must not leak into the new stream)', async () => {
+    const resetSpy = vi.spyOn(SonioxSideTracker.prototype, 'reset');
+    const client = new SonioxClient('key');
+    client.setEventHandlers({});
+    await client.connect({ ...BASE_CONFIG, bidirectional: true, sourceLanguage: 'zh', targetLanguage: 'en', textOnly: true });
+    const stt0 = sttInstances.at(-1)!;
+    resetSpy.mockClear();
+
+    stt0.handlers.onError?.('503', 'temporarily unavailable');
+    stt0.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+    await flush();
+
+    expect(resetSpy).toHaveBeenCalledTimes(1);
+    resetSpy.mockRestore();
+  });
+
+  it('managed-403 duration cutoff is unaffected by the 503 resume path (cutoff still wins, never resumes)', async () => {
+    const client = new SonioxClient('', { managed: { sessionToken: 'tok' } });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        sttApiKey: 'stt-key', ttsApiKey: 'tts-key', expiresAt: '2026-07-25T00:01:00Z',
+        maxSessionDurationSeconds: 900, budgetMicroUsd: 500_000, rateUsdPerHour: 0.6,
+        sku: 'soniox:speech_to_speech', leaseId: 'lease-1', clientReferenceId: 'sokuji1:acct:lease-1',
+      }),
+    }));
+    const errors: any[] = [];
+    const closeEvents: any[] = [];
+    const reconnecting = vi.fn();
+    client.setEventHandlers({
+      onError: (e) => errors.push(e),
+      onClose: (e) => closeEvents.push(e),
+      onReconnecting: reconnecting,
+    });
+    await client.connect({ ...BASE_CONFIG, textOnly: false });
+    const stt0 = sttInstances.at(-1)!;
+
+    stt0.handlers.onError?.('403', 'session duration exceeded');
+    stt0.handlers.onClose?.({ code: 1000, reason: '' });
+    await flush();
+
+    expect(errors).toHaveLength(0);
+    expect(reconnecting).not.toHaveBeenCalled();
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0].sonioxDurationCutoff).toBe(true);
+    vi.unstubAllGlobals();
+  });
+});
+
+describe('SonioxClient STT 503 auto-resume: all attempts fail', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => { vi.useRealTimers(); MockStt.failConnect = false; });
+
+  it('after 3 failed reconnect attempts (0/1000/3000ms gaps), surfaces the ORIGINAL 503 message and closes the session', async () => {
+    const client = new SonioxClient('key');
+    const errors: any[] = [];
+    const updates: any[] = [];
+    const closeEvents: any[] = [];
+    client.setEventHandlers({
+      onConversationUpdated: (d) => updates.push(d),
+      onError: (e) => errors.push(e),
+      onClose: (e) => closeEvents.push(e),
+    });
+    await client.connect(BASE_CONFIG);
+    const stt0 = sttInstances.at(-1)!;
+
+    MockStt.failConnect = true;
+    stt0.handlers.onError?.('503', 'capacity exceeded');
+    stt0.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+
+    // Advance through all 3 backoff gaps (0ms/1000ms/3000ms) in one go —
+    // each subsequent setTimeout is only registered once the prior attempt's
+    // rejection has been caught, so a single runAllTimersAsync interleaves
+    // timers and microtasks correctly (same pattern as GeminiClient's
+    // "3 failed retries" reconnect test).
+    await vi.runAllTimersAsync();
+
+    expect(sttInstances).toHaveLength(4); // original + 3 failed resume attempts
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('503');
+    // The ORIGINAL 503 message — not whatever the 3rd attempt's rejection said.
+    expect(errors[0].message).toBe('capacity exceeded');
+    expect(updates.some((u) => u.item.type === 'error')).toBe(true);
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0]).toEqual({ code: 1006, reason: 'stt resume failed' });
+    expect(client.isConnected()).toBe(false);
+  });
+
+  it('a resume that succeeds on a later attempt does not surface anything and reaches onReconnected', async () => {
+    const client = new SonioxClient('key');
+    const errors: any[] = [];
+    const closeEvents: any[] = [];
+    const reconnected = vi.fn();
+    client.setEventHandlers({
+      onError: (e) => errors.push(e),
+      onClose: (e) => closeEvents.push(e),
+      onReconnected: reconnected,
+    });
+    await client.connect(BASE_CONFIG);
+    const stt0 = sttInstances.at(-1)!;
+
+    MockStt.failConnect = true;
+    stt0.handlers.onError?.('503', 'capacity exceeded');
+    stt0.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+
+    // Let the first (0ms) attempt fail, then flip to succeeding before the
+    // second attempt (after the 1000ms gap) fires.
+    await vi.advanceTimersByTimeAsync(0);
+    MockStt.failConnect = false;
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(reconnected).toHaveBeenCalledTimes(1);
+    expect(errors).toHaveLength(0);
+    expect(closeEvents).toHaveLength(0);
+    expect(client.isConnected()).toBe(true);
   });
 });

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -1082,6 +1082,149 @@ describe('SonioxClient STT 503 auto-resume (transient service-unavailable, not f
     expect(closeEvents[0].sonioxDurationCutoff).toBe(true);
     vi.unstubAllGlobals();
   });
+
+  // C1: pendingSttResume503 must not dangle across disconnect() — the
+  // "503 is always immediately followed by a close" assumption is only
+  // live-verified for the 403 cutoff, not the 503. If the close never
+  // came, and the user hits Stop before it does, disconnect() bumps
+  // generation and closes the socket itself; the resulting close (which a
+  // real WebSocket fires asynchronously, potentially after disconnect()
+  // has already returned) must NOT still find the flag set and kick off a
+  // resume — that would reconnect a zombie socket after Stop.
+  it('C1: a 503 with no close, followed by disconnect(), does not let a later close start a zombie resume', async () => {
+    const { client } = await connectedClient();
+    const stt0 = sttInstances.at(-1)!;
+    const reconnecting = vi.fn();
+    client.setEventHandlers({ onReconnecting: reconnecting });
+
+    stt0.handlers.onError?.('503', 'temporarily unavailable'); // no close follows
+    await client.disconnect(); // user hits Stop
+
+    // Simulate the underlying WebSocket's close event arriving asynchronously
+    // AFTER disconnect() already ran and called stt.close() — this is exactly
+    // what a real browser does (onclose fires after ws.close(), not during it).
+    stt0.handlers.onClose?.({ code: 1006, reason: 'late close' });
+    await flush();
+
+    expect(reconnecting).not.toHaveBeenCalled();
+    expect(sttInstances).toHaveLength(1); // no new stream was ever created
+    expect(client.isConnected()).toBe(false);
+  });
+
+  // I1: managed sessions cannot resume — the backend mints STT temp keys
+  // single_use: true, so a same-key reconnect is rejected AFTER onopen and
+  // would masquerade as a duration cutoff (pendingDurationCutoff) instead
+  // of the outage it actually is. Managed 503s must take the plain error
+  // path, exactly like any other managed STT error.
+  it('I1: managed mode + 503 takes the generic error path — no resume attempted', async () => {
+    const client = new SonioxClient('', { managed: { sessionToken: 'tok' } });
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        sttApiKey: 'stt-key', ttsApiKey: 'tts-key', expiresAt: '2026-07-25T00:01:00Z',
+        maxSessionDurationSeconds: 900, budgetMicroUsd: 500_000, rateUsdPerHour: 0.6,
+        sku: 'soniox:speech_to_speech', leaseId: 'lease-1', clientReferenceId: 'sokuji1:acct:lease-1',
+      }),
+    }));
+    const errors: any[] = [];
+    const closeEvents: any[] = [];
+    const reconnecting = vi.fn();
+    client.setEventHandlers({
+      onError: (e) => errors.push(e),
+      onClose: (e) => closeEvents.push(e),
+      onReconnecting: reconnecting,
+    });
+    await client.connect({ ...BASE_CONFIG, textOnly: false });
+    const stt0 = sttInstances.at(-1)!;
+
+    stt0.handlers.onError?.('503', 'capacity exceeded');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('503');
+    expect(client.getConversationItems().some((i) => i.type === 'error')).toBe(true);
+
+    stt0.handlers.onClose?.({ code: 1000, reason: '' });
+    await flush();
+
+    expect(reconnecting).not.toHaveBeenCalled();
+    expect(sttInstances).toHaveLength(1); // no resume attempt opened a new stream
+    expect(closeEvents).toHaveLength(1);
+    expect(closeEvents[0].sonioxDurationCutoff).toBeUndefined(); // a normal close, not misread as a cutoff
+    vi.unstubAllGlobals();
+  });
+
+  // M1: a 503 that lands before any is_final token leaves an item minted by
+  // emitTextUpdate but with nothing for completeItem to complete (userFinal
+  // is still ''). It must not be left stuck in_progress.
+  it('M1: a partial-only interrupted item (no is_final yet) is completed in place on resume, text untouched', async () => {
+    const { client, stt } = await connectedClient();
+    stt.emit({ tokens: [tok('Hel', { translation_status: 'original', language: 'zh' })] }); // partial only
+    const partialId = client.getConversationItems().find((i) => i.role === 'user')!.id;
+    expect(client.getConversationItems().find((i) => i.id === partialId)!.status).toBe('in_progress');
+
+    stt.handlers.onError?.('503', 'temporarily unavailable');
+    stt.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+    await flush();
+
+    const item = client.getConversationItems().find((i) => i.id === partialId)!;
+    expect(item.status).toBe('completed');
+    expect(item.formatted?.text).toBe('Hel'); // unchanged — partials aren't retained in instance state
+  });
+
+  // M2: a per-session cap stops a flapping server from looping forever.
+  it('M2: caps resume cycles at 5 per session — the 6th 503 takes the generic error path instead', async () => {
+    const { client, updates } = await connectedClient();
+    const errors: any[] = [];
+    const reconnected = vi.fn();
+    client.setEventHandlers({
+      onConversationUpdated: (d) => updates.push(d),
+      onError: (e) => errors.push(e),
+      onReconnected: reconnected,
+    });
+
+    for (let cycle = 1; cycle <= 5; cycle++) {
+      const current = sttInstances.at(-1)!;
+      current.handlers.onError?.('503', `unavailable #${cycle}`);
+      current.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+      await flush();
+    }
+    expect(reconnected).toHaveBeenCalledTimes(5);
+    expect(errors).toHaveLength(0); // all 5 cycles resumed silently
+
+    // 6th 503: cap reached — generic error path, no further resume.
+    const lastStt = sttInstances.at(-1)!;
+    const countBefore = sttInstances.length;
+    lastStt.handlers.onError?.('503', 'unavailable #6');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('503');
+
+    lastStt.handlers.onClose?.({ code: 1000, reason: '' });
+    await flush();
+    expect(sttInstances.length).toBe(countBefore); // no new resume attempt
+    expect(reconnected).toHaveBeenCalledTimes(5); // unchanged
+  });
+
+  // I2: only the STT stream is replaced on resume — the TTS socket survives
+  // untouched, so audio already in flight for the interrupted (now-completed)
+  // utterance must keep landing on that SAME item, not a fresh ghost item
+  // that would then wrongly anchor the next utterance.
+  it('I2: audioItemId/audioItemSide survive the resume — trailing TTS audio still lands on the completed utterance\'s item', async () => {
+    const { client, stt, tts } = await connectedClient({ textOnly: false });
+    stt.emit({ tokens: [tok('Hello', { is_final: true, translation_status: 'translation', language: 'en', source_language: 'zh' })] });
+    const assistantId = client.getConversationItems().find((i) => i.role === 'assistant')!.id;
+
+    stt.handlers.onError?.('503', 'temporarily unavailable');
+    stt.handlers.onClose?.({ code: 1011, reason: 'service unavailable' });
+    await flush();
+
+    // The TTS socket was never touched by the resume — its audio for the
+    // utterance fed before the 503 keeps arriving and must still anchor to
+    // the same (now completed) assistant item, not mint a fresh one.
+    tts!.handlers.onAudio!(new Int16Array([1, 2]));
+    const items = client.getConversationItems();
+    expect(items.filter((i) => i.role === 'assistant')).toHaveLength(1);
+    expect(items.find((i) => i.role === 'assistant')!.id).toBe(assistantId);
+  });
 });
 
 describe('SonioxClient STT 503 auto-resume: all attempts fail', () => {
@@ -1093,10 +1236,12 @@ describe('SonioxClient STT 503 auto-resume: all attempts fail', () => {
     const errors: any[] = [];
     const updates: any[] = [];
     const closeEvents: any[] = [];
+    const realtimeEvents: Array<{ event: { type: string; data: any } }> = [];
     client.setEventHandlers({
       onConversationUpdated: (d) => updates.push(d),
       onError: (e) => errors.push(e),
       onClose: (e) => closeEvents.push(e),
+      onRealtimeEvent: (e: any) => realtimeEvents.push(e),
     });
     await client.connect(BASE_CONFIG);
     const stt0 = sttInstances.at(-1)!;
@@ -1121,6 +1266,10 @@ describe('SonioxClient STT 503 auto-resume: all attempts fail', () => {
     expect(closeEvents).toHaveLength(1);
     expect(closeEvents[0]).toEqual({ code: 1006, reason: 'stt resume failed' });
     expect(client.isConnected()).toBe(false);
+    // M3: the debug timeline must show the session actually ending — the
+    // exhausted-retries path bypasses handleSttClose's generic branch
+    // entirely, so without an explicit emit nothing would mark it closed.
+    expect(realtimeEvents.some((e) => e.event.type === 'session.stt_resume_failed')).toBe(true);
   });
 
   it('a resume that succeeds on a later attempt does not surface anything and reaches onReconnected', async () => {

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -160,9 +160,26 @@ export class SonioxClient implements IClient {
   // (and cleared) by the close that always immediately follows the error
   // frame, which passes it to resumeSttStream() so a final failure can still
   // report the ORIGINAL 503, not whatever the last reconnect attempt threw.
-  // Applies to both BYOK and managed sessions (unlike pendingDurationCutoff,
-  // which is managed-only).
+  // BYOK-only (unlike pendingDurationCutoff, which is managed-only) — see
+  // handleSttError's docstring for why a managed reconnect can't work.
+  // MUST be cleared by disconnect(), not just consumed by the close that is
+  // supposed to follow the error frame: that "always followed by a close"
+  // assumption is only live-verified for the 403 cutoff, not the 503. If a
+  // 503 frame arrives with no close and the user hits Stop, disconnect()
+  // bumps generation and closes the socket itself; the resulting close
+  // (fired by the browser after ws.close(), possibly after disconnect()
+  // has already returned) would otherwise still find this flag set and
+  // kick off resumeSttStream() — which captures the ALREADY-BUMPED
+  // generation at entry, so every "stale attempt" guard trivially passes
+  // and a fresh socket connects after Stop (zombie socket, managed billing
+  // restart if this were ever allowed in managed mode).
   private pendingSttResume503: string | null = null;
+  // Per-session count of 503 resume cycles actually started (incremented in
+  // handleSttError, reset by reset() → i.e. every connect()). Caps a
+  // flapping server from looping forever: past MAX_STT_RESUME_CYCLES a 503
+  // is treated like any other error instead of triggering another resume.
+  private sttResumeCycles = 0;
+  private static readonly MAX_STT_RESUME_CYCLES = 5;
 
   constructor(apiKey: string, options?: SonioxClientOptions) {
     this.apiKey = apiKey;
@@ -454,8 +471,14 @@ export class SonioxClient implements IClient {
 
     // All attempts exhausted: surface the ORIGINAL 503 the same way a
     // generic STT error would have, then close the session so MainPanel
-    // tears it down exactly like any other fatal client close.
+    // tears it down exactly like any other fatal client close. Emit the
+    // realtime milestone BEFORE the error item/onClose — the generic close
+    // branch in handleSttClose always emits one (session.closed); this path
+    // bypasses that branch entirely, so without this the debug timeline
+    // would show the 503 and the resume attempts but nothing marking the
+    // session as actually over.
     if (gen !== this.generation) return;
+    this.emitRealtime('client', 'session.stt_resume_failed', { provider: 'soniox', message: originalMessage });
     this.surfaceSttError('503', originalMessage);
     this.eventHandlers.onClose?.({ code: 1006, reason: 'stt resume failed' });
   }
@@ -487,21 +510,54 @@ export class SonioxClient implements IClient {
   }
 
   /**
+   * An item minted by emitTextUpdate for a PARTIAL-only utterance (no
+   * is_final token ever arrived before the 503 landed) never reaches
+   * completeItem's text-based completion above — userFinal/assistantFinal
+   * is still '' at that point, so completeItem no-ops — yet the item
+   * exists and is listed as 'in_progress'. Left alone it would stay
+   * in_progress forever (partial text is never retained in instance state,
+   * so there's nothing to feed completeItem after the fact). Flip it to
+   * 'completed' WITHOUT touching its existing formatted/content: we cannot
+   * honestly claim any particular text as "final" here, only that nothing
+   * more is coming for it. A no-op if completeItem already completed it
+   * (non-empty final text) or if no item was ever minted for this role.
+   */
+  private forceCompleteStuckItem(id: string | null): void {
+    if (!id) return;
+    const idx = this.conversationItems.findIndex((i) => i.id === id);
+    if (idx === -1) return;
+    const previous = this.conversationItems[idx];
+    if (previous.status === 'completed') return; // already completed above
+    const item: ConversationItem = { ...previous, status: 'completed' };
+    this.conversationItems[idx] = item;
+    this.eventHandlers.onConversationUpdated?.({ item, delta: {} });
+  }
+
+  /**
    * Ahead of a 503 stream resume: complete whatever text the in-flight
    * user/assistant items already have (same "flip in place" as a normal
-   * <end>) and clear every per-utterance field a fresh stream would
-   * otherwise see as stale. Deliberately narrower than
-   * finishUtterance/reset(): it must NOT touch conversationItems HISTORY,
-   * TTS sockets, managed session keys, or the cost meter — those are
-   * session-lifetime state, not per-utterance state, and the session (and
-   * its billing) continues across the resume. Unlike finishUtterance, this
-   * also clears audioItemId/audioItemSide: finishUtterance deliberately
-   * keeps them alive for trailing TTS audio from the SAME stream, but that
-   * audio will never arrive once the stream itself is being replaced.
+   * <end>), catch a partial-only item completeItem couldn't touch, and
+   * clear every per-utterance field a fresh stream would otherwise see as
+   * stale. Deliberately narrower than finishUtterance/reset(): it must NOT
+   * touch conversationItems HISTORY, TTS sockets, managed session keys, or
+   * the cost meter — those are session-lifetime state, not per-utterance
+   * state, and the session (and its billing) continues across the resume.
+   *
+   * Unlike the per-utterance fields below, audioItemId/audioItemSide are
+   * deliberately LEFT ALONE — same rule finishUtterance follows for a
+   * normal <end>. Only the STT stream is being replaced here; the TTS
+   * socket survives the swap untouched and keeps producing audio for text
+   * already fed to it before the 503. Clearing the anchor here would make
+   * emitAssistantAudio mint a fresh in_progress ghost item for that
+   * trailing audio, which would then wrongly anchor the NEXT utterance's
+   * text once it starts arriving on the resumed stream (cross-utterance
+   * bleed).
    */
   private abandonUtteranceState(): void {
     this.completeItem('user', this.currentUserItemId, this.userFinal);
     this.completeItem('assistant', this.currentAssistantItemId, this.assistantFinal);
+    this.forceCompleteStuckItem(this.currentUserItemId);
+    this.forceCompleteStuckItem(this.currentAssistantItemId);
     this.currentUserItemId = null;
     this.currentAssistantItemId = null;
     this.userFinal = '';
@@ -510,8 +566,6 @@ export class SonioxClient implements IClient {
     this.assistantLanguage = null;
     this.utteranceTtsLanguage = null;
     this.utteranceSide = null;
-    this.audioItemId = null;
-    this.audioItemSide = null;
     this.ttsSpokenText = '';
   }
 
@@ -1028,15 +1082,34 @@ export class SonioxClient implements IClient {
       return;
     }
     // 503 "service unavailable" is a transient server condition, not a
-    // fatal one — applies to BOTH BYOK and managed sessions (unlike the
-    // 403 cutoff above, which is a managed-only concept). Soniox always
-    // closes the socket immediately after an error frame, so the actual
-    // resume is kicked off from handleSttClose, which consumes this flag.
-    // No error bubble, no onError here — the user should never see a 503
-    // that successfully resumes.
-    if (code === '503') {
+    // fatal one, and gets a silent auto-resume instead of a generic error —
+    // but ONLY for BYOK sessions, and only up to MAX_STT_RESUME_CYCLES times
+    // per session:
+    //
+    //  - Managed-only gate: the backend mints STT temporary keys with
+    //    single_use: true (sokuji-backend soniox-api.ts,
+    //    CreateTemporaryKeyOpts — it's what stops one issued key opening two
+    //    concurrent transcription sessions; only TTS keys are
+    //    single_use: false). A managed reconnect with the SAME sttApiKey is
+    //    rejected by Soniox, but only AFTER the socket opens (connect()
+    //    resolves pre-validation) — so resumeSttStream would "succeed", then
+    //    immediately take a 403 error frame that pendingDurationCutoff would
+    //    misreport as a normal granted-duration cutoff instead of the outage
+    //    it actually is. Managed 503s fall straight through to the generic
+    //    error path below (surfaceSttError) instead.
+    //  - Cycle cap: a flapping server would otherwise retry forever, each
+    //    cycle silently dropping mic audio for up to ~4 s (0+1+3 s of
+    //    backoff) with zero user-visible signal. Past the cap a 503 is just
+    //    another error.
+    //
+    // Soniox always closes the socket immediately after an error frame, so
+    // the actual resume is kicked off from handleSttClose, which consumes
+    // this flag. No error bubble, no onError here — the user should never
+    // see a 503 that successfully resumes.
+    if (!this.managedOptions && code === '503' && this.sttResumeCycles < SonioxClient.MAX_STT_RESUME_CYCLES) {
+      this.sttResumeCycles++;
       this.pendingSttResume503 = message;
-      console.info(`[SonioxClient] STT reported 503 (service unavailable); will resume after close: ${message}`);
+      console.info(`[SonioxClient] STT reported 503 (service unavailable); will resume after close (cycle ${this.sttResumeCycles}/${SonioxClient.MAX_STT_RESUME_CYCLES}): ${message}`);
       this.emitRealtime('client', 'session.stt_503', { provider: 'soniox', message });
       return;
     }
@@ -1153,6 +1226,19 @@ export class SonioxClient implements IClient {
     // Invalidate any in-flight connect()/ensureTts(): a socket whose connect
     // await resolves after this point must not be installed or fed.
     this.generation++;
+    // Both "pending" error flags are consumed by a close that is SUPPOSED to
+    // follow their error frame immediately — but that assumption isn't
+    // live-verified for 503 (only for 403), and even for 403 the close is
+    // driven by the server, not guaranteed to race ahead of a user-initiated
+    // Stop. Clear both here, synchronously, before this method closes the
+    // socket itself: otherwise the browser's own (possibly delayed) close
+    // event for the socket we're about to close could still see a flag set
+    // and mis-fire — for pendingSttResume503 specifically, that means
+    // resumeSttStream() capturing the already-bumped generation at entry and
+    // sailing past every stale-attempt guard, reconnecting a zombie socket
+    // after Stop.
+    this.pendingDurationCutoff = false;
+    this.pendingSttResume503 = null;
     // Fire-and-forget: a hint, not a transaction — the backend releases the
     // lease only once Soniox's usage logs confirm the session actually
     // ended (or it expires on its own).
@@ -1206,6 +1292,7 @@ export class SonioxClient implements IClient {
     this.costMeter = null;
     this.pendingDurationCutoff = false;
     this.pendingSttResume503 = null;
+    this.sttResumeCycles = 0;
   }
 
   appendInputAudio(audioData: Int16Array): void {

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -9,7 +9,7 @@ import {
   SonioxSessionConfig
 } from '../interfaces/IClient';
 import { Provider, ProviderType } from '../../types/Provider';
-import { SonioxSttStream, SonioxSttMessage, SonioxToken, SonioxTranslationConfig } from './SonioxSttStream';
+import { SonioxSttStream, SonioxSttMessage, SonioxToken, SonioxTranslationConfig, SonioxSttConfig } from './SonioxSttStream';
 import { SonioxTtsStream } from './SonioxTtsStream';
 import { SonioxCostMeter, SonioxBudgetSnapshot } from './SonioxCostMeter';
 import { PcmMixer } from './PcmMixer';
@@ -154,6 +154,15 @@ export class SonioxClient implements IClient {
   // 403 "granted duration reached" error frame; consumed (and cleared) by
   // the close that always immediately follows it — see onClose's docstring.
   private pendingDurationCutoff = false;
+  // Set by handleSttError when the STT stream reports a 503 "service
+  // unavailable" error frame — a transient server condition, not a fatal
+  // one. Holds the original error message (null = no 503 pending); consumed
+  // (and cleared) by the close that always immediately follows the error
+  // frame, which passes it to resumeSttStream() so a final failure can still
+  // report the ORIGINAL 503, not whatever the last reconnect attempt threw.
+  // Applies to both BYOK and managed sessions (unlike pendingDurationCutoff,
+  // which is managed-only).
+  private pendingSttResume503: string | null = null;
 
   constructor(apiKey: string, options?: SonioxClientOptions) {
     this.apiKey = apiKey;
@@ -220,14 +229,7 @@ export class SonioxClient implements IClient {
     const cfg = this.currentConfig;
     // two_way needs a concrete source; degrade to one_way on 'auto'
     // (the descriptor applies the same rule — this is the safety belt).
-    const effectiveTwoWay = cfg.bidirectional && cfg.sourceLanguage !== 'auto';
-    this.bidirectional = effectiveTwoWay;
-    const translation: SonioxTranslationConfig = effectiveTwoWay
-      ? { type: 'two_way', language_a: cfg.sourceLanguage, language_b: cfg.targetLanguage }
-      : { type: 'one_way', target_language: cfg.targetLanguage };
-    const languageHints = effectiveTwoWay
-      ? [cfg.sourceLanguage, cfg.targetLanguage]
-      : (cfg.sourceLanguage !== 'auto' ? [cfg.sourceLanguage] : undefined);
+    this.bidirectional = cfg.bidirectional && cfg.sourceLanguage !== 'auto';
 
     if (this.managedOptions) {
       await this.fetchManagedSession(cfg);
@@ -237,55 +239,13 @@ export class SonioxClient implements IClient {
     }
 
     this.stt = new SonioxSttStream();
-    this.stt.setHandlers({
-      onMessage: (message) => this.handleSttMessage(message),
-      onError: (code, message) => this.handleSttError(code, message),
-      onClose: (event) => {
-        this.isConnectedState = false;
-        // Managed sessions: Soniox drops the session at its granted duration
-        // by sending a 403 error frame (caught by handleSttError, which sets
-        // this flag and suppresses the generic error bubble) immediately
-        // followed by this close. Tag the event so the UI shows a dedicated
-        // "segment ended, tap to continue" state instead of a raw error —
-        // and, per explicit product decision, does NOT auto-reconnect (a
-        // silent reconnect would restart billing without the user knowing).
-        if (this.pendingDurationCutoff) {
-          this.pendingDurationCutoff = false;
-          this.emitRealtime('client', 'session.duration_cutoff', { provider: 'soniox', ...event });
-          this.eventHandlers.onClose?.({ ...event, sonioxDurationCutoff: true });
-          return;
-        }
-        this.emitRealtime('client', 'session.closed', { provider: 'soniox', ...event });
-        this.eventHandlers.onClose?.(event);
-      },
-      // The meter's own clock, not a second timer — see onTick's docstring
-      // on SonioxSttStreamHandlers. A no-op while costMeter is null (BYOK).
-      onTick: () => this.costMeter?.tick(Date.now()),
-    });
-    // Map the session config's camelCase context to the wire's snake_case.
-    // buildSessionConfig only sets `context` when at least one of
-    // terms/translations/background text is non-empty.
-    const sttContext = cfg.context
-      ? {
-          ...(cfg.context.terms?.length ? { terms: cfg.context.terms } : {}),
-          ...(cfg.context.translationTerms?.length
-            ? { translation_terms: cfg.context.translationTerms }
-            : {}),
-          ...(cfg.context.text ? { text: cfg.context.text } : {}),
-        }
-      : undefined;
-    await this.stt.connect({
-      apiKey: this.managedOptions ? this.managedSttApiKey! : this.apiKey,
-      model: cfg.model || STT_MODEL,
-      sampleRate: SAMPLE_RATE,
-      languageHints,
-      translation,
-      ...(sttContext ? { context: sttContext } : {}),
-      endpointSensitivity: cfg.endpointSensitivity,
-      endpointLatencyAdjustmentLevel: cfg.endpointLatencyAdjustmentLevel,
-      clientReferenceId: this.clientReferenceId ?? undefined,
-      ...(effectiveTwoWay ? { enableSpeakerDiarization: true } : {}),
-    });
+    this.wireSttHandlers(this.stt);
+    // buildSttConnectConfig() is a pure function of currentConfig + the
+    // instance fields set above (this.bidirectional, managed keys,
+    // clientReferenceId) — resumeSttStream() calls the exact same helper to
+    // rebuild a byte-identical config frame on a fresh stream.
+    const sttConfig = this.buildSttConnectConfig();
+    await this.stt.connect(sttConfig);
     // If disconnect() ran during the STT connect await, this attempt is stale:
     // close the socket we just opened and bail before wiring anything up.
     if (gen !== this.generation) { this.stt?.close(); this.stt = null; return; }
@@ -340,10 +300,219 @@ export class SonioxClient implements IClient {
     if (gen !== this.generation) return;
     this.emitRealtime('client', 'session.opened', {
       provider: 'soniox',
-      translation,
+      translation: sttConfig.translation,
       textOnly: !!cfg.textOnly,
     });
     this.eventHandlers.onOpen?.();
+  }
+
+  /**
+   * Wire a fresh SonioxSttStream's handlers to this client's message/error/
+   * close/tick routing. Used identically by connect() and resumeSttStream()
+   * so a resumed stream behaves exactly like the original one — including
+   * being eligible for a FUTURE 503 resume of its own.
+   */
+  private wireSttHandlers(stream: SonioxSttStream): void {
+    stream.setHandlers({
+      onMessage: (message) => this.handleSttMessage(message),
+      onError: (code, message) => this.handleSttError(code, message),
+      onClose: (event) => this.handleSttClose(event),
+      // The meter's own clock, not a second timer — see onTick's docstring
+      // on SonioxSttStreamHandlers. A no-op while costMeter is null (BYOK).
+      onTick: () => this.costMeter?.tick(Date.now()),
+    });
+  }
+
+  /**
+   * Build the STT wire config frame. A pure function of currentConfig plus
+   * the instance fields that outlive a single stream (this.bidirectional,
+   * managed session keys, clientReferenceId) — never of local variables
+   * computed inline during one connect() call — so resumeSttStream() can
+   * call this same helper after a 503 and get a byte-identical config on
+   * the fresh stream, without connect()'s caller-specific setup re-running.
+   */
+  private buildSttConnectConfig(): SonioxSttConfig {
+    const cfg = this.currentConfig!;
+    const translation: SonioxTranslationConfig = this.bidirectional
+      ? { type: 'two_way', language_a: cfg.sourceLanguage, language_b: cfg.targetLanguage }
+      : { type: 'one_way', target_language: cfg.targetLanguage };
+    const languageHints = this.bidirectional
+      ? [cfg.sourceLanguage, cfg.targetLanguage]
+      : (cfg.sourceLanguage !== 'auto' ? [cfg.sourceLanguage] : undefined);
+    // Map the session config's camelCase context to the wire's snake_case.
+    // buildSessionConfig only sets `context` when at least one of
+    // terms/translations/background text is non-empty.
+    const sttContext = cfg.context
+      ? {
+          ...(cfg.context.terms?.length ? { terms: cfg.context.terms } : {}),
+          ...(cfg.context.translationTerms?.length
+            ? { translation_terms: cfg.context.translationTerms }
+            : {}),
+          ...(cfg.context.text ? { text: cfg.context.text } : {}),
+        }
+      : undefined;
+    return {
+      apiKey: this.managedOptions ? this.managedSttApiKey! : this.apiKey,
+      model: cfg.model || STT_MODEL,
+      sampleRate: SAMPLE_RATE,
+      languageHints,
+      translation,
+      ...(sttContext ? { context: sttContext } : {}),
+      endpointSensitivity: cfg.endpointSensitivity,
+      endpointLatencyAdjustmentLevel: cfg.endpointLatencyAdjustmentLevel,
+      clientReferenceId: this.clientReferenceId ?? undefined,
+      ...(this.bidirectional ? { enableSpeakerDiarization: true } : {}),
+    };
+  }
+
+  /**
+   * Shared onClose routing for every SonioxSttStream this client ever wires
+   * (the original one from connect() and any resumed one from
+   * resumeSttStream()). Order matters: the managed-duration cutoff is
+   * checked first so a managed 403 is never misread as a resumable 503 —
+   * the two flags are mutually exclusive in practice (handleSttError only
+   * ever sets one per error frame) but cutoff must win if that ever changes.
+   */
+  private handleSttClose(event: { code?: number; reason?: string }): void {
+    this.isConnectedState = false;
+    // Managed sessions: Soniox drops the session at its granted duration
+    // by sending a 403 error frame (caught by handleSttError, which sets
+    // this flag and suppresses the generic error bubble) immediately
+    // followed by this close. Tag the event so the UI shows a dedicated
+    // "segment ended, tap to continue" state instead of a raw error —
+    // and, per explicit product decision, does NOT auto-reconnect (a
+    // silent reconnect would restart billing without the user knowing).
+    if (this.pendingDurationCutoff) {
+      this.pendingDurationCutoff = false;
+      this.emitRealtime('client', 'session.duration_cutoff', { provider: 'soniox', ...event });
+      this.eventHandlers.onClose?.({ ...event, sonioxDurationCutoff: true });
+      return;
+    }
+    // A 503 error frame (transient "service unavailable") is always
+    // immediately followed by a close, same protocol shape as the 403
+    // cutoff above. Unlike the cutoff, this one silently resumes: no error
+    // bubble, no onClose to MainPanel (which would tear the whole session
+    // down) — just onReconnecting while a fresh stream is negotiated.
+    if (this.pendingSttResume503 !== null) {
+      const originalMessage = this.pendingSttResume503;
+      this.pendingSttResume503 = null;
+      this.emitRealtime('client', 'session.stt_resuming', { provider: 'soniox', ...event });
+      this.eventHandlers.onReconnecting?.();
+      void this.resumeSttStream(originalMessage);
+      return;
+    }
+    this.emitRealtime('client', 'session.closed', { provider: 'soniox', ...event });
+    this.eventHandlers.onClose?.(event);
+  }
+
+  /**
+   * Reconnect the STT stream after a transient 503, up to 3 attempts with
+   * 0 ms / 1000 ms / 3000 ms gaps between them. Runs the same config-frame
+   * builder and handler wiring as connect() so the resumed stream is
+   * indistinguishable from the original one on the wire.
+   *
+   * `originalMessage` is the 503 error frame's own message — final failure
+   * surfaces THIS, not whatever the last reconnect attempt's rejection
+   * reason happened to be, since from the user's perspective the story is
+   * "the service was unavailable and never came back", not "attempt 3
+   * failed for reason X".
+   */
+  private async resumeSttStream(originalMessage: string): Promise<void> {
+    // Captured once at entry: disconnect() bumps this.generation, and every
+    // await below re-checks it so a Stop during a backoff delay or an
+    // in-flight connect leaves nothing dangling.
+    const gen = this.generation;
+
+    // The interrupted utterance cannot survive the stream swap: the fresh
+    // socket restarts the server's audio clock at 0 and re-mints its own
+    // speaker labels, so anything keyed to the old stream's timeline must
+    // be abandoned, not carried forward.
+    this.abandonUtteranceState();
+    this.sideTracker?.reset();
+
+    const delaysBeforeAttempt = [0, 1000, 3000];
+    for (const delayMs of delaysBeforeAttempt) {
+      if (delayMs > 0) await SonioxClient.delay(delayMs);
+      if (gen !== this.generation) return; // disconnect() ran during the delay
+      try {
+        const stream = new SonioxSttStream();
+        this.wireSttHandlers(stream);
+        await stream.connect(this.buildSttConnectConfig());
+        // Stale-attempt guard: disconnect() ran while this attempt's connect
+        // was in flight — discard the socket instead of installing it.
+        if (gen !== this.generation) { stream.close(); return; }
+        this.stt = stream;
+        this.isConnectedState = true;
+        this.emitRealtime('client', 'session.stt_resumed', { provider: 'soniox' });
+        this.eventHandlers.onReconnected?.();
+        return;
+      } catch (error) {
+        console.error('[SonioxClient] STT resume attempt failed:', error);
+        if (gen !== this.generation) return; // disconnect() ran during the failed connect await
+      }
+    }
+
+    // All attempts exhausted: surface the ORIGINAL 503 the same way a
+    // generic STT error would have, then close the session so MainPanel
+    // tears it down exactly like any other fatal client close.
+    if (gen !== this.generation) return;
+    this.surfaceSttError('503', originalMessage);
+    this.eventHandlers.onClose?.({ code: 1006, reason: 'stt resume failed' });
+  }
+
+  /**
+   * Complete one role's in-progress item with the text accumulated so far —
+   * flips it to 'completed' in place, preserving any replay audio already
+   * buffered on it. No-op when there's no text. Shared by finishUtterance
+   * (normal <end>) and abandonUtteranceState (an utterance interrupted by a
+   * 503 stream swap) — both need identical "complete what we have" semantics,
+   * just triggered by different events.
+   */
+  private completeItem(role: 'user' | 'assistant', existingId: string | null, text: string): void {
+    if (!text) return;
+    // Preserve any replay audio already accumulated on this item: this
+    // rebuild would otherwise drop TTS audio that arrived before the
+    // completion trigger (keepReplayAudio only — undefined otherwise, a no-op).
+    const prev = existingId ? this.conversationItems.find((i) => i.id === existingId) : undefined;
+    const audio = prev?.formatted?.audio as Int16Array | undefined;
+    const detected = role === 'user' ? this.userLanguage : this.assistantLanguage;
+    const item = this.upsertItem(role, existingId, {
+      status: 'completed',
+      formatted: audio ? { text, transcript: text, audio } : { text, transcript: text },
+      content: [{ type: 'text', text }],
+      ...(detected ? { detectedLanguage: detected } : {}),
+    });
+    if (this.bidirectional && this.utteranceSide) item.source = this.utteranceSide;
+    this.eventHandlers.onConversationUpdated?.({ item, delta: {} });
+  }
+
+  /**
+   * Ahead of a 503 stream resume: complete whatever text the in-flight
+   * user/assistant items already have (same "flip in place" as a normal
+   * <end>) and clear every per-utterance field a fresh stream would
+   * otherwise see as stale. Deliberately narrower than
+   * finishUtterance/reset(): it must NOT touch conversationItems HISTORY,
+   * TTS sockets, managed session keys, or the cost meter — those are
+   * session-lifetime state, not per-utterance state, and the session (and
+   * its billing) continues across the resume. Unlike finishUtterance, this
+   * also clears audioItemId/audioItemSide: finishUtterance deliberately
+   * keeps them alive for trailing TTS audio from the SAME stream, but that
+   * audio will never arrive once the stream itself is being replaced.
+   */
+  private abandonUtteranceState(): void {
+    this.completeItem('user', this.currentUserItemId, this.userFinal);
+    this.completeItem('assistant', this.currentAssistantItemId, this.assistantFinal);
+    this.currentUserItemId = null;
+    this.currentAssistantItemId = null;
+    this.userFinal = '';
+    this.assistantFinal = '';
+    this.userLanguage = null;
+    this.assistantLanguage = null;
+    this.utteranceTtsLanguage = null;
+    this.utteranceSide = null;
+    this.audioItemId = null;
+    this.audioItemSide = null;
+    this.ttsSpokenText = '';
   }
 
   /**
@@ -765,30 +934,13 @@ export class SonioxClient implements IClient {
 
   /** <end>: complete both sides' stored items, reset per-utterance state. */
   private finishUtterance(): void {
-    const complete = (role: 'user' | 'assistant', existingId: string | null, text: string) => {
-      if (!text) return;
-      // <end> can arrive in the same STT message as the finals that complete
-      // it — before the post-loop emitTextUpdate() has ever assigned an item
-      // id for this batch (e.g. a user-side final with no preceding TTS
-      // mint). upsertItem() mints+lists one lazily rather than dropping the
-      // completed item.
-      // Preserve any replay audio already accumulated on this item: this
-      // rebuild would otherwise drop TTS audio that arrived before <end>
-      // (keepReplayAudio only — undefined otherwise, a no-op).
-      const prev = existingId ? this.conversationItems.find((i) => i.id === existingId) : undefined;
-      const audio = prev?.formatted?.audio as Int16Array | undefined;
-      const detected = role === 'user' ? this.userLanguage : this.assistantLanguage;
-      const item = this.upsertItem(role, existingId, {
-        status: 'completed',
-        formatted: audio ? { text, transcript: text, audio } : { text, transcript: text },
-        content: [{ type: 'text', text }],
-        ...(detected ? { detectedLanguage: detected } : {}),
-      });
-      if (this.bidirectional && this.utteranceSide) item.source = this.utteranceSide;
-      this.eventHandlers.onConversationUpdated?.({ item, delta: {} });
-    };
-    complete('user', this.currentUserItemId, this.userFinal);
-    complete('assistant', this.currentAssistantItemId, this.assistantFinal);
+    // <end> can arrive in the same STT message as the finals that complete
+    // it — before the post-loop emitTextUpdate() has ever assigned an item
+    // id for this batch (e.g. a user-side final with no preceding TTS
+    // mint). completeItem()'s upsertItem() mints+lists one lazily rather
+    // than dropping the completed item.
+    this.completeItem('user', this.currentUserItemId, this.userFinal);
+    this.completeItem('assistant', this.currentAssistantItemId, this.assistantFinal);
     this.currentUserItemId = null;
     this.currentAssistantItemId = null;
     // audioItemId is intentionally NOT cleared here: trailing TTS audio for
@@ -875,6 +1027,29 @@ export class SonioxClient implements IClient {
       console.info('[SonioxClient] Managed session reached its granted duration (403); closing');
       return;
     }
+    // 503 "service unavailable" is a transient server condition, not a
+    // fatal one — applies to BOTH BYOK and managed sessions (unlike the
+    // 403 cutoff above, which is a managed-only concept). Soniox always
+    // closes the socket immediately after an error frame, so the actual
+    // resume is kicked off from handleSttClose, which consumes this flag.
+    // No error bubble, no onError here — the user should never see a 503
+    // that successfully resumes.
+    if (code === '503') {
+      this.pendingSttResume503 = message;
+      console.info(`[SonioxClient] STT reported 503 (service unavailable); will resume after close: ${message}`);
+      this.emitRealtime('client', 'session.stt_503', { provider: 'soniox', message });
+      return;
+    }
+    this.surfaceSttError(code, message);
+  }
+
+  /**
+   * Generic STT error surfacing: a system-role error ConversationItem plus
+   * onError. Shared by handleSttError's fallthrough (an error that isn't
+   * the managed-403 cutoff or a resumable 503) and resumeSttStream's final
+   * failure (a 503 that never recovered after 3 attempts).
+   */
+  private surfaceSttError(code: string, message: string): void {
     console.error(`[SonioxClient] STT error ${code}: ${message}`);
     const errorItem: ConversationItem = {
       id: this.generateItemId('error'),
@@ -1030,6 +1205,7 @@ export class SonioxClient implements IClient {
     this.clientReferenceId = null;
     this.costMeter = null;
     this.pendingDurationCutoff = false;
+    this.pendingSttResume503 = null;
   }
 
   appendInputAudio(audioData: Int16Array): void {

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -566,7 +566,7 @@ export class SonioxClient implements IClient {
     this.assistantLanguage = null;
     this.utteranceTtsLanguage = null;
     this.utteranceSide = null;
-    this.ttsSpokenText = '';
+    this.closeTtsUtterance();
   }
 
   /**
@@ -1006,6 +1006,17 @@ export class SonioxClient implements IClient {
     this.assistantLanguage = null;
     this.utteranceTtsLanguage = null;
     this.utteranceSide = null;
+    this.closeTtsUtterance();
+  }
+
+  /**
+   * Shared tail of finishUtterance/abandonUtteranceState: log the spoken
+   * text milestone and close the utterance's TTS stream. Ending the TTS
+   * side matters just as much on the abandon path — the TTS socket survives
+   * an STT stream swap, and an un-ended utterance stream would absorb the
+   * NEXT utterance's text into one combined synthesis.
+   */
+  private closeTtsUtterance(): void {
     // Debug-timeline milestone: the text this utterance sent to TTS to be
     // spoken. Only appears when TTS actually received text — a missing
     // tts.speak next to a translation means spoken output was skipped/degraded.


### PR DESCRIPTION
## Summary

A `503 service_unavailable` error frame on the Soniox stt-rt WebSocket is a transient server condition, but it used to tear the whole session down. The STT stream now auto-resumes (BYOK only): the 503 is consumed like the managed-403 cutoff flag, and the close that follows triggers up to three reconnect attempts (0 s / 1 s / 3 s backoff) that rebuild the exact same config frame on a fresh stream. On success the session continues seamlessly through the existing `onReconnecting`/`onReconnected` handlers (already wired in MainPanel for Gemini); if every attempt fails, the original error surfaces and the session closes as before. `413` and all other error codes are unchanged. Follow-up to the #342 audit (item C1, approved scope: 503 only).

- **Correct state across the stream swap** — the new stream restarts the server audio clock and re-mints speaker labels, so before reconnecting the client completes the interrupted utterance's conversation items (keeping their audio anchor: the TTS socket is *not* replaced and in-flight audio must keep attaching to the completed item), clears all per-utterance fields, and calls `SonioxSideTracker.reset()`. Audio during the gap is already dropped safely by the existing `isOpen` guards.
- **BYOK only, by verified fact** — the backend mints STT temporary keys with `single_use: true` (`sokuji-backend` `src/services/soniox-api.ts`: "it is what stops one issued key opening two concurrent transcription sessions"), so a managed reconnect is rejected — and rejected *after* `onopen`, which would make a "successful" resume take a 403 and masquerade as a duration cutoff. Managed 503s keep the existing error path.
- **Flag hygiene** — `disconnect()` clears both the resume flag and the managed-cutoff flag synchronously before closing the socket; otherwise a 503 frame not followed by a server close would turn the user's Stop into a zombie reconnect (live socket, revived `isConnected`, restarted managed billing).
- **Bounded** — every fetch of the resume loop is generation-guarded against Stop; resume cycles cap at five per session so a flapping server can't loop forever; the exhausted-retries path emits a closing realtime event for the debug timeline.
- Refactor: the STT config-frame construction and handler wiring are extracted from `connect()` into `buildSttConnectConfig()` / `wireSttHandlers()` shared with `resumeSttStream()` — `connect()`'s wire behavior is field-for-field unchanged.

## Known residual (pre-existing, unchanged)

`handleSttError`/`handleSttClose` carry no generation guard, so a stray error frame delivered by an already-closed socket after Stop could in principle re-arm state (same class as the flag-hygiene fix, much narrower window). This predates this PR — the proactive flag clearing here narrows it — and is left for a follow-up.

## Testing

- 13 new tests in `SonioxClient.test.ts` driving the real handler seam with fake timers: silent resume (no error item, no `onClose`, audio reaches the new stream), `onReconnecting`/`onReconnected`, exhausted retries → original error + teardown, 503-without-close then Stop → no zombie resume, managed 503 → plain error (never tagged as cutoff), mid-utterance abandonment (fresh item ids, trailing TTS audio anchored to the completed item, partial-only items completed in place), side-tracker reset, five-cycle cap, and 413 unchanged.
- `src/services/clients`: 312/312. Full vitest suite green relative to base (only the known environment-only worktree failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sm1XsKTaK6ew4DmrYHKxP9


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved speech-to-text recovery after temporary service interruptions.
  * Preserved conversations more reliably when reconnecting, including partially completed items.
  * Prevented duplicate or stale reconnection events during disconnects.
  * Added clearer failure handling when recovery attempts are exhausted.
  * Maintained text-to-speech continuity while speech recognition reconnects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->