### PR TITLE
refactor(settings): scope the account section to Kizuna providers, drop the dead plan UI

### DIFF
--- a/src/components/Auth/UserAccountInfo.scss
+++ b/src/components/Auth/UserAccountInfo.scss
@@ -346,27 +346,6 @@
 }
 
 
-.upgrade-section {
-  margin-top: 8px;
-  
-  .upgrade-button {
-    width: 100%;
-    padding: 8px;
-    background: #10a37f;
-    color: #fff;
-    border: none;
-    border-radius: 4px;
-    font-size: 13px;
-    font-weight: 500;
-    cursor: pointer;
-    transition: background 0.2s;
-    
-    &:hover {
-      background: #0e8f6f;
-    }
-  }
-}
-
 // Email verification message
 .verification-message {
   padding: 8px 12px;
@@ -470,50 +449,6 @@
   // Push refresh button to the right
   .action-button-compact {
     margin-left: auto;
-  }
-  
-  .plan-badge {
-    display: inline-block;
-    padding: 2px 6px;
-    border-radius: 3px;
-    font-size: 10px;
-    font-weight: 600;
-    text-transform: uppercase;
-    
-    &.plan-badge-free {
-      background: #333;
-      color: #999;
-    }
-    
-    &.plan-badge-starter {
-      background: #2a4e7c;
-      color: #5ba0f2;
-    }
-    
-    &.plan-badge-essentials {
-      background: #4a3c28;
-      color: #f0b429;
-    }
-    
-    &.plan-badge-professional, &.plan-badge-pro {
-      background: #3c2a4a;
-      color: #b77ff0;
-    }
-    
-    &.plan-badge-business {
-      background: #2a4a3c;
-      color: #7ff0b7;
-    }
-    
-    &.plan-badge-enterprise {
-      background: #4a2a3c;
-      color: #f07fb7;
-    }
-    
-    &.plan-badge-unlimited {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: #fff;
-    }
   }
   
   .divider {

--- a/src/components/Auth/UserAccountInfo.tsx
+++ b/src/components/Auth/UserAccountInfo.tsx
@@ -8,12 +8,12 @@ import {useUserProfile} from '../../contexts/UserProfileContext';
 import {authClient} from '../../lib/auth-client';
 import {
   AlertCircle,
+  ChartColumn,
   CheckCircle,
   LogOut,
   Mail,
   MessageCircleQuestion,
   RefreshCw,
-  TrendingDown,
   UserCog,
   Wallet
 } from 'lucide-react';
@@ -261,14 +261,6 @@ export function UserAccountInfo({
     openExternalWithAuth('/dashboard/feedback');
   };
 
-  // Handle manage subscription click - navigate to subscription management
-  const handleManageSubscriptionClick = () => {
-    // Track subscription management click
-    trackEvent('subscription_management_clicked', {});
-    // TODO: Implement subscription management page or link to backend billing page
-    console.log('Manage subscription clicked - implement subscription management');
-  };
-
   // Handle refresh click
   const handleRefresh = () => {
     trackEvent('user_profile_refresh_clicked', {});
@@ -375,17 +367,13 @@ export function UserAccountInfo({
           <>
 
             <div className="quota-compact-line">
-              <span className={`plan-badge plan-badge-${subscription}`}>
-                {subscription.toUpperCase()}
-              </span>
-              <span className="divider">|</span>
               <Wallet size={14} className="wallet-icon"/>
               <span className="balance-section">
                 {formatUsd(quota.balance || quota.remaining)}
               </span>
               <span className="divider">|</span>
               <span className="usage-section">
-                <TrendingDown size={14} className="usage-icon"/>
+                <ChartColumn size={14} className="usage-icon"/>
                 30D: {formatUsd(quota.last30DaysUsage || 0)}
               </span>
               <button
@@ -399,17 +387,6 @@ export function UserAccountInfo({
           </>
         )}
       </div>
-
-      {subscription === 'free' && (
-        <div className="upgrade-section">
-          <button
-            className="upgrade-button"
-            onClick={handleManageSubscriptionClick}
-          >
-            {t('tokenUsage.upgradeToPremium')}
-          </button>
-        </div>
-      )}
 
     </div>
   );

--- a/src/components/Settings/sections/AccountSection.test.tsx
+++ b/src/components/Settings/sections/AccountSection.test.tsx
@@ -1,0 +1,92 @@
+/**
+ * The user account section is scoped to the Kizuna-managed providers.
+ *
+ * Everything the section offers - balance, 30-day usage, sign-in - only means
+ * something when the relay is billing the user's wallet. On a bring-your-own-key
+ * provider (OpenAI, Gemini, a local engine) the account panel is noise: it shows
+ * a balance nothing draws from and a sign-in prompt for a service the user is
+ * not about to call. So it renders on `isKizunaManagedProvider(provider)`, not
+ * merely on the Kizuna feature flag being compiled in.
+ *
+ * Both conditions have to hold: the flag alone was the previous behaviour, and
+ * the provider alone would render a dead section in builds where the Kizuna
+ * twins are never registered with ProviderConfigFactory.
+ */
+import React from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import AccountSection from './AccountSection';
+import { Provider } from '../../../types/Provider';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string, def?: string) => def ?? key }),
+}));
+
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock('../../Tooltip/Tooltip', () => ({
+  default: () => <span data-testid="tooltip" />,
+}));
+
+vi.mock('../../Auth/UserAccountInfo', () => ({
+  UserAccountInfo: () => <div data-testid="user-account-info" />,
+}));
+
+vi.mock('../../Auth/AuthGuard', () => ({
+  SignedIn: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  SignedOut: () => null,
+}));
+
+const env = { kizunaEnabled: true };
+vi.mock('../../../utils/environment', () => ({
+  isKizunaAIEnabled: () => env.kizunaEnabled,
+}));
+
+const store = { provider: Provider.KIZUNA_AI_OPENAI_TRANSLATE as string };
+vi.mock('../../../stores/settingsStore', () => ({
+  useProvider: () => store.provider,
+}));
+
+beforeEach(() => {
+  env.kizunaEnabled = true;
+  store.provider = Provider.KIZUNA_AI_OPENAI_TRANSLATE;
+});
+
+const section = () => document.getElementById('user-account-section');
+
+describe('AccountSection provider scoping', () => {
+  it.each([
+    Provider.KIZUNA_AI_OPENAI_TRANSLATE,
+    Provider.KIZUNA_AI_VOLCENGINE_AST2,
+    Provider.KIZUNA_AI_SONIOX,
+  ])('renders for the Kizuna-managed provider %s', (provider) => {
+    store.provider = provider;
+    render(<AccountSection />);
+    expect(section()).not.toBeNull();
+    expect(screen.getByTestId('user-account-info')).toBeTruthy();
+  });
+
+  it.each([
+    Provider.OPENAI,
+    Provider.GEMINI,
+    Provider.OPENAI_TRANSLATE,
+    Provider.VOLCENGINE_AST2,
+    Provider.SONIOX,
+    Provider.LOCAL_INFERENCE,
+  ])('stays hidden on the bring-your-own-key provider %s', (provider) => {
+    store.provider = provider;
+    render(<AccountSection />);
+    expect(section()).toBeNull();
+  });
+
+  it('stays hidden when the Kizuna feature flag is off, even on a Kizuna provider', () => {
+    // A persisted setting can name a Kizuna provider in a build that never
+    // registered it; the flag is what says the section has a backend at all.
+    env.kizunaEnabled = false;
+    store.provider = Provider.KIZUNA_AI_OPENAI_TRANSLATE;
+    render(<AccountSection />);
+    expect(section()).toBeNull();
+  });
+});

