### PR TITLE
feat(gemini): pin Live Translate's target language with translationConfig

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -30,6 +30,7 @@ import { ProviderConfigFactory } from '../../services/providers/ProviderConfigFa
 import { sonioxUsesSharedBothSession, SonioxProviderConfig } from '../../services/providers/SonioxProviderConfig';
 import { reverseTranscriptionDirection } from '../../services/providers/openaiTranscriptionContext';
 import { reverseGeminiTranslationDirection } from '../../services/providers/geminiTranslateModel';
+import { reversesDirectionViaSourceLanguage } from '../../services/providers/autoSourceReversal';
 import {
   useConversationDisplayFontSize,
   useSetConversationDisplayFontSize,
@@ -561,16 +562,19 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     return null;
   }, [currentMode, selectedInputDevice?.deviceId]);
 
-  // Soniox carries direction in source/target and reverses them for the
-  // participant client. An 'auto' source can't be reversed — the participant's
-  // translate target would become 'auto', which Soniox one_way rejects — so
-  // Others/Both with an 'auto' source can't start. Matches the LanguageSection
-  // warning (`showSonioxAutoParticipantWarning`); the user must pick a concrete
-  // source first. `participantWillStart` === isParticipantChannelInScope.
+  // Soniox reverses source/target for the participant client, and Gemini Live
+  // Translate reverses `translationConfig.targetLanguageCode` — see
+  // reversesDirectionViaSourceLanguage. An 'auto' source can't be reversed for
+  // either: the participant's translate target would become the literal
+  // 'auto', which Soniox one_way rejects and which is not a language code for
+  // Gemini. So Others/Both with an 'auto' source can't start. Matches the
+  // LanguageSection warning (`showAutoSourceParticipantWarning`); the user must
+  // pick a concrete source first. `participantWillStart` ===
+  // isParticipantChannelInScope.
   //
   // Resolves the EFFECTIVE provider (kizunaBaseProvider) and reads the
   // ACTIVE provider's settings slice via its descriptor's settingsSliceKey —
-  // mirrors LanguageSection.showSonioxAutoParticipantWarning exactly. A raw
+  // mirrors LanguageSection.showAutoSourceParticipantWarning exactly. A raw
   // `provider === Provider.SONIOX` check against the hardcoded `soniox` slice
   // (as this used to be) is always false for the KIZUNA_AI_SONIOX managed
   // twin, so this gate silently no-op'd for it: LanguageSection still showed
@@ -581,8 +585,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
   const activeProviderSourceLanguage = useSettingsStore(
     (s) => (s[ProviderConfigFactory.getDescriptor(s.provider).settingsSliceKey as keyof SettingsStore] as { sourceLanguage?: string } | undefined)?.sourceLanguage
   );
-  const sonioxAutoParticipantBlocked =
-    (kizunaBaseProvider(provider) ?? provider) === Provider.SONIOX &&
+  const activeProviderModel = useSettingsStore(
+    (s) => (s[ProviderConfigFactory.getDescriptor(s.provider).settingsSliceKey as keyof SettingsStore] as { model?: string } | undefined)?.model
+  );
+  const autoSourceParticipantBlocked =
+    reversesDirectionViaSourceLanguage(provider, activeProviderModel) &&
     participantWillStart && activeProviderSourceLanguage === 'auto';
 
   // canStartSession requires the *intended* mode to have all its devices
@@ -601,10 +608,10 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       provider,
       quota,
       missingDeviceForMode,
-      sonioxAutoParticipantBlocked,
+      autoSourceParticipantBlocked,
       textOnly,
     }),
-    [isApiKeyValid, availableModels.length, loadingModels, isInitializing, provider, quota, missingDeviceForMode, sonioxAutoParticipantBlocked, textOnly],
+    [isApiKeyValid, availableModels.length, loadingModels, isInitializing, provider, quota, missingDeviceForMode, autoSourceParticipantBlocked, textOnly],
   );
   const canStartSession = startGate.canStart;
 
@@ -1906,7 +1913,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       //
       // Resolves the EFFECTIVE provider and reads the ACTIVE provider's settings
       // slice (soniox for BYOK, kizunaSoniox for the KIZUNA_AI_SONIOX managed
-      // twin) — mirrors the sonioxAutoParticipantBlocked gate above. A raw
+      // twin) — mirrors the autoSourceParticipantBlocked gate above. A raw
       // `provider === Provider.SONIOX` check against the hardcoded `soniox` slice
       // (as this used to be) is always false for the twin, so it opened TWO
       // independent managed sessions instead of one shared one; the backend's

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -29,6 +29,7 @@ import type { SettingsStore } from '../../stores/settingsStore';
 import { ProviderConfigFactory } from '../../services/providers/ProviderConfigFactory';
 import { sonioxUsesSharedBothSession, SonioxProviderConfig } from '../../services/providers/SonioxProviderConfig';
 import { reverseTranscriptionDirection } from '../../services/providers/openaiTranscriptionContext';
