### PR TITLE
fix(analytics): carry the wire code and untranslated text into api_error

### DIFF
--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -219,7 +219,7 @@ This document provides a comprehensive overview of all analytics events tracked 
 - `endpoint` (string, optional): API endpoint
 - `status_code` (number, optional): HTTP status code
 - `error_code` (string, optional): Provider or transport error code as sent — `'503'`, `'408'`, `'socket_error'`. A string because the codes that matter are not all numeric
-- `error_message` (string): Error message. The provider's own words, untranslated — a client that localizes its user-facing message sends the original separately so this field stays comparable across UI languages
+- `error_message` (string): Error message. Clients that localize their user-facing text send the untranslated original separately, so this field stays comparable across UI languages. Not a guarantee for every event — a client that neither localizes nor supplies an original falls through to whatever it put in the error, so treat cross-language comparability as true for the paths that opt in, not as a property of the event
 - `error_type` ('auth' | 'rate_limit' | 'network' | 'server' | 'client'): Error category
 
 ### `audio_error`

--- a/docs/ANALYTICS_EVENTS.md
+++ b/docs/ANALYTICS_EVENTS.md
@@ -218,8 +218,8 @@ This document provides a comprehensive overview of all analytics events tracked 
 - `provider` (string): API provider
 - `endpoint` (string, optional): API endpoint
 - `status_code` (number, optional): HTTP status code
-- `error_code` (string, optional): Provider or transport error code
-- `error_message` (string): Error message
+- `error_code` (string, optional): Provider or transport error code as sent — `'503'`, `'408'`, `'socket_error'`. A string because the codes that matter are not all numeric
+- `error_message` (string): Error message. The provider's own words, untranslated — a client that localizes its user-facing message sends the original separately so this field stays comparable across UI languages
 - `error_type` ('auth' | 'rate_limit' | 'network' | 'server' | 'client'): Error category
 
 ### `audio_error`

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -53,6 +53,7 @@ import { ServiceFactory } from '../../services/ServiceFactory'; // Import the Se
 import { IAudioService } from '../../services/interfaces/IAudioService';
 import { useTranslation } from 'react-i18next';
 import { useAnalytics } from '../../lib/analytics';
+import { buildApiErrorProps } from '../../lib/apiErrorProps';
 import { isDevelopment } from '../../config/analytics';
 import { v4 as uuidv4 } from 'uuid';
 import { Provider, isOpenAICompatible, kizunaBaseProvider } from '../../types/Provider';
@@ -1402,13 +1403,13 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           formatted: { text: errorMessage },
         }]);
 
