### PR TITLE
fix(gemini): segment Live Translate on silence, since it never ends a turn

### DIFF
--- a/src/services/clients/GeminiClient.test.ts
+++ b/src/services/clients/GeminiClient.test.ts
@@ -884,6 +884,29 @@ describe('GeminiClient — Live Translate silence segmentation', () => {
     expect(second.formatted.audio?.length).toBe(160);
   });
 
+  it('keeps an open segment on a deadline across a reconnect', async () => {
+    await client.connect(translateConfig as any);
+
+    // A resumption handle is what lets reconnect() take the resume path rather
+    // than declaring a permanent disconnect.
+    capturedCallbacks.onmessage?.({
+      sessionResumptionUpdate: { resumable: true, newHandle: 'handle-1' },
+    });
+    sendInput('interrupted mid-sentence');
+
+    // Drive the real reconnect path. A plain second connect() would not do:
+    // it goes through disconnect(), which closes the segment for an unrelated
+    // reason and would let this test pass with the fix reverted. reconnect()
+    // clears isConnectedState precisely so connect() skips that, arriving with
+    // currentTurn — and the open item — intact.
+    setupSuccessfulConnect();
+    capturedCallbacks.onmessage?.({ goAway: {} });
+    await vi.advanceTimersByTimeAsync(100);
+
+    await vi.advanceTimersByTimeAsync(INPUT_SILENCE_MS);
+    expect(itemsOf('user')[0].status).toBe('completed');
+  });
+
   it('closes the open segment on disconnect instead of stranding it in_progress', async () => {
     await client.connect(translateConfig as any);
 

--- a/src/services/clients/GeminiClient.test.ts
+++ b/src/services/clients/GeminiClient.test.ts
@@ -744,3 +744,154 @@ describe('GeminiClient — Live Translate wire config', () => {
     expect(sentConfig().maxOutputTokens).toBe(2048);
   });
 });