--- a/src/components/Settings/sections/AccountSection.tsx
+++ b/src/components/Settings/sections/AccountSection.tsx
@@ -6,6 +6,8 @@ import Tooltip from '../../Tooltip/Tooltip';
 import { UserAccountInfo } from '../../Auth/UserAccountInfo';
 import { SignedIn, SignedOut } from '../../Auth/AuthGuard';
 import { isKizunaAIEnabled } from '../../../utils/environment';
+import { useProvider } from '../../../stores/settingsStore';
+import { isKizunaManagedProvider } from '../../../types/Provider';
 
 interface AccountSectionProps {
   /** Additional class name */
@@ -15,9 +17,13 @@ interface AccountSectionProps {
 const AccountSection: React.FC<AccountSectionProps> = ({ className = '' }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const provider = useProvider();
 
-  // Only show if Kizuna AI is enabled
-  if (!isKizunaAIEnabled()) {
+  // The account panel only means something while the relay is billing the
+  // user's wallet. On a bring-your-own-key provider it would show a balance
+  // nothing draws from, so scope it to the Kizuna-managed providers - and to
+  // builds where those providers are registered at all.
+  if (!isKizunaAIEnabled() || !isKizunaManagedProvider(provider)) {
     return null;
   }
 


### PR DESCRIPTION
## What this does

Three small settings-panel changes, plus the investigation behind the third.

### 1. The account section only renders for Kizuna-managed providers

`AccountSection` previously rendered whenever `isKizunaAIEnabled()`. It now also requires `isKizunaManagedProvider(provider)`.

The panel only means something while the relay is billing the user's wallet. On a bring-your-own-key provider it showed a balance nothing draws from and a sign-in prompt for a service the user was not about to call.

Both conditions are load-bearing: the flag alone was the previous behaviour, and the provider alone would render a dead section in builds where the Kizuna twins are never registered with `ProviderConfigFactory`. New test covers all three Kizuna providers, six bring-your-own-key providers, and the flag-off case.

The basic onboarding step that targets `#user-account-section` is deliberately left as-is.

### 2. The upgrade prompt is gone

It was gated on `subscription === 'free'` — i.e. always shown — and its click handler was a `console.log` behind a TODO. A button that does nothing is worse than no button.

### 3. The plan badge is gone, because there are no plans

**There is no plan concept anywhere in the system.** The backend's `/api/wallet/status` returns no plan field — it is a pure prepaid wallet, a micro-USD balance plus top-ups — and `mapWalletStatusToQuota` hard-codes `plan: 'free'`.

So the badge always read `FREE`, and the seven `.plan-badge-{starter,essentials,professional,business,enterprise,unlimited}` rules could never match anything. Removed, along with 65 lines of dead SCSS.

### Also

The 30-day usage icon changes from `TrendingDown` to `ChartColumn`. A downward arrow reads as "decreasing", which is not what a usage figure states.

## Verified

Full suite green: 205 files, 2451 tests. `tsc --noEmit` shows no new errors (the two pre-existing ones in `UserAccountInfo.tsx` are unchanged — confirmed by diffing the typecheck output before and after).

## Note

Removing the only consumer of `tokenUsage.upgradeToPremium` leaves that key orphaned in the locale catalogs. Left in place rather than touching 35 translation files in a UI-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Simplified account quota information with a clearer usage indicator.
  - Removed subscription plan badges and upgrade controls from account information.
  - Account settings now show Kizuna AI options only when the feature is enabled and a supported Kizuna-managed provider is selected.
  - Settings are hidden for local and bring-your-own-key configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->