### PR TITLE
chore(deps): upgrade @google/genai to 2.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@electron/fuses": "^2.0.0",
         "@electron/rebuild": "^4.2.0",
         "@floating-ui/react": "^0.27.15",
-        "@google/genai": "^1.46.0",
+        "@google/genai": "^2.16.0",
         "@huggingface/transformers": "^4.2.0",
         "@ricky0123/vad-web": "^0.0.30",
         "@sapphi-red/web-noise-suppressor": "^0.3.5",
@@ -2002,9 +2002,9 @@
       }
     },
     "node_modules/@google/genai": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
-      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-2.16.0.tgz",
+      "integrity": "sha512-K+1C1sqR0u7NJ5xpKJCQBws0QXpfuklo3WTNuUIMvtbQfNW2O5OohX0BYT2V+PXzsUzQEwGCXPWQxttLyGQ6xw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@electron/fuses": "^2.0.0",
     "@electron/rebuild": "^4.2.0",
     "@floating-ui/react": "^0.27.15",
-    "@google/genai": "^1.46.0",
+    "@google/genai": "^2.16.0",
     "@huggingface/transformers": "^4.2.0",
     "@ricky0123/vad-web": "^0.0.30",
     "@sapphi-red/web-noise-suppressor": "^0.3.5",


### PR DESCRIPTION
Prerequisite for #392 (Gemini 3.5 Live Translate as a dedicated provider). Not the feature itself — this only unblocks it.

## Why

`LiveConnectConfig.translationConfig` — the field carrying `targetLanguageCode` / `echoTargetLanguage` — **exists only in 2.x**. The range was pinned `^1.46.0`, which resolves no higher than 1.52.0, where the field is absent entirely:

```
1.52.0  grep -c translationConfig dist/genai.d.ts  ->  0
2.16.0  LiveConnectConfig.translationConfig?: TranslationConfig  ✅
```

## Why this is smaller than it looks

`v2.0.0` is the **only** breaking release in the 2.x line, and its breaks are scoped to the Interactions API — the release notes state `GenerateContent` usage is unaffected, and Live is untouched. Sokuji uses neither.

The entire SDK surface in use, across just two files (`GeminiClient.ts` + its test), is `new GoogleGenAI()`, `live.connect()`, `session.sendRealtimeInput()`, `session.close()`, and nine type/enum imports. All nine survive unchanged into 2.16.0.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` vs a reinstalled 1.52.0 baseline | **byte-identical output** — 281 pre-existing errors either way, **0 new** |
| Full test suite | 192 files / 2242 tests passing |
| `npm run build` | exit 0; renderer + electron artifacts produced |

Those 281 type errors are long-standing, not introduced here — the project has no `typecheck` script and `vite build` goes through esbuild, which strips types without checking them. I reinstalled 1.52.0 and re-ran `tsc` specifically to prove the diff is empty rather than assume it.

## Caveats worth a reviewer's attention

- **`GeminiClient.test.ts` mocks `@google/genai` wholesale**, so 21/21 green asserts nothing about real SDK behavior. The typecheck diff is the actual signal here. **A live Gemini session remains unexercised** — worth one manual smoke test before this rides into a release.
- 2.x deprecates `LiveConnectConfig.generationConfig` for removal in the next major. `GeminiClient` sets every field at the `LiveConnectConfig` top level, so it is unaffected. (This also happens to sidestep the `1007` error other developers hit when following the docs, which place transcription config under `generationConfig`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Google GenAI development tooling to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->