### PR TITLE
fix(audio): tap the application, not the child holding its audio session

### DIFF
--- a/electron/audio-host.js
+++ b/electron/audio-host.js
@@ -38,6 +38,16 @@ function makeLineParser(onLine) {
 }
 
 /**
+ * `Google Chrome` + `pid:24088` -> `Google Chrome (24088)`.
+ * Left alone when the id is not a pid, so a future helper keyed on something
+ * else cannot end up with a meaningless number stapled to its name.
+ */
+function withPid(name, id) {
+  const match = /^pid:(\d+)$/.exec(String(id));
+  return match ? `${name} (${match[1]})` : name;
+}
+
+/**
  * List applications the helper can capture.
  * Always resolves; an unavailable or misbehaving helper yields [] so the picker
  * falls back to whole-system capture.
@@ -82,8 +92,25 @@ async function listAppSources({ spawn = nodeSpawn, resolvePath = resolveAudioHos
             // id; either is stable enough to re-find the app next launch.
             .map((r) => ({
               deviceId: `app:${r.id}`,
-              label: r.label || r.exe || r.id,
+              // The pid rides in the name on every row, not only where two rows
+              // would otherwise read alike. An application name is not unique -
+              // a second Chrome profile is a second, separately capturable
+              // Chrome - and a name that silently means "one of the two" is
+              // worse than an ugly one. Composed here rather than in each
+              // helper so Windows and macOS cannot drift apart; Linux taps
+              // PipeWire nodes rather than processes and does not come through
+              // this module at all.
+              label: withPid(r.label || r.exe || r.id, r.id),
               appKey: r.exe || r.label || null,
+              // A source is a process tree, and one tree can own several
+              // windows that no OS here can capture separately. The row is
+              // therefore named after the application, and its window titles
+              // ride along for the UI to show on hover - otherwise two Chrome
+              // windows look like one arbitrarily-chosen one. Absent on macOS,
+              // where window titles cost the Screen Recording permission.
+              windowTitles: Array.isArray(r.windows)
+                ? r.windows.filter((t) => typeof t === 'string' && t.length > 0)
+                : [],
             }))
         );
       } catch {

--- a/electron/audio-host.test.js
+++ b/electron/audio-host.test.js
@@ -26,8 +26,50 @@ describe('listAppSources', () => {
     child.emit('close', 0);
 
     // appKey is what survives a restart; deviceId's pid does not.
-    expect(await p).toEqual([{ deviceId: 'app:pid:42', label: 'Zoom', appKey: 'Zoom.exe' }]);
+    expect(await p).toEqual([
+      { deviceId: 'app:pid:42', label: 'Zoom (42)', appKey: 'Zoom.exe', windowTitles: [] },
+    ]);
     expect(spawn.mock.calls[0][1]).toEqual(['--list']);
+  });
+
+  it('names two instances of one application apart by pid', async () => {
+    const child = fakeChild();
+    const p = listAppSources({ spawn: () => child, resolvePath });
+
+    // A second Chrome profile is a second, separately capturable Chrome. The
+    // helper cannot tell them apart by name and must not try to.
+    child.stdout.emit('data', Buffer.from(
+      '[{"id":"pid:42","label":"Google Chrome","exe":"chrome.exe"},'
+      + '{"id":"pid:77","label":"Google Chrome","exe":"chrome.exe"}]'));
+    child.emit('close', 0);
+
+    expect((await p).map((s) => s.label)).toEqual(['Google Chrome (42)', 'Google Chrome (77)']);
+  });
+
+  it('leaves a non-pid id out of the name', async () => {
+    const child = fakeChild();
+    const p = listAppSources({ spawn: () => child, resolvePath });
+    child.stdout.emit('data', Buffer.from('[{"id":"node:31","label":"Firefox","exe":"firefox"}]'));
+    child.emit('close', 0);
+    expect((await p)[0].label).toBe('Firefox');
+  });
+
+  it('carries the window titles through for the row tooltip', async () => {
+    const child = fakeChild();
+    const p = listAppSources({ spawn: () => child, resolvePath });
+
+    // One process tree, two windows - the case the label alone cannot express.
+    child.stdout.emit('data', Buffer.from(
+      '[{"id":"pid:42","label":"Google Chrome","exe":"chrome.exe","active":true,'
+      + '"windows":["YouTube - Google Chrome","","Docs - Google Chrome"]}]'));
+    child.emit('close', 0);
+
+    expect(await p).toEqual([{
+      deviceId: 'app:pid:42',
+      label: 'Google Chrome (42)',
+      appKey: 'chrome.exe',
+      windowTitles: ['YouTube - Google Chrome', 'Docs - Google Chrome'],
+    }]);
   });
 
   it('keeps non-ASCII labels intact across chunk boundaries', async () => {
@@ -42,7 +84,9 @@ describe('listAppSources', () => {
     child.stdout.emit('data', buf.subarray(20));
     child.emit('close', 0);
 
-    expect(await p).toEqual([{ deviceId: 'app:pid:7', label: '守望先锋', appKey: 'Overwatch.exe' }]);
+    expect(await p).toEqual([
+      { deviceId: 'app:pid:7', label: '守望先锋 (7)', appKey: 'Overwatch.exe', windowTitles: [] },
+    ]);
   });
 
   it('falls back to exe when label is empty', async () => {
@@ -50,7 +94,9 @@ describe('listAppSources', () => {
     const p = listAppSources({ spawn: () => child, resolvePath });
     child.stdout.emit('data', Buffer.from('[{"id":"pid:9","label":"","exe":"foo.exe"}]'));
     child.emit('close', 0);
-    expect(await p).toEqual([{ deviceId: 'app:pid:9', label: 'foo.exe', appKey: 'foo.exe' }]);
+    expect(await p).toEqual([
+      { deviceId: 'app:pid:9', label: 'foo.exe (9)', appKey: 'foo.exe', windowTitles: [] },
+    ]);
   });
 
   it('returns an empty array when the helper is missing', async () => {

--- a/native/audio-host/README.md
+++ b/native/audio-host/README.md
@@ -22,9 +22,19 @@ sokuji-audio-host --list
 Writes one JSON array to stdout and exits 0:
 
 ```json
-[{"id":"pid:22972","label":"守望先锋","exe":"Overwatch.exe","active":true}]
+[{"id":"pid:22972","label":"守望先锋","exe":"Overwatch.exe","active":true,"windows":["守望先锋"]}]
 ```
 
+`id` names the process to tap, and it must be one that lives as long as the application does —
+not whichever child happens to hold the audio session (see the Windows notes). `label` is the
+**application** name, never a window title: a source is a process tree, one tree owns as many
+windows as the user opened, and no platform here can capture them separately. `windows` carries
+those titles so the UI can show them on hover; it may be empty, and macOS always leaves it so.
+
+Helpers emit the bare application name and must not disambiguate two copies of it themselves:
+`electron/audio-host.js` appends the pid from `id` to every row (`Google Chrome (24088)`), so a
+second Chrome profile — a second, separately capturable Chrome — is always distinguishable
+without each helper inventing its own rule.
 `active` is true when the application currently holds a playing audio session. Labels are
 UTF-8 and routinely non-ASCII. An empty array is a valid answer and makes the UI fall back to
 whole-system capture; it is not an error.
@@ -88,10 +98,29 @@ powershell -ExecutionPolicy Bypass -File win\verify.ps1
 ```
 
 Plays a 440 Hz tone in one process, captures a *different* silent process, and asserts the
-tone did not leak in. Needs no interactive desktop. Expected output ends with `VERIFY OK`.
+tone did not leak in. It also builds a two-level same-image process tree (cmd → powershell →
+powershell, a browser's shape) and asserts `--list` reports the root, hides the audio-holding
+child, and that a tap on the root survives that child's death. Needs no interactive desktop.
+Expected output ends with `VERIFY OK`.
 
 ### Things learned the hard way
 
+- **The audio session's pid is not the application's pid.** Chrome renders through a
+  `--type=utility` audio service child, and `IAudioSessionControl2::GetProcessId` returns
+  *that*. Chrome recycles it around playback: measured Aug 2026, killing it made the helper
+  exit `target_gone`, and the replacement came back under a different pid. Sokuji answers a
+  dead helper by falling back to whole-system capture, so the symptom was one selected
+  application quietly turning into every application, with the picker still naming the app.
+  `--list` therefore reports the topmost ancestor running the *same executable*, which
+  `PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE` covers along with every child it later
+  spawns. The same-image bound is load-bearing: walk past it and a window-less player launched
+  from Explorer would root at the desktop shell, and its tree is nearly everything the user
+  has open.
+- **A window title is not an application name.** Two Chrome windows are one process tree and
+  therefore one capturable source — Windows offers no way to split them — so labelling the row
+  with the first window title found promised a granularity that does not exist. The label is
+  the executable's `FileDescription` ("Google Chrome", the name Task Manager shows), and the
+  window titles are listed separately in `windows`.
 - **Requirements.** The API's documented floor is Windows 10 build 20348, i.e. Windows 11 in
   practice; the header ships in SDK 10.0.19041.0 regardless. On older Windows `--list` simply
   returns `[]` and the UI degrades to whole-system capture.

--- a/native/audio-host/mac/main.swift
+++ b/native/audio-host/mac/main.swift
@@ -153,14 +153,11 @@ func listSources() -> [Source] {
     // Applications actually making noise are the likely target; float them up.
     out.sort { a, b in a.active == b.active ? a.label < b.label : a.active && !b.active }
 
-    // Same application twice is ambiguous in a picker; disambiguate only then.
-    var counts: [String: Int] = [:]
-    for s in out { counts[s.label, default: 0] += 1 }
-    return out.map { s in
-        (counts[s.label] ?? 0) > 1
-            ? Source(pid: s.pid, label: "\(s.label) (\(s.pid))", exe: s.exe, active: s.active)
-            : s
-    }
+    // Two copies of one application used to be disambiguated here, by appending
+    // the pid only when the names collided. The app now appends it to every row
+    // on every platform (see withPid in electron/audio-host.js), so doing it
+    // here too would print the pid twice.
+    return out
 }
 
 func runList() -> Int32 {

--- a/native/audio-host/win/build.bat
+++ b/native/audio-host/win/build.bat
@@ -40,8 +40,10 @@ if not exist out mkdir out
 REM /utf-8 pins the source charset. Without it MSVC decodes the file with the
 REM machine's ANSI code page (932 on the Japanese-locale test box) and warns
 REM C4819, which would silently mangle any non-ASCII literal added later.
+REM version.lib provides GetFileVersionInfo*, which reads the FileDescription
+REM resource the picker labels each application with.
 cl /nologo /EHsc /std:c++17 /O2 /W3 /utf-8 main.cpp /Fo:out\ ^
-   /link ole32.lib user32.lib mmdevapi.lib /out:out\sokuji-audio-host.exe
+   /link ole32.lib user32.lib mmdevapi.lib version.lib /out:out\sokuji-audio-host.exe
 
 if errorlevel 1 (
   echo BUILD FAILED

--- a/native/audio-host/win/main.cpp
+++ b/native/audio-host/win/main.cpp
@@ -2,7 +2,13 @@
 //
 //   sokuji-audio-host.exe --list
 //       Writes one JSON array to stdout and exits 0.
-//       [{"id":"pid:1234","label":"Zoom Meetings","exe":"Zoom.exe","active":true}]
+//       [{"id":"pid:1234","label":"Zoom Meetings","exe":"Zoom.exe","active":true,
+//         "windows":["Zoom Meeting","Chat"]}]
+//       `id` names the application's root process, which outlives the child
+//       that happens to hold the audio session. `label` is the application
+//       name; `windows` are its window titles, which the UI shows on hover
+//       because one process can own several windows and Windows cannot capture
+//       them separately.
 //
 //   sokuji-audio-host.exe --target pid:1234
 //       Writes raw PCM to stdout until killed. Format is fixed at
@@ -23,8 +29,10 @@
 #include <audioclientactivationparams.h>
 #include <audiopolicy.h>
 #include <tlhelp32.h>
+#include <winver.h>
 #include <fcntl.h>
 #include <io.h>
+#include <algorithm>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -79,62 +87,164 @@ static void EmitError(const char* code) {
     fflush(stderr);
 }
 
-static std::string ExeNameOf(DWORD pid) {
+static std::wstring ImagePathOf(DWORD pid) {
     HANDLE h = OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, FALSE, pid);
-    if (!h) return std::string();
+    if (!h) return std::wstring();
     wchar_t path[MAX_PATH] = {};
     DWORD n = MAX_PATH;
-    std::string result;
-    if (QueryFullProcessImageNameW(h, 0, path, &n)) {
-        const wchar_t* slash = wcsrchr(path, L'\\');
-        result = Utf8(slash ? slash + 1 : path);
-    }
+    std::wstring result;
+    if (QueryFullProcessImageNameW(h, 0, path, &n)) result.assign(path, n);
     CloseHandle(h);
     return result;
+}
+
+static std::string ExeNameOf(DWORD pid) {
+    const std::wstring path = ImagePathOf(pid);
+    if (path.empty()) return std::string();
+    const size_t slash = path.find_last_of(L'\\');
+    return Utf8(slash == std::wstring::npos ? path.c_str() : path.c_str() + slash + 1);
+}
+
+/**
+ * The executable's FileDescription resource - "Google Chrome" for chrome.exe.
+ *
+ * This is the name Task Manager shows, and the only application name Windows
+ * offers for free; everything friendlier (AppUserModelID, package display name)
+ * covers packaged apps only.
+ */
+static std::string FileDescription(const wchar_t* path) {
+    DWORD ignored = 0;
+    const DWORD size = GetFileVersionInfoSizeW(path, &ignored);
+    if (size == 0) return std::string();
+    std::vector<BYTE> buffer(size);
+    if (!GetFileVersionInfoW(path, 0, size, buffer.data())) return std::string();
+
+    struct LangCodePage { WORD language; WORD codePage; };
+    LangCodePage* translations = nullptr;
+    UINT bytes = 0;
+    if (!VerQueryValueW(buffer.data(), L"\\VarFileInfo\\Translation",
+                        reinterpret_cast<void**>(&translations), &bytes)
+        || bytes < sizeof(LangCodePage)) {
+        return std::string();
+    }
+    // The first translation is the binary's own language. Later ones are
+    // localisations, which would name the app in a language nobody asked for.
+    wchar_t key[64];
+    swprintf_s(key, L"\\StringFileInfo\\%04x%04x\\FileDescription",
+               translations[0].language, translations[0].codePage);
+    wchar_t* value = nullptr;
+    UINT length = 0;
+    if (!VerQueryValueW(buffer.data(), key, reinterpret_cast<void**>(&value), &length)
+        || length == 0) {
+        return std::string();
+    }
+    return Utf8(value);
 }
 
 // ------------------------------------------------------------------- --list
 
 struct TitleCollector {
-    std::map<DWORD, std::string> byPid;
+    std::map<DWORD, std::vector<std::string>> byPid;
 };
 
 // Chromium and Electron render audio from a child process (the audio service),