+import { reverseGeminiTranslationDirection } from '../../services/providers/geminiTranslateModel';
 import {
   useConversationDisplayFontSize,
   useSetConversationDisplayFontSize,
@@ -47,7 +48,7 @@ import { useLogActions } from '../../stores/logStore';
 import { useNativeAsrLoading } from '../../stores/nativeModelStore';
 import type { RealtimeEvent } from '../../stores/logStore';
 import { IClient, ConversationItem, SessionConfig, ClientEventHandlers, ClientFactory, ResponseConfig } from '../../services/clients';
-import type { VolcengineAST2SessionConfig, VolcengineSTSessionConfig, LocalInferenceSessionConfig, LocalNativeSessionConfig, OpenAITranslateSessionConfig, OpenAISessionConfig, TranslateTargetLanguage, ZoomAISessionConfig, SonioxSessionConfig, PalabraAISessionConfig } from '../../services/interfaces/IClient';
+import type { VolcengineAST2SessionConfig, VolcengineSTSessionConfig, LocalInferenceSessionConfig, LocalNativeSessionConfig, OpenAITranslateSessionConfig, OpenAISessionConfig, TranslateTargetLanguage, ZoomAISessionConfig, SonioxSessionConfig, PalabraAISessionConfig, GeminiSessionConfig } from '../../services/interfaces/IClient';
 import { WavRenderer } from '../../utils/wav_renderer';
 import { ServiceFactory } from '../../services/ServiceFactory'; // Import the ServiceFactory
 import { IAudioService } from '../../services/interfaces/IAudioService';
@@ -815,6 +816,16 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       // Force Auto mode for Gemini participant (no PTT for participant)
       ...(baseConfig.provider === 'gemini' ? { turnDetectionMode: 'Auto' as const } : {}),
     };
+
+    // Gemini's dialogue models need nothing here: their direction rides in the
+    // system instruction, which was already swapped above. A Live Translate
+    // session does, because its `translationConfig.targetLanguageCode`
+    // overrules that instruction — left alone, the participant session would
+    // translate the other party's speech into the language they are already
+    // speaking. No-op when no translationConfig is present.
+    if (config.provider === 'gemini') {
+      reverseGeminiTranslationDirection(config as GeminiSessionConfig);
+    }
 
     // OpenAI Translate carries language direction only in `audio.output.language`
     // (not system instructions — translate doesn't accept instructions). Swap

