### PR TITLE
fix: per-provider transport resolution and a mic waveform for native-capture sessions

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -3424,9 +3424,21 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             // while the session is active — so the mute flag must gate the waveform
             // independently. Without this, mic waveform would animate even when
             // muted, contradicting the spec's "muted = flat waveform" rule.
+            //
+            // Native-capture (WebRTC) sessions never start the shared recorder — their
+            // mic frequencies come from the client's own LOCAL-capture bridge analyser
+            // instead (getInputFrequencies, distinct from the client's getFrequencies()
+            // which reports the remote/AI-output stream). The fallback is suppressed for
+            // push-gated modes (canHoldToSpeak): there the waveform means "transmitting
+            // while held" (the hold handler starts the recorder), and a continuously-hot
+            // native track must not repaint that semantic.
+            const clientFrequencies =
+              !isMicMuted && !recorder.isRecording() && !canHoldToSpeak
+                ? speakerClientRef.current?.getInputFrequencies?.() ?? null
+                : null;
             const result = recorder.isRecording() && !isMicMuted
               ? recorder.getFrequencies('voice')
-              : { values: new Float32Array([0]) };
+              : clientFrequencies ?? { values: new Float32Array([0]) };
             WavRenderer.drawBars(
               clientCanvas,
               clientCtx,
@@ -3554,7 +3566,9 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     // isMicMuted / isParticipantMuted in deps so the render-loop closure
     // re-initializes when mute toggles — without them, the rAF callback
     // captures a stale mute value and the waveform gate never updates.
-  }, [uiMode, effectiveMode, isSessionActive, participantChannelActive, isMicMuted, isParticipantMuted]);
+    // canHoldToSpeak likewise, so the client-analyser fallback gate stays in
+    // sync when the active mode's push-gating changes mid-session.
+  }, [uiMode, effectiveMode, isSessionActive, participantChannelActive, isMicMuted, isParticipantMuted, canHoldToSpeak]);
 
   /**
    * Auto-scroll to the bottom of the conversation when new content is added

--- a/src/lib/modern-audio/WebRTCAudioBridge.test.ts
+++ b/src/lib/modern-audio/WebRTCAudioBridge.test.ts
@@ -125,4 +125,37 @@ describe('WebRTCAudioBridge local analyser lifecycle', () => {
       delete (globalThis as any).AudioContext;
     }
   });
+
+  it('warns once per bridge instance when the backstop resume() rejects, without leaking an unhandled rejection', async () => {
+    (globalThis as any).AudioContext = FakeAudioContext;
+    try {
+      const bridge = new WebRTCAudioBridge({ sampleRate: 24000 });
+      await bridge.getLocalStream('mic-1');
+
+      const localCtx = (bridge as any).localAudioContext as FakeAudioContext;
+      // Stays suspended across both calls: resume() keeps rejecting instead of
+      // flipping state to 'running', so getLocalFrequencies() retries it twice.
+      localCtx.state = 'suspended';
+      localCtx.resume = () => Promise.reject(new Error('resume failed'));
+
+      const warns: string[] = [];
+      const spy = vi.spyOn(console, 'warn').mockImplementation((m: any) => { warns.push(String(m)); });
+
+      const result1 = bridge.getLocalFrequencies();
+      const result2 = bridge.getLocalFrequencies();
+      // Flush microtasks so the rejected resume() promises settle here — if
+      // they weren't caught, vitest would surface them as unhandled rejections.
+      await Promise.resolve();
+      await Promise.resolve();
+
+      spy.mockRestore();
+
+      // Fallback (flat) analyser data must still come back both times.
+      expect(result1).not.toBeNull();
+      expect(result2).not.toBeNull();
+      expect(warns.filter((w) => w.includes('Failed to resume local audio context'))).toHaveLength(1);
+    } finally {
+      delete (globalThis as any).AudioContext;
+    }
+  });
 });

--- a/src/lib/modern-audio/WebRTCAudioBridge.test.ts
+++ b/src/lib/modern-audio/WebRTCAudioBridge.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { WebRTCAudioBridge } from './WebRTCAudioBridge';
+
+/**
+ * jsdom has no Web Audio, so stand up a minimal fake — same idiom as
+ * AppAudioRecorder.test.ts's `(globalThis as any).AudioContext = class {...}`.
+ */
+class FakeAudioContext {
+  state: AudioContextState;
+  sampleRate: number;
+  resumeCalls = 0;
+
+  constructor(opts?: { sampleRate?: number }, initialState: AudioContextState = 'running') {
+    this.sampleRate = opts?.sampleRate ?? 24000;
+    this.state = initialState;
+  }
+  createMediaStreamSource(_stream: MediaStream) {
+    return { connect: () => {}, disconnect: () => {} };
+  }
+  createAnalyser() {
+    return {
+      fftSize: 0,
+      smoothingTimeConstant: 0,
+      frequencyBinCount: 128,
+      connect: () => {},
+      disconnect: () => {},
+      getFloatFrequencyData: (arr: Float32Array) => arr.fill(-50),
+    };
+  }
+  resume() {
+    this.resumeCalls++;
+    this.state = 'running';
+    return Promise.resolve();
+  }
+  close() {
+    this.state = 'closed';
+    return Promise.resolve();
+  }
+}
+
+const getUserMedia = vi.fn();
+
+beforeEach(() => {
+  getUserMedia.mockReset();
+  getUserMedia.mockResolvedValue(fakeStream());
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  });
+});
+
+const fakeStream = () => ({
+  getTracks: () => [{ stop: () => {} }],
+  getAudioTracks: () => [{ stop: () => {} }],
+}) as unknown as MediaStream;
+
+describe('WebRTCAudioBridge local analyser lifecycle', () => {
+  it('survives cleanupRemoteAudio: the local context is dedicated, not the shared remote one', async () => {
+    (globalThis as any).AudioContext = FakeAudioContext;
+    try {
+      const bridge = new WebRTCAudioBridge({ sampleRate: 24000 });
+
+      // Remote audio starts first, exactly the sequence CodeRabbit flagged:
+      // switchInputDevice (local setup) running after remote audio started.
+      await (bridge as any).setupAudioProcessing(fakeStream());
+      const remoteCtx = (bridge as any).audioContext as FakeAudioContext;
+      expect(remoteCtx).toBeInstanceOf(FakeAudioContext);
+
+      // Local device is then set up while the remote context is still open.
+      await bridge.getLocalStream('mic-1');
+      const localCtx = (bridge as any).localAudioContext as FakeAudioContext;
+      expect(localCtx).toBeInstanceOf(FakeAudioContext);
+      expect(localCtx).not.toBe(remoteCtx);
+      expect(bridge.getLocalFrequencies()).not.toBeNull();
+
+      // A later handleRemoteStream (or any remote teardown) must not take the
+      // local analyser down with it.
+      (bridge as any).cleanupRemoteAudio();
+
+      expect(remoteCtx.state).toBe('closed');
+      expect(localCtx.state).not.toBe('closed');
+      expect(bridge.getLocalFrequencies()).not.toBeNull();
+    } finally {
+      delete (globalThis as any).AudioContext;
+    }
+  });
+
+  it('resumes a dedicated context that starts suspended under autoplay policy', async () => {
+    class SuspendedAudioContext extends FakeAudioContext {
+      constructor(opts?: { sampleRate?: number }) {
+        super(opts, 'suspended');
+      }
+    }
+    (globalThis as any).AudioContext = SuspendedAudioContext;
+    try {
+      const bridge = new WebRTCAudioBridge({ sampleRate: 24000 });
+
+      await bridge.getLocalStream('mic-1');
+
+      const localCtx = (bridge as any).localAudioContext as FakeAudioContext;
+      expect(localCtx.resumeCalls).toBeGreaterThanOrEqual(1);
+      expect(localCtx.state).toBe('running');
+    } finally {
+      delete (globalThis as any).AudioContext;
+    }
+  });
+
+  it('getLocalFrequencies retries resume() if the context is still suspended', async () => {
+    (globalThis as any).AudioContext = FakeAudioContext;
+    try {
+      const bridge = new WebRTCAudioBridge({ sampleRate: 24000 });
+      await bridge.getLocalStream('mic-1');
+
+      const localCtx = (bridge as any).localAudioContext as FakeAudioContext;
+      // Simulate the context falling back to suspended after setup (e.g. tab
+      // backgrounding), independent of whatever resumed it during setup.
+      localCtx.state = 'suspended';
+      localCtx.resumeCalls = 0;
+
+      const result = bridge.getLocalFrequencies();
+
+      expect(localCtx.resumeCalls).toBe(1);
+      expect(result).not.toBeNull();
+    } finally {
+      delete (globalThis as any).AudioContext;
+    }
+  });
+});