+
+// ─────────────────────────────────────────────
+describe('GeminiClient — Live Translate silence segmentation', () => {
+  let client: InstanceType<typeof GeminiClient>;
+
+  const INPUT_SILENCE_MS = 2000;
+  const ASSISTANT_SILENCE_MS = 2000;
+
+  const translateConfig = {
+    ...baseConfig,
+    model: 'gemini-3.5-live-translate-preview',
+    translationConfig: { targetLanguageCode: 'ja', echoTargetLanguage: false },
+  };
+  const dialogueConfig = { ...baseConfig, model: 'gemini-3.1-flash-live-preview' };
+
+  const sendInput = (text: string) =>
+    capturedCallbacks.onmessage?.({ serverContent: { inputTranscription: { text } } });
+  const sendOutput = (text: string) =>
+    capturedCallbacks.onmessage?.({ serverContent: { outputTranscription: { text } } });
+  /** Local copy — the one above lives inside another describe's scope. */
+  const pcmBase64 = (samples: Int16Array): string => {
+    const bytes = new Uint8Array(samples.buffer, samples.byteOffset, samples.byteLength);
+    let bin = '';
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    return btoa(bin);
+  };
+  const sendAudio = () =>
+    capturedCallbacks.onmessage?.({
+      serverContent: {
+        modelTurn: { parts: [{ inlineData: { data: pcmBase64(new Int16Array(160)), mimeType: 'audio/pcm' } }] },
+      },
+    });
+
+  // `any[]`: these assertions reach into optional `formatted` fields, and the
+  // narrowing ceremony would bury what each test is actually checking.
+  const itemsOf = (role: 'user' | 'assistant'): any[] =>
+    client.getConversationItems().filter((i: any) => i.role === role);
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    capturedCallbacks = {};
+    mockSessionClose.mockReset();
+    mockLiveConnect.mockReset();
+    client = new GeminiClient('test-api-key');
+    client.setEventHandlers({} as any);
+    setupSuccessfulConnect();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('starts a new user item once the speaker has been quiet', async () => {
+    await client.connect(translateConfig as any);
+
+    sendInput('first utterance');
+    expect(itemsOf('user')).toHaveLength(1);
+
+    await vi.advanceTimersByTimeAsync(INPUT_SILENCE_MS);
+    expect(itemsOf('user')[0].status).toBe('completed');
+
+    sendInput('second utterance');
+    expect(itemsOf('user')).toHaveLength(2);
+    expect(itemsOf('user')[1].formatted.transcript).toBe('second utterance');
+  });
+
+  it('keeps appending to one item while the speaker keeps going', async () => {
+    await client.connect(translateConfig as any);
+
+    sendInput('one ');
+    await vi.advanceTimersByTimeAsync(INPUT_SILENCE_MS - 100);
+    sendInput('two ');
+    await vi.advanceTimersByTimeAsync(INPUT_SILENCE_MS - 100);
+    sendInput('three');
+
+    expect(itemsOf('user')).toHaveLength(1);
+    expect(itemsOf('user')[0].formatted.transcript).toBe('one two three');
+  });
+
+  it('leaves a dialogue session alone — its turnComplete still owns segmentation', async () => {
+    await client.connect(dialogueConfig as any);
+
+    sendInput('hello');
+    await vi.advanceTimersByTimeAsync(INPUT_SILENCE_MS * 10);
+
+    expect(itemsOf('user')).toHaveLength(1);
+    expect(itemsOf('user')[0].status).toBe('in_progress');
+  });
+
+  it('times the two sides independently', async () => {
+    await client.connect(translateConfig as any);
+
+    sendInput('speaking');
+    sendOutput('translating');
+
+    // The speaker carries on while the translation goes quiet. The assistant
+    // side has to close on its own schedule without dragging the still-open
+    // user item shut with it.
+    await vi.advanceTimersByTimeAsync(INPUT_SILENCE_MS - 500);
+    sendInput(' and continuing');
+    await vi.advanceTimersByTimeAsync(600);
+
+    expect(itemsOf('assistant')[0].status).toBe('completed');
+    expect(itemsOf('user')[0].status).toBe('in_progress');
+  });
+
+  it('segments while audio is still streaming — audio never pauses for this model', async () => {
+    await client.connect(translateConfig as any);
+
+    sendOutput('translated text');
+
+    // Chunks keep arriving every ~250ms the way they do in a real session,
+    // straight through the speaker's pause. If audio counted as activity the
+    // timer would never fire and this side would never segment at all.
+    for (let i = 0; i < 10; i++) {
+      sendAudio();
+      await vi.advanceTimersByTimeAsync(250);
+    }
+
+    expect(itemsOf('assistant')[0].status).toBe('completed');
+  });
+
+  it('does not carry one segment\'s audio into the next bubble', async () => {
+    await client.connect({ ...translateConfig, keepReplayAudio: true } as any);
+
+    sendAudio();
+    sendOutput('first');
+    await vi.advanceTimersByTimeAsync(ASSISTANT_SILENCE_MS);
+    const first = itemsOf('assistant')[0];
+    expect(first.status).toBe('completed');
+
+    sendAudio();
+    const second = itemsOf('assistant')[1];
+
+    expect(second).toBeDefined();
+    expect(second.id).not.toBe(first.id);
+    expect(second.formatted.audio?.length).toBe(160);
+  });
+
+  it('closes the open segment on disconnect instead of stranding it in_progress', async () => {
+    await client.connect(translateConfig as any);
+
+    sendInput('unfinished');
+    sendOutput('unfinished translation');
+    await client.disconnect();
+
+    expect(itemsOf('user')[0].status).toBe('completed');
+    expect(itemsOf('assistant')[0].status).toBe('completed');
+  });
+});

--- a/src/services/clients/GeminiClient.ts
+++ b/src/services/clients/GeminiClient.ts
@@ -67,6 +67,50 @@ export class GeminiClient implements IClient {
     textParts: [],
   };
 
