### PR TITLE
fix(providers): reject reversed participant pairs the provider catalog cannot run

### DIFF
--- a/src/services/providers/OpenAITranslateProviderConfig.ts
+++ b/src/services/providers/OpenAITranslateProviderConfig.ts
@@ -128,15 +128,27 @@ export class OpenAITranslateProviderConfig extends BaseProviderDescriptor {
     // targetLanguage to settings.sourceLanguage so the participant client
     // translates "their speech → user's language" instead of mirroring the
     // speaker's direction. If the user picked a sourceLanguage outside the
-    // 13 supported targets, the swap may produce an invalid target — the UI
-    // already warns about this combination, and the API will surface a clear
-    // error if the user proceeds anyway.
+    // 13 supported targets, the swap would produce an invalid target — the
+    // guard below rejects that upfront instead of shipping a config
+    // gpt-realtime-translate would only reject after connect.
     const oldTarget: TranslateTargetLanguage = tConfig.targetLanguage;
     const oldSource: string | undefined = tConfig.sourceLanguage;
-    // Cast: type-system can't validate at this layer; runtime gating is
-    // the UI warning + API error message.
+    // Cast: type-system can't validate at this layer; the guard below is
+    // the runtime check.
     tConfig.targetLanguage = (oldSource ?? oldTarget) as TranslateTargetLanguage;
     tConfig.sourceLanguage = oldTarget;
+
+    const newTarget = tConfig.targetLanguage;
+    const targetValid = OpenAITranslateProviderConfig.TARGET_LANGUAGES.some(l => l.value === newTarget);
+    if (!targetValid) {
+      return {
+        config: null,
+        notices: [{
+          channel: 'error',
+          message: `Participant translation ${tConfig.sourceLanguage} → ${newTarget} is not supported — participant channel skipped`,
+        }],
+      };
+    }
 
     return result;
   }

--- a/src/services/providers/PalabraAIProviderConfig.ts
+++ b/src/services/providers/PalabraAIProviderConfig.ts
@@ -138,11 +138,27 @@ export class PalabraAIProviderConfig extends BaseProviderDescriptor {
     // en-us, sources don't), but the API strips the suffix before validating a
     // source, so a plain swap holds for every target we offer. In the other
     // direction five source languages aren't valid targets (eu, ga, mn, mt, ug);
-    // picking one of those makes the reversed task fail with the API's
-    // VALIDATION_ERROR, which arrives as a data message and surfaces through
-    // handleError rather than throwing out of connect().
+    // the guard below rejects those upfront — matched against TARGET_LANGUAGES
+    // by exact value or by its bare (suffix-stripped) prefix — instead of
+    // shipping a reversed task the API would only answer with a
+    // VALIDATION_ERROR data message after connect.
     const pa = result.config as PalabraAISessionConfig;
     [pa.sourceLanguage, pa.targetLanguage] = [pa.targetLanguage, pa.sourceLanguage];
+
+    const newTarget = pa.targetLanguage;
+    const targetValid = PalabraAIProviderConfig.TARGET_LANGUAGES.some(
+      t => t.value === newTarget || t.value.split('-')[0] === newTarget
+    );
+    if (!targetValid) {
+      return {
+        config: null,
+        notices: [{
+          channel: 'error',
+          message: `Participant translation ${pa.sourceLanguage} → ${newTarget} is not supported — participant channel skipped`,
+        }],
+      };
+    }
+
     return result;
   }
 

--- a/src/services/providers/VolcengineSTProviderConfig.ts
+++ b/src/services/providers/VolcengineSTProviderConfig.ts
@@ -75,6 +75,25 @@ export class VolcengineSTProviderConfig extends BaseProviderDescriptor {
     const oldSource = st.sourceLanguage;
     st.sourceLanguage = st.targetLanguages[0] || oldSource;
     st.targetLanguages = [oldSource];
+
+    const newSource = st.sourceLanguage;
+    const newTarget = st.targetLanguages[0];
+    // The new target (= old source) is always in the 28-entry TARGET_LANGUAGES
+    // list, so only newSource can actually fail — written as a pair check
+    // against both lists anyway to keep the same shape as the other
+    // rotate-pattern guard (ZoomAI) and stay correct if either list narrows.
+    const sourceValid = VolcengineSTProviderConfig.SOURCE_LANGUAGES.some(l => l.value === newSource);
+    const targetValid = VolcengineSTProviderConfig.TARGET_LANGUAGES.some(l => l.value === newTarget);
+    if (!sourceValid || !targetValid) {
+      return {
+        config: null,
+        notices: [{
+          channel: 'error',
+          message: `Participant translation ${newSource} → ${newTarget} is not supported — participant channel skipped`,
+        }],
+      };
+    }
+
     return result;
   }
 

