### PR TITLE
[codex] fix(analytics): include provider error codes

### DIFF
--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -218,6 +218,7 @@ This document provides a comprehensive overview of all analytics events tracked 
 - `provider` (string): API provider
 - `endpoint` (string, optional): API endpoint
 - `status_code` (number, optional): HTTP status code
+- `error_code` (string, optional): Provider or transport error code
 - `error_message` (string): Error message
 - `error_type` ('auth' | 'rate_limit' | 'network' | 'server' | 'client'): Error category
 

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1405,6 +1405,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         // Track API errors
         trackEvent('api_error', {
           provider: provider || Provider.OPENAI,
+          error_code: event.code,
           error_message: errorMessage,
           error_type: event.type === 'error' ? 'client' : 'server'
         });

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -187,6 +187,7 @@ export interface AnalyticsEvents {
     provider: string;
     endpoint?: string;
     status_code?: number;
+    error_code?: string;
     error_message: string;
     error_type: 'auth' | 'rate_limit' | 'network' | 'server' | 'client';
   };
@@ -441,4 +442,4 @@ export function useAnalytics() {
       isCapturingEnabled,
     }),
   };
-} 
+}


### PR DESCRIPTION
Closes #385

## What changed

- Include the provider or transport `code` in the existing `api_error` PostHog event.
- Extend the analytics event type and documentation with optional `error_code` metadata.

## Why

Soniox recoverable outages currently send a localized message to the MainPanel, so analytics cannot distinguish `503`, `408`, and `socket_error` failures. The wire code is already present on the client error event; this preserves the user-facing message while making the event aggregable by cause.

## Validation

- `vitest run src/services/clients/SonioxClient.test.ts src/services/clients/SonioxClient.managed.test.ts` (116 passed)
- `git diff --check`

The repository-wide `tsc --noEmit` command currently reports unrelated baseline errors in existing files; it reported no new `error_code` type error for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - API error analytics now optionally include provider or transport error codes for improved diagnostics.

- **Documentation**
  - Updated analytics event documentation to describe the optional `error_code` property.
  - Privacy guidance remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->