+  /**
+   * True for a Live Translate session, where `turnComplete` never arrives.
+   *
+   * The dialogue models close a turn when the exchange ends, and
+   * `handleMessage`'s turnComplete branch is what finalizes the accumulated
+   * items and resets for the next one. Live Translate is a continuous
+   * interpreter — it starts translating while the speaker is still talking and
+   * has no notion of a turn — so it emits neither `turnComplete` nor
+   * `generationComplete`. Measured against the live API on 2026-08-11: over a
+   * full utterance the dialogue model emitted generationComplete at 9.1s and
+   * turnComplete at 13.4s, while the translate model emitted zero of either,
+   * with or without `translationConfig`. Left alone, every transcript in the
+   * session therefore lands in one conversation item and every translation in
+   * one more, growing without bound.
+   *
+   * So this client segments those sessions itself, on silence. Same problem
+   * and same remedy as OpenAI Translate, whose API also has no server-side
+   * turn detection — see OpenAITranslateGAClient's user/assistant silence
+   * timers, whose thresholds these borrow.
+   */
+  private continuousSegmentation = false;
+  private inputSegmentTimer: ReturnType<typeof setTimeout> | null = null;
+  private assistantSegmentTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * The two sides are timed independently rather than as a pair: a translation
+   * routinely spans several input sentences and lags behind the speech that
+   * produced it, so a boundary on one side is not a boundary on the other.
+   *
+   * The threshold is picked from the model's measured delivery cadence rather
+   * than borrowed from OpenAI Translate, whose 1.0s/0.5s defaults are far too
+   * eager here. Two utterances separated by 2.5s of silence, measured
+   * 2026-08-11:
+   *
+   *   transcript fragments *within* an utterance   ~1000 ms apart (median)
+   *   the pause *between* the two utterances       ~4250 ms (output side)
+   *
+   * so anything at or under a second splits on nearly every fragment. 2s sits
+   * with roughly 2x margin on both sides. Note this is one measured sample; if
+   * it proves wrong in the field, it is one constant to move.
+   */
+  private static readonly INPUT_SEGMENT_SILENCE_MS = 2000;
+  private static readonly ASSISTANT_SEGMENT_SILENCE_MS = 2000;
+
   constructor(apiKey: string) {
     this.apiKey = apiKey;
     this.client = new GoogleGenAI({ apiKey });
@@ -366,6 +410,10 @@ export class GeminiClient implements IClient {
     // which stay the descriptor's business.
     const translationConfig = isGeminiSessionConfig(config) ? config.translationConfig : undefined;
     const isTranslateSession = translationConfig !== undefined;
+    // A translate session never sends turnComplete, so this client has to
+    // close conversation items itself — see continuousSegmentation.
+    this.continuousSegmentation = isTranslateSession;
+    this.clearSegmentTimers();
 
     // Convert SessionConfig to LiveConnectConfig
     const liveConfig: LiveConnectConfig = {
@@ -589,6 +637,7 @@ export class GeminiClient implements IClient {
   }
 
   private resetCurrentTurn(): void {
+    this.clearSegmentTimers();
     this.currentTurn = {
       inputTranscription: '',
       modelTurnParts: [],
@@ -596,6 +645,80 @@ export class GeminiClient implements IClient {
       audioData: [],
       textParts: [],
     };
+  }
+
+  private clearSegmentTimers(): void {
+    if (this.inputSegmentTimer) {
+      clearTimeout(this.inputSegmentTimer);
+      this.inputSegmentTimer = null;
+    }
+    if (this.assistantSegmentTimer) {
+      clearTimeout(this.assistantSegmentTimer);
+      this.assistantSegmentTimer = null;
+    }
+  }
+
+  /** Restart the input-side idle countdown. No-op outside translate sessions. */
+  private armInputSegmentTimer(): void {
+    if (!this.continuousSegmentation) return;
+    if (this.inputSegmentTimer) clearTimeout(this.inputSegmentTimer);
+    this.inputSegmentTimer = setTimeout(
+      () => { this.inputSegmentTimer = null; this.closeInputSegment(); },
+      GeminiClient.INPUT_SEGMENT_SILENCE_MS,
+    );
+  }
+
+  /** Restart the assistant-side idle countdown. No-op outside translate sessions. */
+  private armAssistantSegmentTimer(): void {
+    if (!this.continuousSegmentation) return;
+    if (this.assistantSegmentTimer) clearTimeout(this.assistantSegmentTimer);
+    this.assistantSegmentTimer = setTimeout(
+      () => { this.assistantSegmentTimer = null; this.closeAssistantSegment(); },
+      GeminiClient.ASSISTANT_SEGMENT_SILENCE_MS,
+    );
+  }
+
+  /**
+   * Complete the in-progress user item and drop the reference, so the next
+   * transcription fragment starts a fresh one. Deliberately narrower than
+   * finalizeTurn(), which closes both sides at once — here the two sides end
+   * at different moments.
+   */
+  private closeInputSegment(): void {
+    const item = this.currentTurn.inputTranscriptionItem;
+    const text = this.currentTurn.inputTranscription.trim();
+    if (item && text) {
+      if (item.formatted) item.formatted.transcript = this.normalizeCJKSpaces(text);
+      item.status = 'completed';
+      this.eventHandlers.onConversationUpdated?.({ item });
+    }
+    this.currentTurn.inputTranscription = '';
+    this.currentTurn.inputTranscriptionItem = undefined;
+  }
+
+  /**
+   * Same for the assistant side. The per-segment accumulators are cleared
+   * along with the item because `formatted.audio` and `formatted.text` are
+   * rebuilt from them on every update — carrying them over would replay the
+   * previous segment's audio inside the next one's bubble.
+   */
+  private closeAssistantSegment(): void {
+    const item = this.currentTurn.assistantItem;
+    if (item) {
+      if (item.formatted) {
+        const combinedText = this.currentTurn.textParts.join('');
+        const outputTranscript = this.currentTurn.outputTranscription.trim();
+        if (combinedText && !item.formatted.text) item.formatted.text = combinedText;
+        if (outputTranscript && !item.formatted.transcript) item.formatted.transcript = outputTranscript;
+      }
+      item.status = 'completed';
+      this.eventHandlers.onConversationUpdated?.({ item });
+    }
+    this.currentTurn.assistantItem = undefined;
+    this.currentTurn.outputTranscription = '';
+    this.currentTurn.textParts = [];
+    this.currentTurn.audioData = [];
+    this.currentTurn.modelTurnParts = [];
   }
 
   private async finalizeTurn(): Promise<void> {
@@ -763,6 +886,8 @@ export class GeminiClient implements IClient {
           this.currentTurn.assistantItem.formatted.transcript = this.currentTurn.outputTranscription;
           this.eventHandlers.onConversationUpdated?.({ item: this.currentTurn.assistantItem });
         }
+
+        this.armAssistantSegmentTimer();
       }
     }
 
@@ -798,6 +923,8 @@ export class GeminiClient implements IClient {
           this.currentTurn.inputTranscriptionItem.formatted.transcript = normalizedTranscript;
           this.eventHandlers.onConversationUpdated?.({ item: this.currentTurn.inputTranscriptionItem });
         }
+
+        this.armInputSegmentTimer();
       }
     }
 
@@ -844,7 +971,12 @@ export class GeminiClient implements IClient {
         }
       }
 
