### PR TITLE
fix(openai): add client_secrets timeout + document sparse-update caveats

### DIFF
--- a/src/services/EphemeralTokenService.ts
+++ b/src/services/EphemeralTokenService.ts
@@ -33,6 +33,7 @@ const tokenCache = new Map<string, CachedToken>();
  */
 export class EphemeralTokenService {
   private static readonly OPENAI_API_HOST = 'https://api.openai.com';
+  private static readonly CLIENT_SECRET_REQUEST_TIMEOUT_MS = 15000;
 
   /**
    * Get an ephemeral token for WebRTC connection
@@ -84,6 +85,7 @@ export class EphemeralTokenService {
           'Authorization': `Bearer ${apiKey}`,
           'Content-Type': 'application/json'
         },
+        signal: AbortSignal.timeout(EphemeralTokenService.CLIENT_SECRET_REQUEST_TIMEOUT_MS),
         body: JSON.stringify({
           session: {
             type: 'realtime',

--- a/src/services/clients/openAIRealtimeSession.ts
+++ b/src/services/clients/openAIRealtimeSession.ts
@@ -112,6 +112,12 @@ export function buildOpenAIRealtimeSession(
 /**
  * Build a sparse GA session.update payload. Only explicitly supplied settings
  * are emitted so a runtime update cannot reset unrelated server state.
+ *
+ * As of 2026-08 nothing in the app calls updateSession() on the OpenAI
+ * realtime clients, so this sparse path is exercised by unit tests only and
+ * has never run against a live session. A future caller should also know the
+ * GA API locks the voice after the first audio output: supplying `voice` in
+ * a mid-session update will surface a server error event.
  */
 export function buildOpenAIRealtimeSessionUpdate(
   config: Partial<OpenAISessionConfig>


### PR DESCRIPTION
## Summary

Follow-ups to #373:

- **Timeout symmetry**: the `client_secrets` fetch in `EphemeralTokenService` now aborts after 15s (`AbortSignal.timeout`), matching the 15s timeout #373 added to the WebRTC `/v1/realtime/calls` request on the same connection chain. Previously a hung token mint would stall the WebRTC connect indefinitely with no signal.
- **Documentation**: `buildOpenAIRealtimeSessionUpdate` now documents that, as of 2026-08, nothing in the app calls `updateSession()` on the OpenAI realtime clients — the sparse-update path is exercised by unit tests only and has never run against a live session. It also warns future callers that the GA API locks the voice after the first audio output, so supplying `voice` in a mid-session update will surface a server error event.

## Non-change worth recording

The direct `useLogStore.getState().addLog(...)` in `OpenAIWebRTCClient.sendOfferToOpenAI` was reviewed and deliberately kept: `MainPanel` catches WebRTC connect failures with only a `console.warn` before silently falling back to WebSocket, so that log line is the sole user-visible record of *why* WebRTC failed. Removing it would not deduplicate anything — it would erase the diagnostic.

## Validation

- `vitest --run` on `EphemeralTokenService.test.ts`, `openAIRealtimeSession.test.ts`, `ClientFactory.test.ts`, `OpenAIClient.test.ts` — 15/15 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a 15-second timeout when requesting temporary access credentials, helping prevent requests from hanging indefinitely.

* **Documentation**
  * Documented current limitations affecting voice changes during an active session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->