-// and that child owns no window - so looking the audio session's pid up
-// directly finds nothing and the list falls back to bare exe names. Walking up
-// the parent chain reaches the browser process that does own the window.
-// Capped so a broken or cyclic chain cannot spin.
+// and that child owns no window, so nothing about the application can be read
+// off the audio session's own pid. Walking up the parent chain reaches the
+// process that does represent the app. Capped so a broken or cyclic chain
+// cannot spin.
 static const int kMaxParentHops = 6;
 
-static std::map<DWORD, DWORD> BuildParentMap() {
-    std::map<DWORD, DWORD> parents;
+struct ProcessTable {
+    std::map<DWORD, DWORD> parent;
+    std::map<DWORD, std::string> image;
+};
+
+static ProcessTable BuildProcessTable() {
+    ProcessTable table;
     HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
-    if (snap == INVALID_HANDLE_VALUE) return parents;
+    if (snap == INVALID_HANDLE_VALUE) return table;
     PROCESSENTRY32W entry{};
     entry.dwSize = sizeof(entry);
     if (Process32FirstW(snap, &entry)) {
         do {
-            parents[entry.th32ProcessID] = entry.th32ParentProcessID;
+            table.parent[entry.th32ProcessID] = entry.th32ParentProcessID;
+            // The snapshot's image name needs no handle, so it also covers
+            // processes this helper may not open.
+            table.image[entry.th32ProcessID] = Utf8(entry.szExeFile);
         } while (Process32NextW(snap, &entry));
     }
     CloseHandle(snap);
-    return parents;
+    return table;
 }
 
-/** Window title owned by `pid` or by its nearest ancestor, else empty. */
-static std::string TitleForPid(DWORD pid,
-                               const std::map<DWORD, std::string>& titles,
-                               const std::map<DWORD, DWORD>& parents) {
-    DWORD current = pid;
-    for (int hop = 0; hop < kMaxParentHops && current != 0; hop++) {
-        auto title = titles.find(current);
-        if (title != titles.end() && !title->second.empty()) return title->second;
-        auto parent = parents.find(current);
-        if (parent == parents.end() || parent->second == current) break;
-        current = parent->second;
-        if (current <= 4) break;  // reached System/Idle; nothing useful above
+static std::string ImageOf(DWORD pid, const ProcessTable& table) {
+    auto it = table.image.find(pid);
+    if (it != table.image.end() && !it->second.empty()) return it->second;
+    return ExeNameOf(pid);
+}
+
+static bool SameImage(const std::string& a, const std::string& b) {
+    return !a.empty() && !b.empty() && _stricmp(a.c_str(), b.c_str()) == 0;
+}
+
+/**
+ * The process that represents the *application* holding this audio session.
+ *
+ * The session belongs to whichever process opened the render stream, and for a
+ * multi-process app that is a short-lived child: Chrome plays through a
+ * `--type=utility` audio service it tears down and replaces around playback.
+ * Targeting that child produced a tap that died with it - the helper exited
+ * `target_gone`, and Sokuji answers a dead helper by falling back to
+ * whole-system capture while the picker still names the application, so the
+ * user's whole desktop starts being translated with nothing on screen saying
+ * so. Reporting the root instead gives a pid that lives as long as the app,
+ * and PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE still reaches every
+ * child it spawns - including the replacement audio service.
+ *
+ * The walk stops as soon as the parent runs a different executable, and that
+ * bound is what makes it safe. Multi-process apps spawn their children from
+ * their own image, whereas an unrelated parent - explorer.exe having launched a
+ * window-less player - does not. Without the bound such an app's root would be
+ * the desktop shell, and capturing that tree would capture nearly everything
+ * the user has open: the exact leak this is meant to close.
+ */
+static DWORD AppRootPid(DWORD pid, const ProcessTable& table) {
+    const std::string image = ImageOf(pid, table);
+    if (image.empty()) return pid;
+    DWORD root = pid;
+    for (int hop = 0; hop < kMaxParentHops; hop++) {
+        auto parent = table.parent.find(root);
+        if (parent == table.parent.end()) break;
+        const DWORD up = parent->second;
+        // 0-4 are System/Idle; a self-referencing entry would loop forever.
+        if (up <= 4 || up == root) break;
+        if (!SameImage(ImageOf(up, table), image)) break;
+        root = up;
     }
-    return std::string();
+    return root;
+}
+
+/**
+ * What to call this application in the picker.
+ *
+ * Deliberately not a window title. A capturable source is a process tree, and
+ * one tree routinely owns several windows - two Chrome windows are one process
+ * and therefore one source, which Windows offers no way to split. Naming the
+ * row after whichever window was enumerated first promised a granularity the OS
+ * cannot deliver, and made two windows look like one arbitrary one. The window
+ * titles still travel, in `windows`, for the UI to show on hover.
+ */
+static std::string FriendlyName(DWORD pid, const ProcessTable& table) {
+    const std::wstring path = ImagePathOf(pid);
+    if (!path.empty()) {
+        const std::string described = FileDescription(path.c_str());
+        if (!described.empty()) return described;
+    }
+    const std::string image = ImageOf(pid, table);
+    if (!image.empty()) return image;
+    char b[32];
+    sprintf_s(b, "PID %lu", pid);
+    return b;
 }
 
 static BOOL CALLBACK CollectTitle(HWND hwnd, LPARAM lp) {
@@ -146,8 +256,9 @@ static BOOL CALLBACK CollectTitle(HWND hwnd, LPARAM lp) {
     GetWindowThreadProcessId(hwnd, &pid);
     if (pid == 0) return TRUE;
     auto* c = reinterpret_cast<TitleCollector*>(lp);
-    // First visible window wins; later ones are usually secondary dialogs.
-    if (c->byPid.find(pid) == c->byPid.end()) c->byPid[pid] = Utf8(title);
+    // Every window, not just the first: they are what the row's tooltip lists,
+    // and dropping all but one is what made two Chrome windows indistinguishable.
+    c->byPid[pid].push_back(Utf8(title));
     return TRUE;
 }
 
@@ -156,6 +267,7 @@ struct Entry {
     std::string exe;
     std::string label;
     bool active;
+    std::vector<std::string> windows;
 };
 
 // Enumerate processes that hold an audio session on the default render endpoint.
@@ -189,7 +301,18 @@ static int ListSources() {
 
     TitleCollector titles;
     EnumWindows(CollectTitle, reinterpret_cast<LPARAM>(&titles));
-    const std::map<DWORD, DWORD> parents = BuildParentMap();
+    const ProcessTable procs = BuildProcessTable();
+
+    // A window belongs to the application, not to the process that happens to
+    // own it, so fold every collected title onto its application root. One row
+    // can then list every window the app has open.
+    std::map<DWORD, std::vector<std::string>> windowsByRoot;
+    for (const auto& owner : titles.byPid) {
+        auto& into = windowsByRoot[AppRootPid(owner.first, procs)];
+        for (const auto& title : owner.second) {
+            if (std::find(into.begin(), into.end(), title) == into.end()) into.push_back(title);
+        }
+    }
 
     std::vector<Entry> entries;
     IAudioSessionEnumerator* sessions = nullptr;
@@ -212,21 +335,25 @@ static int ListSources() {
                 AudioSessionState st = AudioSessionStateInactive;
                 ctl->GetState(&st);
 
-                Entry e{};
-                e.pid = pid;
-                e.exe = ExeNameOf(pid);
-                e.active = (st == AudioSessionStateActive);
+                // Report the application, not the process that opened the
+                // stream: see AppRootPid. This also collapses an app that holds
+                // several sessions into the one row a user expects.
+                const DWORD root = AppRootPid(pid, procs);
 
-                const std::string title = TitleForPid(pid, titles.byPid, parents);
-                e.label = !title.empty() ? title : e.exe;
-                if (e.label.empty()) {
-                    char b[32];
-                    sprintf_s(b, "PID %lu", pid);
-                    e.label = b;
-                }
+                Entry e{};
+                e.pid = root;
+                e.exe = ImageOf(root, procs);
+                e.active = (st == AudioSessionStateActive);
+                e.label = FriendlyName(root, procs);
+                auto windows = windowsByRoot.find(root);
+                if (windows != windowsByRoot.end()) e.windows = windows->second;
 
                 bool dup = false;
-                for (const auto& x : entries) if (x.pid == pid) { dup = true; break; }
+                for (auto& x : entries) {
+                    // Merged rows are active when any of their sessions is, or
+                    // an app playing through its second session reads as idle.
+                    if (x.pid == root) { x.active = x.active || e.active; dup = true; break; }
+                }
                 if (!dup) entries.push_back(e);
             }
             ctl2->Release();
@@ -234,15 +361,24 @@ static int ListSources() {
         ctl->Release();
     }
 
+    // Two instances of one application - a second Chrome profile, or Chrome
+    // beside Chrome Beta - carry the same name here, and nothing in this list
+    // tells them apart. Disambiguating them is the caller's job: it appends the
+    // pid from `id` to every row, on every platform, rather than only where a
+    // collision happens to occur.
     printf("[");
     for (size_t i = 0; i < entries.size(); i++) {
         const Entry& e = entries[i];
-        printf("%s{\"id\":\"pid:%lu\",\"label\":\"%s\",\"exe\":\"%s\",\"active\":%s}",
+        printf("%s{\"id\":\"pid:%lu\",\"label\":\"%s\",\"exe\":\"%s\",\"active\":%s,\"windows\":[",
                i ? "," : "",
                e.pid,
                JsonEscape(e.label).c_str(),
                JsonEscape(e.exe).c_str(),
                e.active ? "true" : "false");
+        for (size_t w = 0; w < e.windows.size(); w++) {
+            printf("%s\"%s\"", w ? "," : "", JsonEscape(e.windows[w]).c_str());
+        }
+        printf("]}");
     }
     printf("]");
     fflush(stdout);

--- a/native/audio-host/win/verify.ps1
+++ b/native/audio-host/win/verify.ps1
@@ -1,9 +1,11 @@
 # Acceptance test for sokuji-audio-host.exe (issue #335).
 #
-# Proves the two properties the whole feature rests on:
+# Proves the three properties the whole feature rests on:
 #   1. Isolation - capturing app A yields silence while app B plays.
 #   2. Continuity - the stream keeps flowing at the right rate while the
 #      target is silent, which is why nothing downstream fills gaps.
+#   3. Target stability - the pid `--list` reports outlives playback, so the
+#      tap does not die when a multi-process app recycles its audio child.
 #
 # Run on the Windows box; it needs no interactive desktop.
 $ProgressPreference = 'SilentlyContinue'
@@ -64,6 +66,66 @@ foreach ($case in @(@{n = 'NOISY'; p = $noisy.Id }, @{n = 'QUIET'; p = $quiet.Id
 }
 
 foreach ($x in @($noisy, $quiet)) { Stop-Process -Id $x.Id -Force -ErrorAction SilentlyContinue }
+
+# --- Target stability across a multi-process application.
+#
+# A browser does not render audio from the process the user recognises: Chrome
+# plays through a `--type=utility` audio service child, and that child is
+# short-lived - Chrome recycles it whenever playback stops. A tap pointed at it
+# dies with it ("target_gone"), and Sokuji answers a dead helper by falling back
+# to whole-system capture while the picker still shows the application, so the
+# user's whole desktop starts being translated with nothing on screen saying so.
+# Measured on Chrome (Aug 2026): --list reported a utility child, killing it
+# ended the capture, and the replacement child came back under a different pid.
+#
+# The shape is reproduced here without a browser: cmd.exe launches a parent
+# powershell.exe, which launches a child powershell.exe that plays the tone -
+# same image for parent and child, a different one above them, exactly a
+# browser's tree. The reported pid must be the parent, and a tap on it must
+# survive the child's death.
+$encChild = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(
+    "`$p = New-Object System.Media.SoundPlayer '$tone'; `$p.PlayLooping(); Start-Sleep -Seconds 60"))
+$encParent = [Convert]::ToBase64String([Text.Encoding]::Unicode.GetBytes(
+    "Start-Process powershell -WindowStyle Hidden -ArgumentList '-NoProfile','-EncodedCommand','$encChild'; Start-Sleep -Seconds 60"))
+$launcher = Start-Process cmd -PassThru -WindowStyle Hidden -ArgumentList '/c', "powershell -NoProfile -EncodedCommand $encParent"
+Start-Sleep -Seconds 3
+
+$rootPid = (Get-CimInstance Win32_Process -Filter "ParentProcessId=$($launcher.Id) AND Name='powershell.exe'" |
+    Select-Object -First 1).ProcessId
+$childPid = $null
+if ($rootPid) {
+    $childPid = (Get-CimInstance Win32_Process -Filter "ParentProcessId=$rootPid AND Name='powershell.exe'" |
+        Select-Object -First 1).ProcessId
+}
+Write-Output ("TREE: root(parent)={0} audio-child={1}" -f $rootPid, $childPid)
+
+$listedIds = @()
+try { $listedIds = @((& $exe --list | ConvertFrom-Json) | ForEach-Object { $_.id }) } catch {}
+Write-Output ("  --list ids: " + ($listedIds -join ', '))
+
+$treeOut = Join-Path $env:TEMP 'sokuji_TREE.pcm'
+$treeErr = Join-Path $env:TEMP 'sokuji_TREE.log'
+$treeAlive = $false
+$treePeak = 0
+if ($rootPid -and $childPid) {
+    $helper = Start-Process $exe -PassThru -NoNewWindow `
+        -RedirectStandardOutput $treeOut -RedirectStandardError $treeErr `
+        -ArgumentList '--target', ("pid:{0}" -f $rootPid)
+    Start-Sleep -Seconds 2
+    # Stand in for Chrome recycling its audio service mid-session.
+    Stop-Process -Id $childPid -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Seconds 2
+    $treeAlive = -not $helper.HasExited
+    Stop-Process -Id $helper.Id -Force -ErrorAction SilentlyContinue
+    Start-Sleep -Milliseconds 400
+    $treePeak = Get-Peak $treeOut
+    Write-Output ("  tree capture: peak={0} alive-after-child-exit={1}" -f $treePeak, $treeAlive)
+    Write-Output ("  stderr: " + ((Get-Content $treeErr -Raw -ErrorAction SilentlyContinue) -replace "`r`n", ' ').Trim())
+}
+
+foreach ($p in @($childPid, $rootPid, $launcher.Id)) {
+    if ($p) { Stop-Process -Id $p -Force -ErrorAction SilentlyContinue }
+}
 Remove-Item $tone, "$env:TEMP\sokuji_*.pcm", "$env:TEMP\sokuji_*.log" -Force -ErrorAction SilentlyContinue
 
 # 3 s of 24 kHz mono s16 = 144000 bytes. Allow for startup latency only.
@@ -82,5 +144,14 @@ Check 'continuity-noisy' ([math]::Abs($results['NOISY'].bytes - $expected) -lt 6
     ("bytes={0}, expected ~{1}" -f $results['NOISY'].bytes, $expected)
 Check 'continuity-quiet' ([math]::Abs($results['QUIET'].bytes - $expected) -lt 6000) `
     ("bytes={0}, expected ~{1} even though the target was silent" -f $results['QUIET'].bytes, $expected)
+
+Check 'lists-application-root' ($listedIds -contains ("pid:{0}" -f $rootPid)) `
+    ("expected the parent pid {0} in --list; a browser's audio child is recycled and its pid dies with it" -f $rootPid)
+Check 'hides-audio-child' (-not ($listedIds -contains ("pid:{0}" -f $childPid))) `
+    ("the audio-holding child {0} must not be offered as a target" -f $childPid)
+Check 'tree-capture-reaches-child' ($treePeak -gt 8000) `
+    ("peak={0} capturing the parent while only the child played, expected >8000" -f $treePeak)
+Check 'survives-audio-child-exit' ($treeAlive) `
+    'the helper must outlive the audio child, or Sokuji silently widens to whole-system capture'
 
 if ($ok) { Write-Output 'VERIFY OK'; exit 0 } else { Write-Output 'VERIFY FAILED'; exit 1 }

--- a/src/components/MainPanel/ModeDevicePopover.tsx
+++ b/src/components/MainPanel/ModeDevicePopover.tsx
@@ -22,6 +22,7 @@ import {
 import { isExtension } from '../../utils/environment';
 import { useNavigateToSettings } from '../../stores/settingsStore';
 import { isVirtualDevice, type AudioDevice } from '../Settings/shared/hooks';
+import { describeDeviceOnHover } from '../../utils/audioDevices';
 import './ModeDevicePopover.scss';
 
 interface ModeDevicePopoverProps {
@@ -291,7 +292,7 @@ const ModeDevicePopover: React.FC<ModeDevicePopoverProps> = ({ mode, open, ancho
                         className={`mode-device-popover__device-row${selected ? ' mode-device-popover__device-row--selected' : ''}`}
                         onClick={() => row.onSelectDevice!(d)}
                       >
-                        <span>{d.label || d.deviceId}</span>
+                        <span title={describeDeviceOnHover(d)}>{d.label || d.deviceId}</span>
                         {selected && <span className="mode-device-popover__indicator" />}
                       </button>
                     );

--- a/src/components/Settings/shared/DeviceList.tsx
+++ b/src/components/Settings/shared/DeviceList.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { AudioDevice, isVirtualMic, isVirtualSpeaker } from './hooks';
+import { describeDeviceOnHover } from '../../../utils/audioDevices';
 
 interface DeviceListProps {
   devices: AudioDevice[];
@@ -132,7 +133,7 @@ const DeviceList: React.FC<DeviceListProps> = ({
             aria-disabled={disabled}
             tabIndex={disabled ? -1 : 0}
           >
-            <span title={device.label || undefined}>
+            <span title={describeDeviceOnHover(device)}>
               {device.label || t('audioPanel.unknownDevice')}
             </span>
             {virtual && (

--- a/src/components/Settings/shared/hooks.ts
+++ b/src/components/Settings/shared/hooks.ts
@@ -8,6 +8,13 @@ export interface AudioDevice {
   deviceId: string;
   label: string;
   isDefault?: boolean;
+  /**
+   * Windows owned by a per-application capture source. One process tree can own
+   * several, and no desktop platform can capture them separately, so they are
+   * shown on hover rather than folded into the row's name. Absent on ordinary
+   * audio devices.
+   */
+  windowTitles?: string[];
 }
 
 // Re-exported for backward compatibility — the actual (React-free) predicates

--- a/src/stores/audioStore.ts
+++ b/src/stores/audioStore.ts
@@ -39,6 +39,16 @@ export interface AudioDevice {
    * whole-system capture.
    */
   appKey?: string | null;
+  /**
+   * Titles of the windows this capture source owns.
+   *
+   * A source is a process tree, and neither Windows nor macOS can capture one
+   * window of it separately - two Chrome windows are one source. Naming the row
+   * after one of them hid that, so the row carries the application name and the
+   * titles are shown on hover instead. Empty when the platform cannot read them
+   * (macOS gates window titles behind Screen Recording).
+   */
+  windowTitles?: string[];
 }
 
 /**

--- a/src/utils/audioDevices.ts
+++ b/src/utils/audioDevices.ts
@@ -11,6 +11,26 @@ interface LabeledDevice {
   label: string;
 }
 
+interface HoverableDevice {
+  label: string;
+  windowTitles?: string[];
+}
+
+/**
+ * Hover text for a device row.
+ *
+ * A per-application capture source is a process tree, and one tree owns as many
+ * windows as the user opened - two Chrome windows are a single source that no
+ * desktop platform can split. The row is therefore named after the application,
+ * and the windows it covers are listed here, so "Google Chrome" is not silently
+ * standing in for three of them. Ordinary devices keep their label as the title.
+ */
+export const describeDeviceOnHover = (device: HoverableDevice): string | undefined => {
+  const titles = device.windowTitles?.filter((t) => t) ?? [];
+  if (titles.length === 0) return device.label || undefined;
+  return [device.label, ...titles.map((t) => `• ${t}`)].filter(Boolean).join('\n');
+};
+
 /**
  * Check if a device is a virtual device that should be filtered or warned about
  */


### PR DESCRIPTION
Fixes two bugs reported against per-application participant capture on Windows.

## Bug 1 — picking one application still captured every application

`--list` reported the pid of whichever process opened the render stream. For a
multi-process app that is a short-lived child: Chrome plays through a
`--type=utility` audio service it recycles around playback. Measured on Chrome
and Edge:

```
--list reported pid 27788  ->  --type=utility child, parent 8728 is the browser
kill 27788 mid-capture     ->  helper exits {"event":"error","code":"target_gone"}
Chrome respawns it         ->  new pid 4312; the old id is dead forever
```

`AppAudioRecorder.onLost` answers a dead helper by falling back to **whole-system
capture**, and it does not touch `selectedParticipantSource` — so the picker went
on naming the application while every application on the machine was being
translated. That matches the report exactly: *"the selected app is still
highlighted, but I hear several apps."*

`--list` now reports the topmost ancestor running the **same executable**, which
`PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE` covers along with every child
it later spawns, including the replacement audio service. Targeting the browser
process instead of the child was measured to survive exactly the event that used
to kill it:

```
target = browser pid, kill the audio child mid-capture
  -> helper alive, no target_gone, 8.98 s captured, audio resumes by itself
```

The same-image bound is load-bearing rather than incidental: without it, a
window-less player launched from Explorer roots at the desktop shell, and
capturing *that* tree is nearly everything the user has open — the exact leak
this feature exists to prevent.

## Bug 2 — two Chrome windows showed up as one row

Confirmed as an OS limit, not a bug we can fix: two windows of one Chrome are one
process tree and one audio session, and Windows offers no way to split them. Two
genuinely separate instances do list separately (verified).

So the presentation changed instead, per @jiangzhuo's call: a row is named after
the **application**, never after whichever window enumerated first, since that
promised a granularity that does not exist.

- label = the executable's `FileDescription` — the name Task Manager shows
- the pid is appended to **every** row, by the app rather than by each helper, so
  a second Chrome profile stays distinguishable: `Google Chrome (24088)`
- window titles move to a hover tooltip, carried in a new `windows` field

macOS drops its own collision-only pid suffix, which would otherwise print the
pid twice.

## Verification

`win/verify.ps1` gains four assertions, built on a `cmd -> powershell ->
powershell` same-image tree, so they reproduce a browser's process shape without
needing a browser or an interactive desktop. **They fail on the previous binary
and pass on this one** — the two new listing assertions were confirmed red first.

End-to-end with Chrome and Edge playing simultaneously:

```
--list:  pid:24088 'Google Chrome'   [browser root]   windows=SOKUJI PROBE CHROME 440 ...
         pid:19016 'Microsoft Edge'  [browser root]   windows=SOKUJI PROBE TONE 660 ...
isolation:  target=Chrome -> chrome440=0.14887  edge660=0.00000
            target=Edge   -> chrome440=0.00004  edge660=0.14809
old failure: kill Edge's audio service mid-capture -> helper alive, audio resumes
```

Test suite: 2152/2157 pass. The 5 failures are pre-existing and unrelated —
`electron/audio-host-path.test.js` builds paths with `path.join` and asserts
POSIX literals, which cannot pass on a Windows runner; the file is untouched here.

## Not in this PR

- **The `onLost` fallback policy itself.** Even with a stable target, quitting the
  app still widens capture from one application to the whole system. Left as-is
  by product decision: the user notices and re-picks a source, which is
  acceptable.
- **The macOS counterpart**, filed as #393. Its tap freezes its process list at
  capture start, so an app that restarts its audio helper goes *silent* rather
  than widening. Analysis only — it needs a Mac to reproduce and implement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application audio sources now show process identifiers when needed to distinguish multiple instances.
  * Window titles are displayed in device hover tooltips for easier source identification.
  * Audio source listings provide clearer application labels and active-state information.

* **Bug Fixes**
  * Improved audio capture stability when application audio processes restart or terminate.
  * Prevented unrelated parent processes and child audio processes from being incorrectly listed as sources.

* **Documentation**
  * Updated audio source behavior and verification guidance, including window-title reporting and process selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->