--- a/src/components/MainPanel/sessionStartGate.test.ts
+++ b/src/components/MainPanel/sessionStartGate.test.ts
@@ -17,7 +17,7 @@ const ready: StartGateInput = {
   provider: Provider.OPENAI,
   quota: null,
   missingDeviceForMode: null,
-  sonioxAutoParticipantBlocked: false,
+  autoSourceParticipantBlocked: false,
 };
 
 describe('computeStartGate', () => {
@@ -208,29 +208,29 @@ describe('computeStartGate', () => {
   // Soniox reverses source/target for the participant client, so an 'auto'
   // source cannot be reversed. On main this closed the gate with no
   // explanation at all; it now reports a reason like every other blocker.
-  it('reports soniox-auto-source when auto detection blocks the participant', () => {
-    expect(computeStartGate({ ...ready, sonioxAutoParticipantBlocked: true })).toEqual({
+  it('reports auto-source-participant when auto detection blocks the participant', () => {
+    expect(computeStartGate({ ...ready, autoSourceParticipantBlocked: true })).toEqual({
       canStart: false,
-      reason: 'soniox-auto-source',
+      reason: 'auto-source-participant',
     });
   });
 
-  it('prefers missing-device over soniox-auto-source', () => {
+  it('prefers missing-device over auto-source-participant', () => {
     const gate = computeStartGate({
       ...ready,
       missingDeviceForMode: 'speaker',
-      sonioxAutoParticipantBlocked: true,
+      autoSourceParticipantBlocked: true,
     });
     expect(gate.reason).toBe('missing-device');
   });
 
-  it('prefers soniox-auto-source over a credential problem', () => {
+  it('prefers auto-source-participant over a credential problem', () => {
     const gate = computeStartGate({
       ...ready,
-      sonioxAutoParticipantBlocked: true,
+      autoSourceParticipantBlocked: true,
       isApiKeyValid: false,
     });
-    expect(gate.reason).toBe('soniox-auto-source');
+    expect(gate.reason).toBe('auto-source-participant');
   });
 
   it('prefers wallet-frozen over insufficient-balance', () => {
@@ -257,7 +257,7 @@ describe('reasonToSettingsTarget', () => {
   });
 
   it('routes the Soniox auto-source block to the language settings', () => {
-    expect(reasonToSettingsTarget('soniox-auto-source')).toBe('languages');
+    expect(reasonToSettingsTarget('auto-source-participant')).toBe('languages');
   });
 
   it('routes model and key problems to their sections', () => {
@@ -283,7 +283,7 @@ describe('reasonToSettingsTarget', () => {
 describe('reasonToI18n', () => {
   it('maps every reason to an existing translation key', () => {
     const reasons = [
-      'missing-device', 'soniox-auto-source', 'local-models-missing',
+      'missing-device', 'auto-source-participant', 'local-models-missing',
       'api-key-invalid', 'no-models', 'loading-models', 'wallet-frozen',
       'insufficient-balance', 'quota-unknown',
     ] as const;

--- a/src/components/MainPanel/sessionStartGate.ts
+++ b/src/components/MainPanel/sessionStartGate.ts
@@ -17,7 +17,7 @@ import { formatUsd } from '../../utils/formatters';
 
 export type StartBlockReason =
   | 'missing-device'
-  | 'soniox-auto-source'
+  | 'auto-source-participant'
   | 'local-models-missing'
   | 'api-key-invalid'
   | 'no-models'
@@ -55,12 +55,15 @@ export interface StartGateInput {
   quota: { balance?: number; frozen?: boolean } | null | undefined;
   missingDeviceForMode: DeviceScope | null;
   /**
-   * Soniox carries direction in source/target and reverses them for the
-   * participant client, so an 'auto' source can't be reversed — the
-   * participant's translate target would become 'auto', which Soniox
-   * rejects. True when that combination is selected. See MainPanel.
+   * Some providers build the participant session by swapping a *concrete*
+   * source language into the translate target — Soniox through
+   * source/target, Gemini Live Translate through
+   * `translationConfig.targetLanguageCode`. An 'auto' source cannot be
+   * reversed for either: the participant's target would become the literal
+   * 'auto', which is not a language. True when that combination is selected.
+   * See `reversesDirectionViaSourceLanguage` and MainPanel.
    */
-  sonioxAutoParticipantBlocked: boolean;
+  autoSourceParticipantBlocked: boolean;
   /**
    * Will the session about to start be text-only (no spoken translation)?
    *
@@ -82,7 +85,7 @@ export function computeStartGate(input: StartGateInput): StartGate {
     provider,
     quota,
     missingDeviceForMode,
-    sonioxAutoParticipantBlocked,
+    autoSourceParticipantBlocked,
     textOnly,
   } = input;
 
@@ -118,7 +121,7 @@ export function computeStartGate(input: StartGateInput): StartGate {
     !isInitializing &&
     hasValidBalance &&
     missingDeviceForMode === null &&
-    !sonioxAutoParticipantBlocked;
+    !autoSourceParticipantBlocked;
 
   if (canStart) return { canStart: true, reason: null };
 
@@ -135,8 +138,8 @@ export function computeStartGate(input: StartGateInput): StartGate {
   // generic credential complaint. On main this condition closed the gate
   // with no explanation at all — the silent-disable this module exists to
   // remove.
-  if (sonioxAutoParticipantBlocked) {
-    return { canStart: false, reason: 'soniox-auto-source' };
+  if (autoSourceParticipantBlocked) {
+    return { canStart: false, reason: 'auto-source-participant' };
   }
   if (!isApiKeyValid) {
     // For LOCAL_INFERENCE, "API key valid" is really "required models are
@@ -176,7 +179,7 @@ export function reasonToSettingsTarget(
   switch (reason) {
     case 'missing-device':
       return deviceScope === 'participant' ? 'participant' : 'microphone';
-    case 'soniox-auto-source':
+    case 'auto-source-participant':
       return 'languages';
     case 'local-models-missing':
       return 'model-management';
@@ -210,9 +213,12 @@ export function reasonToI18n(
   switch (reason) {
     case 'missing-device':
       return { key: 'modePicker.missingDevice', defaultValue: 'Configure devices for this mode to start.' };
-    case 'soniox-auto-source':
+    case 'auto-source-participant':
       // Same sentence the language settings already show for this exact
-      // combination (LanguageSection's showSonioxAutoParticipantWarning).
+      // combination (LanguageSection's showAutoSourceParticipantWarning).
+      // The key still reads `soniox...` because Soniox was the first provider
+      // to hit this; the sentence itself never named a provider, and renaming
+      // the key would churn every locale file for no user-visible gain.
       return {
         key: 'settings.sonioxAutoParticipantWarning',
         defaultValue: "Choose a specific source language — with automatic detection, the other participant's speech can't be translated into your language.",

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -38,6 +38,7 @@ import { Provider, kizunaBaseProvider } from '../../../types/Provider';
 import { ProviderConfigFactory } from '../../../services/providers/ProviderConfigFactory';
 import { ProviderConfig } from '../../../services/providers/ProviderConfig';
 import { resolveAST2LanguagePair } from '../../../services/providers/volcengineAST2LanguageSync';
+import { reversesDirectionViaSourceLanguage } from '../../../services/providers/autoSourceReversal';
 import { useIsParticipantChannelInScope } from '../../../stores/audioStore';
 import { changeLanguageWithLoad } from '../../../locales';
 import { useAnalytics } from '../../../lib/analytics';
@@ -385,11 +386,11 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
   // reversed — it would make the participant's translate target 'auto', which
   // Soniox one_way rejects — so require a concrete source language whenever a
   // participant channel is in scope.
-  const showSonioxAutoParticipantWarning = useMemo(() => {
-    return effectiveProvider === Provider.SONIOX
+  const showAutoSourceParticipantWarning = useMemo(() => {
+    return reversesDirectionViaSourceLanguage(effectiveProvider, currentProviderSettings.model)
       && isParticipantChannelInScope
       && currentProviderSettings.sourceLanguage === 'auto';
-  }, [effectiveProvider, isParticipantChannelInScope, currentProviderSettings.sourceLanguage]);
+  }, [effectiveProvider, isParticipantChannelInScope, currentProviderSettings.sourceLanguage, currentProviderSettings.model]);
 
   // Simplified interface language list (12 most common languages)
   const simplifiedLanguages = [
@@ -591,7 +592,7 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
             </div>
           )}
 
-          {showSonioxAutoParticipantWarning && (
+          {showAutoSourceParticipantWarning && (
             <div className="language-warning">
               <AlertTriangle size={12} />
               <span>{t('settings.sonioxAutoParticipantWarning')}</span>

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -4,6 +4,7 @@ import { ProviderConfigFactory } from '../../../services/providers/ProviderConfi
 import { supportsTranscriptionContext } from '../../../services/providers/openaiTranscriptionContext';
 import { OpenAITranscriptModel } from '../../../services/providers/OpenAIProviderConfig';
 import { resolveAST2LanguagePair } from '../../../services/providers/volcengineAST2LanguageSync';
+import { isGeminiTranslateModel } from '../../../services/providers/geminiTranslateModel';
 import {
   useProvider,
   useSystemInstructions,
@@ -442,6 +443,13 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
 
   const renderVoiceSettings = () => {
     if (!config.capabilities.hasVoiceSettings || provider === Provider.PALABRA_AI) {
+      return null;
+    }
+    // Gemini Live Translate reproduces the speaker's own voice; it accepts a
+    // speechConfig and silently ignores it. Offering a picker would promise a
+    // choice that does not exist. Gated per-model rather than per-provider,
+    // the same way reasoning effort is gated to `gpt-realtime-2`.
+    if (provider === Provider.GEMINI && isGeminiTranslateModel(geminiSettings.model)) {
       return null;
     }
 
@@ -985,6 +993,11 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
 
   const renderModelConfigurationSettings = () => {
     if (!config.capabilities.hasModelConfiguration || provider === Provider.PALABRA_AI) {
+      return null;
+    }
+    // Live Translate is a fixed interpreter with no sampling or output-length
+    // controls to offer; GeminiClient stops sending both for that model.
+    if (provider === Provider.GEMINI && isGeminiTranslateModel(geminiSettings.model)) {
       return null;
     }
 

--- a/src/services/clients/GeminiClient.test.ts
+++ b/src/services/clients/GeminiClient.test.ts
@@ -664,3 +664,83 @@ describe('GeminiClient — keepReplayAudio gating', () => {
     expect(assistant!.formatted?.audio).toBeUndefined();
   });
 });
+
+// ─────────────────────────────────────────────
+describe('GeminiClient — Live Translate wire config', () => {
+  let client: InstanceType<typeof GeminiClient>;
+
+  /** The LiveConnectConfig handed to the SDK on the most recent connect().
+   *  Indexed rather than `.at(-1)` — the project's `lib` target predates it. */
+  const sentConfig = () => {
+    const calls = mockLiveConnect.mock.calls;
+    return calls[calls.length - 1][0].config;
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedCallbacks = {};
+    mockSessionClose.mockReset();
+    mockLiveConnect.mockReset();
+    client = new GeminiClient('test-api-key');
+    client.setEventHandlers({} as any);
+    setupSuccessfulConnect();
+  });
+
+  const translateConfig = {
+    ...baseConfig,
+    model: 'gemini-3.5-live-translate-preview',
+    voice: 'Aoede',
+    temperature: 0.8,
+    maxTokens: 2048,
+    instructions: 'Glossary: render "agenda" as 議事次第.',
+    translationConfig: { targetLanguageCode: 'ja', echoTargetLanguage: false },
+  };
+
+  it('forwards translationConfig so the target language does not depend on the prompt', async () => {
+    await client.connect(translateConfig as any);
+
+    expect(sentConfig().translationConfig).toEqual({
+      targetLanguageCode: 'ja',
+      echoTargetLanguage: false,
+    });
+  });
+
+  it('keeps sending the system instruction, which still carries terminology', async () => {
+    await client.connect(translateConfig as any);
+
+    expect(sentConfig().systemInstruction).toEqual({
+      parts: [{ text: 'Glossary: render "agenda" as 議事次第.' }],
+    });
+  });
+
+  it('omits speechConfig — the model reproduces the speaker and ignores a voice', async () => {
+    await client.connect(translateConfig as any);
+
+    expect(sentConfig().speechConfig).toBeUndefined();
+  });
+
+  it('omits the sampling and length knobs the translate model has no use for', async () => {
+    await client.connect(translateConfig as any);
+
+    expect(sentConfig().temperature).toBeUndefined();
+    expect(sentConfig().maxOutputTokens).toBeUndefined();
+  });
+
+  it('leaves a dialogue session untouched: voice and temperature still ride along', async () => {
+    await client.connect({
+      ...baseConfig,
+      model: 'gemini-3.1-flash-live-preview',
+      voice: 'Aoede',
+      temperature: 0.8,
+      maxTokens: 2048,
+      instructions: 'Translate English to Japanese.',
+    } as any);
+
+    expect(sentConfig().translationConfig).toBeUndefined();
+    expect(sentConfig().speechConfig).toEqual({
+      voiceConfig: { prebuiltVoiceConfig: { voiceName: 'Aoede' } },
+    });
+    expect(sentConfig().temperature).toBe(0.8);
+    expect(sentConfig().maxOutputTokens).toBe(2048);
+  });
+});

--- a/src/services/clients/GeminiClient.ts
+++ b/src/services/clients/GeminiClient.ts
@@ -361,15 +361,30 @@ export class GeminiClient implements IClient {
 
     console.info('[Sokuji] [GeminiClient] realtimeInputConfig:', JSON.stringify(realtimeInputConfig));
 
+    // A Live Translate session is identified by carrying a translationConfig —
+    // the client keys off the config's shape rather than matching model names,
+    // which stay the descriptor's business.
+    const translationConfig = isGeminiSessionConfig(config) ? config.translationConfig : undefined;
+    const isTranslateSession = translationConfig !== undefined;
+
     // Convert SessionConfig to LiveConnectConfig
     const liveConfig: LiveConnectConfig = {
       responseModalities,
-      temperature: config.temperature,
-      maxOutputTokens: typeof config.maxTokens === 'number' ? config.maxTokens : undefined,
+      // The translate model takes neither: it is a fixed interpreter with no
+      // sampling or length controls to offer, and the settings UI hides both.
+      temperature: isTranslateSession ? undefined : config.temperature,
+      maxOutputTokens: !isTranslateSession && typeof config.maxTokens === 'number' ? config.maxTokens : undefined,
+      // Still sent for translate sessions: translationConfig fixes the target
+      // language, and the instruction remains the only mechanism that reaches
+      // terminology and style.
       systemInstruction: config.instructions ? {
         parts: [{ text: config.instructions }]
       } : undefined,
-      speechConfig: config.voice && !config.textOnly ? {
+      translationConfig,
+      // The translate model reproduces the speaker's own voice and accepts a
+      // speechConfig only to ignore it. Sending one would imply a choice we
+      // don't have.
+      speechConfig: config.voice && !config.textOnly && !isTranslateSession ? {
         voiceConfig: {
           prebuiltVoiceConfig: {
             voiceName: config.voice

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -141,6 +141,22 @@ export interface GeminiSessionConfig extends BaseSessionConfig {
   vadEndSensitivity: 'high' | 'low';
   vadSilenceDurationMs: number;
   vadPrefixPaddingMs: number;
+  /**
+   * Set only for the Live Translate models, where it — not the system
+   * instruction — is what pins the output language. Absent for the dialogue
+   * models, which carry their direction in the instruction. Built by
+   * buildGeminiTranslationConfig; see geminiTranslateModel.ts.
+   */
+  translationConfig?: {
+    targetLanguageCode: string;
+    echoTargetLanguage: boolean;
+  };
+  /**
+   * The short code for the direction's *other* end, carried for the
+   * participant session's benefit only — never sent to the API. Mirrors how
+   * OpenAITranslateSessionConfig carries `sourceLanguage`.
+   */
+  sourceLanguageCode?: string;
 }
 
 /**

--- a/src/services/providers/GeminiProviderConfig.ts
+++ b/src/services/providers/GeminiProviderConfig.ts
@@ -3,6 +3,11 @@ import { BaseProviderDescriptor, Credentials, ClientOptions } from './ProviderDe
 import { IClient, FilteredModel, SessionConfig, GeminiSessionConfig } from '../interfaces/IClient';
 import { ApiKeyValidationResult } from '../interfaces/ISettingsService';
 import { GeminiClient } from '../clients/GeminiClient';
+import {
+  buildGeminiTranslationConfig,
+  isGeminiTranslateModel,
+  toTranslationLanguageCode,
+} from './geminiTranslateModel';
 
 // Gemini Settings
 export interface GeminiSettings {
@@ -70,6 +75,13 @@ export class GeminiProviderConfig extends BaseProviderDescriptor {
       vadEndSensitivity: settings.vadEndSensitivity,
       vadSilenceDurationMs: settings.vadSilenceDurationMs,
       vadPrefixPaddingMs: settings.vadPrefixPaddingMs,
+      // Undefined for the dialogue models, which carry direction in the
+      // instruction; set for Live Translate, where the instruction alone is
+      // not a reliable target. See geminiTranslateModel.ts.
+      translationConfig: buildGeminiTranslationConfig(settings.model, settings.targetLanguage),
+      sourceLanguageCode: isGeminiTranslateModel(settings.model)
+        ? toTranslationLanguageCode(settings.sourceLanguage)
+        : undefined,
     } as GeminiSessionConfig;
   }
 

--- a/src/services/providers/autoSourceReversal.test.ts
+++ b/src/services/providers/autoSourceReversal.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { reversesDirectionViaSourceLanguage } from './autoSourceReversal';
+import { Provider } from '../../types/Provider';
+
+const TRANSLATE = 'gemini-3.5-live-translate-preview';
+const DIALOGUE = 'gemini-3.1-flash-live-preview';
+
+describe('reversesDirectionViaSourceLanguage', () => {
+  it('is true for Soniox, which swaps source/target directly', () => {
+    expect(reversesDirectionViaSourceLanguage(Provider.SONIOX, undefined)).toBe(true);
+  });
+
+  it('follows a kizuna twin back to its base provider', () => {
+    // The managed twin runs the same client and reverses the same way; a raw
+    // enum comparison would miss it and the gate would silently no-op.
+    expect(reversesDirectionViaSourceLanguage(Provider.KIZUNA_AI_SONIOX, undefined)).toBe(true);
+  });
+
+  it('is true for Gemini only on the translate models', () => {
+    expect(reversesDirectionViaSourceLanguage(Provider.GEMINI, TRANSLATE)).toBe(true);
+  });
+
+  it('is false for Gemini dialogue models, which reverse through the instruction', () => {
+    expect(reversesDirectionViaSourceLanguage(Provider.GEMINI, DIALOGUE)).toBe(false);
+  });
+
+  it('is false for Gemini with no model chosen yet', () => {
+    expect(reversesDirectionViaSourceLanguage(Provider.GEMINI, undefined)).toBe(false);
+    expect(reversesDirectionViaSourceLanguage(Provider.GEMINI, '')).toBe(false);
+  });
+
+  it('is false for providers that carry direction in the instruction', () => {
+    expect(reversesDirectionViaSourceLanguage(Provider.OPENAI, 'gpt-realtime')).toBe(false);
+    expect(reversesDirectionViaSourceLanguage(Provider.OPENAI_TRANSLATE, 'gpt-realtime-translate')).toBe(false);
+    expect(reversesDirectionViaSourceLanguage(Provider.PALABRA_AI, undefined)).toBe(false);
+    expect(reversesDirectionViaSourceLanguage(Provider.LOCAL_NATIVE, undefined)).toBe(false);
+  });
+});

--- a/src/services/providers/autoSourceReversal.ts
+++ b/src/services/providers/autoSourceReversal.ts
@@ -1,0 +1,32 @@
+import { Provider, kizunaBaseProvider } from '../../types/Provider';
+import { isGeminiTranslateModel } from './geminiTranslateModel';
+
+/**
+ * Does this provider/model build its participant session by swapping a
+ * *concrete* source language into the translate target?
+ *
+ * Most providers carry translation direction in the system instruction, and
+ * the participant session is built from an already-reversed one — those are
+ * indifferent to an `auto` source, because nothing has to be swapped.
+ *
+ * The two here are not:
+ * - **Soniox** reverses `sourceLanguage`/`targetLanguage` directly.
+ * - **Gemini Live Translate** reverses `translationConfig.targetLanguageCode`,
+ *   which overrules the instruction, so the instruction swap cannot stand in
+ *   for it. Only the translate models — the dialogue Live models carry
+ *   direction in the instruction like everyone else.
+ *
+ * For both, an `auto` source would reverse into the literal `auto` as the
+ * participant's translate target, which is not a language. Callers require a
+ * concrete source language whenever a participant channel is in scope; see
+ * `computeStartGate`'s `autoSourceParticipantBlocked`.
+ */
+export function reversesDirectionViaSourceLanguage(
+  provider: Provider,
+  model: string | null | undefined,
+): boolean {
+  const base = kizunaBaseProvider(provider) ?? provider;
+  if (base === Provider.SONIOX) return true;
+  if (base === Provider.GEMINI) return isGeminiTranslateModel(model);
+  return false;
+}

--- a/src/services/providers/geminiTranslateModel.test.ts
+++ b/src/services/providers/geminiTranslateModel.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isGeminiTranslateModel,
+  toTranslationLanguageCode,
+  buildGeminiTranslationConfig,
+  reverseGeminiTranslationDirection,
+} from './geminiTranslateModel';
+import { GeminiSessionConfig } from '../interfaces/IClient';
+
+const TRANSLATE = 'gemini-3.5-live-translate-preview';
+const DIALOGUE = 'gemini-3.1-flash-live-preview';
+
+function session(over: Partial<GeminiSessionConfig> = {}): GeminiSessionConfig {
+  return {
+    provider: 'gemini',
+    model: TRANSLATE,
+    turnDetectionMode: 'Auto',
+    vadStartSensitivity: 'low',
+    vadEndSensitivity: 'high',
+    vadSilenceDurationMs: 500,
+    vadPrefixPaddingMs: 300,
+    ...over,
+  } as GeminiSessionConfig;
+}
+
+describe('isGeminiTranslateModel', () => {
+  it('matches the Live Translate model', () => {
+    expect(isGeminiTranslateModel(TRANSLATE)).toBe(true);
+  });
+
+  it('does not match the dialogue Live models', () => {
+    expect(isGeminiTranslateModel(DIALOGUE)).toBe(false);
+    expect(isGeminiTranslateModel('gemini-2.5-flash-native-audio-latest')).toBe(false);
+  });
+
+  it('is narrower than "translate" alone, so a non-Live translation model cannot match', () => {
+    expect(isGeminiTranslateModel('gemini-translate-text-preview')).toBe(false);
+  });
+
+  it('treats a missing model as not-translate rather than throwing', () => {
+    expect(isGeminiTranslateModel(undefined)).toBe(false);
+    expect(isGeminiTranslateModel(null)).toBe(false);
+    expect(isGeminiTranslateModel('')).toBe(false);
+  });
+});
+
+describe('toTranslationLanguageCode', () => {
+  it('reduces a regional value to its primary subtag', () => {
+    expect(toTranslationLanguageCode('ja-JP')).toBe('ja');
+    expect(toTranslationLanguageCode('en-US')).toBe('en');
+    expect(toTranslationLanguageCode('pt-BR')).toBe('pt');
+    expect(toTranslationLanguageCode('uk-UA')).toBe('uk');
+  });
+
+  it('maps Mandarin from Gemini\'s `cmn-CN` to the BCP-47 macrolanguage `zh`', () => {
+    // The one value the generic rule gets wrong: it would yield `cmn`.
+    expect(toTranslationLanguageCode('cmn-CN')).toBe('zh');
+  });
+
+  it('reduces Google\'s pseudo-region for Standard Arabic', () => {
+    expect(toTranslationLanguageCode('ar-XA')).toBe('ar');
+  });
+
+  it('leaves an already-short code alone', () => {
+    expect(toTranslationLanguageCode('fr')).toBe('fr');
+  });
+
+  it('returns empty for a missing value instead of throwing', () => {
+    expect(toTranslationLanguageCode(undefined)).toBe('');
+    expect(toTranslationLanguageCode('')).toBe('');
+  });
+});
+
+describe('buildGeminiTranslationConfig', () => {
+  it('produces nothing for a dialogue model, which carries direction in the instruction', () => {
+    expect(buildGeminiTranslationConfig(DIALOGUE, 'ja-JP')).toBeUndefined();
+  });
+
+  it('pins the target language for the translate model, with echo off', () => {
+    expect(buildGeminiTranslationConfig(TRANSLATE, 'ja-JP')).toEqual({
+      targetLanguageCode: 'ja',
+      echoTargetLanguage: false,
+    });
+  });
+
+  it('applies the short-code mapping rather than passing the regional value through', () => {
+    expect(buildGeminiTranslationConfig(TRANSLATE, 'cmn-CN')?.targetLanguageCode).toBe('zh');
+  });
+});
+
+describe('reverseGeminiTranslationDirection', () => {
+  it('points a translate session at the user\'s own language for the participant channel', () => {
+    const config = session({
+      translationConfig: { targetLanguageCode: 'ja', echoTargetLanguage: false },
+      sourceLanguageCode: 'en',
+    });
+
+    reverseGeminiTranslationDirection(config);
+
+    expect(config.translationConfig).toEqual({ targetLanguageCode: 'en', echoTargetLanguage: false });
+    expect(config.sourceLanguageCode).toBe('ja');
+  });
+
+  it('is a no-op for a dialogue session, whose direction was already swapped in the instruction', () => {
+    const config = session({ model: DIALOGUE, instructions: 'translate Japanese to English' });
+
+    reverseGeminiTranslationDirection(config);
+
+    expect(config.translationConfig).toBeUndefined();
+    expect(config.instructions).toBe('translate Japanese to English');
+  });
+
+  it('leaves the target alone when there is no source to swap in', () => {
+    const config = session({
+      translationConfig: { targetLanguageCode: 'ja', echoTargetLanguage: false },
+    });
+
+    reverseGeminiTranslationDirection(config);
+
+    expect(config.translationConfig?.targetLanguageCode).toBe('ja');
+  });
+
+  it('round-trips: reversing twice restores the speaker direction', () => {
+    const config = session({
+      translationConfig: { targetLanguageCode: 'ja', echoTargetLanguage: false },
+      sourceLanguageCode: 'en',
+    });
+
+    reverseGeminiTranslationDirection(config);
+    reverseGeminiTranslationDirection(config);
+
+    expect(config.translationConfig?.targetLanguageCode).toBe('ja');
+    expect(config.sourceLanguageCode).toBe('en');
+  });
+});

--- a/src/services/providers/geminiTranslateModel.ts
+++ b/src/services/providers/geminiTranslateModel.ts
@@ -1,0 +1,105 @@
+import { GeminiSessionConfig } from '../interfaces/IClient';
+
+/**
+ * Support for Gemini Live Translate (`gemini-3.5-live-translate-preview`).
+ *
+ * The model is a dedicated interpreter served over the *same* Live API as the
+ * dialogue models: same client, same setup message, and — measured against the
+ * live API on 2026-08-10 — not one field rejected that a dialogue model
+ * accepts. It is not a separate provider, because nothing about the session
+ * contract diverges. What differs is which fields carry meaning:
+ *
+ * - `translationConfig.targetLanguageCode` is what actually pins the output
+ *   language. With it set, a system instruction demanding a *different*
+ *   language is overruled. Without it, the model infers the target from the
+ *   instruction, which holds for a short direct prompt but drifted into an
+ *   unrelated language on a longer one — and took the output transcript down
+ *   with it, so the conversation log and subtitles went blank too. Sending it
+ *   is what makes a user-written Advanced-mode prompt safe.
+ * - `systemInstruction` still earns its place and keeps being sent: an
+ *   instruction naming proper nouns corrected both the translation *and* the
+ *   input transcript in the same measurement. That is also the only working
+ *   glossary mechanism here — the dedicated
+ *   `AudioTranscriptionConfig.customVocabulary` field is accepted and then
+ *   silently ignored (0/9 trials showed any effect).
+ * - `speechConfig` is likewise accepted and silently ignored: the model
+ *   reproduces the speaker's own voice, which is the point of using it.
+ *   Sending a voice would imply a choice we do not actually have.
+ */
+
+/** Substring identifying the dedicated translation models within the Gemini
+ *  Live family. Deliberately narrower than `translate` alone so a future
+ *  text-translation model cannot match by accident. */
+const TRANSLATE_MODEL_MARKER = 'live-translate';
+
+export function isGeminiTranslateModel(modelId: string | null | undefined): boolean {
+  return typeof modelId === 'string' && modelId.includes(TRANSLATE_MODEL_MARKER);
+}
+
+/** Gemini spells Mandarin `cmn-CN` in its own language list, so the generic
+ *  rule would send `cmn`. Both codes are accepted, but they are not
+ *  equivalent: measured against the live API on 2026-08-10, `zh` came back in
+ *  Simplified and `cmn` in Traditional. The dropdown entry is "Mandarin
+ *  Chinese (China)", so Simplified is the one that matches it.
+ *
+ *  Every other value we offer reduces correctly by taking the primary subtag —
+ *  `ar-XA` -> `ar`, `sw-KE` -> `sw` and `uk-UA` -> `uk` were each confirmed
+ *  against the API in the same run. */
+const EXPLICIT_TRANSLATION_CODES: Record<string, string> = {
+  'cmn-CN': 'zh',
+};
+
+/**
+ * Reduce one of the Gemini provider's regional language values (`ja-JP`,
+ * `cmn-CN`, `en-US`) to the short BCP-47 code `targetLanguageCode` expects
+ * (`ja`, `zh`, `en`). The model auto-detects the source, so this is only ever
+ * applied to a target.
+ *
+ * Do not reach for `languageCodeShort()` in SubtitleApp for this — that one is
+ * a two-character display truncation and turns `cmn-CN` into `CM`.
+ */
+export function toTranslationLanguageCode(bcp47: string | null | undefined): string {
+  if (!bcp47) return '';
+  return EXPLICIT_TRANSLATION_CODES[bcp47] ?? bcp47.split('-')[0];
+}
+
+/**
+ * Build the `translationConfig` for a Gemini session, or `undefined` when the
+ * selected model is an ordinary dialogue model that has no use for it.
+ *
+ * `echoTargetLanguage` stays false: when the other party already speaks the
+ * target language there is nothing to interpret, and echoing would re-speak
+ * audio the listener just understood.
+ */
+export function buildGeminiTranslationConfig(
+  model: string | null | undefined,
+  targetLanguage: string,
+): GeminiSessionConfig['translationConfig'] {
+  if (!isGeminiTranslateModel(model)) return undefined;
+  return {
+    targetLanguageCode: toTranslationLanguageCode(targetLanguage),
+    echoTargetLanguage: false,
+  };
+}
+
+/**
+ * Reverse a Gemini session's translation direction in place, for the
+ * participant channel.
+ *
+ * The dialogue models get this for free: their direction lives in the system
+ * instruction, and the participant session is built from an already-swapped
+ * one. A translate session does not, because `targetLanguageCode` overrules
+ * that instruction — leaving it alone would translate the other party's speech
+ * into the language they are already speaking.
+ *
+ * No-op for dialogue sessions, which carry no `translationConfig`.
+ */
+export function reverseGeminiTranslationDirection(config: GeminiSessionConfig): void {
+  if (!config.translationConfig || !config.sourceLanguageCode) return;
+  const previousTarget = config.translationConfig.targetLanguageCode;
+  config.translationConfig = {
+    ...config.translationConfig,
+    targetLanguageCode: config.sourceLanguageCode,
+  };
+  config.sourceLanguageCode = previousTarget;
+}


### PR DESCRIPTION
Addresses #392, though not the way it was filed. Worth reading the first section before the diff.

## The report did not reproduce — the fix is for what turned up instead

#392 says `gemini-3.5-live-translate-preview` "fails to start a working session" and asks for a dedicated provider next to OpenAI Translate. Neither premise held up when measured against the live API on 2026-08-10:

- **It starts fine.** Every setup field a dialogue model accepts, the translate model also accepts — `systemInstruction`, `speechConfig`, `temperature`, VAD config, `sessionResumption`, all of it. 11/11 probe cases accepted. The regular Live model even accepts `translationConfig` back. **Nothing about the session contract diverges**, which is why this is not a new provider.
- **It appears to work because it infers the target language from the system instruction** — undocumented behaviour (Google's guide states "no support for tools or instructions"), and the only channel available, since sokuji sends no `translationConfig` anywhere today.

That inference is not safe to keep relying on:

| config | result |
|---|---|
| short direct prompt, no `translationConfig` | correct Japanese |
| **glossary-heavy prompt, no `translationConfig`** | **drifted into Spanish, and `outputAudioTranscription` went empty** |
| `translationConfig=ja` vs prompt demanding French | Japanese — the field overrules the prompt |
| `translationConfig=ja` + glossary prompt | Japanese, glossary honoured |

The second row is the bug. Wrong language *and* a blank conversation log and subtitles at the same time. It is not hypothetical: Advanced mode hands the entire prompt to the user and performs no `{{TARGET_LANGUAGE}}` substitution, so anyone writing their own interpreter prompt is already in exactly that configuration.

## What this does

Send the documented field for the translate models, and gate the knobs that model does not honour — per-model, following the existing `gpt-realtime-2` reasoning-effort precedent rather than splitting the provider.

**Kept deliberately: the system instruction.** It still reaches terminology and style, and an instruction naming proper nouns corrected both the translation *and* the input transcript in the same measurement (`Sokuji` 0/2 → 2/2). It is also the only glossary mechanism that works here — `AudioTranscriptionConfig.customVocabulary` is accepted and then silently ignored (0/9 trials showed any effect), so it is not wired up.

**Dropped for this model:** `speechConfig`, `temperature`, `maxOutputTokens` — all accepted-and-ignored. The voice picker and model-configuration sections are hidden to match, rather than offering a choice that does not exist: the model reproduces the speaker's own voice, which is the reason to use it.

`cmn-CN` needs an explicit mapping and not only for spelling — `zh` and `cmn` are both accepted but return **Simplified and Traditional respectively**. The dropdown entry is "Mandarin Chinese (China)", so `zh` is the match. `ar-XA`, `sw-KE`, `uk-UA` were each confirmed to reduce correctly under the generic primary-subtag rule.

Participant channel: dialogue models reverse direction through the already-swapped instruction; a translate session cannot, because `targetLanguageCode` overrules it — left alone it would translate the other party into the language they are already speaking.

## Two behaviour changes worth knowing

1. **In Advanced mode the language dropdown now wins over the prompt.** A prompt saying "translate to French" while the dropdown says Japanese used to produce French; it now produces Japanese.
2. **Regional variants collapse for target selection.** `en-US`/`en-GB`/`en-AU`/`en-IN` all send `en`; `fr-FR`/`fr-CA` both send `fr`. `targetLanguageCode` only takes short codes. The instruction still carries the full name, so style may still differ, but the authoritative field is coarse.

## Verification

- 21 new tests. **Each was checked for vacuity by reverting its implementation in isolation** — 3 client assertions and 2 mapping assertions went red on cue, while the dialogue-session regression stayed green.
- Full suite: 193 files / 2263 tests passing (baseline 192 / 2242).
- `tsc --noEmit`: 281 errors, **identical to the pre-change baseline — zero new**. (Those 281 are long-standing: the project has no typecheck script and `vite build` uses esbuild.)
- `npm run build` exits 0.
- Short-code mapping verified against the live API, not just asserted: `zh` → Simplified Chinese, `ar`/`sw`/`uk` all correct.
- Manually verified in the app by @jiangzhuo before this PR was opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Gemini Live Translate sessions.
  * Translation sessions apply configured source and target languages.
  * Participant sessions automatically reverse translation direction.
  * Regional and Mandarin language codes are normalized.
  * Standard dialogue sessions retain configurable voice and sampling options.

* **Settings**
  * Voice and unsupported model controls are hidden for Live Translate sessions.
  * Automatic source-language warnings now apply consistently across supported providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->