### PR TITLE
fix(openai): repair WebRTC reconnects and conversation display on GA

### DIFF
--- a/src/services/EphemeralTokenService.test.ts
+++ b/src/services/EphemeralTokenService.test.ts
@@ -3,8 +3,26 @@ import { EphemeralTokenService } from './EphemeralTokenService';
 
 describe('EphemeralTokenService Realtime GA client secrets', () => {
   afterEach(() => {
-    EphemeralTokenService.clearCache();
     vi.unstubAllGlobals();
+  });
+
+  it('mints a fresh client secret on every call because GA secrets are single-use', async () => {
+    let mintCount = 0;
+    const fetchMock = vi.fn().mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({
+        value: `ek_${++mintCount}`,
+        expires_at: Math.floor(Date.now() / 1000) + 600
+      })
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const first = await EphemeralTokenService.getToken('sk-test', 'gpt-realtime-2.1', 'ash');
+    const second = await EphemeralTokenService.getToken('sk-test', 'gpt-realtime-2.1', 'ash');
+
+    expect(first).toBe('ek_1');
+    expect(second).toBe('ek_2');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
   it('mints an Ash client secret with the current GA endpoint and body', async () => {

--- a/src/services/EphemeralTokenService.ts
+++ b/src/services/EphemeralTokenService.ts
@@ -3,9 +3,13 @@ import useLogStore from '../stores/logStore';
 /**
  * EphemeralTokenService
  *
- * Handles fetching and caching ephemeral tokens for OpenAI WebRTC connections.
- * Ephemeral tokens are short-lived credentials that allow browser-based WebRTC
- * connections to the OpenAI Realtime API.
+ * Mints ephemeral tokens for OpenAI WebRTC connections. Ephemeral tokens are
+ * short-lived credentials that allow browser-based WebRTC connections to the
+ * OpenAI Realtime API.
+ *
+ * GA client secrets are single-use: establishing a call consumes the secret,
+ * and reusing it fails with `ephemeral_token_already_used`. Tokens must
+ * therefore be minted fresh for every connection attempt — never cached.
  */
 
 interface EphemeralTokenResponse {
@@ -17,17 +21,6 @@ interface EphemeralTokenResponse {
   };
 }
 
-interface CachedToken {
-  value: string;
-  expiresAt: number;
-}
-
-// Cache buffer - refresh token 30 seconds before expiration
-const CACHE_BUFFER_MS = 30 * 1000;
-
-// Token cache keyed by model+voice
-const tokenCache = new Map<string, CachedToken>();
-
 /**
  * Service for managing ephemeral tokens for OpenAI WebRTC connections
  */
@@ -36,8 +29,8 @@ export class EphemeralTokenService {
   private static readonly CLIENT_SECRET_REQUEST_TIMEOUT_MS = 15000;
 
   /**
-   * Get an ephemeral token for WebRTC connection
-   * Uses caching to avoid unnecessary API calls
+   * Mint a fresh ephemeral token for a WebRTC connection.
+   * Always hits the API: GA client secrets are single-use.
    *
    * @param apiKey - The user's OpenAI API key
    * @param model - The realtime model to use (e.g., 'gpt-realtime-2.1-mini')
@@ -51,19 +44,8 @@ export class EphemeralTokenService {
     voice: string,
     apiHost?: string
   ): Promise<string> {
-    const cacheKey = `${apiHost || this.OPENAI_API_HOST}:${model}:${voice}`;
-    const cached = tokenCache.get(cacheKey);
-
-    // Check if cached token is still valid (with buffer)
-    if (cached && Date.now() < cached.expiresAt - CACHE_BUFFER_MS) {
-      console.debug('[EphemeralTokenService] Using cached token');
-      return cached.value;
-    }
-
-    // Fetch new token
-    console.debug('[EphemeralTokenService] Fetching new ephemeral token');
-    const token = await this.fetchToken(apiKey, model, voice, apiHost);
-    return token;
+    console.debug('[EphemeralTokenService] Minting new ephemeral token');
+    return this.fetchToken(apiKey, model, voice, apiHost);
   }
 
   /**
@@ -117,13 +99,6 @@ export class EphemeralTokenService {
         throw new Error('Invalid token response: missing client_secret');
       }
 
-      // Cache the token
-      const cacheKey = `${host}:${model}:${voice}`;
-      tokenCache.set(cacheKey, {
-        value: tokenValue,
-        expiresAt: expiresAt * 1000 // Convert to milliseconds
-      });
-
       console.debug('[EphemeralTokenService] Obtained new ephemeral token, expires at:',
         new Date(expiresAt * 1000).toISOString());
 
@@ -134,31 +109,6 @@ export class EphemeralTokenService {
       useLogStore.getState().addLog(`Failed to fetch OpenAI Realtime client secret: ${message}`, 'error');
       throw error;
     }
-  }
-
-  /**
-   * Clear cached token for a specific model/voice combination
-   */
-  static clearCache(model?: string, voice?: string, apiHost?: string): void {
-    if (model && voice) {
-      const host = apiHost || this.OPENAI_API_HOST;
-      const cacheKey = `${host}:${model}:${voice}`;
-      tokenCache.delete(cacheKey);
-      console.debug('[EphemeralTokenService] Cleared cache for:', cacheKey);
-    } else {
-      tokenCache.clear();
-      console.debug('[EphemeralTokenService] Cleared all cached tokens');
-    }
-  }
-
-  /**
-   * Check if a cached token exists and is valid
-   */
-  static hasCachedToken(model: string, voice: string, apiHost?: string): boolean {
-    const host = apiHost || this.OPENAI_API_HOST;
-    const cacheKey = `${host}:${model}:${voice}`;
-    const cached = tokenCache.get(cacheKey);
-    return cached !== undefined && Date.now() < cached.expiresAt - CACHE_BUFFER_MS;
   }
 
   /**

--- a/src/services/clients/OpenAIWebRTCClient.test.ts
+++ b/src/services/clients/OpenAIWebRTCClient.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { OpenAIWebRTCClient } from './OpenAIWebRTCClient';
+
+/**
+ * GA conversation-item regression tests.
+ *
+ * A live GA session never emits `conversation.item.created` — user and
+ * assistant items are announced via `conversation.item.added` (assistant items
+ * additionally via `response.output_item.added`, which stays unhandled on
+ * purpose so out-of-band responses do not pollute the conversation). The
+ * WebRTC client must build its conversation from `conversation.item.added`
+ * or the panel stays empty for the whole session.
+ */
+
+function makeClient(): { client: OpenAIWebRTCClient; handle: (ev: unknown) => void } {
+  const client = new OpenAIWebRTCClient({ apiKey: 'sk-test' });
+  const handle = (ev: unknown) => (client as any).handleServerEvent(ev);
+  return { client, handle };
+}
+
+describe('OpenAIWebRTCClient GA conversation items', () => {
+  it('creates items from conversation.item.added and attaches later transcripts', () => {
+    const { client, handle } = makeClient();
+
+    handle({
+      type: 'conversation.item.added',
+      item: { id: 'item_user', role: 'user', type: 'message', status: 'completed' }
+    });
+    handle({
+      type: 'conversation.item.added',
+      item: { id: 'item_asst', role: 'assistant', type: 'message', status: 'in_progress' }
+    });
+    handle({ type: 'response.output_audio_transcript.delta', item_id: 'item_asst', delta: 'Bonjour' });
+    handle({ type: 'response.output_audio_transcript.delta', item_id: 'item_asst', delta: ' !' });
+    handle({
+      type: 'conversation.item.input_audio_transcription.completed',
+      item_id: 'item_user',
+      transcript: 'Hello'
+    });
+
+    const items = client.getConversationItems();
+    expect(items.map(i => i.id)).toEqual(['item_user', 'item_asst']);
+    expect(items[0].role).toBe('user');
+    expect(items[0].formatted?.transcript).toBe('Hello');
+    expect(items[1].formatted?.transcript).toBe('Bonjour !');
+  });
+
+  it('does not duplicate an item announced through both created and added', () => {
+    const { client, handle } = makeClient();
+
+    handle({
+      type: 'conversation.item.created',
+      item: { id: 'item_1', role: 'assistant', type: 'message', status: 'in_progress' }
+    });
+    handle({
+      type: 'conversation.item.added',
+      item: { id: 'item_1', role: 'assistant', type: 'message', status: 'in_progress' }
+    });
+
+    expect(client.getConversationItems()).toHaveLength(1);
+  });
+});

--- a/src/services/clients/OpenAIWebRTCClient.ts
+++ b/src/services/clients/OpenAIWebRTCClient.ts
@@ -348,7 +348,13 @@ export class OpenAIWebRTCClient implements IClient {
         console.debug('[OpenAIWebRTCClient] Session event:', event.type);
         break;
 
+      // GA announces every conversation item (user and assistant) via
+      // conversation.item.added; conversation.item.created is beta-only and
+      // never fires on a GA session. response.output_item.added is left
+      // unhandled on purpose: out-of-band responses (conversation: 'none')
+      // emit it too, and their items must not appear in the conversation.
       case 'conversation.item.created':
+      case 'conversation.item.added':
         this.handleItemCreated(event);
         break;
 
@@ -396,6 +402,10 @@ export class OpenAIWebRTCClient implements IClient {
   private handleItemCreated(event: ServerEvent): void {
     const item = event.item;
     if (!item) return;
+
+    // The same item can be announced by more than one event (e.g. created +
+    // added on compat servers); only the first announcement creates it.
+    if (this.conversationItems.some(existing => existing.id === item.id)) return;
 
     const createdAt = Date.now();
     this.itemCreatedAtMap.set(item.id, createdAt);


### PR DESCRIPTION
## Summary

Two user-visible WebRTC bugs left over from the GA migration (#373), both reproduced live and fixed test-first.

### 1. Every session after the first fell back to WebSocket (`401 ephemeral_token_already_used`)

GA client secrets are **single-use**: establishing a call consumes the secret, and reusing it fails with `ephemeral_token_already_used`. `EphemeralTokenService` still had the beta-era token cache (refresh only 30s before expiry). Measured GA secret TTL is ~600s, so any second session within ~9.5 minutes reused the consumed secret and silently degraded to WebSocket. The beta-era cache never bit because beta tokens lived only 60s.

Fix: remove the cache entirely — mint a fresh secret per connection attempt (one cheap POST, same pattern as `mintTranslationClientSecret`). `clearCache`/`hasCachedToken` had no production callers and are removed too.

### 2. The conversation panel stayed empty for the whole WebRTC session

A live GA session **never emits `conversation.item.created`** — verified by recording the full event sequence of a real session: user and assistant items are both announced via `conversation.item.added` (assistant items additionally via `response.output_item.added`). The WebRTC client's only item-creation path was keyed on the beta-only `created` event, so no item ever materialized and transcript deltas were silently dropped for lack of a target item. The WebSocket client was unaffected because it builds items from `input_audio_buffer.committed` / `response.output_item.added`.

Fix: handle `conversation.item.added` as the GA item source, keep `created` for beta-speaking OpenAI-compatible hosts, and dedupe by item id. `response.output_item.added` stays unhandled on purpose: out-of-band responses (`conversation: 'none'`) emit it too and must not pollute the conversation — this keeps the WebRTC client free of the `outOfBandResponseIds` bookkeeping the WS client needs.

## Validation

- New regression tests written first (failed on the old code): fresh-secret-per-call, item creation from `conversation.item.added` + transcript attachment, created/added dedupe
- `vitest --run` on `OpenAIWebRTCClient.test.ts`, `EphemeralTokenService.test.ts`, `openAIRealtimeSession.test.ts` — 14/14 passed after rebase onto current main
- Live API evidence: GA secret TTL measured at 599s; failed `/v1/realtime/calls` attempts do not consume a secret (consumption happens on successful establishment); full GA event sequence recorded showing `conversation.item.added` and no `conversation.item.created`

Recommended manual check after merge: start two consecutive WebRTC sessions — both should stay on WebRTC, and the conversation should display from the first session on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ephemeral client secrets are now freshly generated for every token request, preventing reuse of single-use tokens.
  * Conversation items announced through additional real-time events are now captured correctly.
  * Duplicate conversation items are prevented when the same item is reported more than once.
  * User and assistant transcripts remain attached to the correct conversation items, with item order preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->