### PR TITLE
fix(audio): bind the Linux app-capture source to the tap, not the default input

### DIFF
--- a/electron/pipewire-app-audio.js
+++ b/electron/pipewire-app-audio.js
@@ -115,6 +115,93 @@ async function dumpGraph(exec) {
   return JSON.parse(stdout);
 }
 
+function findNodeByName(dump, name) {
+  if (!Array.isArray(dump)) return undefined;
+  return dump.find((o) =>
+    o?.type === 'PipeWire:Interface:Node' &&
+    o?.info?.props?.['node.name'] === name);
+}
+
+const defaultDelay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Point the remapped source's capture stream at the capture sink's monitor.
+ *
+ * `master=` is only a hint. pactl turns it into `node.target`, and on PipeWire
+ * 0.3.x that name resolves to nothing, because `<sink>.monitor` is a PulseAudio
+ * name rather than a node - a sink's monitor is just output ports on the sink
+ * itself. The stream still carries `node.autoconnect`, so the session manager
+ * falls back to the *default source*: the tap then records whatever the default
+ * input carries, identically no matter which application the user picked.
+ * Reproduced on PipeWire 0.3.48, where a 1 kHz tone linked into the capture sink
+ * read back at 0.6% of full scale (room noise) instead of 61%.
+ *
+ * createVirtualAudioDevices() in pulseaudio-utils.js has always repaired the
+ * same autoconnect by hand for the virtual mic. This is that repair, for the
+ * capture tap.
+ *
+ * Idempotent, and a no-op wherever the session manager already got it right.
+ *
+ * @returns {Promise<boolean>} true once the stream's only inputs are the monitor
+ */
+async function bindCaptureSourceToSink({ exec, delay = defaultDelay, attempts = 4 }) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    // The session manager autoconnects asynchronously, so a repair applied
+    // before it runs would simply be undone by it. Let the graph settle, then
+    // look at what it actually did.
+    await delay(150);
+
+    const dump = await dumpGraph(exec);
+    const sink = findNodeByName(dump, CAPTURE_SINK_NAME);
+    const stream = findNodeByName(dump, `input.${CAPTURE_SOURCE_NAME}`);
+    // A PipeWire that builds the remap differently exposes no such stream.
+    // Leave its graph alone rather than guess at a shape we cannot see.
+    if (!sink || !stream) return true;
+
+    // A sink's monitor is its output ports; the remap's capture stream consumes
+    // them through its inputs. Both are sorted by port name, so the channels
+    // pair up positionally.
+    const monitors = resolvePortIds(dump, sink.id, 'output');
+    const inputs = resolvePortIds(dump, stream.id, 'input');
+    if (monitors.length === 0 || inputs.length === 0) continue;
+
+    const pairs = [];
+    for (let i = 0; i < Math.min(monitors.length, inputs.length); i++) {
+      pairs.push([monitors[i], inputs[i]]);
+    }
+    const wanted = new Set(pairs.map(([out, inp]) => `${out}:${inp}`));
+    const inputSet = new Set(inputs);
+
+    const present = new Set();
+    let changed = false;
+    for (const obj of dump) {
+      if (obj?.type !== 'PipeWire:Interface:Link') continue;
+      const props = obj?.info?.props;
+      const out = props?.['link.output.port'];
+      const inp = props?.['link.input.port'];
+      if (!inputSet.has(inp)) continue;
+      const pair = `${out}:${inp}`;
+      if (wanted.has(pair)) { present.add(pair); continue; }
+      // Anything else is the session manager's fallback to the default source.
+      if (!Number.isInteger(out) || !Number.isInteger(inp)) continue;
+      await exec(`pw-link -d ${out} ${inp}`);
+      changed = true;
+    }
+
+    for (const [out, inp] of pairs) {
+      if (present.has(`${out}:${inp}`)) continue;
+      if (!Number.isInteger(out) || !Number.isInteger(inp)) continue;
+      await exec(`pw-link ${out} ${inp}`);
+      changed = true;
+    }
+
+    // Nothing needed changing, so the previous pass stuck: the stream is fed by
+    // the capture sink and by nothing else.
+    if (!changed) return true;
+  }
+  return false;
+}
+
 /**
  * List the applications currently playing audio.
  * @returns {Promise<Array<{deviceId: string, label: string}>>}
@@ -159,7 +246,7 @@ async function listAppSources({ exec = defaultExec, windowTitles = listWindowTit
  * @param {string} deviceId - `app:<nodeId>`
  * @returns {Promise<{success: boolean, monitorLabel?: string, error?: string}>}
  */
