### PR TITLE
fix(audio): follow the macOS target's audio processes instead of freezing them

### DIFF
--- a/native/audio-host/README.md
+++ b/native/audio-host/README.md
@@ -60,8 +60,13 @@ Before the first PCM byte it writes one line to stderr:
 and on failure:
 
 ```json
-{"event":"error","code":"bad_target|activation_failed|initialize_failed|target_gone"}
+{"event":"error","code":"bad_target|no_such_audio_process|activation_failed|initialize_failed|target_gone"}
+{"event":"warning","code":"silent_no_permission|retarget_failed"}
 ```
+
+An `error` tells Sokuji its capture is gone and it tears the recorder down; a
+`warning` does not. Anything degraded-but-still-capturing must therefore be a
+warning.
 
 Exit codes: `0` clean, `1` runtime failure, `2` bad usage.
 
@@ -158,6 +163,19 @@ mac/build.sh
 `resources/bin/darwin-arm64` or `darwin-x64` depending on the build machine's architecture.
 As on Windows the copy is part of the build, not a step to remember.
 
+### Verify
+
+```
+mac/verify.sh [binary]
+```
+
+Captures a process that only starts playing after the session does, captures one
+whose audio child is replaced mid-session, and captures a silent process while
+another one plays. Expected output ends with `VERIFY OK`; it fails five
+assertions on the pre-#393 binary. The audio-content assertions need the
+"System Audio Recording Only" grant, which TCC attributes to the terminal running
+the script — without it the script says so and keeps only the structural checks.
+
 ### Things learned the hard way
 
 - **TCC denies by silence, not by error.** Without the "System Audio Recording Only" grant
@@ -186,6 +204,36 @@ As on Windows the copy is part of the build, not a step to remember.
   every one of the app's streams; macOS has to expand the tree itself. The same
   applies to `IsRunningOutput`: asked of the parent it is always false, so any
   browser reads as idle.
+- **That tree is a snapshot, and it goes stale on its own.** An audio process
+  object is destroyed when its process stops rendering and a *new* object is
+  created for the replacement. Measured Aug 2026 on 15.7.3: killing Chrome's
+  `audio.mojom.AudioService` child removed object 199 from Chrome's tree and the
+  respawned service arrived as object 202 under a new pid. A tap resolved once at
+  capture start then covers only dead objects — and the HAL prunes those, leaving
+  the tap with an empty process list. The symptom is the nastiest one available:
+  correctly-clocked buffers of pure zeros, forever, with the session looking
+  perfectly healthy. This is the macOS half of the Windows "audio session's pid is
+  not the application's pid" defect above; Windows failed loudly by exiting, macOS
+  failed silently.
+- **A live tap can be re-pointed in place.** Writing `kAudioTapPropertyDescription`
+  on a running tap with a new process list returns `noErr` and the HAL re-reads it:
+  measured, audio from the newly named processes resumes within one 0.25 s poll,
+  and the aggregate device keeps its IOProc, its clock and its sample rate — no
+  rebuild, no gap in the frame count. Rebuilding the tap and aggregate device was
+  the fallback plan and turned out to be unnecessary.
+- **An empty mixdown list is not a global tap** — the two initialisers set
+  different flags and do not collapse into each other. Measured: a
+  `monoMixdownOfProcesses: []` tap reads peak 0.0000 while another process is
+  audibly playing, where a global tap on the same audio reads 11994. So the helper
+  can safely create the tap before its target owns any audio object, which is what
+  lets an idle application be picked at all. **But** such a tap delivers no buffers
+  whatsoever — not even silent ones, unlike the Windows path — so the writer thread
+  synthesises silence against the wall clock to keep the stream from stalling.
+- **`IsRunningOutput` leads the first audible sample.** Core Audio marks a process
+  as running output a poll or two before the tap hands over anything non-zero, so
+  a naive reading fires `silent_no_permission` at the exact moment playback starts
+  — the one moment the permission is provably fine. The warning requires the
+  contradiction to hold for two seconds.
 - **Whole-system capture uses a global tap, not getDisplayMedia.** Screen
   Recording is a second, heavier permission, and a `stereoGlobalTapButExcludeProcesses: []`
   tap does the same job under the audio-capture grant the per-application path

--- a/native/audio-host/mac/main.swift
+++ b/native/audio-host/mac/main.swift
@@ -46,6 +46,12 @@ import AppKit
 let kOutRate = 24000.0
 let kOutChannels = 1
 