--- a/src/services/providers/ZoomAIProviderConfig.ts
+++ b/src/services/providers/ZoomAIProviderConfig.ts
@@ -77,6 +77,26 @@ export class ZoomAIProviderConfig extends BaseProviderDescriptor {
     const oldSource = z.sourceLanguage;
     z.sourceLanguage = z.targetLanguages[0] || oldSource;
     z.targetLanguages = [oldSource];
+
+    const newSource = z.sourceLanguage;
+    const newTarget = z.targetLanguages[0];
+    // Asymmetric matrix: sources are the 5 Scribe-recognizable languages,
+    // and a valid target depends on which source it pairs with (PAIRS).
+    // Reversing base en-US→ko-KR lands on ko-KR→[en-US]: ko-KR isn't a
+    // source at all, so it must be rejected before it ships and fails late
+    // as an API error.
+    const sourceValid = ZoomAIProviderConfig.SOURCE_LANGUAGES.some(l => l.value === newSource);
+    const targetValid = sourceValid && this.resolveTargetLanguages(newSource).some(l => l.value === newTarget);
+    if (!sourceValid || !targetValid) {
+      return {
+        config: null,
+        notices: [{
+          channel: 'error',
+          message: `Participant translation ${newSource} → ${newTarget} is not supported — participant channel skipped`,
+        }],
+      };
+    }
+
     return result;
   }
 

--- a/src/services/providers/participantConfig.test.ts
+++ b/src/services/providers/participantConfig.test.ts
@@ -102,6 +102,74 @@ describe('participant config: direction lives in config fields', () => {
   });
 });
 
