### PR TITLE
feat(soniox): upgrade TTS to tts-rt-v2 before v1 is removed

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -28,6 +28,7 @@ import useSettingsStore, { createParticipantLocalInferenceConfig, createParticip
 import type { SettingsStore } from '../../stores/settingsStore';
 import { ProviderConfigFactory } from '../../services/providers/ProviderConfigFactory';
 import { SonioxProviderConfig } from '../../services/providers/SonioxProviderConfig';
+import { SONIOX_DEFAULT_VOICE, resolveVoice } from '../../lib/soniox/ttsCatalog';
 import { sonioxBothModePlan, type SonioxBothModePlan } from '../../services/providers/sonioxBothMode';
 import { reverseTranscriptionDirection } from '../../services/providers/openaiTranscriptionContext';
 import { reverseGeminiTranslationDirection } from '../../services/providers/geminiTranslateModel';
@@ -126,7 +127,6 @@ function usesLocalSileroVad(provider: string): boolean {
 const SONIOX_BUILTIN_VOICES = new Set(
   new SonioxProviderConfig().getConfig().voices.map((v) => v.value)
 );
-const SONIOX_DEFAULT_VOICE = 'Maya';
 
 // ---------------------------------------------------------------------------
 // ConversationBubble – row renderer extracted from MainPanel.renderConversationItem
@@ -2004,7 +2004,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         (kizunaBaseProvider(provider) ?? provider) === Provider.SONIOX &&
         isKizunaManagedProvider(provider)
       ) {
-        const sonioxVoiceSetting = readStoredSonioxVoice();
+        // Normalized first: "not a built-in" is how a cloned voice is
+        // recognized here, and the tts-rt-v2 upgrade retired seven built-in
+        // names. Without this, a settings file still holding 'Maya' would look
+        // like a cloned-voice UUID and send this down the rebuild path.
+        const sonioxVoiceSetting = resolveVoice(readStoredSonioxVoice());
         if (sonioxVoiceSetting && !SONIOX_BUILTIN_VOICES.has(sonioxVoiceSetting)) {
           setVoicePreparing(true);
           try {

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -27,8 +27,7 @@ import {
 import useSettingsStore, { createParticipantLocalInferenceConfig, createParticipantLocalNativeConfig } from '../../stores/settingsStore';
 import type { SettingsStore } from '../../stores/settingsStore';
 import { ProviderConfigFactory } from '../../services/providers/ProviderConfigFactory';
-import { SonioxProviderConfig } from '../../services/providers/SonioxProviderConfig';
-import { SONIOX_DEFAULT_VOICE, resolveVoice } from '../../lib/soniox/ttsCatalog';
+import { SonioxProviderConfig, defaultSonioxSettings } from '../../services/providers/SonioxProviderConfig';
 import { sonioxBothModePlan, type SonioxBothModePlan } from '../../services/providers/sonioxBothMode';
 import { reverseTranscriptionDirection } from '../../services/providers/openaiTranscriptionContext';
 import { reverseGeminiTranslationDirection } from '../../services/providers/geminiTranslateModel';
@@ -127,6 +126,7 @@ function usesLocalSileroVad(provider: string): boolean {
 const SONIOX_BUILTIN_VOICES = new Set(
   new SonioxProviderConfig().getConfig().voices.map((v) => v.value)
 );
+const SONIOX_DEFAULT_VOICE = defaultSonioxSettings.voice;
 
 // ---------------------------------------------------------------------------
 // ConversationBubble – row renderer extracted from MainPanel.renderConversationItem
@@ -2004,11 +2004,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         (kizunaBaseProvider(provider) ?? provider) === Provider.SONIOX &&
         isKizunaManagedProvider(provider)
       ) {
-        // Normalized first: "not a built-in" is how a cloned voice is
-        // recognized here, and the tts-rt-v2 upgrade retired seven built-in
-        // names. Without this, a settings file still holding 'Maya' would look
-        // like a cloned-voice UUID and send this down the rebuild path.
-        const sonioxVoiceSetting = resolveVoice(readStoredSonioxVoice());
+        const sonioxVoiceSetting = readStoredSonioxVoice();
         if (sonioxVoiceSetting && !SONIOX_BUILTIN_VOICES.has(sonioxVoiceSetting)) {
           setVoicePreparing(true);
           try {

--- a/src/components/MainPanel/voicePrepWiring.test.ts
+++ b/src/components/MainPanel/voicePrepWiring.test.ts
@@ -79,21 +79,21 @@ describe('voice-prep notice vs. the post-init setItems overwrite', () => {
 describe('voice-prep result wiring: the asymmetric settings write (resolveVoicePrepOutcome, the real production function)', () => {
   it('never produces a settings patch when prepareManagedVoice fails', () => {
     const result: VoicePrepResult = { ok: false, reason: 'pool_exhausted' };
-    const outcome = resolveVoicePrepOutcome(result, 'cloned-uuid-123', 'Maya');
+    const outcome = resolveVoicePrepOutcome(result, 'cloned-uuid-123', 'Adrian');
     // A busy pool tonight must not silently demote the stored preference —
     // the next session should try the real voice again.
     expect(outcome.settingsPatch).toBeNull();
     // The session still gets a usable voice — just not a persisted one.
-    expect(outcome.sessionVoice).toBe('Maya');
+    expect(outcome.sessionVoice).toBe('Adrian');
     expect(outcome.notice).not.toBeNull();
   });
 
   it('produces a settings patch only when the successful id actually changed', () => {
-    const unchanged = resolveVoicePrepOutcome({ ok: true, voiceId: 'cloned-uuid-123' }, 'cloned-uuid-123', 'Maya');
+    const unchanged = resolveVoicePrepOutcome({ ok: true, voiceId: 'cloned-uuid-123' }, 'cloned-uuid-123', 'Adrian');
     expect(unchanged.settingsPatch).toBeNull();
     expect(unchanged.sessionVoice).toBe('cloned-uuid-123');
 
-    const rebuilt = resolveVoicePrepOutcome({ ok: true, voiceId: 'cloned-uuid-999' }, 'cloned-uuid-123', 'Maya');
+    const rebuilt = resolveVoicePrepOutcome({ ok: true, voiceId: 'cloned-uuid-999' }, 'cloned-uuid-123', 'Adrian');
     expect(rebuilt.settingsPatch).toEqual({ voice: 'cloned-uuid-999' });
     expect(rebuilt.sessionVoice).toBe('cloned-uuid-999');
   });
@@ -110,10 +110,10 @@ describe('voice-prep result wiring: the asymmetric settings write (resolveVoiceP
       return { voice: builtinFallback };
     }
     const failed: VoicePrepResult = { ok: false, reason: 'pool_exhausted' };
-    const wrongPatch = unconditionalWrite(failed, 'Maya');
-    expect(wrongPatch).toEqual({ voice: 'Maya' }); // the bug the real guard prevents
+    const wrongPatch = unconditionalWrite(failed, 'Adrian');
+    expect(wrongPatch).toEqual({ voice: 'Adrian' }); // the bug the real guard prevents
 
-    const realOutcome = resolveVoicePrepOutcome(failed, 'cloned-uuid-123', 'Maya');
+    const realOutcome = resolveVoicePrepOutcome(failed, 'cloned-uuid-123', 'Adrian');
     expect(realOutcome.settingsPatch).toBeNull();
     expect(realOutcome.settingsPatch).not.toEqual(wrongPatch);
   });
@@ -190,11 +190,11 @@ describe('voice-prep freshness: a choice made during preparation wins', () => {
       makeVoiceWorld(SNAPSHOT),
       { ok: true, voiceId: REBUILT },
       SNAPSHOT,
-      'Maya',
-      (w) => { w.storedVoice = 'Maya'; }
+      'Adrian',
+      (w) => { w.storedVoice = 'Adrian'; }
     );
-    expect(world.storedVoice).toBe('Maya');       // preference not reverted
-    expect(world.sessionConfigVoice).toBe('Maya'); // and this session speaks as asked
+    expect(world.storedVoice).toBe('Adrian');       // preference not reverted
+    expect(world.sessionConfigVoice).toBe('Adrian'); // and this session speaks as asked
   });
 
   it('contrast: without the guard the rebuilt UUID clobbers both', () => {
@@ -204,8 +204,8 @@ describe('voice-prep freshness: a choice made during preparation wins', () => {
       makeVoiceWorld(SNAPSHOT),
       { ok: true, voiceId: REBUILT },
       SNAPSHOT,
-      'Maya',
-      (w) => { w.storedVoice = 'Maya'; },
+      'Adrian',
+      (w) => { w.storedVoice = 'Adrian'; },
       undefined,
       { guarded: false }
     );
@@ -220,7 +220,7 @@ describe('voice-prep freshness: a choice made during preparation wins', () => {
       makeVoiceWorld(SNAPSHOT),
       { ok: true, voiceId: REBUILT },
       SNAPSHOT,
-      'Maya'
+      'Adrian'
     );
     expect(world.storedVoice).toBe(REBUILT);
     expect(world.sessionConfigVoice).toBe(REBUILT);
@@ -235,7 +235,7 @@ describe('voice-prep freshness: a choice made during preparation wins', () => {
       makeVoiceWorld(SNAPSHOT),
       { ok: false, reason: 'pool_exhausted' },
       SNAPSHOT,
-      'Maya',
+      'Adrian',
       undefined,
       (w) => { w.storedVoice = 'Aurora'; }
     );
@@ -248,10 +248,10 @@ describe('voice-prep freshness: a choice made during preparation wins', () => {
       makeVoiceWorld(SNAPSHOT),
       { ok: false, reason: 'pool_exhausted' },
       SNAPSHOT,
-      'Maya'
+      'Adrian'
     );
     expect(world.storedVoice).toBe(SNAPSHOT); // fallback is never persisted
-    expect(world.sessionConfigVoice).toBe('Maya');
+    expect(world.sessionConfigVoice).toBe('Adrian');
     expect(world.notice).toBe('mainPanel.sonioxVoicePoolBusy');
   });
 });

--- a/src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
@@ -189,7 +189,7 @@ describe('ProviderSpecificSettings — Soniox advanced settings wiring (#342)', 
     expect(useSettingsStore.getState().soniox.contextText).toBe('Quarterly roadmap sync');
   });
 
-  it('renders no model dropdown for Soniox (fixed stt-rt-v5 + tts-rt-v1 pipeline, nothing to choose)', () => {
+  it('renders no model dropdown for Soniox (fixed stt-rt-v5 + tts-rt-v2 pipeline, nothing to choose)', () => {
     const { container } = mount();
     expect(container.querySelector('.model-selection-container')).toBeNull();
     useSettingsStore.setState({ provider: Provider.KIZUNA_AI_SONIOX });

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -697,7 +697,7 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
   const renderModelSettings = () => {
     // PalabraAI and Local (Offline/Native) inference don't have model selection.
     // Soniox (and its Kizuna twin) neither: the service is a fixed two-model
-    // pipeline (stt-rt-v5 + tts-rt-v1), so a single-option dropdown only
+    // pipeline (stt-rt-v5 + tts-rt-v2), so a single-option dropdown only
     // suggests a choice that doesn't exist.
     if (
       provider === Provider.PALABRA_AI ||

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -85,7 +85,7 @@ function mount(over: object = {}) {
   const onUpdate = vi.fn();
   const utils = render(
     <SonioxVoiceSection
-      settings={{ voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 }}
+      settings={{ voice: SONIOX_DEFAULT_VOICE, apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 }}
       onUpdate={onUpdate}
       source={fakeSource()}
       managed={false}
@@ -142,10 +142,12 @@ describe('SonioxVoiceSection', () => {
     listMock.mockResolvedValue([cloned()]);
     const { container } = mount();
     const select = container.querySelector('select')!;
-    // A count, not a roster: which voices exist is Soniox's to change (see
-    // ttsCatalog). What this asserts is that built-ins render before the
-    // fetch settles, so the dropdown is never momentarily empty.
-    expect(select.querySelectorAll('option').length).toBeGreaterThanOrEqual(20);
+    // Not a count either: any threshold is still a roster-size contract, and
+    // which voices exist is Soniox's to change (see ttsCatalog). The property
+    // is that built-ins are already rendered before the fetch settles, so the
+    // dropdown is never momentarily empty and always offers the default.
+    const optionValues = () => [...select.querySelectorAll('option')].map((o) => o.value);
+    expect(optionValues()).toContain(SONIOX_DEFAULT_VOICE);
     await waitFor(() => expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(true));
   });
 
@@ -470,7 +472,7 @@ describe('SonioxVoiceSection', () => {
   it('clears the previous project\'s clones as soon as the API key changes', async () => {
     listMock.mockResolvedValueOnce([cloned()]).mockReturnValueOnce(new Promise(() => {}));
     const onUpdate = vi.fn();
-    const props = { settings: { voice: 'Adrian', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
+    const props = { settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
     const { container, rerender } = render(<SonioxVoiceSection {...props} />);
     const select = container.querySelector('select')!;
     await waitFor(() => expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(true));
@@ -478,7 +480,7 @@ describe('SonioxVoiceSection', () => {
     // this is a fresh SonioxVoicesClient instance behind a fresh memoized
     // source (ProviderSpecificSettings.tsx's useMemo keyed on the key
     // string); a new fakeSource() here plays that same role.
-    rerender(<SonioxVoiceSection {...props} settings={{ voice: 'Adrian', apiKey: 'other-key' }} source={fakeSource()} />);
+    rerender(<SonioxVoiceSection {...props} settings={{ voice: SONIOX_DEFAULT_VOICE, apiKey: 'other-key' }} source={fakeSource()} />);
     // The new key's fetch never resolves — the old project's clone must
     // already be gone rather than lingering selectable.
     await waitFor(() => expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(false));
@@ -491,7 +493,7 @@ describe('SonioxVoiceSection', () => {
     waitMock.mockReturnValue(new Promise((resolve) => { resolveWait = resolve; }));
     stubAudioContext(16000, 16000 * 5);
     const onUpdate = vi.fn();
-    const props = { settings: { voice: 'Adrian', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
+    const props = { settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
     const { container, rerender } = render(<SonioxVoiceSection {...props} />);
     openManageDetails();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -518,7 +520,7 @@ describe('SonioxVoiceSection', () => {
     waitMock.mockReturnValue(new Promise((resolve) => { resolveWait = resolve; }));
     stubAudioContext(16000, 16000 * 5);
     const onUpdate = vi.fn();
-    const props = { settings: { voice: 'Adrian', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
+    const props = { settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
     const { container, rerender } = render(<SonioxVoiceSection {...props} />);
     openManageDetails();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -531,7 +533,7 @@ describe('SonioxVoiceSection', () => {
     // The user swaps to a different project's key while the clone processes —
     // the old project's UUID must not be written under the new key. A new
     // fakeSource() mirrors the fresh memoized source a real key swap produces.
-    rerender(<SonioxVoiceSection {...props} settings={{ voice: 'Adrian', apiKey: 'other-key' }} source={fakeSource()} />);
+    rerender(<SonioxVoiceSection {...props} settings={{ voice: SONIOX_DEFAULT_VOICE, apiKey: 'other-key' }} source={fakeSource()} />);
 
     resolveWait({ id: 'new-id', name: 'x', models: [READY] });
     await waitFor(() => expect(listMock.mock.calls.length).toBeGreaterThanOrEqual(2));
@@ -822,7 +824,7 @@ describe('SonioxVoiceSection', () => {
 
   it('previews a ready clone with the target language pair and the configured speed', async () => {
     listMock.mockResolvedValue([cloned()]);
-    mount({ settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.2 } });
+    mount({ settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.2 } });
     openManageDetails();
     const playBtn = await screen.findByRole('button', { name: /^play$/i });
     fireEvent.click(playBtn);
@@ -838,7 +840,7 @@ describe('SonioxVoiceSection', () => {
 
   it('falls back to the English pair for a target language with no seeded sentence', async () => {
     listMock.mockResolvedValue([cloned()]);
-    mount({ settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'cy', ttsSpeed: 1.0 } });
+    mount({ settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k', targetLanguage: 'cy', ttsSpeed: 1.0 } });
     openManageDetails();
     fireEvent.click(await screen.findByRole('button', { name: /^play$/i }));
     await waitFor(() => expect(synthesizeMock).toHaveBeenCalledTimes(1));
@@ -868,7 +870,7 @@ describe('SonioxVoiceSection', () => {
     listMock.mockResolvedValue([cloned()]);
     const onUpdate = vi.fn();
     const props = {
-      settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
+      settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
       onUpdate,
       source: fakeSource(),
       managed: false,
@@ -897,7 +899,7 @@ describe('SonioxVoiceSection', () => {
     let release: (v: { audio: Float32Array; sampleRate: number }) => void = () => {};
     synthesizeMock.mockImplementationOnce(() => new Promise((res) => { release = res; }));
     const props = {
-      settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
+      settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
       onUpdate: vi.fn(),
       source: fakeSource(),
       managed: false,
@@ -958,7 +960,7 @@ describe('SonioxVoiceSection', () => {
   });
 
   it('offers no preview affordance and no cost hint without an API key', async () => {
-    mount({ settings: { voice: 'Adrian', apiKey: '', targetLanguage: 'ja', ttsSpeed: 1.0 }, source: null });
+    mount({ settings: { voice: SONIOX_DEFAULT_VOICE, apiKey: '', targetLanguage: 'ja', ttsSpeed: 1.0 }, source: null });
     await waitFor(() => expect(screen.queryByRole('button', { name: /^play$/i })).toBeNull());
     expect(screen.queryByText(/your own Soniox quota/i)).toBeNull();
   });

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import type { VoiceLibrarySource } from './voiceLibrarySource';
+import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE } from '../../../lib/soniox/ttsCatalog';
 
 vi.mock('react-i18next', async (importOriginal) => {
   const actual = await importOriginal<typeof import('react-i18next')>();
@@ -46,7 +47,7 @@ vi.mock('../../../services/clients/SonioxTtsRest', () => ({
 const { default: SonioxVoiceSection } = await import('./SonioxVoiceSection');
 const { SonioxVoicesError } = await import('../../../services/clients/SonioxVoicesClient');
 
-const READY = { model: 'tts-rt-v1', status: 'ready', error_type: null, error_message: null };
+const READY = { model: SONIOX_TTS_MODEL, status: 'ready', error_type: null, error_message: null };
 const cloned = (over: object = {}) => ({ id: 'uuid-1', name: 'Me', models: [READY], ...over });
 
 // jsdom has no Web Audio — stub AudioContext.decodeAudioData to resolve a
@@ -84,7 +85,7 @@ function mount(over: object = {}) {
   const onUpdate = vi.fn();
   const utils = render(
     <SonioxVoiceSection
-      settings={{ voice: 'Maya', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 }}
+      settings={{ voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 }}
       onUpdate={onUpdate}
       source={fakeSource()}
       managed={false}
@@ -137,11 +138,14 @@ describe('SonioxVoiceSection', () => {
     };
   });
 
-  it('renders the 28 built-ins immediately and cloned voices after fetch', async () => {
+  it('renders the built-ins immediately and cloned voices after fetch', async () => {
     listMock.mockResolvedValue([cloned()]);
     const { container } = mount();
     const select = container.querySelector('select')!;
-    expect(select.querySelectorAll('option').length).toBeGreaterThanOrEqual(28);
+    // A count, not a roster: which voices exist is Soniox's to change (see
+    // ttsCatalog). What this asserts is that built-ins render before the
+    // fetch settles, so the dropdown is never momentarily empty.
+    expect(select.querySelectorAll('option').length).toBeGreaterThanOrEqual(20);
     await waitFor(() => expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(true));
   });
 
@@ -167,6 +171,21 @@ describe('SonioxVoiceSection', () => {
     expect(select.value).toBe('gone-uuid'); // stored setting is not rewritten
   });
 
+  it('does not mistake a voice retired by tts-rt-v2 for a deleted clone', async () => {
+    // 'Maya' was Sokuji's shipped default under tts-rt-v1 and is absent from
+    // v2's roster, so after the upgrade it is neither a built-in nor a clone —
+    // exactly the shape the "(deleted voice)" placeholder is built to detect.
+    // Showing it here would offer a Delete button for a voice the user never
+    // cloned, and there is nothing behind that button to delete.
+    listMock.mockResolvedValue([]);
+    const { container } = mount({ settings: { voice: 'Maya', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 } });
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    const select = container.querySelector('select')!;
+    await waitFor(() => expect(select.value).toBe(SONIOX_DEFAULT_VOICE));
+    expect([...select.querySelectorAll('option')].some((o) => o.value === 'Maya')).toBe(false);
+    expect(screen.queryByRole('button', { name: /^delete$/i })).toBeNull();
+  });
+
   it('managed mode renders built-ins only: no fetch, no refresh/create affordances', () => {
     mount({ managed: true, source: null });
     expect(listMock).not.toHaveBeenCalled();
@@ -176,7 +195,7 @@ describe('SonioxVoiceSection', () => {
   });
 
   it('marks failed clones and offers no selection benefit (label carries the failed hint)', async () => {
-    listMock.mockResolvedValue([cloned({ id: 'bad', name: 'Broken', models: [{ model: 'tts-rt-v1', status: 'failed' }] })]);
+    listMock.mockResolvedValue([cloned({ id: 'bad', name: 'Broken', models: [{ model: SONIOX_TTS_MODEL, status: 'failed' }] })]);
     const { container } = mount();
     const select = container.querySelector('select')!;
     await waitFor(() => {
@@ -436,8 +455,8 @@ describe('SonioxVoiceSection', () => {
   it('renders processing/failed clones as disabled options; ready clones stay selectable', async () => {
     listMock.mockResolvedValue([
       cloned(),
-      cloned({ id: 'proc', name: 'Cooking', models: [{ model: 'tts-rt-v1', status: 'processing' }] }),
-      cloned({ id: 'bad', name: 'Broken', models: [{ model: 'tts-rt-v1', status: 'failed' }] }),
+      cloned({ id: 'proc', name: 'Cooking', models: [{ model: SONIOX_TTS_MODEL, status: 'processing' }] }),
+      cloned({ id: 'bad', name: 'Broken', models: [{ model: SONIOX_TTS_MODEL, status: 'failed' }] }),
     ]);
     const { container } = mount();
     const select = container.querySelector('select')!;
@@ -451,7 +470,7 @@ describe('SonioxVoiceSection', () => {
   it('clears the previous project\'s clones as soon as the API key changes', async () => {
     listMock.mockResolvedValueOnce([cloned()]).mockReturnValueOnce(new Promise(() => {}));
     const onUpdate = vi.fn();
-    const props = { settings: { voice: 'Maya', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
+    const props = { settings: { voice: 'Adrian', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
     const { container, rerender } = render(<SonioxVoiceSection {...props} />);
     const select = container.querySelector('select')!;
     await waitFor(() => expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(true));
@@ -459,7 +478,7 @@ describe('SonioxVoiceSection', () => {
     // this is a fresh SonioxVoicesClient instance behind a fresh memoized
     // source (ProviderSpecificSettings.tsx's useMemo keyed on the key
     // string); a new fakeSource() here plays that same role.
-    rerender(<SonioxVoiceSection {...props} settings={{ voice: 'Maya', apiKey: 'other-key' }} source={fakeSource()} />);
+    rerender(<SonioxVoiceSection {...props} settings={{ voice: 'Adrian', apiKey: 'other-key' }} source={fakeSource()} />);
     // The new key's fetch never resolves — the old project's clone must
     // already be gone rather than lingering selectable.
     await waitFor(() => expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(false));
@@ -472,7 +491,7 @@ describe('SonioxVoiceSection', () => {
     waitMock.mockReturnValue(new Promise((resolve) => { resolveWait = resolve; }));
     stubAudioContext(16000, 16000 * 5);
     const onUpdate = vi.fn();
-    const props = { settings: { voice: 'Maya', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
+    const props = { settings: { voice: 'Adrian', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
     const { container, rerender } = render(<SonioxVoiceSection {...props} />);
     openManageDetails();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -499,7 +518,7 @@ describe('SonioxVoiceSection', () => {
     waitMock.mockReturnValue(new Promise((resolve) => { resolveWait = resolve; }));
     stubAudioContext(16000, 16000 * 5);
     const onUpdate = vi.fn();
-    const props = { settings: { voice: 'Maya', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
+    const props = { settings: { voice: 'Adrian', apiKey: 'k' }, onUpdate, source: fakeSource(), managed: false, isSessionActive: false };
     const { container, rerender } = render(<SonioxVoiceSection {...props} />);
     openManageDetails();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -512,7 +531,7 @@ describe('SonioxVoiceSection', () => {
     // The user swaps to a different project's key while the clone processes —
     // the old project's UUID must not be written under the new key. A new
     // fakeSource() mirrors the fresh memoized source a real key swap produces.
-    rerender(<SonioxVoiceSection {...props} settings={{ voice: 'Maya', apiKey: 'other-key' }} source={fakeSource()} />);
+    rerender(<SonioxVoiceSection {...props} settings={{ voice: 'Adrian', apiKey: 'other-key' }} source={fakeSource()} />);
 
     resolveWait({ id: 'new-id', name: 'x', models: [READY] });
     await waitFor(() => expect(listMock.mock.calls.length).toBeGreaterThanOrEqual(2));
@@ -560,7 +579,7 @@ describe('SonioxVoiceSection', () => {
   it('managed mode keeps record/import when the existing voice terminally failed', async () => {
     // The backend DOES rebuild from a fresh clip in this case, so withdrawing
     // the affordances here would strand the user with a dead voice.
-    listMock.mockResolvedValue([cloned({ models: [{ model: 'tts-rt-v1', status: 'failed' }] })]);
+    listMock.mockResolvedValue([cloned({ models: [{ model: SONIOX_TTS_MODEL, status: 'failed' }] })]);
     mount({ managed: true, source: fakeSource({ canPreview: false }) });
     await waitFor(() => expect(listMock).toHaveBeenCalled());
     openManageDetails();
@@ -596,7 +615,7 @@ describe('SonioxVoiceSection', () => {
     fireEvent.click(deleteBtn);
     // DELETE /mine answers 200 with no row, so this is safe and idempotent.
     await waitFor(() => expect(deleteMock).toHaveBeenCalledWith('evicted-uuid'));
-    await waitFor(() => expect(onUpdate).toHaveBeenCalledWith({ voice: 'Maya' }));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledWith({ voice: SONIOX_DEFAULT_VOICE }));
   });
 
   it('BYOK still refuses to delete an unknown id — there it belongs to another project', async () => {
@@ -641,7 +660,7 @@ describe('SonioxVoiceSection', () => {
     // The list is re-fetched...
     await waitFor(() => expect(listMock).toHaveBeenCalledTimes(2));
     // ...and the setting stops pointing at a voice that no longer exists.
-    await waitFor(() => expect(onUpdate).toHaveBeenCalledWith({ voice: 'Maya' }));
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledWith({ voice: SONIOX_DEFAULT_VOICE }));
     // The clip failure is still reported, just after the panel tells the truth.
     expect(screen.queryByText(/could not be removed from this device/i)).not.toBeNull();
   });
@@ -803,7 +822,7 @@ describe('SonioxVoiceSection', () => {
 
   it('previews a ready clone with the target language pair and the configured speed', async () => {
     listMock.mockResolvedValue([cloned()]);
-    mount({ settings: { voice: 'Maya', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.2 } });
+    mount({ settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.2 } });
     openManageDetails();
     const playBtn = await screen.findByRole('button', { name: /^play$/i });
     fireEvent.click(playBtn);
@@ -819,7 +838,7 @@ describe('SonioxVoiceSection', () => {
 
   it('falls back to the English pair for a target language with no seeded sentence', async () => {
     listMock.mockResolvedValue([cloned()]);
-    mount({ settings: { voice: 'Maya', apiKey: 'k', targetLanguage: 'cy', ttsSpeed: 1.0 } });
+    mount({ settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'cy', ttsSpeed: 1.0 } });
     openManageDetails();
     fireEvent.click(await screen.findByRole('button', { name: /^play$/i }));
     await waitFor(() => expect(synthesizeMock).toHaveBeenCalledTimes(1));
@@ -849,7 +868,7 @@ describe('SonioxVoiceSection', () => {
     listMock.mockResolvedValue([cloned()]);
     const onUpdate = vi.fn();
     const props = {
-      settings: { voice: 'Maya', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
+      settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
       onUpdate,
       source: fakeSource(),
       managed: false,
@@ -878,7 +897,7 @@ describe('SonioxVoiceSection', () => {
     let release: (v: { audio: Float32Array; sampleRate: number }) => void = () => {};
     synthesizeMock.mockImplementationOnce(() => new Promise((res) => { release = res; }));
     const props = {
-      settings: { voice: 'Maya', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
+      settings: { voice: 'Adrian', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 },
       onUpdate: vi.fn(),
       source: fakeSource(),
       managed: false,
@@ -906,8 +925,8 @@ describe('SonioxVoiceSection', () => {
 
   it('renders no preview button for processing or failed clones', async () => {
     listMock.mockResolvedValue([
-      cloned({ id: 'proc', name: 'Cooking', models: [{ model: 'tts-rt-v1', status: 'processing' }] }),
-      cloned({ id: 'bad', name: 'Broken', models: [{ model: 'tts-rt-v1', status: 'failed' }] }),
+      cloned({ id: 'proc', name: 'Cooking', models: [{ model: SONIOX_TTS_MODEL, status: 'processing' }] }),
+      cloned({ id: 'bad', name: 'Broken', models: [{ model: SONIOX_TTS_MODEL, status: 'failed' }] }),
     ]);
     mount();
     openManageDetails();
@@ -939,7 +958,7 @@ describe('SonioxVoiceSection', () => {
   });
 
   it('offers no preview affordance and no cost hint without an API key', async () => {
-    mount({ settings: { voice: 'Maya', apiKey: '', targetLanguage: 'ja', ttsSpeed: 1.0 }, source: null });
+    mount({ settings: { voice: 'Adrian', apiKey: '', targetLanguage: 'ja', ttsSpeed: 1.0 }, source: null });
     await waitFor(() => expect(screen.queryByRole('button', { name: /^play$/i })).toBeNull());
     expect(screen.queryByText(/your own Soniox quota/i)).toBeNull();
   });

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -173,19 +173,19 @@ describe('SonioxVoiceSection', () => {
     expect(select.value).toBe('gone-uuid'); // stored setting is not rewritten
   });
 
-  it('does not mistake a voice retired by tts-rt-v2 for a deleted clone', async () => {
-    // 'Maya' was Sokuji's shipped default under tts-rt-v1 and is absent from
-    // v2's roster, so after the upgrade it is neither a built-in nor a clone —
-    // exactly the shape the "(deleted voice)" placeholder is built to detect.
-    // Showing it here would offer a Delete button for a voice the user never
-    // cloned, and there is nothing behind that button to delete.
+  it('renders a retired built-in the same way as any other unknown stored voice', async () => {
+    // 'Maya' was the shipped default under tts-rt-v1 and is absent from v2's
+    // roster, so after the upgrade it is neither a built-in nor a clone — the
+    // same shape as a deleted clone, and shown the same way. Nothing rewrites
+    // it: the stored setting stands until the user picks something else.
     listMock.mockResolvedValue([]);
     const { container } = mount({ settings: { voice: 'Maya', apiKey: 'k', targetLanguage: 'ja', ttsSpeed: 1.0 } });
     await waitFor(() => expect(listMock).toHaveBeenCalled());
     const select = container.querySelector('select')!;
-    await waitFor(() => expect(select.value).toBe(SONIOX_DEFAULT_VOICE));
-    expect([...select.querySelectorAll('option')].some((o) => o.value === 'Maya')).toBe(false);
-    expect(screen.queryByRole('button', { name: /^delete$/i })).toBeNull();
+    await waitFor(() => {
+      expect([...select.querySelectorAll('option')].some((o) => o.value === 'Maya')).toBe(true);
+    });
+    expect(select.value).toBe('Maya');
   });
 
   it('managed mode renders built-ins only: no fetch, no refresh/create affordances', () => {

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -41,6 +41,7 @@ import {
 import { synthesizeOnce } from '../../../services/clients/SonioxTtsRest';
 import { previewSampleFor } from './sonioxPreviewSample';
 import { SonioxProviderConfig, clampNumber } from '../../../services/providers/SonioxProviderConfig';
+import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE, resolveVoice } from '../../../lib/soniox/ttsCatalog';
 import {
   validateVoiceClip,
   downmixToMono,
@@ -75,8 +76,8 @@ export interface SonioxVoiceSectionProps {
 }
 
 const BUILTIN_VOICES = new SonioxProviderConfig().getConfig().voices;
-const TTS_MODEL = 'tts-rt-v1';
-const DEFAULT_VOICE = 'Maya';
+const TTS_MODEL = SONIOX_TTS_MODEL;
+const DEFAULT_VOICE = SONIOX_DEFAULT_VOICE;
 // Reference-clip bounds Soniox enforces server-side; validated client-side on
 // upload too (mirrors NativeVoiceSection / validateVoiceClip's defaults).
 const MIN_CLIP_SECONDS = 3;
@@ -275,8 +276,15 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
   // Latest selection, read at auto-select time: the ready-wait below runs for
   // up to a minute in the background, and a choice the user made meanwhile
   // must not be silently overwritten.
-  const selectedVoiceRef = useRef(settings.voice);
-  useEffect(() => { selectedVoiceRef.current = settings.voice; }, [settings.voice]);
+  // A settings file written under tts-rt-v1 can still name a voice that
+  // tts-rt-v2 retired. Those names left BUILTIN_VOICES with the upgrade, and
+  // everything below keys off "not a known voice ⇒ a cloned one" — so an
+  // unnormalized 'Maya' would render as a "(deleted voice)" row with a Delete
+  // button for a voice the user never cloned. Normalizing once, here, keeps
+  // that misreading out of every consumer below.
+  const selectedVoice = resolveVoice(settings.voice);
+  const selectedVoiceRef = useRef(selectedVoice);
+  useEffect(() => { selectedVoiceRef.current = selectedVoice; }, [selectedVoice]);
 
   const finishCreate = async (
     created: SonioxVoice,
@@ -327,7 +335,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
   const handleConfirm = async (name: string) => {
     if (!source || !pending || modalBusy) return;
     const createSource = source;
-    const selectionAtCreate = settings.voice;
+    const selectionAtCreate = selectedVoice;
     setModalBusy(true);
     setModalError(null);
     try {
@@ -418,7 +426,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
     // The live session's SonioxClient captured this voice id at session start
     // and reuses it for every TTS stream — deleting it server-side would break
     // spoken translation for the rest of the session.
-    if (isSessionActive && settings.voice === id) {
+    if (isSessionActive && selectedVoice === id) {
       setCaptureError(
         t('settings.sonioxVoiceDeleteInUse', 'This voice is being used by the active session — end the session before deleting it')
       );
@@ -532,12 +540,12 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
     // fetch to settle at all, so the entry makes no claim about deletion —
     // it shows the raw id rather than asserting something we have no
     // evidence for.
-    if (settings.voice && !known.has(settings.voice) && listState !== 'loading') {
+    if (selectedVoice && !known.has(selectedVoice) && listState !== 'loading') {
       custom.push({
-        id: settings.voice,
+        id: selectedVoice,
         label: source
           ? t('settings.sonioxVoiceDeletedPlaceholder', '(deleted voice)')
-          : settings.voice,
+          : selectedVoice,
         group: 'custom',
         // MANAGED, and only once the list is KNOWN: an unknown id here is
         // this account's OWN voice after an eviction — the normal outcome of
@@ -565,7 +573,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       });
     }
     return [...builtin, ...custom];
-  }, [clones, managed, managedName, managedListKnown, settings.voice, listState, source, t]);
+  }, [clones, managed, managedName, managedListKnown, selectedVoice, listState, source, t]);
 
   return (
     <div className="settings-section" id="soniox-voice-section">
@@ -584,7 +592,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       )}
       <VoiceLibrarySection
         voices={entries}
-        selectedId={settings.voice}
+        selectedId={selectedVoice}
         onSelect={(id) => onUpdate({ voice: id })}
         onImport={canCreate ? onImport : undefined}
         onRecord={canCreate ? onRecord : undefined}

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -41,7 +41,7 @@ import {
 import { synthesizeOnce } from '../../../services/clients/SonioxTtsRest';
 import { previewSampleFor } from './sonioxPreviewSample';
 import { SonioxProviderConfig, clampNumber } from '../../../services/providers/SonioxProviderConfig';
-import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE, resolveVoice } from '../../../lib/soniox/ttsCatalog';
+import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE } from '../../../lib/soniox/ttsCatalog';
 import {
   validateVoiceClip,
   downmixToMono,
@@ -276,15 +276,8 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
   // Latest selection, read at auto-select time: the ready-wait below runs for
   // up to a minute in the background, and a choice the user made meanwhile
   // must not be silently overwritten.
-  // A settings file written under tts-rt-v1 can still name a voice that
-  // tts-rt-v2 retired. Those names left BUILTIN_VOICES with the upgrade, and
-  // everything below keys off "not a known voice ⇒ a cloned one" — so an
-  // unnormalized 'Maya' would render as a "(deleted voice)" row with a Delete
-  // button for a voice the user never cloned. Normalizing once, here, keeps
-  // that misreading out of every consumer below.
-  const selectedVoice = resolveVoice(settings.voice);
-  const selectedVoiceRef = useRef(selectedVoice);
-  useEffect(() => { selectedVoiceRef.current = selectedVoice; }, [selectedVoice]);
+  const selectedVoiceRef = useRef(settings.voice);
+  useEffect(() => { selectedVoiceRef.current = settings.voice; }, [settings.voice]);
 
   const finishCreate = async (
     created: SonioxVoice,
@@ -335,7 +328,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
   const handleConfirm = async (name: string) => {
     if (!source || !pending || modalBusy) return;
     const createSource = source;
-    const selectionAtCreate = selectedVoice;
+    const selectionAtCreate = settings.voice;
     setModalBusy(true);
     setModalError(null);
     try {
@@ -426,7 +419,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
     // The live session's SonioxClient captured this voice id at session start
     // and reuses it for every TTS stream — deleting it server-side would break
     // spoken translation for the rest of the session.
-    if (isSessionActive && selectedVoice === id) {
+    if (isSessionActive && settings.voice === id) {
       setCaptureError(
         t('settings.sonioxVoiceDeleteInUse', 'This voice is being used by the active session — end the session before deleting it')
       );
@@ -540,12 +533,12 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
     // fetch to settle at all, so the entry makes no claim about deletion —
     // it shows the raw id rather than asserting something we have no
     // evidence for.
-    if (selectedVoice && !known.has(selectedVoice) && listState !== 'loading') {
+    if (settings.voice && !known.has(settings.voice) && listState !== 'loading') {
       custom.push({
-        id: selectedVoice,
+        id: settings.voice,
         label: source
           ? t('settings.sonioxVoiceDeletedPlaceholder', '(deleted voice)')
-          : selectedVoice,
+          : settings.voice,
         group: 'custom',
         // MANAGED, and only once the list is KNOWN: an unknown id here is
         // this account's OWN voice after an eviction — the normal outcome of
@@ -573,7 +566,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       });
     }
     return [...builtin, ...custom];
-  }, [clones, managed, managedName, managedListKnown, selectedVoice, listState, source, t]);
+  }, [clones, managed, managedName, managedListKnown, settings.voice, listState, source, t]);
 
   return (
     <div className="settings-section" id="soniox-voice-section">
@@ -592,7 +585,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       )}
       <VoiceLibrarySection
         voices={entries}
-        selectedId={selectedVoice}
+        selectedId={settings.voice}
         onSelect={(id) => onUpdate({ voice: id })}
         onImport={canCreate ? onImport : undefined}
         onRecord={canCreate ? onRecord : undefined}

--- a/src/components/Settings/sections/voiceLibrarySource.test.ts
+++ b/src/components/Settings/sections/voiceLibrarySource.test.ts
@@ -37,15 +37,17 @@ describe('managedVoiceSource.list', () => {
   });
 
   it('projects the single voice into the shape the section renders', async () => {
-    // The section decides ready/failed by looking for a tts-rt-v1 entry in
-    // `models`. Without that projection a perfectly ready managed voice
-    // renders as "processing…" forever and can never be selected.
+    // The section decides ready/failed by looking for an entry matching the
+    // model this build talks to. Without that projection a perfectly ready
+    // managed voice renders as "processing…" forever and can never be
+    // selected — and projecting the WRONG model id has the same effect, which
+    // is why the id is pinned literally here rather than imported.
     const client = fakeClient({
       mine: vi.fn().mockResolvedValue({ voiceId: 'v1', status: 'ready', createdAt: 42 }),
     });
     const [voice] = await managedVoiceSource(client, ACCOUNT).list();
     expect(voice.id).toBe('v1');
-    expect(voice.models).toEqual([{ model: 'tts-rt-v1', status: 'ready' }]);
+    expect(voice.models).toEqual([{ model: 'tts-rt-v2', status: 'ready' }]);
   });
 });
 

--- a/src/components/Settings/sections/voiceLibrarySource.ts
+++ b/src/components/Settings/sections/voiceLibrarySource.ts
@@ -16,6 +16,7 @@ import type { SonioxVoice, SonioxVoicesClient } from '../../../services/clients/
 import type { ManagedVoicesClient, ManagedVoice } from '../../../services/clients/ManagedVoicesClient';
 import { SonioxVoicesError } from '../../../services/clients/SonioxVoicesClient';
 import { saveVoiceClip, clearVoiceClip } from '../../../lib/soniox/voiceClipStorage';
+import { SONIOX_TTS_MODEL } from '../../../lib/soniox/ttsCatalog';
 
 export interface VoiceLibrarySource {
   /** Every voice this source can offer. The managed source returns zero or
@@ -41,7 +42,7 @@ export function byokVoiceSource(client: SonioxVoicesClient): VoiceLibrarySource 
   };
 }
 
-const TTS_MODEL = 'tts-rt-v1';
+const TTS_MODEL = SONIOX_TTS_MODEL;
 
 /** Project the backend's flat voice record into the per-model shape the
  *  section reads readiness from. Without this the section's isReady/isFailed

--- a/src/lib/soniox/ttsCatalog.ts
+++ b/src/lib/soniox/ttsCatalog.ts
@@ -1,22 +1,25 @@
 /**
  * What Soniox Text-to-Speech accepts: the model id, the built-in voice roster,
- * and the fallback that keeps a saved-but-retired voice from killing a session.
+ * and the wire options that go with them.
  *
  * This module exists because `tts-rt-v1` → `tts-rt-v2` was not the drop-in the
  * vendor changelog promised. Soniox announced v2 as "fully compatible ... simply
  * replace the model name" (GA 2026-08-11, v1 removed 2026-08-31), but v2 drops
- * 7 voices that v1 served — Claire, Elise, Jack, Maya, Meera, Noah, Sofia —
+ * seven voices that v1 served — Claire, Elise, Jack, Maya, Meera, Noah, Sofia —
  * and rejects them with HTTP 400. Sokuji had the model id copied into five
- * modules and the default voice ('Maya', one of the dropped ones) into four, so
- * a rename-per-call-site migration had five chances to miss one and four ways
- * to keep shipping a voice the new model refuses.
+ * modules and the default voice into four, so a rename-per-call-site migration
+ * had five chances to miss one.
+ *
+ * A settings file written under v1 can still name one of the dropped voices.
+ * That is not repaired here: the name reaches the wire, Soniox answers 400, and
+ * the session degrades to subtitles the way any other TTS failure does. The
+ * alternative — a rewrite table mapping retired names to a survivor — hides a
+ * roster change behind a silent voice substitution, and has to be carried
+ * forever afterwards.
  *
  * The roster is a SNAPSHOT (source: `GET /v1/tts-models`, 70 voices,
- * 2026-08-11), not a contract. Soniox deleted the voice table from its own docs
- * in favour of that endpoint, and the v2 roster moved (71 → 70) within hours
- * of GA. `resolveVoice` is what makes a stale snapshot survivable: an unknown
- * name — retired upstream, or persisted in settings from a previous release —
- * degrades to the default instead of reaching the wire and failing the request.
+ * 2026-08-11), not a contract: Soniox deleted the voice table from its own docs
+ * in favour of that endpoint, and the roster moved (71 → 70) within hours of GA.
  */
 import type { VoiceOption } from '../../services/providers/ProviderConfig';
 
@@ -114,27 +117,3 @@ export const SONIOX_VOICES: VoiceOption[] = [
   { name: 'Bianca', value: 'Bianca' }, // female — A serious female voice with a Brazilian accent and crisp, deliberate deli…
   { name: 'Sari', value: 'Sari' }, // female — A calm female voice with a gentle, deep tone and clear delivery
 ];
-
-const KNOWN = new Set(SONIOX_VOICES.map((v) => v.value));
-
-/**
- * Built-ins that v1 served and v2 does not. Named explicitly rather than
- * inferred, because "not in the roster" is also true of every cloned voice.
- */
-const RETIRED = new Set(['Claire', 'Elise', 'Jack', 'Maya', 'Meera', 'Noah', 'Sofia']);
-
-/**
- * A voice name the current model will accept.
- *
- * Cloned voices are UUIDs issued by Soniox and are not in the built-in roster,
- * so anything that is not a known built-in is passed through untouched — only
- * a name that LOOKS like a built-in but is not one gets replaced. That keeps
- * this from silently overriding a user's cloned voice while still catching
- * 'Maya' and the other retired v1 names left in persisted settings.
- */
-export function resolveVoice(voice: string | undefined | null): string {
-  if (!voice) return SONIOX_DEFAULT_VOICE;
-  if (KNOWN.has(voice)) return voice;
-  return RETIRED.has(voice) ? SONIOX_DEFAULT_VOICE : voice;
-}
-

--- a/src/lib/soniox/ttsCatalog.ts
+++ b/src/lib/soniox/ttsCatalog.ts
@@ -1,0 +1,140 @@
+/**
+ * What Soniox Text-to-Speech accepts: the model id, the built-in voice roster,
+ * and the fallback that keeps a saved-but-retired voice from killing a session.
+ *
+ * This module exists because `tts-rt-v1` → `tts-rt-v2` was not the drop-in the
+ * vendor changelog promised. Soniox announced v2 as "fully compatible ... simply
+ * replace the model name" (GA 2026-08-11, v1 removed 2026-08-31), but v2 drops
+ * 7 voices that v1 served — Claire, Elise, Jack, Maya, Meera, Noah, Sofia —
+ * and rejects them with HTTP 400. Sokuji had the model id copied into five
+ * modules and the default voice ('Maya', one of the dropped ones) into four, so
+ * a rename-per-call-site migration had five chances to miss one and four ways
+ * to keep shipping a voice the new model refuses.
+ *
+ * The roster is a SNAPSHOT (source: `GET /v1/tts-models`, 70 voices,
+ * 2026-08-11), not a contract. Soniox deleted the voice table from its own docs
+ * in favour of that endpoint, and the v2 roster moved (71 → 70) within hours
+ * of GA. `resolveVoice` is what makes a stale snapshot survivable: an unknown
+ * name — retired upstream, or persisted in settings from a previous release —
+ * degrades to the default instead of reaching the wire and failing the request.
+ */
+import type { VoiceOption } from '../../services/providers/ProviderConfig';
+
+/** The only TTS model id Sokuji sends. Every call site imports this one. */
+export const SONIOX_TTS_MODEL = 'tts-rt-v2';
+
+/**
+ * Shortens the pauses BETWEEN words without changing how fast the words
+ * themselves are spoken (that is `speed`, and the two are independent).
+ *
+ * On by default because v2's natural pacing is slower than the v1 it replaces:
+ * measured against v1 on identical text, voice and speed, v2 runs ~14% longer
+ * with this off and ~7% shorter with it on. Leaving it off would have shipped
+ * the upgrade as a pacing regression in a live-translation product — and, since
+ * Soniox bills generated audio, a bill increase nobody asked for.
+ */
+export const SONIOX_REDUCE_SILENCE = true;
+
+/** Present in the v2 roster, so it survives the migration. */
+export const SONIOX_DEFAULT_VOICE = 'Adrian';
+
+/**
+ * Built-in v2 voices. Descriptions are Soniox's own, kept because accent is the
+ * part users pick on and it appears nowhere else in the UI.
+ */
+export const SONIOX_VOICES: VoiceOption[] = [
+  { name: 'Daniel', value: 'Daniel' }, // male — A rich, steady male voice with a polished tone, controlled pacing, and a…
+  { name: 'Nina', value: 'Nina' }, // female — A bright, expressive female voice with youthful energy, natural rhythm, a…
+  { name: 'Bryce', value: 'Bryce' }, // male — A deep, powerful male voice with strong projection and a commanding delivery
+  { name: 'Kayla', value: 'Kayla' }, // female — A natural Gen Z female voice with a casual, low-key, and unpolished style
+  { name: 'Nora', value: 'Nora' }, // female — A young female voice with a casual, chatty style and an inquisitive tone
+  { name: 'Emerson', value: 'Emerson' }, // male — A warm, elegant male voice with a formal style and a slight American accent
+  { name: 'Miles', value: 'Miles' }, // male — A deep, smooth British male voice with a relaxed, intimate delivery
+  { name: 'Imogen', value: 'Imogen' }, // female — A clear British female voice with a sincere, down-to-earth, and professio…
+  { name: 'Alistair', value: 'Alistair' }, // male — An older British male voice with a gentle, warm, and grandfatherly sound
+  { name: 'Bennett', value: 'Bennett' }, // male — A deep, articulate male voice with the calm authority of an experienced t…
+  { name: 'Harlan', value: 'Harlan' }, // male — A polished American male narrator with clear, steady delivery for factual…
+  { name: 'Emma', value: 'Emma' }, // female — A smooth, natural female voice with a relaxed pace, subtle warmth, and a…
+  { name: 'Adrian', value: 'Adrian' }, // male — A deep, focused male voice with crisp articulation, measured pacing, and…
+  { name: 'Grace', value: 'Grace' }, // female — A gentle, soothing female voice with soft clarity, unhurried pacing, and…
+  { name: 'Owen', value: 'Owen' }, // male — A grounded male voice with even pacing and a dry, composed tone that feel…
+  { name: 'Mina', value: 'Mina' }, // female — A soft, thoughtful female voice with gentle clarity, steady pacing, and a…
+  { name: 'Kenji', value: 'Kenji' }, // male — A calm, precise male voice with smooth clarity, balanced pacing, and a co…
+  { name: 'Rafael', value: 'Rafael' }, // male — A clear, composed male voice with a warm Spanish accent, balanced pacing,…
+  { name: 'Mateo', value: 'Mateo' }, // male — A warm, youthful male voice with a soft Spanish accent, clear pacing, and…
+  { name: 'Lucia', value: 'Lucia' }, // female — A clear, mature female voice with a natural Spanish accent, steady pacing…
+  { name: 'Oliver', value: 'Oliver' }, // male — A refined male voice with a smooth British accent, gentle pacing, and a c…
+  { name: 'Arthur', value: 'Arthur' }, // male — A deep, mature male voice with a rich British accent, measured pacing, an…
+  { name: 'Isla', value: 'Isla' }, // female — A lively female voice with a bright British accent, clear delivery, and e…
+  { name: 'Victoria', value: 'Victoria' }, // female — A poised female voice with a refined British accent, smooth pacing, and a…
+  { name: 'Cooper', value: 'Cooper' }, // male — A bold male voice with a strong Australian accent, relaxed pacing, and a…
+  { name: 'Mason', value: 'Mason' }, // male — A relaxed male voice with a natural Australian accent, smooth pacing, and…
+  { name: 'Ruby', value: 'Ruby' }, // female — A confident female voice with a natural Australian accent, lively pacing,…
+  { name: 'Arjun', value: 'Arjun' }, // male — A deep male voice with a natural Indian accent, warm resonance, and an ea…
+  { name: 'Rohan', value: 'Rohan' }, // male — A lively male voice with a natural Indian accent, expressive rhythm, and…
+  { name: 'Priya', value: 'Priya' }, // female — A clear female voice with a natural Indian accent, warm pacing, and a com…
+  { name: 'Trevor', value: 'Trevor' }, // male — A casual male voice with a slightly gritty tone and a confident, unrehear…
+  { name: 'Evan', value: 'Evan' }, // male — A friendly, clear male voice that makes detailed information easy to follow
+  { name: 'Nathan', value: 'Nathan' }, // male — A deep, gentle male voice with a soft, calming delivery
+  { name: 'Karan', value: 'Karan' }, // male — A deep, friendly male voice with an Indian accent and a light, upbeat touch
+  { name: 'Wesley', value: 'Wesley' }, // male — A rich, deep male voice with a smooth and authoritative sound
+  { name: 'Curtis', value: 'Curtis' }, // male — A deep, resonant male voice with a relaxed and comforting tone
+  { name: 'Preston', value: 'Preston' }, // male — A confident, friendly male voice with lively emphasis and a persuasive tone
+  { name: 'Walter', value: 'Walter' }, // male — A deep, mature male voice with an earnest, kind, and sincere delivery
+  { name: 'Russell', value: 'Russell' }, // male — A deep, gravelly male voice with a warm and intimate delivery
+  { name: 'Tunde', value: 'Tunde' }, // male — A young nigerian male voice with a deep, melodic sound
+  { name: 'Nigel', value: 'Nigel' }, // male — A warm, neutral British male voice with a clean and balanced delivery
+  { name: 'Shane', value: 'Shane' }, // male — A pleasant male voice with clear speech and steady, easy pacing
+  { name: 'Silas', value: 'Silas' }, // male — An older, deep male voice with a rugged Southern drawl and a wise, unhurr…
+  { name: 'Reid', value: 'Reid' }, // male — A calm, precise male voice with a steady and trustworthy delivery
+  { name: 'Emilio', value: 'Emilio' }, // male — A lively male voice with a Mexican accent and a warm, joyful energy
+  { name: 'Dominic', value: 'Dominic' }, // male — A deep male voice with a wide emotional range and a bold, dramatic delivery
+  { name: 'Elliot', value: 'Elliot' }, // male — A soft-spoken British male voice with warm, calm, and even delivery
+  { name: 'Hugo', value: 'Hugo' }, // male — A deep British male voice with a dramatic, polished storytelling style
+  { name: 'Sebastian', value: 'Sebastian' }, // male — A deep, gravelly British male voice with an intimate and understated sarc…
+  { name: 'Haruto', value: 'Haruto' }, // male — A young male voice with a calm, smooth, and measured delivery
+  { name: 'Freddie', value: 'Freddie' }, // male — A youthful British male voice with a warm, friendly, and enthusiastic style
+  { name: 'Logan', value: 'Logan' }, // male — A warm, conversational male voice with a natural and quietly confident de…
+  { name: 'Poppy', value: 'Poppy' }, // female — A youthful British female voice with bright energy and an easy, casual style
+  { name: 'Harper', value: 'Harper' }, // female — A relaxed female voice with natural pauses and a casual, unscripted delivery
+  { name: 'Cordelia', value: 'Cordelia' }, // female — A calm, polished female character voice with an elegant but menacing edge
+  { name: 'Reese', value: 'Reese' }, // female — A young female voice with confident energy and a bold, determined delivery
+  { name: 'Hazel', value: 'Hazel' }, // female — A warm female voice with a clear, natural, and understated delivery
+  { name: 'Juliet', value: 'Juliet' }, // female — A warm, soothing female voice with slow, poetic phrasing
+  { name: 'Piper', value: 'Piper' }, // female — A cheerful female voice with upbeat energy and a bright, lively delivery
+  { name: 'Reyna', value: 'Reyna' }, // female — A mature female voice with a powerful theatrical range and a warm, comman…
+  { name: 'Sloane', value: 'Sloane' }, // female — A crisp, articulate female narrator with enough range to keep long storie…
+  { name: 'Iris', value: 'Iris' }, // female — A clear, patient female voice with a gentle and reassuring tone
+  { name: 'Freya', value: 'Freya' }, // female — A clear, bright British female voice with a neutral and easy-to-follow de…
+  { name: 'Brooke', value: 'Brooke' }, // female — A bright American female voice with a casual, friendly conversational style
+  { name: 'Bonnie', value: 'Bonnie' }, // female — A soft Australian female voice with a gentle, calming delivery
+  { name: 'Arabella', value: 'Arabella' }, // female — A rich, silky British female voice with a soft and sophisticated delivery
+  { name: 'Colleen', value: 'Colleen' }, // female — A warm, clear female voice that moves naturally between storytelling and…
+  { name: 'Margo', value: 'Margo' }, // female — A dry female voice with flat delivery and sharp, understated sarcasm
+  { name: 'Bianca', value: 'Bianca' }, // female — A serious female voice with a Brazilian accent and crisp, deliberate deli…
+  { name: 'Sari', value: 'Sari' }, // female — A calm female voice with a gentle, deep tone and clear delivery
+];
+
+const KNOWN = new Set(SONIOX_VOICES.map((v) => v.value));
+
+/**
+ * Built-ins that v1 served and v2 does not. Named explicitly rather than
+ * inferred, because "not in the roster" is also true of every cloned voice.
+ */
+const RETIRED = new Set(['Claire', 'Elise', 'Jack', 'Maya', 'Meera', 'Noah', 'Sofia']);
+
+/**
+ * A voice name the current model will accept.
+ *
+ * Cloned voices are UUIDs issued by Soniox and are not in the built-in roster,
+ * so anything that is not a known built-in is passed through untouched — only
+ * a name that LOOKS like a built-in but is not one gets replaced. That keeps
+ * this from silently overriding a user's cloned voice while still catching
+ * 'Maya' and the other retired v1 names left in persisted settings.
+ */
+export function resolveVoice(voice: string | undefined | null): string {
+  if (!voice) return SONIOX_DEFAULT_VOICE;
+  if (KNOWN.has(voice)) return voice;
+  return RETIRED.has(voice) ? SONIOX_DEFAULT_VOICE : voice;
+}
+

--- a/src/lib/soniox/ttsCatalog.ts
+++ b/src/lib/soniox/ttsCatalog.ts
@@ -11,11 +11,23 @@
  * had five chances to miss one.
  *
  * A settings file written under v1 can still name one of the dropped voices.
- * That is not repaired here: the name reaches the wire, Soniox answers 400, and
- * the session degrades to subtitles the way any other TTS failure does. The
- * alternative — a rewrite table mapping retired names to a survivor — hides a
- * roster change behind a silent voice substitution, and has to be carried
- * forever afterwards.
+ * That is deliberately not repaired here. The alternative — a rewrite table
+ * mapping retired names onto a survivor — hides a roster change behind a silent
+ * voice substitution, and has to be carried forever afterwards.
+ *
+ * What a stale name actually does depends on who is asking, because "not in
+ * this roster" is also how the app recognizes a CLONED voice:
+ *
+ *  - BYOK: the name reaches the wire, Soniox answers 400, and the session
+ *    degrades to subtitles the way any other TTS failure does.
+ *  - Managed (Kizuna AI): MainPanel reads it as a cloned voice and runs the
+ *    managed-voice preparation path first.
+ *  - Settings: SonioxVoiceSection lists it as an unknown stored voice — the
+ *    same presentation a deleted clone gets, delete affordance included.
+ *
+ * Only the first is a property of this module. The other two are the existing
+ * "unknown id ⇒ cloned voice" heuristic meeting a roster that shrank, and they
+ * behave that way for any name the roster does not list.
  *
  * The roster is a SNAPSHOT (source: `GET /v1/tts-models`, 70 voices,
  * 2026-08-11), not a contract: Soniox deleted the voice table from its own docs

--- a/src/lib/soniox/ttsCatalog.ts
+++ b/src/lib/soniox/ttsCatalog.ts
@@ -22,8 +22,10 @@
  *    degrades to subtitles the way any other TTS failure does.
  *  - Managed (Kizuna AI): MainPanel reads it as a cloned voice and runs the
  *    managed-voice preparation path first.
- *  - Settings: SonioxVoiceSection lists it as an unknown stored voice — the
- *    same presentation a deleted clone gets, delete affordance included.
+ *  - Settings: SonioxVoiceSection shows it as "(deleted voice)", never
+ *    selectable. The delete affordance beside that row is managed-only
+ *    (`removable: managed && !!source && managedListKnown`), so BYOK gets the
+ *    label without a destructive action next to it.
  *
  * Only the first is a property of this module. The other two are the existing
  * "unknown id ⇒ cloned voice" heuristic meeting a roster that shrank, and they

--- a/src/services/clients/SonioxClient.managed.test.ts
+++ b/src/services/clients/SonioxClient.managed.test.ts
@@ -52,7 +52,7 @@ vi.mock('./SonioxTtsStream', () => ({ SonioxTtsStream: vi.fn(function (o: Soniox
 const BASE_CONFIG: SonioxSessionConfig = {
   provider: 'soniox',
   model: 'stt-rt-v5',
-  voice: 'Maya',
+  voice: 'Adrian',
   sourceLanguage: 'zh',
   targetLanguage: 'en',
   bidirectional: false,

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -64,7 +64,9 @@ vi.mock('./SonioxTtsStream', () => ({ SonioxTtsStream: vi.fn(function (o: unknow
 const BASE_CONFIG: SonioxSessionConfig = {
   provider: 'soniox',
   model: 'stt-rt-v5',
-  voice: 'Maya',
+  // A voice tts-rt-v2 actually serves, so the tests below exercise the normal
+  // path; the retired-voice fallback is asserted explicitly where it belongs.
+  voice: 'Adrian',
   sourceLanguage: 'zh',
   targetLanguage: 'en',
   bidirectional: false,
@@ -750,6 +752,31 @@ describe('SonioxClient compact debug logging', () => {
     // TTS audio arriving surfaces as tts.audio events (logStore groups them)
     tts.handlers.onAudio!(new Int16Array([1, 2, 3]));
     expect(events.find((e) => e.event.type === 'tts.audio')?.event.data).toEqual({ bytes: 3 });
+  });
+
+  it('opens the TTS stream on tts-rt-v2 and never forwards a voice that model retired', async () => {
+    // BASE_CONFIG carries 'Maya' — the voice Sokuji shipped as its default
+    // under tts-rt-v1 and the one tts-rt-v2 rejects with HTTP 400. A live
+    // session config is built from stored settings, so this is the state every
+    // existing installation is in on the first run after the upgrade; letting
+    // it through would fail TTS for all of them and degrade every session to
+    // subtitles.
+    const client = new SonioxClient(byokCredentials('key'));
+    client.setEventHandlers({});
+    await client.connect({ ...BASE_CONFIG, voice: 'Maya', textOnly: false });
+    const opts = ttsInstances.at(-1)!.options as { model: string; voice: string };
+    expect(opts.model).toBe('tts-rt-v2');
+    expect(opts.voice).toBe('Adrian');
+  });
+
+  it('forwards a cloned-voice id to TTS unchanged', async () => {
+    // The fallback keys off a list of retired built-ins, not off "unknown", so
+    // a cloned voice — always absent from the built-in roster — stays intact.
+    const client = new SonioxClient(byokCredentials('key'));
+    client.setEventHandlers({});
+    const uuid = 'bf8c1ec8-548f-4d2c-8706-72e3b840f349';
+    await client.connect({ ...BASE_CONFIG, voice: uuid, textOnly: false });
+    expect((ttsInstances.at(-1)!.options as { voice: string }).voice).toBe(uuid);
   });
 });
 

--- a/src/services/clients/SonioxClient.test.ts
+++ b/src/services/clients/SonioxClient.test.ts
@@ -754,24 +754,21 @@ describe('SonioxClient compact debug logging', () => {
     expect(events.find((e) => e.event.type === 'tts.audio')?.event.data).toEqual({ bytes: 3 });
   });
 
-  it('opens the TTS stream on tts-rt-v2 and never forwards a voice that model retired', async () => {
-    // BASE_CONFIG carries 'Maya' — the voice Sokuji shipped as its default
-    // under tts-rt-v1 and the one tts-rt-v2 rejects with HTTP 400. A live
-    // session config is built from stored settings, so this is the state every
-    // existing installation is in on the first run after the upgrade; letting
-    // it through would fail TTS for all of them and degrade every session to
-    // subtitles.
+  it('opens the TTS stream on tts-rt-v2 and forwards the configured voice verbatim', async () => {
+    // No rewrite layer sits between settings and the wire: a voice tts-rt-v2
+    // retired (settings written under v1) is sent as-is, Soniox answers 400,
+    // and the session degrades to subtitles like any other TTS failure.
     const client = new SonioxClient(byokCredentials('key'));
     client.setEventHandlers({});
     await client.connect({ ...BASE_CONFIG, voice: 'Maya', textOnly: false });
     const opts = ttsInstances.at(-1)!.options as { model: string; voice: string };
     expect(opts.model).toBe('tts-rt-v2');
-    expect(opts.voice).toBe('Adrian');
+    expect(opts.voice).toBe('Maya');
   });
 
   it('forwards a cloned-voice id to TTS unchanged', async () => {
-    // The fallback keys off a list of retired built-ins, not off "unknown", so
-    // a cloned voice — always absent from the built-in roster — stays intact.
+    // Cloned voices are Soniox-issued UUIDs, never members of the built-in
+    // roster; nothing between settings and the wire may normalize them.
     const client = new SonioxClient(byokCredentials('key'));
     client.setEventHandlers({});
     const uuid = 'bf8c1ec8-548f-4d2c-8706-72e3b840f349';

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -12,6 +12,7 @@ import { Provider, ProviderType } from '../../types/Provider';
 import { SonioxSttStream, SonioxSttMessage, SonioxToken, SonioxTranslationConfig, SonioxSttConfig } from './SonioxSttStream';
 import { SonioxTtsStream } from './SonioxTtsStream';
 import { SonioxBudgetSnapshot } from './SonioxCostMeter';
+import { SONIOX_TTS_MODEL, resolveVoice } from '../../lib/soniox/ttsCatalog';
 import type { ManagedSonioxSession, SonioxCredentialBundle, SonioxSttRole } from './ManagedSonioxSession';
 import type { SonioxSessionLeg, SonioxSessionOutcomeNotice } from './SonioxSessionOutcome';
 import { PcmMixer } from './PcmMixer';
@@ -35,7 +36,6 @@ import i18n from '../../locales';
  */
 
 const STT_MODEL = 'stt-rt-v5';
-const TTS_MODEL = 'tts-rt-v1';
 const SAMPLE_RATE = 24000; // Sokuji mic pipeline and ModernAudioPlayer both run at 24 kHz
 const AUTH_PROBE_URL = 'https://api.soniox.com/v1/auth/temporary-api-key';
 /**
@@ -871,8 +871,11 @@ export class SonioxClient implements IClient, SonioxSessionLeg {
     }
     const stream = new SonioxTtsStream({
       apiKey: ttsApiKey,
-      voice: this.currentConfig?.voice || 'Maya',
-      model: TTS_MODEL,
+      // resolveVoice, not `|| default`: a session config can carry a voice the
+      // current model retired (settings persisted under tts-rt-v1), which is
+      // truthy and would reach the wire as a 400.
+      voice: resolveVoice(this.currentConfig?.voice),
+      model: SONIOX_TTS_MODEL,
       sampleRate: SAMPLE_RATE,
       speed: this.currentConfig?.ttsSpeed,
       // Same id as the STT stream — required for the TTS half of a managed

--- a/src/services/clients/SonioxClient.ts
+++ b/src/services/clients/SonioxClient.ts
@@ -12,7 +12,7 @@ import { Provider, ProviderType } from '../../types/Provider';
 import { SonioxSttStream, SonioxSttMessage, SonioxToken, SonioxTranslationConfig, SonioxSttConfig } from './SonioxSttStream';
 import { SonioxTtsStream } from './SonioxTtsStream';
 import { SonioxBudgetSnapshot } from './SonioxCostMeter';
-import { SONIOX_TTS_MODEL, resolveVoice } from '../../lib/soniox/ttsCatalog';
+import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE } from '../../lib/soniox/ttsCatalog';
 import type { ManagedSonioxSession, SonioxCredentialBundle, SonioxSttRole } from './ManagedSonioxSession';
 import type { SonioxSessionLeg, SonioxSessionOutcomeNotice } from './SonioxSessionOutcome';
 import { PcmMixer } from './PcmMixer';
@@ -871,10 +871,7 @@ export class SonioxClient implements IClient, SonioxSessionLeg {
     }
     const stream = new SonioxTtsStream({
       apiKey: ttsApiKey,
-      // resolveVoice, not `|| default`: a session config can carry a voice the
-      // current model retired (settings persisted under tts-rt-v1), which is
-      // truthy and would reach the wire as a 400.
-      voice: resolveVoice(this.currentConfig?.voice),
+      voice: this.currentConfig?.voice || SONIOX_DEFAULT_VOICE,
       model: SONIOX_TTS_MODEL,
       sampleRate: SAMPLE_RATE,
       speed: this.currentConfig?.ttsSpeed,

--- a/src/services/clients/SonioxTtsRest.test.ts
+++ b/src/services/clients/SonioxTtsRest.test.ts
@@ -35,12 +35,15 @@ describe('synthesizeOnce', () => {
     expect(init.headers.Authorization).toBe('Bearer k');
     expect(init.headers['Content-Type']).toBe('application/json');
     expect(JSON.parse(init.body)).toEqual({
-      model: 'tts-rt-v1',
+      model: 'tts-rt-v2',
       voice: 'uuid-1',
       language: 'ja',
       text: 'こんにちは。',
       audio_format: 'pcm_s16le',
       sample_rate: 24000,
+      // An audition is paced like the session it auditions for, so the live
+      // stream and this request have to send the same value.
+      reduce_silence: true,
     });
   });
 

--- a/src/services/clients/SonioxTtsRest.ts
+++ b/src/services/clients/SonioxTtsRest.ts
@@ -21,9 +21,9 @@
  *   (it already listed only the `wss://` origin, which does NOT cover https)
  */
 import { SonioxVoicesError, throwApiError } from './SonioxVoicesClient';
+import { SONIOX_TTS_MODEL, SONIOX_REDUCE_SILENCE } from '../../lib/soniox/ttsCatalog';
 
 const TTS_REST_URL = 'https://tts-rt.soniox.com/tts';
-const TTS_MODEL = 'tts-rt-v1';
 const SAMPLE_RATE = 24000;
 // A preview is one short sentence; anything past this is a stall, not slowness.
 const REQUEST_TIMEOUT_MS = 20_000;
@@ -97,12 +97,15 @@ export async function synthesizeOnce(
           Authorization: `Bearer ${opts.apiKey}`,
         },
         body: JSON.stringify({
-          model: TTS_MODEL,
+          model: SONIOX_TTS_MODEL,
           voice: opts.voice,
           language: opts.language,
           text: opts.text,
           audio_format: 'pcm_s16le',
           sample_rate: SAMPLE_RATE,
+          // Matches the live stream, so an audition is paced like the session
+          // it is auditioning for.
+          reduce_silence: SONIOX_REDUCE_SILENCE,
           ...(opts.speed != null && opts.speed !== 1.0 ? { speed: opts.speed } : {}),
         }),
         signal: controller.signal,

--- a/src/services/clients/SonioxTtsStream.test.ts
+++ b/src/services/clients/SonioxTtsStream.test.ts
@@ -30,7 +30,7 @@ afterEach(() => {
   vi.useRealTimers();
 });
 
-const OPTS = { apiKey: 'k', voice: 'Maya', model: 'tts-rt-v1', sampleRate: 24000 };
+const OPTS = { apiKey: 'k', voice: 'Adrian', model: 'tts-rt-v2', sampleRate: 24000 };
 
 async function openTts() {
   const t = new SonioxTtsStream(OPTS);
@@ -62,8 +62,10 @@ describe('SonioxTtsStream', () => {
     t.sendText('world', 'en');
     const msgs = ws.jsonSent();
     expect(msgs[0]).toMatchObject({
-      api_key: 'k', stream_id: 'utt-1', model: 'tts-rt-v1', voice: 'Maya',
+      api_key: 'k', stream_id: 'utt-1', model: 'tts-rt-v2', voice: 'Adrian',
       language: 'en', audio_format: 'pcm_s16le', sample_rate: 24000,
+      // Only tts-rt-v2 accepts this; a model without silence reduction 400s.
+      reduce_silence: true,
     });
     expect(msgs[1]).toEqual({ stream_id: 'utt-1', text: 'Hello ', text_end: false });
     expect(msgs[2]).toEqual({ stream_id: 'utt-1', text: 'world', text_end: false });

--- a/src/services/clients/SonioxTtsStream.ts
+++ b/src/services/clients/SonioxTtsStream.ts
@@ -28,6 +28,7 @@
  *   `hadActiveStream` so the caller can tell this ordinary idle drop (no
  *   stream was carrying content) apart from one that hit real speech.
  */
+import { SONIOX_REDUCE_SILENCE } from '../../lib/soniox/ttsCatalog';
 
 export interface SonioxTtsOptions {
   apiKey: string;
@@ -293,6 +294,11 @@ export class SonioxTtsStream {
       language,
       audio_format: 'pcm_s16le',
       sample_rate: this.options.sampleRate,
+      // Sent unconditionally: it is only valid on models that advertise
+      // supports_silence_reduction, and this stream only ever opens against
+      // one (SONIOX_TTS_MODEL). A model that does not support it answers 400,
+      // which is the loud failure we want if that constant ever moves back.
+      reduce_silence: SONIOX_REDUCE_SILENCE,
       ...(this.options.speed != null && this.options.speed !== 1.0 ? { speed: this.options.speed } : {}),
       ...(this.options.clientReferenceId ? { client_reference_id: this.options.clientReferenceId } : {}),
     }));

--- a/src/services/clients/SonioxVoicesClient.test.ts
+++ b/src/services/clients/SonioxVoicesClient.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SonioxVoicesClient, encodeWavPcm16 } from './SonioxVoicesClient';
+import { SONIOX_TTS_MODEL } from '../../lib/soniox/ttsCatalog';
 
 const fetchMock = vi.fn();
 
@@ -18,7 +19,7 @@ const ok = (body: unknown) => ({ ok: true, status: 200, json: async () => body }
 const err = (status: number, body: unknown) => ({ ok: false, status, json: async () => body });
 const VOICE = (over: object = {}) => ({
   id: 'v-1', name: 'My Voice',
-  models: [{ model: 'tts-rt-v1', status: 'processing', error_type: null, error_message: null }],
+  models: [{ model: SONIOX_TTS_MODEL, status: 'processing', error_type: null, error_message: null }],
   ...over,
 });
 
@@ -66,14 +67,14 @@ describe('SonioxVoicesClient', () => {
   it('waitUntilReady polls until ready', async () => {
     fetchMock
       .mockResolvedValueOnce(ok(VOICE()))
-      .mockResolvedValueOnce(ok(VOICE({ models: [{ model: 'tts-rt-v1', status: 'ready' }] })));
+      .mockResolvedValueOnce(ok(VOICE({ models: [{ model: SONIOX_TTS_MODEL, status: 'ready' }] })));
     const p = new SonioxVoicesClient('k').waitUntilReady('v-1', { intervalMs: 100 });
     await vi.advanceTimersByTimeAsync(250);
     await expect(p).resolves.toMatchObject({ id: 'v-1' });
   });
 
   it('waitUntilReady rejects terminally on failed (no retry) and on timeout', async () => {
-    fetchMock.mockResolvedValueOnce(ok(VOICE({ models: [{ model: 'tts-rt-v1', status: 'failed', error_message: 'bad clip' }] })));
+    fetchMock.mockResolvedValueOnce(ok(VOICE({ models: [{ model: SONIOX_TTS_MODEL, status: 'failed', error_message: 'bad clip' }] })));
     await expect(new SonioxVoicesClient('k').waitUntilReady('v-1'))
       .rejects.toMatchObject({ errorType: 'voice_failed' });
 

--- a/src/services/clients/SonioxVoicesClient.ts
+++ b/src/services/clients/SonioxVoicesClient.ts
@@ -15,8 +15,10 @@
  * - The organization-wide quota is 20 voices (all projects combined).
  */
 
+import { SONIOX_TTS_MODEL } from '../../lib/soniox/ttsCatalog';
+
 const VOICES_URL = 'https://api.soniox.com/v1/voices';
-const TTS_MODEL = 'tts-rt-v1';
+const TTS_MODEL = SONIOX_TTS_MODEL;
 
 export type SonioxVoiceModelStatus = 'not_computed' | 'processing' | 'ready' | 'failed';
 

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -6,6 +6,10 @@ import {
   parseVocabularyTranslations,
 } from './SonioxProviderConfig';
 import { SonioxSessionConfig } from '../interfaces/IClient';
+import { SONIOX_DEFAULT_VOICE, resolveVoice } from '../../lib/soniox/ttsCatalog';
+
+/** Built-ins tts-rt-v1 served that tts-rt-v2 rejects with HTTP 400. */
+const RETIRED_BY_V2 = ['Claire', 'Elise', 'Jack', 'Maya', 'Meera', 'Noah', 'Sofia'];
 
 describe('parseVocabularyTerms', () => {
   it('splits lines, trims, drops empties and dedupes', () => {
@@ -224,17 +228,43 @@ describe('SonioxProviderConfig.buildSessionConfig', () => {
 });
 
 describe('SonioxProviderConfig voices', () => {
-  it('exposes exactly the official 28-voice catalog (originals first, accented additions after)', () => {
+  const descriptor = new SonioxProviderConfig();
+  const voiceOf = (voice: string) =>
+    (descriptor.buildSessionConfig({ ...defaultSonioxSettings, voice }, '') as SonioxSessionConfig).voice;
+
+  it('offers the tts-rt-v2 roster and none of the seven voices v2 retired', () => {
     const voices = new SonioxProviderConfig().getConfig().voices.map((v) => v.value);
-    expect(voices).toEqual([
-      // Original twelve (order preserved — existing users' stored values):
-      'Adrian', 'Claire', 'Daniel', 'Emma', 'Grace', 'Jack',
-      'Kenji', 'Maya', 'Mina', 'Nina', 'Noah', 'Owen',
-      // Accented additions (official catalog, 2026-07-31):
-      'Rafael', 'Mateo', 'Lucia', 'Sofia',        // Spanish
-      'Oliver', 'Arthur', 'Isla', 'Victoria',     // British
-      'Cooper', 'Mason', 'Ruby', 'Elise',         // Australian
-      'Arjun', 'Rohan', 'Priya', 'Meera',         // Indian
-    ]);
+    // Pinning all 70 names would make this fail on Soniox's release schedule
+    // rather than on ours — the roster is a snapshot of GET /v1/tts-models and
+    // already moved once (71 → 70) on GA day. What must hold is the property
+    // the v1 → v2 migration is about: nothing offered is something v2 rejects.
+    expect(voices.length).toBeGreaterThan(0);
+    expect(new Set(voices).size).toBe(voices.length);
+    for (const retired of RETIRED_BY_V2) expect(voices).not.toContain(retired);
+    // Survivors: still offered, so a user who picked one under v1 keeps it.
+    expect(voices).toEqual(expect.arrayContaining(['Adrian', 'Daniel', 'Kenji', 'Mina', 'Nina']));
+  });
+
+  it('never offers a voice that resolveVoice would rewrite', () => {
+    // The dropdown and the wire have to agree. An option the user can pick
+    // that resolveVoice then swaps out would speak in a voice they did not
+    // choose, with nothing in the UI admitting it.
+    for (const { value } of new SonioxProviderConfig().getConfig().voices) {
+      expect(resolveVoice(value)).toBe(value);
+    }
+  });
+
+  it('rewrites a retired v1 voice from saved settings instead of sending it', () => {
+    // The upgrade path that actually exists: settings written under tts-rt-v1,
+    // read back by a build that talks to v2. 'Maya' was the shipped default,
+    // so this is the common case, not an edge one.
+    for (const retired of RETIRED_BY_V2) expect(voiceOf(retired)).toBe(SONIOX_DEFAULT_VOICE);
+  });
+
+  it('passes a cloned-voice id through untouched', () => {
+    // Cloned voices are Soniox-issued UUIDs and are absent from the built-in
+    // roster by design — the fallback must not mistake that for a stale name.
+    const uuid = 'bf8c1ec8-548f-4d2c-8706-72e3b840f349';
+    expect(voiceOf(uuid)).toBe(uuid);
   });
 });

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -245,11 +245,19 @@ describe('SonioxProviderConfig voices', () => {
     expect(voices).toEqual(expect.arrayContaining(['Adrian', 'Daniel', 'Kenji', 'Mina', 'Nina']));
   });
 
-
+  it('defaults to a voice the roster actually offers', () => {
+    // Nothing rewrites a voice on its way to the wire, so a default that the
+    // model does not serve would fail TTS for every install that has never
+    // picked one — the state a fresh install is in.
+    const voices = new SonioxProviderConfig().getConfig().voices.map((v) => v.value);
+    expect(voices).toContain(SONIOX_DEFAULT_VOICE);
+    expect(defaultSonioxSettings.voice).toBe(SONIOX_DEFAULT_VOICE);
+  });
 
   it('passes a cloned-voice id through untouched', () => {
     // Cloned voices are Soniox-issued UUIDs and are absent from the built-in
-    // roster by design — the fallback must not mistake that for a stale name.
+    // roster by design; nothing between settings and the wire may normalize
+    // them just because the roster does not list them.
     const uuid = 'bf8c1ec8-548f-4d2c-8706-72e3b840f349';
     expect(voiceOf(uuid)).toBe(uuid);
   });

--- a/src/services/providers/SonioxProviderConfig.test.ts
+++ b/src/services/providers/SonioxProviderConfig.test.ts
@@ -6,7 +6,7 @@ import {
   parseVocabularyTranslations,
 } from './SonioxProviderConfig';
 import { SonioxSessionConfig } from '../interfaces/IClient';
-import { SONIOX_DEFAULT_VOICE, resolveVoice } from '../../lib/soniox/ttsCatalog';
+import { SONIOX_DEFAULT_VOICE } from '../../lib/soniox/ttsCatalog';
 
 /** Built-ins tts-rt-v1 served that tts-rt-v2 rejects with HTTP 400. */
 const RETIRED_BY_V2 = ['Claire', 'Elise', 'Jack', 'Maya', 'Meera', 'Noah', 'Sofia'];
@@ -245,21 +245,7 @@ describe('SonioxProviderConfig voices', () => {
     expect(voices).toEqual(expect.arrayContaining(['Adrian', 'Daniel', 'Kenji', 'Mina', 'Nina']));
   });
 
-  it('never offers a voice that resolveVoice would rewrite', () => {
-    // The dropdown and the wire have to agree. An option the user can pick
-    // that resolveVoice then swaps out would speak in a voice they did not
-    // choose, with nothing in the UI admitting it.
-    for (const { value } of new SonioxProviderConfig().getConfig().voices) {
-      expect(resolveVoice(value)).toBe(value);
-    }
-  });
 
-  it('rewrites a retired v1 voice from saved settings instead of sending it', () => {
-    // The upgrade path that actually exists: settings written under tts-rt-v1,
-    // read back by a build that talks to v2. 'Maya' was the shipped default,
-    // so this is the common case, not an edge one.
-    for (const retired of RETIRED_BY_V2) expect(voiceOf(retired)).toBe(SONIOX_DEFAULT_VOICE);
-  });
 
   it('passes a cloned-voice id through untouched', () => {
     // Cloned voices are Soniox-issued UUIDs and are absent from the built-in

--- a/src/services/providers/SonioxProviderConfig.ts
+++ b/src/services/providers/SonioxProviderConfig.ts
@@ -4,6 +4,7 @@ import { IClient, FilteredModel, SessionConfig, SonioxSessionConfig } from '../i
 import { ApiKeyValidationResult } from '../interfaces/ISettingsService';
 import { SonioxClient } from '../clients/SonioxClient';
 import { byokCredentials } from '../clients/ManagedSonioxSession';
+import { SONIOX_VOICES, SONIOX_DEFAULT_VOICE, resolveVoice } from '../../lib/soniox/ttsCatalog';
 
 // Soniox Settings — single BYOK API key (extractCredentials inherited from base)
 export interface SonioxSettings {
@@ -33,7 +34,7 @@ export const defaultSonioxSettings: SonioxSettings = {
   sourceLanguage: 'auto',
   targetLanguage: 'en',
   bothModeSharedSession: true,
-  voice: 'Maya',
+  voice: SONIOX_DEFAULT_VOICE,
   model: 'stt-rt-v5',
   vocabularyTerms: '',
   vocabularyTranslations: '',
@@ -204,7 +205,9 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
     return {
       provider: 'soniox',
       model: settings.model || 'stt-rt-v5',
-      voice: settings.voice || 'Maya',
+      // Settings saved under tts-rt-v1 can name a voice v2 retired; resolveVoice
+      // maps those to the default instead of letting them reach the wire.
+      voice: resolveVoice(settings.voice),
       instructions: systemInstructions,
       sourceLanguage: settings.sourceLanguage,
       targetLanguage: settings.targetLanguage,
@@ -297,39 +300,11 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
   ];
 
   // Every voice is multilingual — any voice speaks any language (official
-  // catalog, 2026-07-31; zh/ja/en live-verified 2026-07-18 for the original
-  // twelve) — so one voice serves both two_way directions.
-  private static readonly VOICES: VoiceOption[] = [
-    { name: 'Adrian', value: 'Adrian' },
-    { name: 'Claire', value: 'Claire' },
-    { name: 'Daniel', value: 'Daniel' },
-    { name: 'Emma', value: 'Emma' },
-    { name: 'Grace', value: 'Grace' },
-    { name: 'Jack', value: 'Jack' },
-    { name: 'Kenji', value: 'Kenji' },
-    { name: 'Maya', value: 'Maya' },
-    { name: 'Mina', value: 'Mina' },
-    { name: 'Nina', value: 'Nina' },
-    { name: 'Noah', value: 'Noah' },
-    { name: 'Owen', value: 'Owen' },
-    // Accented additions (official catalog, 2026-07-31):
-    { name: 'Rafael', value: 'Rafael' },     // Spanish accent
-    { name: 'Mateo', value: 'Mateo' },       // Spanish accent
-    { name: 'Lucia', value: 'Lucia' },       // Spanish accent
-    { name: 'Sofia', value: 'Sofia' },       // Spanish accent
-    { name: 'Oliver', value: 'Oliver' },     // British accent
-    { name: 'Arthur', value: 'Arthur' },     // British accent
-    { name: 'Isla', value: 'Isla' },         // British accent
-    { name: 'Victoria', value: 'Victoria' }, // British accent
-    { name: 'Cooper', value: 'Cooper' },     // Australian accent
-    { name: 'Mason', value: 'Mason' },       // Australian accent
-    { name: 'Ruby', value: 'Ruby' },         // Australian accent
-    { name: 'Elise', value: 'Elise' },       // Australian accent
-    { name: 'Arjun', value: 'Arjun' },       // Indian accent
-    { name: 'Rohan', value: 'Rohan' },       // Indian accent
-    { name: 'Priya', value: 'Priya' },       // Indian accent
-    { name: 'Meera', value: 'Meera' },       // Indian accent
-  ];
+  // catalog; zh/ja/en live-verified 2026-07-18 for the original twelve) — so
+  // one voice serves both two_way directions. The roster itself now lives in
+  // lib/soniox/ttsCatalog, because which voices exist is a property of the TTS
+  // model and changes when the model does.
+  private static readonly VOICES: VoiceOption[] = SONIOX_VOICES;
 
   private static readonly MODELS: ModelOption[] = [
     { id: 'stt-rt-v5', type: 'realtime' }

--- a/src/services/providers/SonioxProviderConfig.ts
+++ b/src/services/providers/SonioxProviderConfig.ts
@@ -4,7 +4,7 @@ import { IClient, FilteredModel, SessionConfig, SonioxSessionConfig } from '../i
 import { ApiKeyValidationResult } from '../interfaces/ISettingsService';
 import { SonioxClient } from '../clients/SonioxClient';
 import { byokCredentials } from '../clients/ManagedSonioxSession';
-import { SONIOX_VOICES, SONIOX_DEFAULT_VOICE, resolveVoice } from '../../lib/soniox/ttsCatalog';
+import { SONIOX_VOICES, SONIOX_DEFAULT_VOICE } from '../../lib/soniox/ttsCatalog';
 
 // Soniox Settings — single BYOK API key (extractCredentials inherited from base)
 export interface SonioxSettings {
@@ -205,9 +205,7 @@ export class SonioxProviderConfig extends BaseProviderDescriptor {
     return {
       provider: 'soniox',
       model: settings.model || 'stt-rt-v5',
-      // Settings saved under tts-rt-v1 can name a voice v2 retired; resolveVoice
-      // maps those to the default instead of letting them reach the wire.
-      voice: resolveVoice(settings.voice),
+      voice: settings.voice || SONIOX_DEFAULT_VOICE,
       instructions: systemInstructions,
       sourceLanguage: settings.sourceLanguage,
       targetLanguage: settings.targetLanguage,


### PR DESCRIPTION
Closes #402.

Soniox made `tts-rt-v2` generally available on **2026-08-11** and marked `tts-rt-v1` **deprecated with removal on 2026-08-31**, after which v1 requests auto-route to v2. Without this change Soniox TTS stops working on that date.

## Why this is more than a rename

The vendor changelog says the upgrade is *"fully compatible … simply replace the model name."* Verified against the live API, it is not:

**1. v2 drops seven voices v1 served.** `Claire`, `Elise`, `Jack`, `Maya`, `Meera`, `Noah`, `Sofia` — all rejected with HTTP 400 on v2. `Maya` was our shipped default.

**2. v2 paces speech more slowly than v1.** Measured against the live API on identical text, voice and speed:

| config | audio length |
| --- | --- |
| `tts-rt-v1` | 5.63 s |
| `tts-rt-v2` (default) | 6.40 s (**+14%**) |
| `tts-rt-v2` + `reduce_silence` | 5.21 s (**−7%**) |

`reduce_silence` shortens the gaps between words without touching speaking rate (it is independent of `speed`). Shipping without it would have made a live-translation product slower and — since Soniox bills generated audio — more expensive, with no code change on our side to explain either.

## What changed

- **New `src/lib/soniox/ttsCatalog.ts`** — the model id, the voice roster and the wire options in one place. The model id had been copied into five modules and the default voice into four, so a rename-per-call-site migration had five chances to miss one.
- **`reduce_silence` is sent** on both the realtime stream and the REST preview, so an audition is paced like the session it auditions for.
- **Voice roster refreshed to v2's 70 voices**, generated from `GET /v1/tts-models` with Soniox's own descriptions.
- **New default voice `Adrian`**, replacing the retired `Maya`.

## What happens to a settings file written under v1

Nothing rewrites it. A retired voice name reaches the wire, Soniox answers 400, and the session degrades to subtitles the way any other TTS failure does; in Settings the name shows up as an unknown stored voice, the same as a deleted clone.

An earlier revision of this branch carried a `resolveVoice` shim that mapped retired names onto the default. It was removed deliberately: it is a compatibility layer with no end date, and it pays for itself by silently substituting a voice the user did not choose.

## On the roster being a snapshot

Soniox removed the voice table from its docs in favour of `GET /v1/tts-models`, and the v2 roster moved (71 → 70) within hours of GA. The tests assert that nothing we offer is something v2 rejects, rather than pinning 70 names to a list that would fail on Soniox's release schedule instead of ours.

## Verification

- `vitest`: **204 files / 2445 tests passing**
- `vite build`: passing
- `tsc --noEmit`: no new errors on touched files
- The 400s and the timings above were measured against the live Soniox API, not taken from the changelog

## Not included

- **Regional endpoints.** Soniox serves EU and JP from separate domains (`api.eu.soniox.com`, `tts-rt.eu.soniox.com`, and the `.jp.` equivalents) and keys are bound to their region — a US key returns 401 against them. We hardcode the US hosts in four modules *and* in the extension CSP allowlist, so a BYOK user with an EU/JP key cannot connect today. Pre-existing and independent of this upgrade; worth its own issue.
- **Audio tags.** v2's changelog advertises emotion/delivery control via "audio tags", but there is no documentation page and no mention in the API reference. Not wired up.
- **A UI toggle for `reduce_silence`.** Currently a constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Updated Soniox text-to-speech to the `tts-rt-v2` model.
  - Added reduced-silence processing for clearer, more natural speech.
  - Refreshed the built-in voice catalog with 70 voices and Adrian as the default.
- **Bug Fixes**
  - Preserved saved cloned and retired voice selections during migration.
  - Improved handling and display of unavailable voices.
- **Settings**
  - Voice options and selections now consistently reflect the current Soniox catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->