+// Most silence the writer will synthesise in one go to catch up to wall clock.
+// The read that precedes it times out at 0.1 s, so a healthy loop owes about
+// that much; this leaves an order of magnitude for scheduling jitter and treats
+// anything beyond it as a clock jump to be absorbed, not replayed.
+let kMaxSilenceCatchUp = 1.0
+
 // MARK: - small helpers
 
 func emit(_ json: String) {
@@ -499,7 +505,20 @@ func runCapture(pid: pid_t?) -> Int32 {
                 if gStop { break }
                 // Fill the silence the tap owes us, so the reader sees an
                 // unbroken 24 kHz stream whether or not the target is playing.
-                let owed = Int(Date().timeIntervalSince(writtenUntil) * kOutRate)
+                //
+                // Bounded, because the debt is measured against wall clock and
+                // wall clock can jump: system sleep freezes this thread, and a
+                // reader that stops draining stdout blocks it in writePCM. Both
+                // return with writtenUntil hours behind, and materialising that
+                // as one array is 2 bytes per 1/24000 s - an eight-hour sleep
+                // asks for 1.4 GB and kills the helper instead of resuming it.
+                // Past the cap the debt is uncollectable anyway: nobody wants
+                // hours of injected silence, they want the stream to resume.
+                let now = Date()
+                if now.timeIntervalSince(writtenUntil) > kMaxSilenceCatchUp {
+                    writtenUntil = now.addingTimeInterval(-kMaxSilenceCatchUp)
+                }
+                let owed = Int(now.timeIntervalSince(writtenUntil) * kOutRate)
                 if owed > 0 { writePCM([Int16](repeating: 0, count: owed)) }
                 continue
             }

--- a/native/audio-host/mac/main.swift
+++ b/native/audio-host/mac/main.swift
@@ -14,8 +14,12 @@
 //       24000 Hz, 1 channel, signed 16-bit little-endian.
 //       Writes one JSON object per line to stderr:
 //         {"event":"format","sampleRate":24000,"channels":1,"encoding":"s16le"}
-//         {"event":"warning","code":"silent_no_permission"}
+//         {"event":"warning","code":"silent_no_permission|retarget_failed"}
 //         {"event":"error","code":"..."}
+//
+//       A targeted capture starts whether or not the application is currently
+//       playing, and follows the application's audio process objects as macOS
+//       destroys and recreates them - see retarget() below.
 //
 // Exit codes: 0 clean, 1 runtime failure, 2 bad usage.
 //
@@ -200,10 +204,16 @@ final class RingBuffer: @unchecked Sendable {
         lock.unlock()
     }
 
-    /// Blocks until at least `minimum` samples are available or the ring closes.
-    func read(into dst: inout [Float], minimum: Int) -> Int {
+    /// Blocks until at least `minimum` samples are available, the ring closes,
+    /// or `timeout` elapses. A timeout returns 0 and is not an error: a tap
+    /// whose process list is momentarily empty delivers no buffers at all - not
+    /// even silent ones - so the caller has to make up the missing time itself.
+    func read(into dst: inout [Float], minimum: Int, timeout: TimeInterval) -> Int {
         lock.lock()
-        while count < minimum && !closed { lock.wait() }
+        let deadline = Date().addingTimeInterval(timeout)
+        while count < minimum && !closed {
+            if !lock.wait(until: deadline) { break }
+        }
         let n = min(count, dst.count)
         for i in 0..<n { dst[i] = storage[(readIndex + i) % storage.count] }
         readIndex = (readIndex + n) % storage.count
@@ -251,9 +261,16 @@ func ppidOf(_ pid: pid_t) -> pid_t {
 /// even silence. Windows already captures the whole tree
 /// (PROCESS_LOOPBACK_MODE_INCLUDE_TARGET_PROCESS_TREE) and Linux links every one
 /// of the app's streams; this brings macOS in line.
+///
+/// The result is a snapshot, never a constant: measured on macOS 15.7.3, an
+/// audio process object is destroyed when its process stops rendering and a
+/// fresh one is created for the replacement. Killing Chrome's
+/// audio.mojom.AudioService child took its object out of Chrome's tree and the
+/// respawned service arrived as a different object under a different pid, so a
+/// list resolved once at capture start goes stale on its own.
 func audioObjectsInTree(of targetPid: pid_t) -> [AudioObjectID] {
     let all = objectIDs(kAudioHardwarePropertyProcessObjectList)
-    return all.filter { obj in
+    return all.sorted().filter { obj in
         // pidOf is optional; an object without a pid cannot be in any tree.
         guard var current = pidOf(obj) else { return false }
         // Walk up to the target; the depth bound stops a cycle from hanging us.
@@ -266,6 +283,73 @@ func audioObjectsInTree(of targetPid: pid_t) -> [AudioObjectID] {
     }
 }
 
+/// The tap description for one target. `nil` processes means the whole system.
+///
+/// A targeted capture always uses the mixdown initialiser, even while the list
+/// is empty. The two initialisers are not interchangeable and the difference is
+/// the whole per-application feature: measured on macOS 15.7.3, a mixdown tap
+/// with an empty list captures nothing and clocks nothing, while the global
+/// initialiser with an empty exclusion list captures every application. Reaching
+/// for the wrong one when a target momentarily owns no audio objects is how a
+/// capture of one application silently becomes a capture of all of them.
+func tapDescription(processes: [AudioObjectID]?, uuid: UUID) -> CATapDescription {
+    let desc = processes.map { CATapDescription(monoMixdownOfProcesses: $0) }
+        ?? CATapDescription(stereoGlobalTapButExcludeProcesses: [])
+    desc.uuid = uuid
+    desc.name = "Sokuji Application Capture"
+    desc.isPrivate = true   // visible only to us; CATapUnmuted is the default
+    return desc
+}
+
+/// Point a live tap at a new set of process objects.
+///
+/// Writing kAudioTapPropertyDescription on a running tap is honoured in place:
+/// measured on macOS 15.7.3, the HAL re-reads the list, audio from the newly
+/// named processes arrives within one poll interval, and the aggregate device
+/// keeps its IOProc, its clock and its sample rate throughout - no rebuild, no
+/// gap in the frame count. That is why this is a property write rather than a
+/// teardown of the tap, the aggregate device and the writer thread.
+func retarget(_ tapID: AudioObjectID, processes: [AudioObjectID], uuid: UUID) -> OSStatus {
+    var addr = globalAddress(kAudioTapPropertyDescription)
+    var boxed: CATapDescription? = tapDescription(processes: processes, uuid: uuid)
+    return withUnsafeMutablePointer(to: &boxed) {
+        AudioObjectSetPropertyData(tapID, &addr, 0, nil,
+                                   UInt32(MemoryLayout<CATapDescription?>.size), $0)
+    }
+}
+
+/// The tap's current sample rate and channel count, read off the aggregate
+/// device's input stream. Re-read after a retarget: the rate is the one thing a
+/// new process list could plausibly change under the writer thread.
+func inputFormat(of aggID: AudioObjectID) -> (rate: Double, channels: UInt32)? {
+    var streamAddr = AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyStreams,
+                                                mScope: kAudioObjectPropertyScopeInput,
+                                                mElement: kAudioObjectPropertyElementMain)
+    var streamSize: UInt32 = 0
+    AudioObjectGetPropertyDataSize(aggID, &streamAddr, 0, nil, &streamSize)
+    guard streamSize >= UInt32(MemoryLayout<AudioObjectID>.size) else { return nil }
+    var streamIDs = [AudioObjectID](repeating: 0, count: Int(streamSize) / MemoryLayout<AudioObjectID>.size)
+    guard AudioObjectGetPropertyData(aggID, &streamAddr, 0, nil, &streamSize, &streamIDs) == noErr,
+          let first = streamIDs.first else { return nil }
+    var fmtAddr = globalAddress(kAudioStreamPropertyVirtualFormat)
+    var asbd = AudioStreamBasicDescription()
+    var asbdSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
+    guard AudioObjectGetPropertyData(first, &fmtAddr, 0, nil, &asbdSize, &asbd) == noErr,
+          asbd.mSampleRate > 0 else { return nil }
+    return (asbd.mSampleRate, max(1, asbd.mChannelsPerFrame))
+}
+
+/// Resampling ratio shared between the watch loop and the writer thread. It was
+/// a `let` while the tap was immutable; a retarget can in principle bring a new
+/// sample rate, and a writer using the old one would drift.
+final class RatioBox: @unchecked Sendable {
+    private var value: Double
+    private let lock = NSLock()
+    init(_ v: Double) { value = v }
+    var current: Double { lock.lock(); defer { lock.unlock() }; return value }
+    func set(_ v: Double) { lock.lock(); value = v; lock.unlock() }
+}
+
 @inline(__always)
 func appendSample(_ pcm: inout [Int16], _ v: Float) {
     let clamped = max(-1.0, min(1.0, v))
@@ -273,24 +357,23 @@ func appendSample(_ pcm: inout [Int16], _ v: Float) {
 }
 
 func runCapture(pid: pid_t?) -> Int32 {
-    var procObjs: [AudioObjectID] = []
-    if let pid {
-        procObjs = audioObjectsInTree(of: pid)
-        guard !procObjs.isEmpty else {
-            emitError("no_such_audio_process")
-            return 1
-        }
+    // The target must exist, but it need not be making a sound. An application
+    // owns audio process objects only while something in its tree renders, so
+    // requiring a non-empty list here refused to capture any application that
+    // happened to be quiet at the moment the user pressed start - which is most
+    // of them, most of the time. The tap is created empty instead and adopts the
+    // target's objects as they appear, exactly as it does when they are replaced
+    // mid-session.
+    if let pid, kill(pid, 0) != 0, errno == ESRCH {
+        emitError("no_such_audio_process")
+        return 1
     }
+    var procObjs: [AudioObjectID] = pid.map { audioObjectsInTree(of: $0) } ?? []
 
     let tapUUID = UUID()
-    // Excluding nothing yields a global tap; both variants are governed by the
-    // same audio-capture permission.
-    let desc = procObjs.isEmpty
-        ? CATapDescription(stereoGlobalTapButExcludeProcesses: [])
-        : CATapDescription(monoMixdownOfProcesses: procObjs)
-    desc.uuid = tapUUID
-    desc.name = "Sokuji Application Capture"
-    desc.isPrivate = true   // visible only to us; CATapUnmuted is the default
+    // Global and per-application taps are governed by the same audio-capture
+    // permission; see tapDescription for why the two are never interchanged.
+    let desc = tapDescription(processes: pid == nil ? nil : procObjs, uuid: tapUUID)
 
     var tapID: AudioObjectID = 0
     guard AudioHardwareCreateProcessTap(desc, &tapID) == noErr else {
@@ -326,29 +409,15 @@ func runCapture(pid: pid_t?) -> Int32 {
     // than assume - the decimation factor below depends on it.
     var inRate = 48000.0
     var channelsIn: UInt32 = 1
-    var streamAddr = AudioObjectPropertyAddress(mSelector: kAudioDevicePropertyStreams,
-                                                mScope: kAudioObjectPropertyScopeInput,
-                                                mElement: kAudioObjectPropertyElementMain)
-    var streamSize: UInt32 = 0
-    AudioObjectGetPropertyDataSize(aggID, &streamAddr, 0, nil, &streamSize)
-    if streamSize >= UInt32(MemoryLayout<AudioObjectID>.size) {
-        var streamIDs = [AudioObjectID](repeating: 0, count: Int(streamSize) / MemoryLayout<AudioObjectID>.size)
-        if AudioObjectGetPropertyData(aggID, &streamAddr, 0, nil, &streamSize, &streamIDs) == noErr,
-           let first = streamIDs.first {
-            var fmtAddr = globalAddress(kAudioStreamPropertyVirtualFormat)
-            var asbd = AudioStreamBasicDescription()
-            var asbdSize = UInt32(MemoryLayout<AudioStreamBasicDescription>.size)
-            if AudioObjectGetPropertyData(first, &fmtAddr, 0, nil, &asbdSize, &asbd) == noErr, asbd.mSampleRate > 0 {
-                inRate = asbd.mSampleRate
-                if asbd.mChannelsPerFrame > 0 { channelsIn = asbd.mChannelsPerFrame }
-            }
-        }
+    if let fmt = inputFormat(of: aggID) {
+        inRate = fmt.rate
+        channelsIn = fmt.channels
     }
     // Resample by the true ratio, not an integer one. Rounding it meant a
     // 44.1 kHz tap - the common case on macOS - emitted 22050 Hz while still
     // declaring 24000 Hz, so everything downstream ran ~9% fast; a 16 kHz tap
     // (a Bluetooth headset in HFP) was out by a third.
-    let ratio = inRate / kOutRate
+    let ratioBox = RatioBox(inRate / kOutRate)
 
     let ring = RingBuffer(capacity: Int(inRate) * 2)   // ~2 s of slack
     let state = CaptureState()
@@ -408,9 +477,36 @@ func runCapture(pid: pid_t?) -> Int32 {
         var previous: Float = 0
         var havePrevious = false
 
+        // Wall-clock position of the last sample written. A tap with no process
+        // in it - a target that has not started playing yet - delivers no
+        // buffers at all, so without this the stream would simply stop until the
+        // application made a sound, and everything downstream is built on the
+        // stream never stalling.
+        var writtenUntil = Date()
+
+        func writePCM(_ samples: [Int16]) {
+            guard !samples.isEmpty else { return }
+            samples.withUnsafeBufferPointer { bp in
+                let data = Data(bytes: bp.baseAddress!, count: bp.count * MemoryLayout<Int16>.size)
+                out.write(data)
+            }
+            writtenUntil = writtenUntil.addingTimeInterval(Double(samples.count) / kOutRate)
+        }
+
         while !gStop {
-            let n = ring.read(into: &floats, minimum: 256)
-            if n == 0 { if gStop { break } else { continue } }
+            let n = ring.read(into: &floats, minimum: 256, timeout: 0.1)
+            if n == 0 {
+                if gStop { break }
+                // Fill the silence the tap owes us, so the reader sees an
+                // unbroken 24 kHz stream whether or not the target is playing.
+                let owed = Int(Date().timeIntervalSince(writtenUntil) * kOutRate)
+                if owed > 0 { writePCM([Int16](repeating: 0, count: owed)) }
+                continue
+            }
+            // Real audio has resumed; drop any silence we were about to owe
+            // rather than inserting it in front of the samples.
+            if writtenUntil < Date() { writtenUntil = Date() }
+            let ratio = ratioBox.current
 
             pcm.removeAll(keepingCapacity: true)
             while true {
@@ -443,17 +539,14 @@ func runCapture(pid: pid_t?) -> Int32 {
             previous = floats[n - 1]
             havePrevious = true
 
-            if !pcm.isEmpty {
-                pcm.withUnsafeBufferPointer { bp in
-                    let data = Data(bytes: bp.baseAddress!, count: bp.count * MemoryLayout<Int16>.size)
-                    out.write(data)
-                }
-            }
+            writePCM(pcm)
         }
     }
     writer.start()
 
     // Watch the target and the permission situation from the main thread.
+    var warnedRetarget = false
+    var renderingSince: Date? = nil
     while !gStop {
         Thread.sleep(forTimeInterval: 0.25)
 
@@ -462,6 +555,32 @@ func runCapture(pid: pid_t?) -> Int32 {
             emitError("target_gone")
             gStop = true
             break
+        }
+
+        // Follow the target's audio process objects. Polling here rather than
+        // installing a property listener keeps the update on the thread that
+        // already owns teardown, so a listener callback cannot race the tap's
+        // destruction.
+        if let pid {
+            let current = audioObjectsInTree(of: pid)
+            if current != procObjs {
+                let status = retarget(tapID, processes: current, uuid: tapUUID)
+                if status == noErr {
+                    procObjs = current
+                    // A new process list could in principle bring a new sample
+                    // rate; the writer would drift on the old one.
+                    if let fmt = inputFormat(of: aggID), fmt.rate > 0 {
+                        ratioBox.set(fmt.rate / kOutRate)
+                    }
+                } else if !warnedRetarget {
+                    // A warning, not an error: the app answers an error by
+                    // tearing the capture down, and a tap still pointing at the
+                    // previous objects is worth more than no tap at all. Once
+                    // only - this loop runs four times a second.
+                    warnedRetarget = true
+                    emit("{\"event\":\"warning\",\"code\":\"retarget_failed\"}")
+                }
+            }
         }
 
         // A missing TCC grant and a quiet application both look like silence,
@@ -475,7 +594,28 @@ func runCapture(pid: pid_t?) -> Int32 {
             && Date().timeIntervalSince(state.startedAt) > 3.0
         state.lock.unlock()
 
-        if unexplainedSilence && isRenderingOutput(procObjs) {
+        // `procObjs` is now the live list, which is what makes this diagnostic
+        // work at all: guarded by the frozen one it could never fire, because
+        // the objects it asked about were the dead ones. An empty targeted list
+        // means the target is rendering nothing - not "ask the whole system",
+        // which is what isRenderingOutput does with an empty argument.
+        let targetRendering = pid == nil
+            ? isRenderingOutput([])
+            : (!procObjs.isEmpty && isRenderingOutput(procObjs))
+
+        // "Rendering" leads the first audible sample by a poll or two - Core
+        // Audio marks the process as running output before the tap has handed us
+        // anything - so an instantaneous reading fires the warning at the exact
+        // moment a target starts playing, which is the one moment we can be sure
+        // the permission is fine. Require the contradiction to hold for a while.
+        if targetRendering {
+            if renderingSince == nil { renderingSince = Date() }
+        } else {
+            renderingSince = nil
+        }
+        let renderingLongEnough = renderingSince.map { Date().timeIntervalSince($0) > 2.0 } ?? false
+
+        if unexplainedSilence && renderingLongEnough {
             state.lock.lock()
             state.warned = true
             state.lock.unlock()

--- a/native/audio-host/mac/verify.sh
+++ b/native/audio-host/mac/verify.sh
@@ -21,7 +21,7 @@
 #
 # Expected output ends with VERIFY OK.
 set -uo pipefail
-cd "$(dirname "$0")"
+cd "$(dirname "$0")" || exit 1
 
 BIN=${1:-out/sokuji-audio-host-darwin-arm64}
 [ -x "$BIN" ] || { echo "not built: $BIN (run mac/build.sh)"; exit 1; }
@@ -121,9 +121,15 @@ T=$!
 ( sleep 1; afplay "$TONE" ) &
 capture "$WORK/c.pcm" "$WORK/c.log" "pid:$T" 6
 kill $T 2>/dev/null; wait 2>/dev/null
-CPEAK=$(peaks "$WORK/c.pcm" | tail -1 | tr ' ' '\n' | sort -n | tail -1)
-echo "  peak from a silent target while another process plays: ${CPEAK:-0}"
-[ "${CPEAK:-0}" -lt 100 ]; check "a silent target does not capture other applications" $?
+if [ "$GRANTED" = yes ]; then
+  CPEAK=$(peaks "$WORK/c.pcm" | tail -1 | tr ' ' '\n' | sort -n | tail -1)
+  echo "  peak from a silent target while another process plays: ${CPEAK:-0}"
+  [ "${CPEAK:-0}" -lt 100 ]; check "a silent target does not capture other applications" $?
+else
+  # Without the grant every sample is zero whether the tap is isolated or
+  # global, so this assertion would pass without testing anything.
+  echo "  skip - isolation is unjudgeable without System Audio Recording"
+fi
 
 echo
 if [ "$fails" -eq 0 ]; then echo "VERIFY OK"; else echo "VERIFY FAILED ($fails)"; exit 1; fi

--- a/native/audio-host/mac/verify.sh
+++ b/native/audio-host/mac/verify.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Acceptance test for sokuji-audio-host on macOS (issues #335, #393).
+#
+# Proves the four properties the per-application path rests on:
+#   1. Continuity  - the stream flows at the right rate while the target is
+#      silent, so nothing downstream has to fill gaps.
+#   2. Late start  - an application that is not playing when the session starts
+#      is still captured once it does. Its audio process objects do not exist
+#      yet at that moment, and refusing to start on that basis refused most
+#      applications most of the time.
+#   3. Retargeting - when the target replaces the child that renders its audio -
+#      what Chrome does with its audio.mojom.AudioService - capture follows it
+#      instead of going permanently silent on a dead object.
+#   4. Isolation   - a target that never plays yields silence while another
+#      process is audibly playing, i.e. the tap did not widen to everything.
+#
+# The audio assertions need the "System Audio Recording Only" grant, which TCC
+# attributes to the *responsible* process - here the terminal, not this script.
+# Without it every sample is zero by design; the script detects that, keeps the
+# structural assertions and skips the ones it cannot judge.
+#
+# Expected output ends with VERIFY OK.
+set -uo pipefail
+cd "$(dirname "$0")"
+
+BIN=${1:-out/sokuji-audio-host-darwin-arm64}
+[ -x "$BIN" ] || { echo "not built: $BIN (run mac/build.sh)"; exit 1; }
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+TONE=$WORK/tone.wav
+
+# 440 Hz at amplitude 12000, 44.1 kHz mono - deliberately NOT the 24 kHz capture
+# rate, so a pass also proves the helper's resampling ratio is right.
+python3 - "$TONE" <<'PY'
+import math, struct, sys, wave
+w = wave.open(sys.argv[1], 'w')
+w.setnchannels(1); w.setsampwidth(2); w.setframerate(44100)
+w.writeframes(b''.join(struct.pack('<h', int(12000 * math.sin(2 * math.pi * 440 * t / 44100)))
+                      for t in range(44100 * 4)))
+w.close()
+PY
+
+fails=0
+check() {  # check <description> <condition-exit-status>
+  if [ "$2" -eq 0 ]; then echo "  ok   - $1"; else echo "  FAIL - $1"; fails=$((fails + 1)); fi
+}
+
+# peaks <pcm> -> one peak amplitude per second of 24 kHz mono s16, plus duration
+peaks() {
+  python3 - "$1" <<'PY'
+import struct, sys
+d = open(sys.argv[1], 'rb').read()
+s = struct.unpack('<%dh' % (len(d) // 2), d[:len(d) // 2 * 2])
+print('%.2f' % (len(s) / 24000.0))
+print(' '.join(str(max((abs(x) for x in s[i*24000:(i+1)*24000]), default=0))
+               for i in range(int(len(s) / 24000))))
+PY
+}
+
+# capture <pcm-out> <log-out> <target> <seconds>
+capture() {
+  "$BIN" --target "$3" > "$1" 2> "$2" &
+  local h=$!
+  sleep "$4"
+  kill -TERM $h 2>/dev/null
+  wait $h 2>/dev/null
+}
+
+echo "== sokuji-audio-host verify ($BIN) =="
+
+# Is the grant present? A global tap over a tone answers that in one shot, and
+# whether the helper resamples correctly at all.
+( sleep 1; afplay "$TONE" ) &
+capture "$WORK/g.pcm" "$WORK/g.log" system 6
+wait 2>/dev/null
+read -r GDUR <<< "$(peaks "$WORK/g.pcm" | head -1)"
+GPEAK=$(peaks "$WORK/g.pcm" | tail -1 | tr ' ' '\n' | sort -n | tail -1)
+GRANTED=$([ "${GPEAK:-0}" -gt 1000 ] && echo yes || echo no)
+echo "global tap: ${GDUR}s captured, peak ${GPEAK:-0}, grant=$GRANTED"
+if [ "$GRANTED" = no ]; then
+  echo "  NOTE: no System Audio Recording grant for this terminal - audio-content"
+  echo "        assertions are skipped. Structural ones still apply."
+fi
+
+# 1 + 2. Target owns no audio object at capture start, plays three seconds in.
+echo "-- idle at start, plays later --"
+bash -c 'sleep 3; afplay "$0"' "$TONE" &
+T=$!
+capture "$WORK/a.pcm" "$WORK/a.log" "pid:$T" 8
+kill $T 2>/dev/null; wait 2>/dev/null
+ADUR=$(peaks "$WORK/a.pcm" | head -1)
+APEAKS=$(peaks "$WORK/a.pcm" | tail -1)
+echo "  ${ADUR}s captured, per-second peaks: $APEAKS"
+grep -q no_such_audio_process "$WORK/a.log"; check "starts on an idle target" $((1 - $?))
+grep -q '"event":"format"' "$WORK/a.log"; check "announces its format" $?
+awk -v d="$ADUR" 'BEGIN { exit !(d > 6.5) }'; check "stream never stalls (>6.5s in 8s)" $?
+if [ "$GRANTED" = yes ]; then
+  echo "$APEAKS" | awk '{ exit !($1 == 0 && $NF > 1000) }'
+  check "silent before playback, audible after" $?
+fi
+
+# 3. The child holding the audio is replaced while capture is running.
+echo "-- audio child replaced mid-capture --"
+bash -c 'afplay "$0"; afplay "$0"' "$TONE" &
+T=$!
+sleep 0.5
+capture "$WORK/b.pcm" "$WORK/b.log" "pid:$T" 8
+kill $T 2>/dev/null; wait 2>/dev/null
+BPEAKS=$(peaks "$WORK/b.pcm" | tail -1)
+echo "  per-second peaks: $BPEAKS"
+if [ "$GRANTED" = yes ]; then
+  echo "$BPEAKS" | awk '{ for (i = 1; i <= NF; i++) if ($i < 1000) exit 1; exit 0 }'
+  check "audio survives the target's audio child being replaced" $?
+fi
+
+# 4. A target that never plays must not pick up the tone another process plays.
+echo "-- isolation --"
+bash -c 'sleep 30' &
+T=$!
+( sleep 1; afplay "$TONE" ) &
+capture "$WORK/c.pcm" "$WORK/c.log" "pid:$T" 6
+kill $T 2>/dev/null; wait 2>/dev/null
+CPEAK=$(peaks "$WORK/c.pcm" | tail -1 | tr ' ' '\n' | sort -n | tail -1)
+echo "  peak from a silent target while another process plays: ${CPEAK:-0}"
+[ "${CPEAK:-0}" -lt 100 ]; check "a silent target does not capture other applications" $?
+
+echo
+if [ "$fails" -eq 0 ]; then echo "VERIFY OK"; else echo "VERIFY FAILED ($fails)"; exit 1; fi


### PR DESCRIPTION
Closes #393. Both defects the issue describes are real; both were reproduced on hardware (macOS 15.7.3, Apple silicon) against a binary built from `origin/main`, not by code reading alone.

## What was measured

The terminal running the tests happens to hold the "System Audio Recording Only" grant, so these are real samples, not just return codes. Per-second peak amplitude of the helper's PCM output, 11994 = the test tone, 0 = silence:

| scenario | before | after |
|---|---|---|
| target owns no audio object when capture starts | `no_such_audio_process`, 0 bytes, channel never starts | `[0,0,0,11994,11994,11994,11994]` — clocked silence, then audio when playback begins |
| target's audio child replaced mid-capture | `[11994,11994,11994,11994,0,0,0,0]` — buffers still arrive on schedule, every sample zero, no warning | `[11994]×7` |

The Chrome case named in the issue was confirmed directly: killing `--utility-sub-type=audio.mojom.AudioService` (pid 91594, audio object 199) had Chrome respawn it as pid 92227 carrying a **new** object 202, while 199 vanished from the process object list. The HAL then prunes dead objects from the tap, leaving its process list empty — hence permanent silence with the session still looking healthy.

Two corrections to the issue's analysis:

- **Its reproduction plan probably would not reproduce.** Chrome shares one AudioService across tabs, so opening a second playing tab does not change the process set. The trigger is the AudioService being recycled — idle timeout, crash, or a manual kill.
- **"An empty process list could silently become capture-everything" is not the case.** The two initialisers set different flags and do not collapse into each other: a `monoMixdownOfProcesses: []` tap reads peak 0.0000 while another process is audibly playing, where a global tap on the same audio reads 11994. That is what makes it safe to create the tap before the target owns anything. It does deliver no buffers at all in that state — not even silent ones, unlike the Windows path — which is why the writer now synthesises silence.

## The fix

Option A from the issue, and it works: writing `kAudioTapPropertyDescription` on a **running** tap returns `noErr`, the HAL re-reads the list, audio from the newly named processes resumes within one poll, and the aggregate device keeps its IOProc, its clock and its sample rate throughout — no rebuild, no gap in the frame count. Option B's teardown was unnecessary.

- The target's audio process objects are recomputed in the 0.25 s watch loop that already exists; a change is written onto the live tap. Polling rather than a property listener keeps the update on the thread that already owns teardown.
- The rate is re-read after a retarget and `ratio` becomes a synchronised value, since a writer holding the old one would drift.
- Capture no longer refuses a target that owns no audio object yet — only one whose pid is gone. The tap is created empty and adopts objects as they appear.
- A failed retarget is a `warning`, not an `error`: the renderer answers an error by tearing the recorder down, and a tap still pointing at the previous objects beats no tap at all.

Two smaller bugs fall out of making the list live, and are fixed here:

- `isRenderingOutput` treats an empty argument as "ask the whole system", which would have made the permission warning fire on any application's audio once a targeted list could legitimately be empty.
- Core Audio marks a process as running output a poll or two before the tap hands over anything audible, which fired `silent_no_permission` at the exact moment playback started — the one moment the permission is provably fine. The contradiction now has to hold for two seconds. (This one bit the first version of the patch.)

## Verification

`native/audio-host/mac/verify.sh` is new — the macOS counterpart to `win/verify.ps1`. It covers late start, mid-session retargeting, stream continuity and isolation, and degrades gracefully when the terminal has no TCC grant.

```
VERIFY OK                       # this branch
VERIFY FAILED (5), exit 1       # the previous binary
```

`mac/build.sh` builds both slices clean. `electron/audio-host.test.js` + `AppAudioRecorder.test.ts`: 47 passed.

## Not covered

A full Chrome session end-to-end (play audio in Chrome, let the AudioService recycle mid-session) needs an interactive desktop and was not run. The mechanism it depends on was measured separately, as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved macOS audio capture for applications that start silently or change their audio processes during playback.
  - Added support for dynamic process retargeting, more reliable silence handling, and stereo-to-mono input conversion.
  - Capture now adapts to changing audio formats and reports retargeting failures more clearly.

- **Bug Fixes**
  - Reduced false permission warnings by requiring sustained, unexplained silence before reporting an issue.
  - Added clearer handling for missing audio processes and non-fatal capture warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->