-async function connectAppSourceUnsafe(deviceId, { exec = defaultExec } = {}) {
+async function connectAppSourceUnsafe(deviceId, { exec = defaultExec, delay = defaultDelay } = {}) {
   const id = String(deviceId);
   if (!id.startsWith('app:')) {
     return { success: false, error: `Not an application source: ${deviceId}` };
@@ -241,6 +328,16 @@ async function connectAppSourceUnsafe(deviceId, { exec = defaultExec } = {}) {
       throw new Error('no ports to link (the application may have stopped playing)');
     }
 
+    // The tap is built, but the source the renderer will record still has to be
+    // fed by it rather than by the default input. Capturing the wrong device is
+    // worse than capturing nothing: the user picked one application, and audio
+    // they never chose to share would reach the translation provider.
+    if (!await bindCaptureSourceToSink({ exec, delay })) {
+      throw new Error(
+        'the capture source stayed attached to the default input instead of the tap'
+      );
+    }
+
     return { success: true, monitorLabel: CAPTURE_SINK_DESCRIPTION };
   } catch (e) {
     // Never leave the null sink behind: it shows up as a phantom audio device
@@ -302,6 +399,7 @@ async function disconnectAppSource(opts = {}) {
 module.exports = {
   parseAppStreams,
   resolvePortIds,
+  bindCaptureSourceToSink,
   listAppSources,
   connectAppSource,
   disconnectAppSource,

--- a/electron/pipewire-app-audio.js
+++ b/electron/pipewire-app-audio.js
@@ -145,6 +145,11 @@ const defaultDelay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
  * @returns {Promise<boolean>} true once the stream's only inputs are the monitor
  */
 async function bindCaptureSourceToSink({ exec, delay = defaultDelay, attempts = 4 }) {
+  // Whether each node was ever seen, which is what separates "this PipeWire
+  // builds the remap some other way" from "it has not published the node yet".
+  let sawSink = false;
+  let sawStream = false;
+
   for (let attempt = 0; attempt < attempts; attempt++) {
     // The session manager autoconnects asynchronously, so a repair applied
     // before it runs would simply be undone by it. Let the graph settle, then
@@ -154,14 +159,15 @@ async function bindCaptureSourceToSink({ exec, delay = defaultDelay, attempts = 
     const dump = await dumpGraph(exec);
     const sink = findNodeByName(dump, CAPTURE_SINK_NAME);
     const stream = findNodeByName(dump, `input.${CAPTURE_SOURCE_NAME}`);
-    // A PipeWire that builds the remap differently exposes no such stream.
-    // Leave its graph alone rather than guess at a shape we cannot see.
-    if (!stream) return true;
-    // The sink, by contrast, is ours: module-null-sink created it and the caller
-    // already found it with ports. Missing now means this tap can never carry
-    // audio, so keep looking and let the attempts run out rather than call it a
-    // shape we do not support.
-    if (!sink) continue;
+    if (sink) sawSink = true;
+    if (stream) sawStream = true;
+    // Absent is not the same as absent for good. pactl returns a module id the
+    // moment the module loads, but PipeWire publishes the node into the graph
+    // afterwards, so either of these can simply be late. Spend the attempts
+    // before drawing any conclusion - deciding on the first look would report
+    // success having never examined the autoconnected links, which is the very
+    // bug this exists to prevent.
+    if (!sink || !stream) continue;
 
     // A sink's monitor is its output ports; the remap's capture stream consumes
     // them through its inputs. Both are sorted by port name, so the channels
@@ -207,6 +213,15 @@ async function bindCaptureSourceToSink({ exec, delay = defaultDelay, attempts = 
     // the capture sink and by nothing else.
     if (!changed) return true;
   }
+
+  // Out of attempts. The sink is ours and must exist; without it there is no tap
+  // to bind and no honest way to call this a success.
+  if (!sawSink) return false;
+  // A stream that never appeared at all is a remap this PipeWire builds some
+  // other way. Now that it has had the full budget to show up, leaving its
+  // graph alone is a judgement rather than a guess.
+  if (!sawStream) return true;
+  // Both were there and the wiring would not settle.
   return false;
 }
 

--- a/electron/pipewire-app-audio.js
+++ b/electron/pipewire-app-audio.js
@@ -156,7 +156,12 @@ async function bindCaptureSourceToSink({ exec, delay = defaultDelay, attempts = 
     const stream = findNodeByName(dump, `input.${CAPTURE_SOURCE_NAME}`);
     // A PipeWire that builds the remap differently exposes no such stream.
     // Leave its graph alone rather than guess at a shape we cannot see.
-    if (!sink || !stream) return true;
+    if (!stream) return true;
+    // The sink, by contrast, is ours: module-null-sink created it and the caller
+    // already found it with ports. Missing now means this tap can never carry
+    // audio, so keep looking and let the attempts run out rather than call it a
+    // shape we do not support.
+    if (!sink) continue;
 
     // A sink's monitor is its output ports; the remap's capture stream consumes
     // them through its inputs. Both are sorted by port name, so the channels
@@ -164,11 +169,14 @@ async function bindCaptureSourceToSink({ exec, delay = defaultDelay, attempts = 
     const monitors = resolvePortIds(dump, sink.id, 'output');
     const inputs = resolvePortIds(dump, stream.id, 'input');
     if (monitors.length === 0 || inputs.length === 0) continue;
+    // Pairing the overlap while clearing links from every input would leave the
+    // surplus input fed by nothing, and the next pass would find a graph it has
+    // no complaint about: success reported over a channel of silence. Both
+    // lists come from the same null sink, so a mismatch is not a layout to
+    // adapt to - it is a graph to leave alone.
+    if (monitors.length !== inputs.length) continue;
 
-    const pairs = [];
-    for (let i = 0; i < Math.min(monitors.length, inputs.length); i++) {
-      pairs.push([monitors[i], inputs[i]]);
-    }
+    const pairs = monitors.map((monitor, i) => [monitor, inputs[i]]);
     const wanted = new Set(pairs.map(([out, inp]) => `${out}:${inp}`));
     const inputSet = new Set(inputs);
 

--- a/electron/pipewire-app-audio.test.js
+++ b/electron/pipewire-app-audio.test.js
@@ -289,6 +289,37 @@ const DUMP_CORRECT = [
   link(601, 311, 402),
 ];
 
+// The capture sink gone from under us, with the remap stream still present.
+const DUMP_SINK_GONE = DUMP_MISWIRED.filter((o) =>
+  o.id !== 300 && o?.info?.props?.['node.id'] !== 300);
+
+// A stream with one more input than the sink has monitor ports. Contrived -
+// both derive from the same null sink - but the pairing must not quietly wire
+// the overlap and clear the rest.
+const DUMP_UNEVEN_PORTS = [
+  ...DUMP_MISWIRED,
+  port(403, 400, 'input', 'input_RC'),
+];
+
+/**
+ * Returns each dump in turn: the first for every pw-dump before the capture
+ * modules exist, the next for every one after. Lets a test change the graph
+ * out from under the binding loop.
+ */
+function fakeExecStages(calls, dumps, { moduleId = '536870913' } = {}) {
+  let seen = 0;
+  return async (cmd) => {
+    calls.push(cmd);
+    if (cmd.startsWith('pw-dump')) {
+      const dump = dumps[Math.min(seen, dumps.length - 1)];
+      seen++;
+      return { stdout: JSON.stringify(dump) };
+    }
+    if (cmd.includes('load-module')) return { stdout: `${moduleId}\n` };
+    return { stdout: '' };
+  };
+}
+
 /**
  * A fake graph that responds to the edits made to it, so a repair can be
  * observed converging instead of asserted one call at a time. `pw-link` adds a
@@ -380,6 +411,40 @@ describe('the remapped source is bound to the capture sink, not the default inpu
 
     expect(r.success).toBe(true);
     expect(calls.some((c) => c.startsWith('pw-link -d'))).toBe(false);
+  });
+
+  it('fails when the capture sink disappears before binding', async () => {
+    // The sink is ours: module-null-sink created it and it was already found
+    // once, with ports, before we got here. Its absence now is not an
+    // unrecognised remap shape - it means this tap can never carry audio, and
+    // reporting success would send the renderer to whole-system capture.
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      // Two dumps happen before binding starts: resolving the application, then
+      // finding the freshly loaded sink. The sink goes missing only after that.
+      exec: fakeExecStages(calls, [DUMP_MISWIRED, DUMP_MISWIRED, DUMP_SINK_GONE]),
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/capture source/i);
+    expect(calls.some((c) => c.includes('unload-module'))).toBe(true);
+  });
+
+  it('refuses to half-wire a graph whose port counts do not line up', async () => {
+    // Pairing the shorter list while clearing links from every input leaves the
+    // surplus input connected to nothing, and the next pass sees a graph it has
+    // no complaint about - success reported over a channel of silence.
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      exec: fakeExecLiveGraph(calls, DUMP_UNEVEN_PORTS),
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(false);
+    // Better to leave the graph as found than to rewire part of it.
+    expect(calls.some((c) => c.startsWith('pw-link -d'))).toBe(false);
+    expect(calls.some((c) => c === 'pw-link 310 401')).toBe(false);
   });
 });
 

--- a/electron/pipewire-app-audio.test.js
+++ b/electron/pipewire-app-audio.test.js
@@ -152,13 +152,17 @@ function fakeExec(calls, { dump = FULL_DUMP, moduleId = '536870913' } = {}) {
   };
 }
 
+// Binding retries on a real timer. No test here is about timing, so none of
+// them should sit through it.
+const noWait = async () => {};
+
 // The module holds captureModuleId in module scope; release it between tests.
 beforeEach(async () => { await disconnectAppSource({ exec: async () => ({ stdout: '' }) }); });
 
 describe('connectAppSource', () => {
   it('creates the null sink and links every channel pair by numeric id', async () => {
     const calls = [];
-    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls) });
+    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls), delay: noWait });
 
     expect(r.success).toBe(true);
     expect(r.monitorLabel).toBe(CAPTURE_SINK_DESCRIPTION);
@@ -192,7 +196,7 @@ describe('connectAppSource', () => {
       port(78, 206, 'output', 'output_FR'),
     ];
     const calls = [];
-    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { dump: twoTabs }) });
+    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { dump: twoTabs }), delay: noWait });
 
     expect(r.success).toBe(true);
     expect(calls).toContain('pw-link 91 153');   // first stream
@@ -204,7 +208,7 @@ describe('connectAppSource', () => {
     const calls = [];
     // Enumeration and selection are seconds apart; the app can quit in between.
     const gone = FULL_DUMP.filter((o) => o.id !== 205);
-    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { dump: gone }) });
+    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { dump: gone }), delay: noWait });
 
     expect(r.success).toBe(false);
     expect(r.error).toMatch(/no longer playing/i);
@@ -214,14 +218,14 @@ describe('connectAppSource', () => {
 
   it('never moves the stream off its existing sink', async () => {
     const calls = [];
-    await connectAppSource('app:pid:4242', { exec: fakeExec(calls) });
+    await connectAppSource('app:pid:4242', { exec: fakeExec(calls), delay: noWait });
     // move-sink-input would steal the audio from the user's speakers.
     expect(calls.some((c) => c.includes('move-sink-input'))).toBe(false);
   });
 
   it('rejects a deviceId that is not an app: id', async () => {
     const calls = [];
-    const r = await connectAppSource('desktop-audio-loopback', { exec: fakeExec(calls) });
+    const r = await connectAppSource('desktop-audio-loopback', { exec: fakeExec(calls), delay: noWait });
     expect(r.success).toBe(false);
     expect(calls.some((c) => c.includes('load-module'))).toBe(false);
   });
@@ -229,7 +233,7 @@ describe('connectAppSource', () => {
   it('tears the sink back down when the target node has no ports', async () => {
     const calls = [];
     const dumpNoPorts = FULL_DUMP.filter((o) => o.type !== 'PipeWire:Interface:Port');
-    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { dump: dumpNoPorts }) });
+    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { dump: dumpNoPorts }), delay: noWait });
 
     expect(r.success).toBe(false);
     // A leaked null sink shows up as a phantom device in system settings.
@@ -239,7 +243,7 @@ describe('connectAppSource', () => {
   it('refuses a module id that is not digits', async () => {
     const calls = [];
     // Anything but digits would later be interpolated into a shell string.
-    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { moduleId: '1; rm -rf /' }) });
+    const r = await connectAppSource('app:pid:4242', { exec: fakeExec(calls, { moduleId: '1; rm -rf /' }), delay: noWait });
     expect(r.success).toBe(false);
     expect(calls.some((c) => c.includes('rm -rf'))).toBe(false);
   });
@@ -247,9 +251,9 @@ describe('connectAppSource', () => {
   it('releases a previous tap before creating a new one', async () => {
     const calls = [];
     const exec = fakeExec(calls);
-    await connectAppSource('app:pid:4242', { exec });
+    await connectAppSource('app:pid:4242', { exec, delay: noWait });
     calls.length = 0;
-    await connectAppSource('app:pid:4242', { exec });
+    await connectAppSource('app:pid:4242', { exec, delay: noWait });
 
     // Two live taps would feed both applications into the same capture sink.
     expect(calls.some((c) => c.includes('unload-module 536870913'))).toBe(true);
@@ -325,14 +329,24 @@ function fakeExecStages(calls, dumps, { moduleId = '536870913' } = {}) {
  * observed converging instead of asserted one call at a time. `pw-link` adds a
  * link and `pw-link -d` removes one, exactly as they do on a real graph.
  */
-function fakeExecLiveGraph(calls, initial, { moduleId = '536870913' } = {}) {
+function fakeExecLiveGraph(calls, initial, { moduleId = '536870913', hideStreamUntilDump = 0 } = {}) {
   const nodesAndPorts = initial.filter((o) => o.type !== 'PipeWire:Interface:Link');
   let links = initial.filter((o) => o.type === 'PipeWire:Interface:Link');
   let nextLinkId = 900;
+  let dumps = 0;
 
   return async (cmd) => {
     calls.push(cmd);
-    if (cmd.startsWith('pw-dump')) return { stdout: JSON.stringify([...nodesAndPorts, ...links]) };
+    if (cmd.startsWith('pw-dump')) {
+      dumps++;
+      // pactl hands back a module id the moment the module loads, but PipeWire
+      // publishes the node into the graph a moment later. Hide it for the first
+      // few dumps to reproduce that gap.
+      const nodes = dumps <= hideStreamUntilDump
+        ? nodesAndPorts.filter((o) => o.id !== 400 && o?.info?.props?.['node.id'] !== 400)
+        : nodesAndPorts;
+      return { stdout: JSON.stringify([...nodes, ...links]) };
+    }
     if (cmd.includes('load-module')) return { stdout: `${moduleId}\n` };
 
     const cut = cmd.match(/^pw-link -d (\d+) (\d+)$/);
@@ -413,6 +427,25 @@ describe('the remapped source is bound to the capture sink, not the default inpu
     expect(calls.some((c) => c.startsWith('pw-link -d'))).toBe(false);
   });
 
+  it('waits for a remap stream that PipeWire has not published yet', async () => {
+    // pactl returns the module id as soon as the module loads; the node reaches
+    // the graph afterwards. Calling the shape unsupported on the first look
+    // reports success having never examined the autoconnected links - which is
+    // this bug all over again, on a slower machine.
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      // Dumps 1 and 2 resolve the application and the new sink; dump 3 is the
+      // first binding attempt, and the stream only shows up for dump 4.
+      exec: fakeExecLiveGraph(calls, DUMP_MISWIRED, { hideStreamUntilDump: 3 }),
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(true);
+    // It must have actually done the repair, not shrugged and returned early.
+    expect(calls).toContain('pw-link -d 501 401');
+    expect(calls).toContain('pw-link 310 401');
+  });
+
   it('fails when the capture sink disappears before binding', async () => {
     // The sink is ours: module-null-sink created it and it was already found
     // once, with ports, before we got here. Its absence now is not an
@@ -452,7 +485,7 @@ describe('disconnectAppSource', () => {
   it('unloads the module recorded by connect and is idempotent', async () => {
     const calls = [];
     const exec = fakeExec(calls);
-    await connectAppSource('app:pid:4242', { exec });
+    await connectAppSource('app:pid:4242', { exec, delay: noWait });
 
     expect((await disconnectAppSource({ exec })).success).toBe(true);
     expect(calls.some((c) => c.includes('unload-module 536870913'))).toBe(true);
@@ -541,8 +574,8 @@ describe('capture lifecycle is serialized', () => {
     };
 
     await Promise.all([
-      connectAppSource('app:pid:4242', { exec }),
-      connectAppSource('app:pid:4242', { exec }),
+      connectAppSource('app:pid:4242', { exec, delay: noWait }),
+      connectAppSource('app:pid:4242', { exec, delay: noWait }),
     ]);
     await disconnectAppSource({ exec });
 

--- a/electron/pipewire-app-audio.test.js
+++ b/electron/pipewire-app-audio.test.js
@@ -32,6 +32,11 @@ const port = (id, nodeId, direction, portName) => ({
   type: 'PipeWire:Interface:Port',
   info: { direction, props: { 'node.id': nodeId, 'port.name': portName } },
 });
+const link = (id, outPort, inPort) => ({
+  id,
+  type: 'PipeWire:Interface:Link',
+  info: { props: { 'link.output.port': outPort, 'link.input.port': inPort } },
+});
 
 describe('parseAppStreams', () => {
   it('returns one entry per application, keyed app:pid:<pid>', () => {
@@ -248,6 +253,133 @@ describe('connectAppSource', () => {
 
     // Two live taps would feed both applications into the same capture sink.
     expect(calls.some((c) => c.includes('unload-module 536870913'))).toBe(true);
+  });
+});
+
+// The graph a real PipeWire 0.3.x leaves behind once both modules are loaded:
+// the remapped source's capture stream (node 400) exists, but the session
+// manager has autoconnected it to the default *microphone* rather than to the
+// capture sink's monitor, because master= resolves to nothing on that version.
+const DUMP_MISWIRED = [
+  ...FULL_DUMP,
+  port(310, 300, 'output', 'monitor_FL'),
+  port(311, 300, 'output', 'monitor_FR'),
+  {
+    id: 400,
+    type: 'PipeWire:Interface:Node',
+    info: { props: { 'media.class': 'Stream/Input/Audio', 'node.name': 'input.sokuji_app_capture_mic' } },
+  },
+  port(401, 400, 'input', 'input_FL'),
+  port(402, 400, 'input', 'input_FR'),
+  {
+    id: 500,
+    type: 'PipeWire:Interface:Node',
+    info: { props: { 'media.class': 'Audio/Source', 'node.name': 'alsa_input.builtin_mic' } },
+  },
+  port(501, 500, 'output', 'capture_FL'),
+  port(502, 500, 'output', 'capture_FR'),
+  link(600, 501, 401),
+  link(601, 502, 402),
+];
+
+// Same graph, but already wired the way PipeWire 1.x does it.
+const DUMP_CORRECT = [
+  ...DUMP_MISWIRED.filter((o) => o.type !== 'PipeWire:Interface:Link'),
+  link(600, 310, 401),
+  link(601, 311, 402),
+];
+
+/**
+ * A fake graph that responds to the edits made to it, so a repair can be
+ * observed converging instead of asserted one call at a time. `pw-link` adds a
+ * link and `pw-link -d` removes one, exactly as they do on a real graph.
+ */
+function fakeExecLiveGraph(calls, initial, { moduleId = '536870913' } = {}) {
+  const nodesAndPorts = initial.filter((o) => o.type !== 'PipeWire:Interface:Link');
+  let links = initial.filter((o) => o.type === 'PipeWire:Interface:Link');
+  let nextLinkId = 900;
+
+  return async (cmd) => {
+    calls.push(cmd);
+    if (cmd.startsWith('pw-dump')) return { stdout: JSON.stringify([...nodesAndPorts, ...links]) };
+    if (cmd.includes('load-module')) return { stdout: `${moduleId}\n` };
+
+    const cut = cmd.match(/^pw-link -d (\d+) (\d+)$/);
+    if (cut) {
+      links = links.filter((l) => l.info.props['link.output.port'] !== Number(cut[1])
+        || l.info.props['link.input.port'] !== Number(cut[2]));
+      return { stdout: '' };
+    }
+    const join = cmd.match(/^pw-link (\d+) (\d+)$/);
+    if (join) {
+      links = [...links, link(nextLinkId++, Number(join[1]), Number(join[2]))];
+      return { stdout: '' };
+    }
+    return { stdout: '' };
+  };
+}
+
+describe('the remapped source is bound to the capture sink, not the default input', () => {
+  // master= is only a hint: pactl turns it into node.target, and on PipeWire
+  // 0.3.x "<sink>.monitor" resolves to no node at all. node.autoconnect then
+  // sends the stream to the default source, so every application the user picks
+  // yields the same audio - whatever the default input happens to carry.
+  // Reproduced on PipeWire 0.3.48.
+
+  it('drops the autoconnected link and links the sink monitor instead', async () => {
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      exec: fakeExecLiveGraph(calls, DUMP_MISWIRED),
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(true);
+    expect(calls).toContain('pw-link -d 501 401');
+    expect(calls).toContain('pw-link -d 502 402');
+    expect(calls).toContain('pw-link 310 401');
+    expect(calls).toContain('pw-link 311 402');
+  });
+
+  it('leaves a correctly wired graph untouched', async () => {
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      exec: fakeExecLiveGraph(calls, DUMP_CORRECT),
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(true);
+    expect(calls.some((c) => c.startsWith('pw-link -d'))).toBe(false);
+    // Already linked; relinking would error on a real graph.
+    expect(calls).not.toContain('pw-link 310 401');
+  });
+
+  it('fails the tap rather than capturing the wrong device', async () => {
+    // A static dump stands in for a session manager that reinstates its link
+    // every time. The user picked one application; handing them their
+    // microphone instead has to fail loudly, not record the wrong thing.
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      exec: fakeExec(calls, { dump: DUMP_MISWIRED }),
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/capture source/i);
+    // And it must not leave the phantom devices behind.
+    expect(calls.some((c) => c.includes('unload-module'))).toBe(true);
+  });
+
+  it('leaves an unrecognised graph alone instead of guessing', async () => {
+    // A PipeWire that builds the remap some other way exposes no
+    // input.<source> stream node. Rewiring blind would be worse than nothing.
+    const calls = [];
+    const r = await connectAppSource('app:pid:4242', {
+      exec: fakeExec(calls),   // FULL_DUMP has no remap stream node
+      delay: async () => {},
+    });
+
+    expect(r.success).toBe(true);
+    expect(calls.some((c) => c.startsWith('pw-link -d'))).toBe(false);
   });
 });
 


### PR DESCRIPTION
Follow-up to #380. Reported against 0.35.2: on Linux, per-application capture records the same audio whichever application is selected.

## What actually happens

The tap is built correctly. It is just never the thing being recorded.

`connectAppSource()` creates the null sink, links the chosen application's ports into it, then publishes the sink's monitor as a real source with `module-remap-source master=sokuji_app_capture.monitor`.

`master=` is only a hint. pactl turns it into `node.target`, and on PipeWire 0.3.x that name resolves to nothing — `<sink>.monitor` is a PulseAudio name rather than a node, since a sink's monitor is just output ports on the sink itself. The remap's capture stream still carries `node.autoconnect`, so the session manager falls back to the **default source**:

```
input.sokuji_app_capture_mic:input_FL  |<-  alsa_input.usb-ZOOM_ZUM-2-01:capture_FL
```

Every application yields identical audio because none of them is what is being recorded. Where the user's default input is a monitor, that audio is the whole system — which is how this was reported.

Measured on PipeWire 0.3.48: a 1 kHz tone at 0.6104 full-scale linked into the capture sink read back at **0.0063** full-scale from the source — room noise off the default microphone.

## Why this was not caught

`createVirtualAudioDevices()` in `pulseaudio-utils.js` builds the virtual mic with the identical `module-remap-source master=<sink>.monitor` call, and has always repaired the same autoconnect by hand:

```js
await disconnectPhysicalPorts('sokuji_virtual_mic');
await connectPorts('sokuji_virtual_output', 'sokuji_virtual_mic');
```

The comment there reads *"Disconnect automatic connections from physical mics"*. The behaviour was known; the new module did not carry the workaround across.

`pipewire-app-audio.test.js` notes its fixtures are *"copied from a real `pw-dump` on PipeWire 1.x"*, where `master=` does resolve. The gap is a PipeWire version difference, invisible to a mocked graph.

## The fix

`bindCaptureSourceToSink()` settles, then makes the remap stream's only inputs the capture sink's monitor ports: it drops links the session manager added and adds the ones it should have, re-dumping to confirm the repair stuck rather than assuming it did.

- **Idempotent.** On PipeWire 1.x the first pass finds the graph already correct and returns after one dump — no edits, ~150 ms.
- **Fails open on shapes it cannot see.** A PipeWire that builds the remap without an `input.<source>` stream node is left alone rather than rewired blind.
- **Fails closed when the repair will not stick.** The tap fails instead of recording. Capturing the wrong device is worse than capturing nothing: the user chose one application, and silently widening that to their microphone sends audio they never chose to share to the translation provider.

## Verification

Against the live PipeWire graph on a 0.3.48 machine, driving the real module — not only unit tests:

| | shipped 0.35.2 | this branch |
|---|---|---|
| select the app playing a 1 kHz tone | peak 596 | **20000** (0.6104 FS) |
| then select a different, silent app | peak 1423 | **0** |

Before, neither reading contains the tone and the selection is irrelevant. After, the selection determines what is captured. Tap teardown leaves no modules, sinks or sources behind, and default sink/source are unchanged.

Unit tests: 6 added, 4 of which fail against the code they fix (checked by reverting it). Full suite is 2153 green across 187 files; `electron/` is 239. The fake exec in the new tests mutates its own graph in response to `pw-link` / `pw-link -d`, so convergence is observed rather than asserted call by call.

## Not addressed here

Two things found while investigating, deliberately left out rather than bundled in:

- `ModernBrowserAudioService.ts:938` degrades to whole-system capture with only a `console.warn` when the monitor device cannot be resolved. The same file *does* surface the equivalent helper-lost case to the user via `onParticipantWarning('app_capture_lost_using_system_audio')`. The two paths widen capture identically and should report identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio capture routing to connect remapped application audio to the correct capture sink.
  * Removed incorrect fallback microphone connections during capture setup.
  * Added verification and retry handling to prevent incomplete or incorrect audio connections.
  * Preserved existing correct audio wiring and avoided changes to unrecognized configurations.
  * Improved reliability when multiple audio connections are started at the same time.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