--- a/src/lib/modern-audio/WebRTCAudioBridge.ts
+++ b/src/lib/modern-audio/WebRTCAudioBridge.ts
@@ -83,16 +83,14 @@ export class WebRTCAudioBridge {
   // Local (microphone) analyser chain — independent of the remote analyser above,
   // which is fed by the received/AI-output track and has its own audioContext
   // lifecycle (created/closed per remote track in setupAudioProcessing /
-  // cleanupRemoteAudio). Reuses that context when one is already open at setup
-  // time to avoid proliferating AudioContexts; otherwise owns a dedicated one.
+  // cleanupRemoteAudio). The local chain owns a dedicated AudioContext so its
+  // lifecycle never depends on the remote path: reusing the remote context used
+  // to leave a dangling analyser whenever cleanupRemoteAudio() closed it out
+  // from under a local setup that had borrowed it (mic waveform going flat
+  // until the next device switch).
   private localAudioContext: AudioContext | null = null;
   private localSourceNode: MediaStreamAudioSourceNode | null = null;
   private localAnalyserNode: AnalyserNode | null = null;
-  // True when localAudioContext is a reused reference to the shared `audioContext`
-  // (the remote side's). In that case cleanupRemoteAudio() owns closing it, so
-  // stopLocalStream() must only disconnect the local nodes, never close it out
-  // from under the remote path.
-  private localAudioContextIsShared: boolean = false;
   private currentInputDeviceId: string | undefined;
   private currentOutputDeviceId: string | undefined;
   private onAudioData: ((pcmData: Int16Array) => void) | undefined;
@@ -227,7 +225,7 @@ export class WebRTCAudioBridge {
       this.localStream = await navigator.mediaDevices.getUserMedia(constraints);
       this.currentInputDeviceId = deviceId;
 
-      this.setupLocalAudioProcessing(this.localStream);
+      await this.setupLocalAudioProcessing(this.localStream);
 
       console.debug('[WebRTCAudioBridge] Got local stream from device:', deviceId || 'default');
       return this.localStream;
@@ -244,17 +242,20 @@ export class WebRTCAudioBridge {
    * are shape-compatible. No PCM extraction here: the local stream's PCM
    * already reaches the caller via the peer connection's own track, not
    * through this bridge's worklet path.
+   *
+   * Always opens its own dedicated AudioContext (see the localAudioContext
+   * field comment for why reusing the remote one was unsafe). A freshly
+   * created context can start 'suspended' under autoplay policy if the mic
+   * permission prompt or token round trip outlives the click that started
+   * the session, so resume it here the same way ParticipantRecorder.begin()
+   * and ModernAudioRecorder.begin() resume their own contexts on creation.
    */
-  private setupLocalAudioProcessing(stream: MediaStream): void {
+  private async setupLocalAudioProcessing(stream: MediaStream): Promise<void> {
     try {
-      if (this.audioContext && this.audioContext.state !== 'closed') {
-        // Reuse the remote side's context instead of opening a second one.
-        this.localAudioContext = this.audioContext;
-        this.localAudioContextIsShared = true;
-      } else {
-        const sampleRate = this.options.sampleRate ?? 24000;
-        this.localAudioContext = new AudioContext({ sampleRate });
-        this.localAudioContextIsShared = false;
+      const sampleRate = this.options.sampleRate ?? 24000;
+      this.localAudioContext = new AudioContext({ sampleRate });
+      if (this.localAudioContext.state === 'suspended') {
+        await this.localAudioContext.resume();
       }
 
       this.localSourceNode = this.localAudioContext.createMediaStreamSource(stream);
@@ -271,9 +272,8 @@ export class WebRTCAudioBridge {
   }
 
   /**
-   * Tear down the local analyser chain. Only closes localAudioContext when it
-   * is NOT the shared remote-side context (localAudioContextIsShared), so a
-   * device switch or mic stop never closes a context the remote path still owns.
+   * Tear down the local analyser chain, including its dedicated AudioContext.
+   * Independent of the remote path: never touches `this.audioContext`.
    */
   private cleanupLocalAudioProcessing(): void {
     if (this.localSourceNode) {
@@ -287,12 +287,11 @@ export class WebRTCAudioBridge {
     }
 
     if (this.localAudioContext) {
-      if (!this.localAudioContextIsShared && this.localAudioContext.state !== 'closed') {
+      if (this.localAudioContext.state !== 'closed') {
         this.localAudioContext.close().catch(console.warn);
       }
       this.localAudioContext = null;
     }
-    this.localAudioContextIsShared = false;
   }
 
   /**
@@ -520,12 +519,21 @@ export class WebRTCAudioBridge {
    * Get LOCAL (microphone) frequency data for visualization — the input-side
    * counterpart to getFrequencies() above, which reports the REMOTE/received
    * stream. Same normalization, independent analyser and context.
+   *
+   * Also resumes the context if it's still 'suspended' here, same as
+   * AppAudioRecorder.feedAnalyser(): setup-time resume() can lose the race
+   * against autoplay policy, so this read site is a backstop that keeps
+   * retrying on every poll instead of leaving the waveform flat forever.
    * @returns Object with frequencies array, or null before the local stream
    *          (and its analyser) has been set up
    */
   getLocalFrequencies(): { values: Float32Array } | null {
     if (!this.localAnalyserNode) {
       return null;
+    }
+
+    if (this.localAudioContext && this.localAudioContext.state === 'suspended') {
+      void this.localAudioContext.resume();
     }
 
     const frequencies = new Float32Array(this.localAnalyserNode.frequencyBinCount);

--- a/src/lib/modern-audio/WebRTCAudioBridge.ts
+++ b/src/lib/modern-audio/WebRTCAudioBridge.ts
@@ -91,6 +91,13 @@ export class WebRTCAudioBridge {
   private localAudioContext: AudioContext | null = null;
   private localSourceNode: MediaStreamAudioSourceNode | null = null;
   private localAnalyserNode: AnalyserNode | null = null;
+  // Tracks whether getLocalFrequencies() has already warned about a rejected
+  // backstop resume() for the current localAudioContext. getLocalFrequencies
+  // is polled from MainPanel's render loop, so without this a persistently
+  // rejecting resume() would otherwise warn (and risk an unhandled rejection)
+  // at frame rate. Reset in setupLocalAudioProcessing() so a fresh context
+  // gets one fresh warning opportunity.
+  private localResumeWarned = false;
   private currentInputDeviceId: string | undefined;
   private currentOutputDeviceId: string | undefined;
   private onAudioData: ((pcmData: Int16Array) => void) | undefined;
@@ -254,6 +261,7 @@ export class WebRTCAudioBridge {
     try {
       const sampleRate = this.options.sampleRate ?? 24000;
       this.localAudioContext = new AudioContext({ sampleRate });
+      this.localResumeWarned = false;
       if (this.localAudioContext.state === 'suspended') {
         await this.localAudioContext.resume();
       }
@@ -533,7 +541,12 @@ export class WebRTCAudioBridge {
     }
 
     if (this.localAudioContext && this.localAudioContext.state === 'suspended') {
-      void this.localAudioContext.resume();
+      this.localAudioContext.resume().catch((error) => {
+        if (!this.localResumeWarned) {
+          this.localResumeWarned = true;
+          console.warn('[WebRTCAudioBridge] Failed to resume local audio context:', error);
+        }
+      });
     }
 
     const frequencies = new Float32Array(this.localAnalyserNode.frequencyBinCount);

--- a/src/lib/modern-audio/WebRTCAudioBridge.ts
+++ b/src/lib/modern-audio/WebRTCAudioBridge.ts
@@ -80,6 +80,19 @@ export class WebRTCAudioBridge {
   private analyserNode: AnalyserNode | null = null;
   private remoteSourceNode: MediaStreamAudioSourceNode | null = null;
   private pcmWorkletNode: AudioWorkletNode | null = null;
+  // Local (microphone) analyser chain — independent of the remote analyser above,
+  // which is fed by the received/AI-output track and has its own audioContext
+  // lifecycle (created/closed per remote track in setupAudioProcessing /
+  // cleanupRemoteAudio). Reuses that context when one is already open at setup
+  // time to avoid proliferating AudioContexts; otherwise owns a dedicated one.
+  private localAudioContext: AudioContext | null = null;
+  private localSourceNode: MediaStreamAudioSourceNode | null = null;
+  private localAnalyserNode: AnalyserNode | null = null;
+  // True when localAudioContext is a reused reference to the shared `audioContext`
+  // (the remote side's). In that case cleanupRemoteAudio() owns closing it, so
+  // stopLocalStream() must only disconnect the local nodes, never close it out
+  // from under the remote path.
+  private localAudioContextIsShared: boolean = false;
   private currentInputDeviceId: string | undefined;
   private currentOutputDeviceId: string | undefined;
   private onAudioData: ((pcmData: Int16Array) => void) | undefined;
@@ -214,12 +227,72 @@ export class WebRTCAudioBridge {
       this.localStream = await navigator.mediaDevices.getUserMedia(constraints);
       this.currentInputDeviceId = deviceId;
 
+      this.setupLocalAudioProcessing(this.localStream);
+
       console.debug('[WebRTCAudioBridge] Got local stream from device:', deviceId || 'default');
       return this.localStream;
     } catch (error) {
       console.error('[WebRTCAudioBridge] Error getting local stream:', error);
       throw error;
     }
+  }
+
+  /**
+   * Set up the local (microphone) analyser chain for visualization only —
+   * mirrors setupAudioProcessing's analyser config exactly (fftSize 256,
+   * smoothingTimeConstant 0.8) so getFrequencies() and getLocalFrequencies()
+   * are shape-compatible. No PCM extraction here: the local stream's PCM
+   * already reaches the caller via the peer connection's own track, not
+   * through this bridge's worklet path.
+   */
+  private setupLocalAudioProcessing(stream: MediaStream): void {
+    try {
+      if (this.audioContext && this.audioContext.state !== 'closed') {
+        // Reuse the remote side's context instead of opening a second one.
+        this.localAudioContext = this.audioContext;
+        this.localAudioContextIsShared = true;
+      } else {
+        const sampleRate = this.options.sampleRate ?? 24000;
+        this.localAudioContext = new AudioContext({ sampleRate });
+        this.localAudioContextIsShared = false;
+      }
+
+      this.localSourceNode = this.localAudioContext.createMediaStreamSource(stream);
+      this.localAnalyserNode = this.localAudioContext.createAnalyser();
+      this.localAnalyserNode.fftSize = 256;
+      this.localAnalyserNode.smoothingTimeConstant = 0.8;
+      this.localSourceNode.connect(this.localAnalyserNode);
+      // Note: analyser doesn't need to connect to destination — visualization only.
+
+      console.debug('[WebRTCAudioBridge] Local audio processing set up');
+    } catch (error) {
+      console.warn('[WebRTCAudioBridge] Failed to set up local audio processing:', error);
+    }
+  }
+
+  /**
+   * Tear down the local analyser chain. Only closes localAudioContext when it
+   * is NOT the shared remote-side context (localAudioContextIsShared), so a
+   * device switch or mic stop never closes a context the remote path still owns.
+   */
+  private cleanupLocalAudioProcessing(): void {
+    if (this.localSourceNode) {
+      this.localSourceNode.disconnect();
+      this.localSourceNode = null;
+    }
+
+    if (this.localAnalyserNode) {
+      this.localAnalyserNode.disconnect();
+      this.localAnalyserNode = null;
+    }
+
+    if (this.localAudioContext) {
+      if (!this.localAudioContextIsShared && this.localAudioContext.state !== 'closed') {
+        this.localAudioContext.close().catch(console.warn);
+      }
+      this.localAudioContext = null;
+    }
+    this.localAudioContextIsShared = false;
   }
 
   /**
@@ -444,6 +517,31 @@ export class WebRTCAudioBridge {
   }
 
   /**
+   * Get LOCAL (microphone) frequency data for visualization — the input-side
+   * counterpart to getFrequencies() above, which reports the REMOTE/received
+   * stream. Same normalization, independent analyser and context.
+   * @returns Object with frequencies array, or null before the local stream
+   *          (and its analyser) has been set up
+   */
+  getLocalFrequencies(): { values: Float32Array } | null {
+    if (!this.localAnalyserNode) {
+      return null;
+    }
+
+    const frequencies = new Float32Array(this.localAnalyserNode.frequencyBinCount);
+    this.localAnalyserNode.getFloatFrequencyData(frequencies);
+
+    // Normalize to 0-1 range (dB values are typically -100 to 0)
+    const normalized = new Float32Array(frequencies.length);
+    for (let i = 0; i < frequencies.length; i++) {
+      // Convert dB to linear scale (0-1)
+      normalized[i] = Math.max(0, Math.min(1, (frequencies[i] + 100) / 100));
+    }
+
+    return { values: normalized };
+  }
+
+  /**
    * Set output device for remote audio playback
    * @param deviceId - The device ID to use for output
    */
@@ -508,6 +606,7 @@ export class WebRTCAudioBridge {
       this.localStream.getTracks().forEach(track => track.stop());
       this.localStream = null;
       this.currentInputDeviceId = undefined;
+      this.cleanupLocalAudioProcessing();
       console.debug('[WebRTCAudioBridge] Local stream stopped');
     }
   }

--- a/src/services/clients/OpenAITranslateWebRTCClient.test.ts
+++ b/src/services/clients/OpenAITranslateWebRTCClient.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest';
+import { OpenAITranslateWebRTCClient } from './OpenAITranslateWebRTCClient';
+
+/**
+ * getInputFrequencies contract test — pins the IClient addition made for the
+ * mic-waveform fallback (MainPanel's render loop falls back to the client's
+ * own LOCAL-capture analyser for native-capture WebRTC sessions, since those
+ * never start the shared recorder). Mirrors OpenAIWebRTCClient.test.ts's
+ * equivalent case.
+ */
+describe('OpenAITranslateWebRTCClient.getInputFrequencies', () => {
+  it('returns null before a local stream (and its analyser) exists', () => {
+    // No session has connected (no getUserMedia call has happened yet), so
+    // the bridge's LOCAL analyser has nothing to report.
+    const client = new OpenAITranslateWebRTCClient({ apiKey: 'sk-test' });
+
+    expect(client.getInputFrequencies()).toBeNull();
+  });
+
+  it('delegates to the bridge LOCAL analyser, not the remote/output one', () => {
+    // getInputFrequencies() must forward to the bridge's getLocalFrequencies
+    // (mic input), never to getFrequencies (remote/AI output) — the spy
+    // proves forwarding rather than both coincidentally returning null.
+    const client = new OpenAITranslateWebRTCClient({ apiKey: 'sk-test' });
+    const bridge = (client as any).audioBridge;
+    const localSpy = vi.spyOn(bridge, 'getLocalFrequencies')
+      .mockReturnValue({ values: new Float32Array([0.5]) });
+    const remoteSpy = vi.spyOn(bridge, 'getFrequencies');
+
+    const result = client.getInputFrequencies();
+
+    expect(localSpy).toHaveBeenCalledTimes(1);
+    expect(remoteSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ values: new Float32Array([0.5]) });
+  });
+});

--- a/src/services/clients/OpenAITranslateWebRTCClient.ts
+++ b/src/services/clients/OpenAITranslateWebRTCClient.ts
@@ -743,8 +743,19 @@ export class OpenAITranslateWebRTCClient implements IClient {
     console.debug('[OpenAITranslateWebRTCClient] Output muted request (no-op, handled by audioStore):', muted);
   }
 
+  /** REMOTE/received audio (the AI's translated output). No current consumer; kept as-is. */
   getFrequencies(): { values: Float32Array } | null {
     return this.audioBridge.getFrequencies();
+  }
+
+  /**
+   * Get LOCAL (microphone) frequency data for visualization — the input-side
+   * counterpart to getFrequencies() above. Backs MainPanel's mic-waveform
+   * fallback for native-capture sessions, which never start the shared
+   * recorder.
+   */
+  getInputFrequencies(): { values: Float32Array } | null {
+    return this.audioBridge.getLocalFrequencies();
   }
 }
 

--- a/src/services/clients/OpenAIWebRTCClient.test.ts
+++ b/src/services/clients/OpenAIWebRTCClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { OpenAIWebRTCClient } from './OpenAIWebRTCClient';
 
 /**
@@ -58,5 +58,33 @@ describe('OpenAIWebRTCClient GA conversation items', () => {
     });
 
     expect(client.getConversationItems()).toHaveLength(1);
+  });
+});
+
+describe('OpenAIWebRTCClient.getInputFrequencies', () => {
+  it('returns null before a local stream (and its analyser) exists', () => {
+    // No session has connected (no getUserMedia call has happened yet), so
+    // the bridge's LOCAL analyser has nothing to report.
+    const { client } = makeClient();
+
+    expect(client.getInputFrequencies()).toBeNull();
+  });
+
+  it('delegates to the bridge LOCAL analyser, not the remote/output one', () => {
+    // Pins the IClient contract added for the mic-waveform fallback:
+    // getInputFrequencies() must forward to the bridge's getLocalFrequencies
+    // (mic input), never to getFrequencies (remote/AI output) — the spy
+    // proves forwarding rather than both coincidentally returning null.
+    const { client } = makeClient();
+    const bridge = (client as any).audioBridge;
+    const localSpy = vi.spyOn(bridge, 'getLocalFrequencies')
+      .mockReturnValue({ values: new Float32Array([0.5]) });
+    const remoteSpy = vi.spyOn(bridge, 'getFrequencies');
+
+    const result = client.getInputFrequencies();
+
+    expect(localSpy).toHaveBeenCalledTimes(1);
+    expect(remoteSpy).not.toHaveBeenCalled();
+    expect(result).toEqual({ values: new Float32Array([0.5]) });
   });
 });

--- a/src/services/clients/OpenAIWebRTCClient.ts
+++ b/src/services/clients/OpenAIWebRTCClient.ts
@@ -808,9 +808,20 @@ export class OpenAIWebRTCClient implements IClient {
   }
 
   /**
-   * Get frequency data for visualization
+   * Get frequency data for visualization (REMOTE/received audio — the AI's
+   * spoken output). No current consumer; kept as-is.
    */
   getFrequencies(): { values: Float32Array } | null {
     return this.audioBridge.getFrequencies();
+  }
+
+  /**
+   * Get LOCAL (microphone) frequency data for visualization — the input-side
+   * counterpart to getFrequencies() above. Backs MainPanel's mic-waveform
+   * fallback for native-capture sessions, which never start the shared
+   * recorder.
+   */
+  getInputFrequencies(): { values: Float32Array } | null {
+    return this.audioBridge.getLocalFrequencies();
   }
 }

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -456,6 +456,11 @@ export interface IClient {
   setOutputMuted?(muted: boolean): void;
   setOutputVolume?(volume: number): void;
 
+  /** Input-side (local capture) frequency data for visualization, where the client
+   * owns its own capture (WebRTC bridge analyser). Absent on clients fed by the
+   * shared recorder. */
+  getInputFrequencies?(): { values: Float32Array } | null;
+
   // Optional Both single-session (Soniox) mixer methods
   /** Feed the second audio channel (Both single-session mixer). SonioxClient only. */
   appendParticipantAudio?(audioData: Int16Array): void;

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { renderHook } from '@testing-library/react';
 import { Provider } from '../types/Provider';
 import { buildDefaultLocalPrompt } from '../lib/local-inference/prompts';
 
@@ -40,6 +41,7 @@ vi.mock('../lib/local-inference/modelManifest', async () => {
 // Import after mocking
 const {
   default: useSettingsStore,
+  useTransportType,
 } = await import('./settingsStore');
 
 describe('settingsStore', () => {
@@ -355,6 +357,37 @@ describe('settingsStore', () => {
       await useSettingsStore.getState().setKeepReplayAudio(true);
       // State must roll back to the previous value.
       expect(useSettingsStore.getState().keepReplayAudio).toBe(false);
+    });
+  });
+
+  describe('useTransportType', () => {
+    it('resolves the active provider slice, not a hardcoded openai slice (bug repro: OpenAI Translate reads its own websocket choice, not OpenAI leftover webrtc)', async () => {
+      const store = useSettingsStore.getState();
+      await store.updateOpenAI({ transportType: 'webrtc' });
+      await store.updateOpenAITranslate({ transportType: 'websocket' });
+      useSettingsStore.setState({ provider: Provider.OPENAI_TRANSLATE });
+
+      const { result } = renderHook(() => useTransportType());
+
+      expect(result.current).toBe('websocket');
+    });
+
+    it('resolves OpenAI itself to its own webrtc choice', async () => {
+      const store = useSettingsStore.getState();
+      await store.updateOpenAI({ transportType: 'webrtc' });
+      useSettingsStore.setState({ provider: Provider.OPENAI });
+
+      const { result } = renderHook(() => useTransportType());
+
+      expect(result.current).toBe('webrtc');
+    });
+
+    it('defaults to websocket for a provider slice with no transportType field', () => {
+      useSettingsStore.setState({ provider: Provider.GEMINI });
+
+      const { result } = renderHook(() => useTransportType());
+
+      expect(result.current).toBe('websocket');
     });
   });
 

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -3,6 +3,7 @@ import {subscribeWithSelector} from 'zustand/middleware';
 import {ServiceFactory} from '../services/ServiceFactory';
 import {ProviderConfigFactory} from '../services/providers/ProviderConfigFactory';
 import {ProviderConfig} from '../services/providers/ProviderConfig';
+import type {TransportType} from '../services/providers/ProviderDescriptor';
 import {
   FilteredModel,
   SessionConfig,
@@ -1258,8 +1259,15 @@ export const useKizunaSonioxSettings = () => useSettingsStore((state) => state.k
 export const useLocalInferenceSettings = () => useSettingsStore((state) => state.localInference);
 export const useLocalNativeSettings = () => useSettingsStore((state) => state.localNative);
 
-// Transport type selector (for OpenAI provider)
-export const useTransportType = () => useSettingsStore((state) => state.openai.transportType);
+// Transport type selector — resolves the ACTIVE provider's own slice (a
+// selector hardcoded to `state.openai` let OpenAI's WebRTC choice silently
+// govern other providers' sessions while their own pickers wrote an unread
+// field).
+export const useTransportType = (): TransportType => useSettingsStore((state) => {
+  const descriptor = ProviderConfigFactory.getDescriptor(state.provider);
+  const slice = state[descriptor.settingsSliceKey as keyof SettingsStore] as { transportType?: TransportType };
+  return slice?.transportType ?? 'websocket';
+});
 
 // Validation state
 export const useIsApiKeyValid = () => useSettingsStore((state) => state.isApiKeyValid);


### PR DESCRIPTION
## What

Two pre-existing bugs found during #408's manual testing (both reproduce identically on pre-#408 main; diagnosis was done by direct diff against it):

1. **The transport selector read the wrong provider's slice.** `useTransportType` was hardcoded to `state.openai.transportType`, so a WebRTC choice made under OpenAI silently governed other providers' sessions (e.g. OpenAI Translate ran WebRTC while its own settings UI showed — and wrote — WebSocket). Now resolved through the active provider's `settingsSliceKey`, mirroring `useCurrentTurnDetectionMode`; tests pin the exact leak scenario.

2. **Native-capture (WebRTC) sessions never had a mic waveform.** The mic strip's only data source was the shared recorder, which WebRTC sessions never start. `WebRTCAudioBridge` now wires a genuine local-input analyser (`getLocalFrequencies`); the WebRTC clients expose it as the new optional `IClient.getInputFrequencies()` (the pre-existing remote-side `getFrequencies()` is untouched); MainPanel's mic render branch falls back to it when the recorder is not recording — gated off push-gated modes (PTT keeps its waveform-means-transmitting semantic) and off mute, as before.

Combined effect: the input waveform now shows for every provider under every transport, and each provider's transport setting actually governs its own sessions.

## Behavior matrix (all verified in review)

- Push-to-Translate: unchanged (recorder runs continuously; primary path).
- OpenAI + WebRTC + push-gated 'Disabled': unchanged (flat until held; hold starts the recorder).
- Non-push-gated + WebRTC (e.g. OpenAI Translate): fixed — continuous local-mic waveform.
- WebSocket modes, mute: unchanged.

## Known non-blockers (documented in the second commit's message)

- A narrow, self-healing analyser-staleness edge when a mid-session device switch shares the remote AudioContext and a later renegotiation closes it.
- Separate pre-existing finding (not addressed here): mic mute does not disable the local WebRTC track mid-session — the UI stays correct, but transmission gating deserves its own look.

## Testing

216 files / 2589 tests green; tsc baseline unchanged; vite build green. Fix 1 red/green-verified against the old selector; the client delegation pinned by new unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Microphone waveforms now reflect local input audio when shared recording is inactive.
  * Push-to-speak modes keep the waveform flat until recording is held.
  * Transport settings now follow the active provider, with WebSocket as the default.

* **Bug Fixes**
  * Improved waveform behavior when switching recording modes and managing microphone audio.

* **Tests**
  * Added coverage for local audio visualization and provider-specific transport settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->