-      // Create or update conversation item for real-time display
+      // Deliberately NOT arming the assistant segment timer here. Audio
+      // carries no boundary information for this model: measured 2026-08-11,
+      // chunks arrive every ~250 ms with a 315 ms worst case and never once a
+      // gap of 500 ms, straight through a 2.5 s pause in the speech. Treating
+      // that as activity would hold the timer open forever and the assistant
+      // side would never segment at all. Only the output transcript pauses.
       if (hasNewAudio || hasNewText) {
         if (!this.currentTurn.assistantItem) {
           this.currentTurn.assistantItem = {
@@ -932,6 +1064,14 @@ export class GeminiClient implements IClient {
     this.isReconnecting = false;
     this.savedResumptionHandle = undefined;
     this.lastConfig = null;  // Marks user-initiated disconnect — onclose must not reconnect
+    // Close whatever segment is open rather than leaving the last utterance
+    // stuck at in_progress, then stop the timers from firing into a dead
+    // session.
+    if (this.continuousSegmentation) {
+      this.closeInputSegment();
+      this.closeAssistantSegment();
+    }
+    this.clearSegmentTimers();
     if (this.session) {
       this.session.close();
       this.session = null;

--- a/src/services/clients/GeminiClient.ts
+++ b/src/services/clients/GeminiClient.ts
@@ -413,7 +413,17 @@ export class GeminiClient implements IClient {
     // A translate session never sends turnComplete, so this client has to
     // close conversation items itself — see continuousSegmentation.
     this.continuousSegmentation = isTranslateSession;
+    // reconnect() reaches this method with currentTurn deliberately intact: it
+    // clears isConnectedState so the disconnect() above is skipped, and
+    // hasLocalSessionState() exists precisely because that state survives. An
+    // open segment therefore outlives the outage, and dropping its deadline
+    // would strand it at in_progress forever if the speaker stopped talking
+    // while the socket was down. Restart the countdown instead.
     this.clearSegmentTimers();
+    if (this.continuousSegmentation) {
+      if (this.currentTurn.inputTranscriptionItem) this.armInputSegmentTimer();
+      if (this.currentTurn.assistantItem) this.armAssistantSegmentTimer();
+    }
 
     // Convert SessionConfig to LiveConnectConfig
     const liveConfig: LiveConnectConfig = {
@@ -953,6 +963,17 @@ export class GeminiClient implements IClient {
           const audioChunk = new Int16Array(audioData);
           // Per-turn replay buffer: skip when keepReplayAudio is off so the
           // entire turn's PCM doesn't pile up in memory before being dropped.
+          //
+          // KNOWN GAP for translate sessions with the flag on: chunks keep
+          // arriving through the pause between utterances, and the first of
+          // them re-creates assistantItem below, so the idle interval ends up
+          // heading the next segment's replay buffer. Gating this push alone
+          // does not fix it — item creation is what admits the idle audio, and
+          // moving that behind the transcript means first hoisting the live
+          // playback delta out of the same block, which is a change to every
+          // Gemini model's playback path and does not belong in this fix. This
+          // is still strictly better than before segmentation existed, when the
+          // buffer grew for the whole session. Tracked separately.
           if (this.keepReplayAudio) {
             this.currentTurn.audioData.push(audioChunk);
           }


### PR DESCRIPTION
Reported from a real v0.36.0 session: with `gemini-3.5-live-translate-preview`, **every transcript in the session lands in one conversation item and every translation in one more**, both growing without bound.

## Why

`turnComplete` is the only thing that closes a Gemini conversation item — its branch in `handleMessage` calls `finalizeTurn()` then `resetCurrentTurn()`, and nothing else clears the accumulators except `interrupted`. Live Translate sends neither.

Measured against the live API on 2026-08-11, feeding the same utterance to each model:

| session | turnComplete | generationComplete |
|---|---|---|
| translate + `translationConfig` | **0** | 0 |
| translate + system instruction only (pre-#398 shape) | **0** | 0 |
| dialogue `gemini-3.1-flash-live-preview` | 1 @13.4s | 1 @9.1s |

Both translate rows produced real output (6 input transcripts, 6 output transcripts, 91 audio chunks) — they simply never signal a turn. **This is the model's nature, not a regression from #398**: the pre-#398 configuration behaves identically. It is a continuous interpreter that begins translating while the speaker is still going, so there is no turn to end.

So the client segments those sessions itself, on silence, per side. Same problem and same remedy as OpenAI Translate, whose API also has no server-side turn detection.

## Two things the measurement changed about the obvious implementation

Both of these are corrections to what I wrote first, caught by measuring instead of reasoning.

**Audio must not count as activity.** The natural reading is that audio outlives the transcript, so arming on both protects against cutting mid-utterance. In fact chunks arrive every **~250 ms, worst case 315 ms, and not one 500 ms gap in the entire session** — straight through a 2.5 s pause in the speech. Arming on audio holds the timer open forever and the assistant side never segments at all. Only the transcript pauses, so only the transcript arms.

**OpenAI Translate's 1.0s / 0.5s thresholds are far too eager here.** Transcript fragments *within* one utterance arrive ~1000 ms apart; the gap *between* two utterances measured ~4250 ms. A one-second threshold splits on nearly every fragment. 2 s carries roughly 2× margin either way, and on the measured sample it cuts exactly once per side — two utterances, two items each:

```
input  gaps: 750 980 1024 997 [5068] 975 1019 968 1004 1006  ms
output gaps: 691 1011 987 1011 994 [4254] 1002 998 1006 992 1002  ms
                                    ^ only these exceed 2000
```

This is one measured sample. If it proves wrong in the field it is one constant to move, and the reasoning is recorded at the constant.

## Design notes

- The two sides keep **independent timers**: a translation spans several input sentences and lags the speech that produced it, so a boundary on one side is not a boundary on the other.
- Per-segment accumulators are cleared along with the item, because `formatted.audio` / `formatted.text` are rebuilt from them — carrying them over would replay the previous segment's audio inside the next one's bubble.
- `disconnect()` closes whatever segment is open rather than stranding the last utterance at `in_progress`.
- **Dialogue sessions are untouched**: `continuousSegmentation` is false for them and every new path sits behind it.

## Verification

- 7 new tests. **Verified non-vacuous twice**: disabling the flag turns 5 red, and restoring the arm-on-audio version turns exactly the one test that pins the audio measurement red — so the mistake this PR corrects would not survive review a second time.
- Full suite: 194 files / 2276 tests passing.
- `tsc --noEmit`: 281, identical to the pre-change baseline — zero new.
- `npm run build` exits 0.

Not yet exercised end-to-end through the app; the segmentation logic is unit-tested and the thresholds come from live-API measurement, but a real session is the remaining check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Live Translate conversation segmentation with independent silence detection for speakers.
  * Keeps transcripts together during continuous speech and separates completed segments after silence.
  * Preserves separate audio for each segment, including while streaming.
  * Maintains accurate segmentation when conversations reconnect or continue across dialogue turns.

* **Bug Fixes**
  * Open conversation segments are now completed when a session disconnects.
  * Segmentation remains reliable during ongoing audio streams and turn resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->