+describe('participant config: reversed pairs the provider catalog cannot run', () => {
+  it('zoom_ai rejects a reversed pair outside its asymmetric matrix (en-US -> ko-KR reverses to ko-KR, not a source)', () => {
+    const d = ProviderConfigFactory.getDescriptor(Provider.ZOOM_AI);
+    const slice = { ...defaultZoomAISettings, sourceLanguage: 'en-US', targetLanguage: 'ko-KR' };
+    const { config, notices } = d.buildParticipantSessionConfig(slice, 'i', shell);
+    expect(config).toBeNull();
+    expect(notices).toHaveLength(1);
+    expect(notices[0].channel).toBe('error');
+    expect(notices[0].message).toContain('ko-KR');
+    expect(notices[0].message).toContain('en-US');
+  });
+
+  it('volcengine_st rejects a reversed pair whose new source is outside SOURCE_LANGUAGES (zh -> ko reverses to ko as source)', () => {
+    const d = ProviderConfigFactory.getDescriptor(Provider.VOLCENGINE_ST);
+    const slice = { ...defaultVolcengineSTSettings, sourceLanguage: 'zh', targetLanguage: 'ko' };
+    const { config, notices } = d.buildParticipantSessionConfig(slice, 'i', shell);
+    expect(config).toBeNull();
+    expect(notices).toHaveLength(1);
+    expect(notices[0].channel).toBe('error');
+    expect(notices[0].message).toContain('ko');
+    expect(notices[0].message).toContain('zh');
+  });
+
+  it('palabraai rejects a reversed target from the five source-only codes (eu is not a valid target)', () => {
+    const d = ProviderConfigFactory.getDescriptor(Provider.PALABRA_AI);
+    const slice = { ...defaultPalabraAISettings, sourceLanguage: 'eu', targetLanguage: 'ja' };
+    const { config, notices } = d.buildParticipantSessionConfig(slice, 'i', shell);
+    expect(config).toBeNull();
+    expect(notices).toHaveLength(1);
+    expect(notices[0].channel).toBe('error');
+    expect(notices[0].message).toContain('eu');
+    expect(notices[0].message).toContain('ja');
+  });
+
+  it('openai_translate rejects a reversed target outside the 13-entry TARGET_LANGUAGES (th is source-only)', () => {
+    const d = ProviderConfigFactory.getDescriptor(Provider.OPENAI_TRANSLATE);
+    const slice = { ...defaultOpenAITranslateSettings, sourceLanguage: 'th', targetLanguage: 'en' };
+    const { config, notices } = d.buildParticipantSessionConfig(slice, 'i', shell);
+    expect(config).toBeNull();
+    expect(notices).toHaveLength(1);
+    expect(notices[0].channel).toBe('error');
+    expect(notices[0].message).toContain('th');
+    expect(notices[0].message).toContain('en');
+  });
+
+  it('zoom_ai accepts a reversed pair the catalog can run (en-US -> ja-JP reverses to ja-JP -> [en-US])', () => {
+    const d = ProviderConfigFactory.getDescriptor(Provider.ZOOM_AI);
+    const slice = { ...defaultZoomAISettings, sourceLanguage: 'en-US', targetLanguage: 'ja-JP' };
+    const { config, notices } = d.buildParticipantSessionConfig(slice, 'i', shell);
+    expect(config).not.toBeNull();
+    expect(notices).toEqual([]);
+  });
+
+  it('palabraai accepts a reversed target that exactly matches a TARGET_LANGUAGES entry (es)', () => {
+    // Pins the exact-match arm of the guard (`t.value === newTarget`) — 'es'
+    // has its own entry in TARGET_LANGUAGES. The split('-')[0] arm described
+    // in PalabraAIProviderConfig's guard comment is currently unreachable
+    // defensive cover for future suffixed-only target entries: every source
+    // code in today's catalog either matches exactly or is one of the five
+    // excluded source-only codes (eu, ga, mn, mt, ug).
+    const d = ProviderConfigFactory.getDescriptor(Provider.PALABRA_AI);
+    const slice = { ...defaultPalabraAISettings, sourceLanguage: 'es', targetLanguage: 'ja' };
+    const { config, notices } = d.buildParticipantSessionConfig(slice, 'i', shell);
+    expect(config).not.toBeNull();
+    expect(notices).toEqual([]);
+  });
+});
+
 describe('participant config: helper-based reversals', () => {
   it('gemini forces turnDetectionMode Auto and reverses translationConfig when present', () => {
     const d = ProviderConfigFactory.getDescriptor(Provider.GEMINI);


### PR DESCRIPTION
Fixes #409.

## What

Four providers reverse the translation direction for the participant leg into pairs their own catalogs cannot run, and shipped the invalid config anyway — the failure surfaced only as a late API error after `connect()` (two of them documented this gap in their own comments). Each now validates the reversed pair right where it computes it and, on failure, returns the existing reject contract (`{ config: null, notices: [{ channel: 'error', message }] }` — the same idiom LocalInference/LocalNative already use): the participant channel is skipped with an error notice, the speaker leg still runs.

## Per provider

- **ZoomAI** — reversed source must be one of the 5 Scribe source languages AND the reversed target must be valid for it per the PAIRS matrix (base `en-US→ko-KR` reverses to `ko-KR→[en-US]`: `ko-KR` is target-only → rejected upfront).
- **Volcengine ST** — reversed source must be in `{zh, ja, en}` (targets span 28 languages; most reverse into an unsupported ASR source).
- **PalabraAI** — the reversed target (= old source) must have an exact or suffix-stripped match in the target catalog; this data-derived check excludes exactly the five source-only codes (`eu, ga, mn, mt, ug`) the file's own comment used to accept as a known late `VALIDATION_ERROR`. Comment rewritten accordingly.
- **OpenAI Translate** — the reversed target (= old source) must be one of the 13 supported targets; the `sourceLanguage`-undefined fallback can never be rejected (guaranteed by the target type's 13-value union).

Untouched by design: Soniox, Gemini, Volcengine AST2, OpenAI/OpenAI-Compatible, and the local providers — their reversals are safe by construction (symmetric catalogs or instructions-driven). The kizuna twins inherit the guarded methods (verified: no overrides).

## Testing

6 new cases in `participantConfig.test.ts` (4 rejects built from each provider's real catalog data + 2 accept boundaries), red/green-verified; the 17 existing swap tests are unchanged and green. Full suite 217 files / 2601 tests green; tsc baseline unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for reversed participant language translations across supported translation providers.
  * Unsupported language combinations are now rejected immediately with a clear error notice instead of failing after connection.
  * Valid regional language codes and supported reversed pairs continue to work as expected.

* **Tests**
  * Added coverage for accepted and rejected reversed language combinations across providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->