### PR TITLE
fix(macos): put the virtual device back to unity gain so the far end stops hearing silence

### DIFF
--- a/electron/audio-host.js
+++ b/electron/audio-host.js
@@ -187,4 +187,53 @@ function stopCapture() {
   current = null;
 }
 
-module.exports = { listAppSources, startCapture, stopCapture };
+/**
+ * Put a virtual device's volume back to unity, and unmute it.
+ *
+ * macOS stores that volume itself and restores it onto the driver, so it
+ * survives reinstalling the driver - and a macOS 15 -> 26 upgrade was measured
+ * leaving Sokuji's device at scalar 0.5, which the driver's logarithmic control
+ * turns into -32 dB. The audio still flows, so nothing reports an error; the
+ * other application simply hears silence. See the helper's --ensure-unity-gain
+ * documentation for the measurement.
+ *
+ * Never throws and never rejects: this runs on the startup path, and a device
+ * whose gain could not be checked must not be the reason the app fails to come
+ * up. A null result means "could not tell", which the caller logs and moves on.
+ *
+ * @param {string} deviceName  Substring matched against device names
+ * @returns {Promise<{found: boolean, changed?: boolean, unmuted?: boolean,
+ *                    before?: object, after?: object}|null>}
+ */
+async function ensureUnityGain(deviceName, { spawn = nodeSpawn, resolvePath = resolveAudioHostPath } = {}) {
+  const exe = resolvePath();
+  if (!exe) return null;
+
+  return new Promise((resolve) => {
+    let out = '';
+    let child;
+    try {
+      child = spawn(exe, ['--ensure-unity-gain', deviceName]);
+    } catch {
+      return resolve(null);
+    }
+
+    child.stdout.on('data', (d) => { out += d.toString('utf8'); });
+    child.on('error', () => resolve(null));
+    child.on('close', () => {
+      try {
+        const result = JSON.parse(out);
+        // An older shipped helper predates this mode and answers with its usage
+        // text on stderr and nothing on stdout. Treat anything that is not the
+        // documented object as "could not tell" rather than as a device that is
+        // missing, which would send the caller down the not-installed path.
+        if (!result || typeof result.found !== 'boolean') return resolve(null);
+        resolve(result);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}
+
+module.exports = { listAppSources, startCapture, stopCapture, ensureUnityGain };

--- a/electron/audio-host.js
+++ b/electron/audio-host.js
@@ -199,7 +199,10 @@ function stopCapture() {
  *
  * Never throws and never rejects: this runs on the startup path, and a device
  * whose gain could not be checked must not be the reason the app fails to come
- * up. A null result means "could not tell", which the caller logs and moves on.
+ * up. A null result means "could not tell", which the caller logs and moves on:
+ * no helper, a helper too old to know the mode, output that is not the
+ * documented object, or any non-zero exit - including a refused write, where
+ * the helper has still printed a perfectly well-formed measurement.
  *
  * @param {string} deviceName  Substring matched against device names
  * @returns {Promise<{found: boolean, changed?: boolean, unmuted?: boolean,
@@ -220,7 +223,13 @@ async function ensureUnityGain(deviceName, { spawn = nodeSpawn, resolvePath = re
 
     child.stdout.on('data', (d) => { out += d.toString('utf8'); });
     child.on('error', () => resolve(null));
-    child.on('close', () => {
+    child.on('close', (code) => {
+      // The helper reports what it measured and *then* exits non-zero when a
+      // write was refused, so the payload alone cannot be trusted: it would say
+      // found, unchanged, which the caller reads as "already at unity" - the
+      // same silent-success failure this whole path exists to remove. A signal
+      // kill arrives here as a null code and is equally untrustworthy.
+      if (code !== 0) return resolve(null);
       try {
         const result = JSON.parse(out);
         // An older shipped helper predates this mode and answers with its usage

--- a/electron/audio-host.test.js
+++ b/electron/audio-host.test.js
@@ -305,6 +305,28 @@ describe('ensureUnityGain', () => {
     expect(await p).toBeNull();
   });
 
+  // The helper prints its measurement and then exits 1 when Core Audio refused
+  // the write. Trusting the payload would report "found, unchanged" - which the
+  // caller reads as "already at unity" while the device is still attenuated.
+  it('returns null when the helper reports a measurement but exits non-zero', async () => {
+    const child = fakeChild();
+    const p = ensureUnityGain('SokujiVirtualAudio', { spawn: () => child, resolvePath });
+    child.stdout.emit('data', Buffer.from(
+      '{"found":true,"name":"SokujiVirtualAudio","changed":false,"unmuted":false,'
+      + '"before":{"output":0.5000,"input":0.5000},"after":{"output":0.5000,"input":0.5000}}'));
+    child.stderr.emit('data', Buffer.from('{"event":"error","code":"volume_write_failed"}\n'));
+    child.emit('close', 1);
+    expect(await p).toBeNull();
+  });
+
+  it('returns null when the helper is killed by a signal', async () => {
+    const child = fakeChild();
+    const p = ensureUnityGain('SokujiVirtualAudio', { spawn: () => child, resolvePath });
+    child.stdout.emit('data', Buffer.from('{"found":true,"changed":false}'));
+    child.emit('close', null, 'SIGKILL');
+    expect(await p).toBeNull();
+  });
+
   it('returns null on malformed output instead of throwing', async () => {
     const child = fakeChild();
     const p = ensureUnityGain('SokujiVirtualAudio', { spawn: () => child, resolvePath });

--- a/electron/audio-host.test.js
+++ b/electron/audio-host.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { EventEmitter } from 'events';
-import { listAppSources, startCapture, stopCapture } from './audio-host.js';
+import { listAppSources, startCapture, stopCapture, ensureUnityGain } from './audio-host.js';
 
 function fakeChild() {
   const c = new EventEmitter();
@@ -265,5 +265,64 @@ describe('stopCapture', () => {
 
   it('is safe when nothing was ever started', () => {
     expect(() => stopCapture()).not.toThrow();
+  });
+});
+
+describe('ensureUnityGain', () => {
+  const REPAIRED = '{"found":true,"name":"SokujiVirtualAudio","changed":true,"unmuted":false,'
+    + '"before":{"output":0.5000,"input":0.5000},"after":{"output":1.0000,"input":1.0000}}';
+
+  it('passes the device name through and returns what the helper measured', async () => {
+    const child = fakeChild();
+    const spawn = vi.fn(() => child);
+    const p = ensureUnityGain('SokujiVirtualAudio', { spawn, resolvePath });
+
+    child.stdout.emit('data', Buffer.from(REPAIRED));
+    child.emit('close', 0);
+
+    const result = await p;
+    expect(spawn.mock.calls[0][1]).toEqual(['--ensure-unity-gain', 'SokujiVirtualAudio']);
+    expect(result.changed).toBe(true);
+    expect(result.before).toEqual({ output: 0.5, input: 0.5 });
+  });
+
+  it('reports a device that is not registered rather than guessing', async () => {
+    const child = fakeChild();
+    const p = ensureUnityGain('SokujiVirtualAudio', { spawn: () => child, resolvePath });
+    child.stdout.emit('data', Buffer.from('{"found":false}'));
+    child.emit('close', 0);
+    expect(await p).toEqual({ found: false });
+  });
+
+  // A helper shipped before this mode existed writes its usage text to stderr
+  // and nothing to stdout. That has to read as "could not tell", never as
+  // "the device is missing" - the caller treats those differently.
+  it('returns null for a helper too old to know the mode', async () => {
+    const child = fakeChild();
+    const p = ensureUnityGain('SokujiVirtualAudio', { spawn: () => child, resolvePath });
+    child.stderr.emit('data', Buffer.from('usage:\n'));
+    child.emit('close', 2);
+    expect(await p).toBeNull();
+  });
+
+  it('returns null on malformed output instead of throwing', async () => {
+    const child = fakeChild();
+    const p = ensureUnityGain('SokujiVirtualAudio', { spawn: () => child, resolvePath });
+    child.stdout.emit('data', Buffer.from('{not json'));
+    child.emit('close', 0);
+    expect(await p).toBeNull();
+  });
+
+  it('returns null when the helper cannot be spawned or found', async () => {
+    const throwing = () => { throw new Error('EACCES'); };
+    expect(await ensureUnityGain('X', { spawn: throwing, resolvePath })).toBeNull();
+    expect(await ensureUnityGain('X', { spawn: () => fakeChild(), resolvePath: () => null })).toBeNull();
+  });
+
+  it('returns null when the child errors out', async () => {
+    const child = fakeChild();
+    const p = ensureUnityGain('X', { spawn: () => child, resolvePath });
+    child.emit('error', new Error('ENOENT'));
+    expect(await p).toBeNull();
   });
 });

--- a/electron/macos-audio-utils.js
+++ b/electron/macos-audio-utils.js
@@ -10,20 +10,68 @@ const execPromise = util.promisify(exec);
 const fs = require('fs').promises;
 const path = require('path');
 
+// The device the driver publishes. Matched as a substring, and kept here rather
+// than inline so the renderer's own label match (detectAndSetVirtualSpeaker)
+// and this one cannot drift apart.
+const VIRTUAL_DEVICE_NAME = 'SokujiVirtualAudio';
+
+/**
+ * Put the virtual device back to unity gain if something moved it.
+ *
+ * Reported as "SokujiVirtualAudio is visible but receives no audio": macOS
+ * stores the device's volume and restores it onto the driver, a macOS 15 -> 26
+ * upgrade was measured leaving it at scalar 0.5, and the driver's logarithmic
+ * volume control makes that -32 dB - 2.5% of the amplitude, which reads as
+ * silence at the far end while every diagnostic says the device is fine.
+ *
+ * Best-effort by construction: a helper that is missing, old, or unable to
+ * write the property must not stop the app from starting.
+ */
+async function restoreVirtualDeviceGain({ host = audioHost } = {}) {
+  let result = null;
+  try {
+    result = await host.ensureUnityGain(VIRTUAL_DEVICE_NAME);
+  } catch (error) {
+    console.warn('[Sokuji] [macOS Audio] Could not check virtual device gain:', error);
+    return;
+  }
+
+  if (!result) {
+    console.warn('[Sokuji] [macOS Audio] Could not check the virtual device gain; if other applications hear silence, check that SokujiVirtualAudio is at full volume in Audio MIDI Setup');
+    return;
+  }
+  if (!result.found) {
+    // Installed on disk but not registered with Core Audio - a restart usually
+    // settles it, and the caller has already told the user how that looks.
+    console.warn('[Sokuji] [macOS Audio] Virtual device is installed but not registered with Core Audio yet');
+    return;
+  }
+  if (result.changed || result.unmuted) {
+    console.log(`[Sokuji] [macOS Audio] Virtual device gain restored to unity (was output=${result.before?.output}, input=${result.before?.input}${result.unmuted ? ', and it was muted' : ''})`);
+    return;
+  }
+  console.log('[Sokuji] [macOS Audio] Virtual device gain is at unity');
+}
+
 /**
  * Create virtual audio devices on macOS using Sokuji Virtual Audio
  * This function checks if our bundled driver is installed by the PKG installer
+ * @param {{host?: object, isInstalled?: function}} deps - injected in tests
  * @returns {Promise<boolean>} True if virtual devices can be used, false otherwise
  */
-async function createVirtualAudioDevices() {
+async function createVirtualAudioDevices({
+  host = audioHost,
+  isInstalled: checkInstalled = isSokujiVirtualAudioInstalled,
+} = {}) {
   try {
     console.log('[Sokuji] [macOS Audio] Checking for Sokuji Virtual Audio devices...');
 
     // Check if our custom driver is installed
-    const isInstalled = await isSokujiVirtualAudioInstalled();
+    const isInstalled = await checkInstalled();
 
     if (isInstalled) {
       console.log('[Sokuji] [macOS Audio] Sokuji Virtual Audio is installed and ready');
+      await restoreVirtualDeviceGain({ host });
       return true;
     }
 
@@ -314,6 +362,8 @@ module.exports = {
   startCapture: audioHost.startCapture,
   stopCapture: audioHost.stopCapture,
   createVirtualAudioDevices,
+  restoreVirtualDeviceGain,
+  VIRTUAL_DEVICE_NAME,
   removeVirtualAudioDevices,
   isMacOSAudioAvailable,
   cleanupOrphanedDevices,

--- a/electron/macos-audio-utils.unitygain.test.js
+++ b/electron/macos-audio-utils.unitygain.test.js
@@ -1,0 +1,75 @@
+// Virtual-device gain repair on the macOS startup path.
+//
+// Reported as "SokujiVirtualAudio is visible in system devices but receives no
+// audio": macOS stores the device's volume and restores it onto the driver, a
+// macOS 15 -> 26 upgrade was measured leaving it at scalar 0.5, and the
+// driver's logarithmic volume control turns that into -32 dB. Audio still
+// flows, so no layer reports an error and the far end simply hears silence.
+//
+// These inject a fake `host` rather than vi.mock'ing audio-host.js, for the
+// same reason as macos-audio-utils.appaudio.test.js: this module is CommonJS
+// and reaches it through require().
+import { describe, it, expect, vi } from 'vitest';
+import {
+  createVirtualAudioDevices,
+  restoreVirtualDeviceGain,
+  VIRTUAL_DEVICE_NAME,
+} from './macos-audio-utils.js';
+
+const repaired = {
+  found: true,
+  name: 'SokujiVirtualAudio',
+  changed: true,
+  unmuted: false,
+  before: { output: 0.5, input: 0.5 },
+  after: { output: 1, input: 1 },
+};
+
+const host = (result = repaired) => ({
+  ensureUnityGain: vi.fn(async () => result),
+});
+
+describe('restoreVirtualDeviceGain', () => {
+  it('asks the helper about the device the driver publishes', async () => {
+    const h = host();
+    await restoreVirtualDeviceGain({ host: h });
+    expect(h.ensureUnityGain).toHaveBeenCalledWith(VIRTUAL_DEVICE_NAME);
+  });
+
+  it('survives a helper that cannot tell', async () => {
+    await expect(restoreVirtualDeviceGain({ host: host(null) })).resolves.toBeUndefined();
+  });
+
+  it('survives a device that is installed but not registered', async () => {
+    await expect(restoreVirtualDeviceGain({ host: host({ found: false }) })).resolves.toBeUndefined();
+  });
+
+  it('survives a helper that rejects', async () => {
+    const h = { ensureUnityGain: vi.fn(async () => { throw new Error('EACCES'); }) };
+    await expect(restoreVirtualDeviceGain({ host: h })).resolves.toBeUndefined();
+  });
+});
+
+describe('createVirtualAudioDevices', () => {
+  it('repairs the gain once the driver is known to be installed', async () => {
+    const h = host();
+    const ok = await createVirtualAudioDevices({ host: h, isInstalled: async () => true });
+    expect(ok).toBe(true);
+    expect(h.ensureUnityGain).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch device gain when the driver is not installed', async () => {
+    const h = host();
+    const ok = await createVirtualAudioDevices({ host: h, isInstalled: async () => false });
+    expect(ok).toBe(false);
+    expect(h.ensureUnityGain).not.toHaveBeenCalled();
+  });
+
+  // The repair is a convenience on the startup path. If it could fail the call,
+  // a Mac whose helper is missing would lose virtual-microphone support
+  // entirely - a strictly worse outcome than the quiet device it fixes.
+  it('still reports the device usable when the repair fails', async () => {
+    const h = { ensureUnityGain: vi.fn(async () => { throw new Error('EACCES'); }) };
+    expect(await createVirtualAudioDevices({ host: h, isInstalled: async () => true })).toBe(true);
+  });
+});

--- a/native/audio-host/mac/build.sh
+++ b/native/audio-host/mac/build.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
-# Build sokuji-audio-host for macOS and refresh the vendored copy.
+# Build sokuji-audio-host for macOS and refresh the copy the app loads.
 #
-# The committed binary under resources/bin is what the app loads; out/ is only
-# the compiler's scratch output. Copying is part of the build, not a step to
+# The binary under resources/bin is what the app loads; out/ is only the
+# compiler's scratch output. Copying is part of the build, not a step to
 # remember - the Windows helper lost a debugging round trip to exactly that gap.
+#
+# resources/bin is gitignored: these are build artifacts, produced by CI before
+# packaging (npm run build:audio-host) and never committed. Changing main.swift
+# is therefore the whole change; there is no binary to refresh in the repo.
 set -euo pipefail
 cd "$(dirname "$0")"
 

--- a/native/audio-host/mac/main.swift
+++ b/native/audio-host/mac/main.swift
@@ -21,6 +21,15 @@
 //       playing, and follows the application's audio process objects as macOS
 //       destroys and recreates them - see retarget() below.
 //
+//   sokuji-audio-host --ensure-unity-gain <device name substring>
+//       Restores that device's volume to unity and clears its mute, then writes
+//       one JSON object to stdout and exits 0:
+//         {"found":true,"name":"SokujiVirtualAudio","changed":true,
+//          "before":{"output":0.5,"input":0.5},"after":{"output":1,"input":1},
+//          "unmuted":false}
+//       A device that is not present is {"found":false} and still exit 0 - not
+//       having the driver installed is a normal state, not a failure.
+//
 // Exit codes: 0 clean, 1 runtime failure, 2 bad usage.
 //
 // stdout carries ONLY PCM. Everything else goes to stderr, or the audio stream
@@ -175,6 +184,138 @@ func runList() -> Int32 {
         "{\"id\":\"pid:\(s.pid)\",\"label\":\"\(jsonEscape(s.label))\",\"exe\":\"\(jsonEscape(s.exe))\",\"active\":\(s.active)}"
     }
     FileHandle.standardOutput.write(("[" + rows.joined(separator: ",") + "]").data(using: .utf8)!)
+    return 0
+}
+
+// MARK: - --ensure-unity-gain
+
+// macOS keeps a per-device volume in coreaudiod's own settings store and pushes
+// it onto the driver as the device registers, so the stored value outlives the
+// driver binary - reinstalling the driver does not reset it.
+//
+// A macOS 15 -> 26 upgrade was measured leaving SokujiVirtualAudio's stored
+// volume at scalar 0.5. The driver's volume control is logarithmic across a
+// 64 dB range, so scalar 0.5 is -32 dB: it passes 2.5% of the amplitude, not
+// half. Nothing errors and audio still flows, but the receiving application
+// hears what sounds like silence and the level meter in Audio MIDI Setup does
+// not move - which reads as "the virtual device is broken", and is exactly how
+// it was reported.
+//
+// Unity is the only meaningful setting for a bus no human listens to directly,
+// so put it back instead of asking every user to find a slider they never
+// knowingly moved. Writing the scalar needs no privilege and no entitlement,
+// and coreaudiod persists it at its next restart - verified on 26.6.1.
+
+func scopedAddress(_ selector: AudioObjectPropertySelector,
+                   _ scope: AudioObjectPropertyScope) -> AudioObjectPropertyAddress {
+    AudioObjectPropertyAddress(mSelector: selector,
+                               mScope: scope,
+                               mElement: kAudioObjectPropertyElementMain)
+}
+
+func volumeScalar(_ device: AudioObjectID, _ scope: AudioObjectPropertyScope) -> Float32? {
+    var addr = scopedAddress(kAudioDevicePropertyVolumeScalar, scope)
+    guard AudioObjectHasProperty(device, &addr) else { return nil }
+    var value: Float32 = 0
+    var size = UInt32(MemoryLayout<Float32>.size)
+    guard AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &value) == noErr else { return nil }
+    return value
+}
+
+/// True only when the value was actually written. A device without the control,
+/// or one that reports it read-only, is not a failure worth reporting: some
+/// virtual devices legitimately have no volume at all.
+func setVolumeScalar(_ device: AudioObjectID, _ scope: AudioObjectPropertyScope, _ value: Float32) -> Bool {
+    var addr = scopedAddress(kAudioDevicePropertyVolumeScalar, scope)
+    guard AudioObjectHasProperty(device, &addr) else { return false }
+    var settable: DarwinBoolean = false
+    guard AudioObjectIsPropertySettable(device, &addr, &settable) == noErr, settable.boolValue else { return false }
+    var v = value
+    return AudioObjectSetPropertyData(device, &addr, 0, nil, UInt32(MemoryLayout<Float32>.size), &v) == noErr
+}
+
+func muteFlag(_ device: AudioObjectID, _ scope: AudioObjectPropertyScope) -> UInt32? {
+    var addr = scopedAddress(kAudioDevicePropertyMute, scope)
+    guard AudioObjectHasProperty(device, &addr) else { return nil }
+    var value: UInt32 = 0
+    var size = UInt32(MemoryLayout<UInt32>.size)
+    guard AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &value) == noErr else { return nil }
+    return value
+}
+
+func clearMute(_ device: AudioObjectID, _ scope: AudioObjectPropertyScope) -> Bool {
+    var addr = scopedAddress(kAudioDevicePropertyMute, scope)
+    guard AudioObjectHasProperty(device, &addr) else { return false }
+    var settable: DarwinBoolean = false
+    guard AudioObjectIsPropertySettable(device, &addr, &settable) == noErr, settable.boolValue else { return false }
+    var v: UInt32 = 0
+    return AudioObjectSetPropertyData(device, &addr, 0, nil, UInt32(MemoryLayout<UInt32>.size), &v) == noErr
+}
+
+func jsonNumber(_ value: Float32?) -> String {
+    guard let value else { return "null" }
+    return String(format: "%.4f", value)
+}
+
+func runEnsureUnityGain(deviceName needle: String) -> Int32 {
+    // Both scopes carry a control, and in BlackHole-derived drivers they are two
+    // faces of one value - but that is the driver's business, not ours. Setting
+    // each independently keeps this correct for any device.
+    let scopes: [(String, AudioObjectPropertyScope)] = [
+        ("output", kAudioObjectPropertyScopeOutput),
+        ("input", kAudioObjectPropertyScopeInput),
+    ]
+
+    let device = objectIDs(kAudioHardwarePropertyDevices).first {
+        (stringProp($0, kAudioObjectPropertyName) ?? "").localizedCaseInsensitiveContains(needle)
+    }
+    guard let device else {
+        FileHandle.standardOutput.write("{\"found\":false}".data(using: .utf8)!)
+        return 0
+    }
+
+    var before: [String: Float32?] = [:]
+    var after: [String: Float32?] = [:]
+    var changed = false
+    var unmuted = false
+    var writeFailed = false
+
+    // Read every scope before writing any of them. In BlackHole-derived drivers
+    // the two scopes are two faces of one stored value, so repairing the output
+    // scope silently repairs the input scope too - and a read-as-you-go loop
+    // would then report the input scope as having been fine all along. The
+    // report is what we get to debug from, so it has to describe the state we
+    // actually found.
+    for (label, scope) in scopes { before[label] = volumeScalar(device, scope) }
+
+    for (label, scope) in scopes {
+        // Compared against a tolerance because the scalar makes a round trip
+        // through the driver's dB curve: writing 1.0 and reading it back can
+        // land a hair under, and re-writing it on every launch would be noise.
+        if let current = before[label] ?? nil, current < 0.999 {
+            if setVolumeScalar(device, scope, 1.0) { changed = true } else { writeFailed = true }
+        }
+
+        if let mute = muteFlag(device, scope), mute != 0 {
+            if clearMute(device, scope) { unmuted = true } else { writeFailed = true }
+        }
+    }
+
+    for (label, scope) in scopes { after[label] = volumeScalar(device, scope) }
+
+    let name = stringProp(device, kAudioObjectPropertyName) ?? needle
+    let json = "{\"found\":true,\"name\":\"\(jsonEscape(name))\"," +
+        "\"changed\":\(changed),\"unmuted\":\(unmuted)," +
+        "\"before\":{\"output\":\(jsonNumber(before["output"] ?? nil)),\"input\":\(jsonNumber(before["input"] ?? nil))}," +
+        "\"after\":{\"output\":\(jsonNumber(after["output"] ?? nil)),\"input\":\(jsonNumber(after["input"] ?? nil))}}"
+    FileHandle.standardOutput.write(json.data(using: .utf8)!)
+
+    // A device that is present but refuses the write is worth surfacing: the
+    // caller cannot tell it apart from success by the audio alone.
+    if writeFailed {
+        emitError("volume_write_failed")
+        return 1
+    }
     return 0
 }
 
@@ -660,6 +801,12 @@ func SetupSignals() {
 let args = CommandLine.arguments
 if args.count >= 2 && args[1] == "--list" {
     exit(runList())
+} else if args.count >= 3 && args[1] == "--ensure-unity-gain" {
+    guard !args[2].isEmpty else {
+        emitError("bad_device_name")
+        exit(2)
+    }
+    exit(runEnsureUnityGain(deviceName: args[2]))
 } else if args.count >= 3 && args[1] == "--target" {
     if args[2] == "system" {
         SetupSignals()
@@ -675,5 +822,6 @@ if args.count >= 2 && args[1] == "--list" {
     emit("usage:")
     emit("  sokuji-audio-host --list")
     emit("  sokuji-audio-host --target pid:<processId>")
+    emit("  sokuji-audio-host --ensure-unity-gain <deviceName>")
     exit(2)
 }


### PR DESCRIPTION
Fixes the "SokujiVirtualAudio is visible but receives no audio" report in #381.

## What was actually wrong

macOS keeps each device's volume in coreaudiod's own settings store and pushes it onto the driver as the device registers. That stored value outlives the driver binary — reinstalling the driver does **not** reset it.

A macOS 15 → 26 upgrade left the device at **scalar 0.5**, and the driver's volume control is logarithmic across a 64 dB range:

```
dB   = scalar × 64 − 64          scalar 0.5 → −32.0 dB → 2.51% gain
gain = 10^(dB/20)                scalar 0.9 →  −6.4 dB → 47.9% gain
```

So half-slider is not half volume, it is −32 dB. Audio still flows and no layer reports an error — the level meter in Audio MIDI Setup just doesn't move and the receiving application hears silence. Every diagnostic says the device is fine, which is exactly how it was reported.

## Evidence

Measured on the affected machine (macOS 26.6.1, build 25G76, driver 0.6.1):

- Stored settings for `SokujiVirtualAudio2ch_UID` held `outp/volm = 0.5` and `inpt/volm = 0.5`, next to neighbouring devices holding hand-set values like `0.2893525362`. 0.5 is a default-shaped number.
- The value was written at a coreaudiod restart that happened *after* a fresh driver install — a new driver instance defaults to 1.0 internally, so the 0.5 could only have come from the store. That rules out the installer scripts as the origin and places it before the reinstall, in the upgrade.
- Setting the scalar back to unity from an unprivileged process succeeds, and coreaudiod persists it at its next restart (verified by restarting the daemon and re-reading).

What is *not* established: whether the upgrade explicitly rewrote the value or dropped the entry and the system supplied a 0.5 midpoint — the pre-upgrade store was overwritten and the machine has no snapshots. Both are the same thing from the user's side. It is also possible this can bite a first-time install on any macOS version; the fix covers that case either way.

## The change

- `native/audio-host/mac/main.swift` — new `--ensure-unity-gain <device>` mode. Reads both scopes *before* writing either (in BlackHole-derived drivers the two scopes are one stored value, so a read-as-you-go loop would report the second scope as fine all along), writes unity where something moved it, clears mute, and prints what it found as JSON.
- `electron/audio-host.js` — `ensureUnityGain()` wrapper. Never throws, never rejects; a helper that is missing, too old to know the mode, or unable to write returns `null` meaning "could not tell".
- `electron/macos-audio-utils.js` — `createVirtualAudioDevices()` calls it once the driver is known to be installed, and logs what it found.
- `native/audio-host/mac/build.sh` — comment fix only: it claimed the binary under `resources/bin` is committed, but `.gitignore` excludes it and CI builds it before packaging. That stale comment cost me a round trip; no binary needs to ship with this PR.

Deliberately best-effort: if the gain check fails, virtual-microphone support is left exactly as it was. Failing startup over a volume probe would be a worse outcome than the quiet device it repairs.

## Verification

- Full suite: **205 files, 2454 tests passing**.
- New tests cover the helper wrapper (device name passed through, `found:false`, an old helper answering with usage text, malformed output, spawn failure, child error) and the startup wiring (repairs when installed, doesn't when not, and a failing repair still reports the device usable).
- On real hardware: device deliberately set to 0.5 → mode reported `before {0.5, 0.5} → after {1.0, 1.0}, changed:true` and repaired it; the following run was a no-op; an absent device returns `{"found":false}` and exit 0; an empty name exits 2.
- Both `arm64-apple-macosx14.2` and `x86_64-apple-macosx14.2` compile, since CI builds both slices.

## Not in this PR

- The driver could be built with `kEnableVolumeControl=false` so the control cannot attenuate at all. That is a one-token change to the build script, but it only reaches users who reinstall the pkg, whereas this fixes machines that already upgraded.
- No reply has been posted to #381 yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * macOS virtual audio devices now restore volume to unity gain and clear mute states when needed.
  * Added support for checking and repairing audio device gain through the native audio helper.
  * Missing or unsupported devices are handled safely without blocking startup.

* **Bug Fixes**
  * Improved handling of helper failures, invalid responses, launch errors, and unavailable devices.

* **Documentation**
  * Added usage guidance for audio gain restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->