-        // Track API errors
-        trackEvent('api_error', {
-          provider: provider || Provider.OPENAI,
-          error_code: event.code,
-          error_message: errorMessage,
-          error_type: event.type === 'error' ? 'client' : 'server'
-        });
+        // Track API errors. Built by buildApiErrorProps, not inline: which
+        // string becomes error_message decides whether outages are groupable
+        // at all, and `errorMessage` above is the user-facing (possibly
+        // localized) one this panel renders — not the one analytics wants.
+        // It also omits error_code when a client reports none, rather than
+        // sending the property as undefined.
+        trackEvent('api_error', buildApiErrorProps(event, provider || Provider.OPENAI));
       },
       onReconnecting: () => {
         console.info('[Sokuji] [MainPanel] Session reconnecting...');

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -187,6 +187,9 @@ export interface AnalyticsEvents {
     provider: string;
     endpoint?: string;
     status_code?: number;
+    /** Provider wire code as sent: '503', '408', 'socket_error', … Kept a
+     *  string because the codes that matter are not all numeric, and one
+     *  field beats a numeric/symbolic pair. */
     error_code?: string;
     error_message: string;
     error_type: 'auth' | 'rate_limit' | 'network' | 'server' | 'client';

--- a/src/lib/apiErrorProps.test.ts
+++ b/src/lib/apiErrorProps.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { buildApiErrorProps } from './apiErrorProps';
+
+describe('buildApiErrorProps', () => {
+  it('prefers rawMessage: a client that localizes `message` for the UI puts the untranslated original there', () => {
+    const props = buildApiErrorProps(
+      {
+        code: '503',
+        message: '接続が中断されました——少ししてから「セッション開始」をタップして続けてください。',
+        rawMessage: 'service unavailable',
+      },
+      'soniox'
+    );
+    expect(props.error_message).toBe('service unavailable');
+  });
+
+  it('falls back to message, then error, then a placeholder', () => {
+    expect(buildApiErrorProps({ message: 'boom' }, 'openai').error_message).toBe('boom');
+    expect(buildApiErrorProps({ error: 'boom' }, 'openai').error_message).toBe('boom');
+    expect(buildApiErrorProps({}, 'openai').error_message).toBe('Unknown error');
+  });
+
+  it('carries the wire code so outages can be grouped by cause', () => {
+    expect(buildApiErrorProps({ code: '503' }, 'soniox').error_code).toBe('503');
+    // Symbolic codes matter as much as numeric ones — socket_error is a
+    // transport failure with no HTTP status at all.
+    expect(buildApiErrorProps({ code: 'socket_error' }, 'soniox').error_code).toBe('socket_error');
+    // Numeric codes reach us as numbers from some clients; one field, one type.
+    expect(buildApiErrorProps({ code: 408 }, 'soniox').error_code).toBe('408');
+  });
+
+  it('omits error_code entirely when the client reported none, rather than sending undefined', () => {
+    const props = buildApiErrorProps({ message: 'boom' }, 'openai');
+    expect('error_code' in props).toBe(false);
+  });
+
+  it('does not treat an empty-string code as a code', () => {
+    expect('error_code' in buildApiErrorProps({ code: '', message: 'boom' }, 'openai')).toBe(false);
+  });
+
+  it('passes the provider through and preserves the existing error_type mapping', () => {
+    expect(buildApiErrorProps({ type: 'error' }, 'gemini')).toMatchObject({
+      provider: 'gemini',
+      error_type: 'client',
+    });
+    expect(buildApiErrorProps({}, 'gemini').error_type).toBe('server');
+  });
+});

--- a/src/lib/apiErrorProps.ts
+++ b/src/lib/apiErrorProps.ts
@@ -1,0 +1,55 @@
+import type { AnalyticsEvents } from './analytics';
+
+/**
+ * The error shape clients hand to `ClientEventHandlers.onError`. It is `any` on
+ * the interface and every client fills a different subset, so everything here
+ * is optional.
+ */
+export interface ClientErrorEvent {
+  /** Provider wire code: '503', 408, 'socket_error', 'auth_failed', … */
+  code?: string | number;
+  /** What the UI shows. May be localized — see `rawMessage`. */
+  message?: string;
+  /**
+   * The provider's own, untranslated words, when `message` is not them.
+   *
+   * A client that localizes `message` (so the conversation bubble reads well
+   * in the user's language) must put the original here, or the same failure
+   * reaches analytics as one of 30 translations of one sentence and cannot be
+   * grouped at all. Clients whose `message` is already the raw text — most of
+   * them — simply omit this.
+   */
+  rawMessage?: string;
+  /** Older clients pass the description here instead of `message`. */
+  error?: string;
+  type?: string;
+}
+
+/**
+ * Map a client error onto the `api_error` analytics event.
+ *
+ * Lives in its own module rather than inline in MainPanel's `onError` handler:
+ * MainPanel has no test file, and which string becomes `error_message` is a
+ * decision, not plumbing — it decides whether outages are groupable.
+ */
+export function buildApiErrorProps(
+  event: ClientErrorEvent,
+  provider: string
+): AnalyticsEvents['api_error'] {
+  const code = event.code === undefined || event.code === null || event.code === ''
+    ? undefined
+    : String(event.code);
+  return {
+    provider,
+    error_message: event.rawMessage || event.message || event.error || 'Unknown error',
+    // Omitted rather than set to undefined: an absent property and a property
+    // whose value is undefined are different rows once they reach PostHog.
+    ...(code === undefined ? {} : { error_code: code }),
+    // Deliberately unchanged. `type` is set by almost no client, so this has
+    // always resolved to 'server' in practice — including for transport-level
+    // failures that are anything but. Correcting it would shift the meaning of
+    // an existing analytics dimension, which needs a look at what queries it
+    // first; `error_code` now carries the truth in the meantime.
+    error_type: event.type === 'error' ? 'client' : 'server',
+  };
+}

--- a/src/services/clients/SonioxClient.managed.test.ts
+++ b/src/services/clients/SonioxClient.managed.test.ts
@@ -351,8 +351,11 @@ describe('SonioxClient managed mode: cost meter wiring', () => {
     expect(items).toHaveLength(1);
     expect(items[0].formatted?.text).toMatch(BALANCE_USED_UP);
     expect(items[0].formatted?.text).not.toMatch(OUTAGE);
-    // onError still fires for analytics (api_error), same as before.
+    // onError still fires for analytics (api_error), same as before — and the
+    // message it carries is localized, so a stable English original rides
+    // along for the analytics side.
     expect(errors.some((e) => e.code === 'budget_exhausted')).toBe(true);
+    expect(errors[0].rawMessage).toBe('Session budget exhausted');
     // No false session.connection_lost / second onError from the fallthrough.
     expect(errors).toHaveLength(1);
     expect(closeEvents).toHaveLength(1);

--- a/src/services/clients/SonioxClient.managed.test.ts
+++ b/src/services/clients/SonioxClient.managed.test.ts
@@ -582,6 +582,10 @@ describe('SonioxClient managed recoverable outages', () => {
     expect(errors).toHaveLength(1);
     expect(errors[0].code).toBe('503');
     expect(errors[0].message).toMatch(OUTAGE);
+    // ...but analytics must not be fed the localized sentence, or the same
+    // failure arrives as one of 30 translations. The server's own words ride
+    // along separately (buildApiErrorProps prefers them).
+    expect(errors[0].rawMessage).toBe('service unavailable');
   });
 
   it('keeps the raw server text in the debug timeline', async () => {

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -177,6 +177,12 @@ describe('SonioxClient connect', () => {
     // "the session is dead".
     expect(errors[0].message).toMatch(/spoken translation has stopped/i);
     expect(errors[0].message).toMatch(/still running/i);
+    // ...but the message above is localized, so analytics gets the wire code
+    // and the server's own words separately — otherwise a silent quality
+    // regression arrives as 30 translations of one sentence and cannot be
+    // counted. The raw text is right here at the failure site; don't drop it.
+    expect(errors[0].rawMessage).toMatch(/boom/);
+    expect(errors[0].rawMessage).not.toMatch(/spoken translation has stopped/i);
 
     // Still one report per failure episode: it is a notice, not a per-utterance alarm.
     translate();

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -825,7 +825,13 @@ export class SonioxClient implements IClient {
     this.emitRealtime('client', 'session.budget_exhausted', { provider: 'soniox' });
     const message = i18n.t('mainPanel.sonioxBudgetExhausted', 'Your session balance is used up. Top up your balance to keep translating.');
     this.emitSystemNotice(message);
-    this.eventHandlers.onError?.({ code: 'budget_exhausted', message });
+    // `message` is localized for the bubble; analytics gets a stable English
+    // original so this ending stays countable across UI languages.
+    this.eventHandlers.onError?.({
+      code: 'budget_exhausted',
+      message,
+      rawMessage: 'Session budget exhausted',
+    });
     // Must be set before this.stt?.end() — see sttOutcomeAnnounced's
     // declaration for why (and handleSttClose's bare-close branch, which
     // reads it once the close this triggers arrives).
@@ -1325,6 +1331,10 @@ export class SonioxClient implements IClient {
           'mainPanel.sonioxTtsFailed',
           'Spoken translation has stopped. Transcription and text translation are still running.'
         ),
+        // The localized sentence above is for the user; analytics needs what
+        // actually broke. Degraded TTS is a silent quality regression, so
+        // being able to count it by cause is the whole point of measuring it.
+        rawMessage: message,
       });
     }
   }

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -1284,7 +1284,10 @@ export class SonioxClient implements IClient {
       'The connection was interrupted — tap Start Session in a moment to continue.'
     );
     this.emitSystemNotice(text);
-    this.eventHandlers.onError?.({ code, message: text });
+    // `message` is what the UI shows, so it is localized; `rawMessage` carries
+    // the server's own words for analytics, which would otherwise receive one
+    // of 30 translations of this sentence and be unable to group by cause.
+    this.eventHandlers.onError?.({ code, message: text, rawMessage: message });
   }
 
   private handleTtsError(code: string, message: string, hadActiveStream: boolean): void {


### PR DESCRIPTION
Rebased on #387, which landed the `error_code` half of #385. This PR is now the remaining half.

## Summary

#387 made the *cause* of a Soniox outage groupable by adding `error_code`. What it could not fix from the analytics side is that `error_message` itself is unusable: `SonioxClient.surfaceRecoverableOutage` passes the **localized** notice as `onError`'s `message`, so the same failure still reaches PostHog as one of 30 translations of "The connection was interrupted — tap Start Session in a moment to continue."

The root cause is not a missing field: **`onError.message` was serving two consumers that want opposite things.** MainPanel renders it (wants localized, human), analytics aggregates it (wants stable, machine). So split them rather than making one side lose.

- A client that localizes `message` now puts the provider's own words in `rawMessage`; `buildApiErrorProps` prefers that for `error_message`. Every other client omits it and is **byte-for-byte unaffected** — their `message` is already the raw text, which is what analytics wanted all along.
- The payload moves out of MainPanel's `onError` handler into `buildApiErrorProps`. `MainPanel.tsx` has no test file, and choosing which string becomes `error_message` is a decision — it decides whether outages are groupable at all — not plumbing.
- That also fixes a detail #387 left: `error_code: event.code` sets the property to `undefined` when a client reports no code, and an absent property and a present-but-undefined one land as different rows in PostHog. The key is now omitted instead.
- `docs/ANALYTICS_EVENTS.md`: expands #387's `error_code` line with the codes that actually occur and why it is a string, and documents the constraint this change exists to enforce — that `error_message` is the untranslated original.

## Deliberately unchanged: `error_type`

`error_type` is derived from `event.type`, which almost no client sets, so it has always resolved to `'server'` in practice — including for transport-level `socket_error`, which is a client-side condition. That is wrong, but correcting it **shifts the meaning of an existing analytics dimension**, so historical and new rows would stop being comparable. That needs a look at what actually queries `error_type` before it is touched; `error_code` carries the truth in the meantime. Called out in the code comment so the next reader does not "fix" it unaware.

## Testing

- 6 new tests in `src/lib/apiErrorProps.test.ts`: `rawMessage` wins over a localized `message`; the existing `message` → `error` → `'Unknown error'` fallback chain is preserved verbatim; symbolic and numeric codes both land as strings (`408` → `'408'`); an absent or empty code omits the property rather than sending `undefined`; provider passthrough and the unchanged `error_type` mapping.
- `SonioxClient.managed.test.ts` extended: the managed-503 error event now also asserts `rawMessage` is the server's own `service unavailable`, alongside the existing assertions that the bubble stays localized.
- Full suite: **185 files / 2124 tests passing**. `npm run build` succeeds.

Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved API error analytics by preserving original provider messages and error codes.
  - User-facing outage messages remain localized and unchanged.
  - Standardized error classification and provider details in analytics events.
- **Documentation**
  - Clarified supported error-code formats and preservation of original provider wording.
- **Tests**
  - Added coverage for error-message prioritization, error codes, providers, and error types.
  - Verified that localized outage messages are not recorded instead of the original server error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->