### PR TITLE
fix(soniox): style the region select like every other one in the panel

### DIFF
--- a/src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.soniox.test.tsx
@@ -384,6 +384,14 @@ describe('region selector', () => {
     const el = container.querySelector('#soniox-region-select') as HTMLSelectElement;
     expect(el).toBeTruthy();
     expect([...el.options].map((o) => o.value)).toEqual(['us', 'eu', 'jp']);
+    // Every select in this panel carries `select-dropdown`; without it the
+    // browser default renders a light, shrink-to-fit control inside a dark
+    // panel. Shipped that way once -- caught by rendering it, not by reading it.
+    expect(el.className).toContain('select-dropdown');
+    // The <h2> already names the control. A second visible label rendered
+    // "Region" twice; `aria-label` keeps it named without the duplicate.
+    expect(el.getAttribute('aria-label')).toBeTruthy();
+    expect(container.querySelectorAll('#soniox-region-section .setting-label')).toHaveLength(0);
 
     fireEvent.change(el, { target: { value: 'eu' } });
     expect(useSettingsStore.getState().soniox.region).toBe('eu');

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -1900,11 +1900,14 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
             </Tooltip>
           </h2>
           <div className="setting-item">
-            <label className="setting-label" htmlFor="soniox-region-select">
-              {t('settings.sonioxRegion', 'Region')}
-            </label>
+            {/* No visible label: the <h2> above already names this control, and
+                every other select in this panel relies on that. A second
+                "Region" line rendered the word twice. `aria-label` keeps the
+                control named for assistive tech without the duplicate. */}
             <select
               id="soniox-region-select"
+              className="select-dropdown"
+              aria-label={t('settings.sonioxRegion', 'Region')}
               value={sonioxRegion}
               disabled={sonioxRegionLocked}
               onChange={(e) => updateActiveSonioxSettings({ region: asSonioxRegion(e.target.value) })}


### PR DESCRIPTION
Follow-up to #413. The region selector shipped with two defects that are obvious the moment the section is rendered and invisible when it is read.

## What was wrong

**The `<select>` carried no `select-dropdown` class.** Every other select in `ProviderSpecificSettings.tsx` has it — it is what supplies `appearance: none`, the custom chevron SVG, `background: $bg-control`, the border, the radius and `font-size: $font-title`. Without it the control fell back to the browser default: a **light, shrink-to-fit native box roughly a third of the width**, sitting directly above the full-width dark Voice dropdown in the same panel.

**The section rendered "Region" twice** — once as the `<h2>`, once as a `setting-label` above the control. No other section in this file labels its select; the heading *is* the label.

## Why it happened

I composed the markup from a mental model built by reading the **vocabulary** section — a textarea whose `setting-label` is a div wrapping a span. But I was adding a `<select>`, and all six selects in the file are `.setting-item > select.select-dropdown` with no label. I copied the structure of a different control type, so the result was plausible and wrong.

`grep -n "<select" -A 6` on the same file would have caught both in seconds.

## The fix

Drop the visible label, add `select-dropdown`, move the name to `aria-label` so assistive tech still has it (the other selects have no accessible name at all, so this is a small improvement over the convention rather than a regression against it).

## Verification

Rendered a pixel-faithful specimen — token values copied out of `shared/_variables.scss` and `Settings.scss`, not approximated — and compared the shipped markup against the file's convention side by side at the **300px `PANEL_MIN_WIDTH`**, with the Voice dropdown in frame as the adversarial neighbour. After the fix the two are identical, and Region/Voice align.

Also confirmed the longest option labels (`日本 (Japan)`, `European Union`) neither wrap nor overflow at 300px.

## Why nothing caught it

Worth recording, because it is a category rather than an oversight:

- TypeScript has no opinion on `className`.
- My tests asserted **behaviour** — writes to the store, disabled during a session, disabled during startup — and all 23 passed on the visibly broken control.
- Three rounds of Codex and CodeRabbit review on #413 found 11 real logic bugs and **zero** pixel problems. Automated review does not cover this layer.

So the tests here now pin the appearance-affecting attributes: the `select-dropdown` class, the presence of `aria-label`, and that the section contains no `.setting-label`.

2662 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the duplicate “Region” label from the Soniox settings.
  * Improved accessibility by adding a clear label to the region selector.
  * Preserved the existing region selection behavior and control styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->