### PR TITLE
feat(providers): gate the Kizuna relay twins separately from Soniox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,12 @@ VITE_BACKEND_URL=http://localhost:8787
 
 # Enable Kizuna AI provider (true/false)
 VITE_ENABLE_KIZUNA_AI=true
+# The relay-managed twins (OpenAI Translate, Volcengine AST2) are gated
+# separately from Soniox, because the managed providers are released
+# independently. Leave unset in release builds until they ship: they bill per
+# second of session time while Soniox bills on reported usage, and the wallet
+# page states only Soniox's rates.
+VITE_ENABLE_KIZUNA_RELAY_PROVIDERS=true
 
 # PostHog Analytics Configuration
 # Set VITE_POSTHOG_KEY to enable analytics tracking

--- a/.env.example
+++ b/.env.example
@@ -13,10 +13,15 @@ VITE_BACKEND_URL=http://localhost:8787
 VITE_ENABLE_KIZUNA_AI=true
 # The relay-managed twins (OpenAI Translate, Volcengine AST2) are gated
 # separately from Soniox, because the managed providers are released
-# independently. Leave unset in release builds until they ship: they bill per
-# second of session time while Soniox bills on reported usage, and the wallet
-# page states only Soniox's rates.
-VITE_ENABLE_KIZUNA_RELAY_PROVIDERS=true
+# independently. They bill per second of session time while Soniox bills on
+# reported usage, and the wallet page states only Soniox's rates — so offering
+# them today would charge a user at one rate and show them another.
+#
+# FALSE here on purpose. This file is meant to be copied to .env (see the top),
+# including for release builds, so a `true` sample would hand every copier the
+# configuration this gate exists to prevent. Development ignores the value
+# anyway: isKizunaRelayProvidersEnabled() returns true whenever DEV is set.
+VITE_ENABLE_KIZUNA_RELAY_PROVIDERS=false
 
 # PostHog Analytics Configuration
 # Set VITE_POSTHOG_KEY to enable analytics tracking

--- a/extension/vite.config.ts
+++ b/extension/vite.config.ts
@@ -161,6 +161,15 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.VITE_ENABLE_KIZUNA_AI': JSON.stringify(
         envVal('VITE_ENABLE_KIZUNA_AI', 'false', 'true')
       ),
+      // Forwarded explicitly, like every key above: Vite's automatic loading
+      // reads the EXTENSION directory, so a flag documented in the root .env
+      // reaches this build only by appearing in this list. Omitted, the gate
+      // would read false in extension builds no matter how it was configured —
+      // harmless today (the twins are meant to be off) but it would make the
+      // switch unturnable-on when they ship.
+      'import.meta.env.VITE_ENABLE_KIZUNA_RELAY_PROVIDERS': JSON.stringify(
+        envVal('VITE_ENABLE_KIZUNA_RELAY_PROVIDERS', 'false', 'true')
+      ),
       'import.meta.env.VITE_ENABLE_PALABRA_AI': JSON.stringify(
         envVal('VITE_ENABLE_PALABRA_AI', 'false')
       ),

--- a/src/components/MainLayout/MainLayout.tsx
+++ b/src/components/MainLayout/MainLayout.tsx
@@ -11,11 +11,12 @@ import { clampPanelWidth, maxPanelWidth, readPanelWidth, savePanelWidth, PANEL_M
 import './MainLayout.scss';
 import { useAnalytics } from '../../lib/analytics';
 import { useProvider, useUIMode, useSetProvider, useSetUIMode, useSettingsNavigationTarget, useSubtitleModeActive } from '../../stores/settingsStore';
-import { isElectron, isKizunaAIEnabled } from '../../utils/environment';
+import { isElectron } from '../../utils/environment';
 import SubtitleApp from '../Subtitle/SubtitleApp';
 import { useOnboarding } from '../../contexts/OnboardingContext';
 import { useAuth } from '../../lib/auth/hooks';
-import { Provider, isKizunaManagedProvider } from '../../types/Provider';
+import { isKizunaManagedProvider } from '../../types/Provider';
+import { ProviderConfigFactory } from '../../services/providers/ProviderConfigFactory';
 
 type PanelName = 'settings' | 'logs' | 'main';
 
@@ -153,18 +154,23 @@ const MainLayout: React.FC = () => {
   useEffect(() => {
     // Check if user just logged in (was false, now true)
     if (!prevIsSignedInRef.current && isSignedIn) {
-      // User just logged in. Only auto-switch when the Kizuna twins are actually
-      // registered (isKizunaAIEnabled); otherwise we'd strand non-Kizuna builds on
-      // a provider that ProviderConfigFactory/ClientFactory never registered.
-      if (isKizunaAIEnabled() && uiMode === 'basic' && !isKizunaManagedProvider(provider)) {
+      // User just logged in. The target is derived from what is REGISTERED, not
+      // from a feature flag: the managed providers are gated independently now,
+      // so isKizunaAIEnabled() no longer implies the Translate twin exists. In
+      // the shipping build (Kizuna on, relay twins off) selecting it would set
+      // a provider ProviderConfigFactory never registered, and the getDescriptor
+      // calls throughout MainPanel/ProviderSection throw on the next render —
+      // signing in would break the app outright.
+      const managedDefault = ProviderConfigFactory.getDefaultManagedProvider();
+      if (managedDefault && uiMode === 'basic' && !isKizunaManagedProvider(provider)) {
         // User is in Basic Mode and not using a Kizuna-managed provider; switch
-        // to the default relay-managed provider (the Translate twin).
-        setProvider(Provider.KIZUNA_AI_OPENAI_TRANSLATE);
+        // to whichever managed provider this build actually offers.
+        setProvider(managedDefault);
 
         // Track the auto-switch
         trackEvent('settings_modified', {
           setting_name: 'provider',
-          new_value: Provider.KIZUNA_AI_OPENAI_TRANSLATE,
+          new_value: managedDefault,
           old_value: provider,
           category: 'api'
         });

--- a/src/locales/locales.consistency.test.ts
+++ b/src/locales/locales.consistency.test.ts
@@ -4,6 +4,9 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/clients/ClientFactory.test.ts
+++ b/src/services/clients/ClientFactory.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect, vi } from "vitest";
 vi.mock("../../utils/environment", async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   getRelayWsUrl: () => "wss://r.example/v1",
 }));
 import { ClientFactory } from "./ClientFactory";

--- a/src/services/providers/ProviderConfigFactory.ts
+++ b/src/services/providers/ProviderConfigFactory.ts
@@ -15,7 +15,7 @@ import { LocalNativeProviderConfig } from './LocalNativeProviderConfig';
 import { ZoomAIProviderConfig } from './ZoomAIProviderConfig';
 import { SonioxProviderConfig } from './SonioxProviderConfig';
 import { Provider, ProviderType } from '../../types/Provider';
-import { isKizunaAIEnabled, isPalabraAIEnabled, isLocalNativeEnabled, isElectron, isExtension } from '../../utils/environment';
+import { isKizunaAIEnabled, isKizunaRelayProvidersEnabled, isPalabraAIEnabled, isLocalNativeEnabled, isElectron, isExtension } from '../../utils/environment';
 
 export class ProviderConfigFactory {
   private static configs: Map<ProviderType, ProviderDescriptor> = new Map();
@@ -54,8 +54,15 @@ export class ProviderConfigFactory {
 
     // Only register Kizuna AI if the feature flag is enabled
     if (isKizunaAIEnabled()) {
-      ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_OPENAI_TRANSLATE, new KizunaAIOpenAITranslateProviderConfig());
-      ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_VOLCENGINE_AST2, new KizunaAIVolcengineAST2ProviderConfig());
+      // The two relay twins are gated SEPARATELY: the managed providers are
+      // released independently, and only Soniox is released today. Without
+      // this, turning the master gate on to ship Soniox would also offer two
+      // providers that bill on a different model and whose rates the wallet
+      // page does not state.
+      if (isKizunaRelayProvidersEnabled()) {
+        ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_OPENAI_TRANSLATE, new KizunaAIOpenAITranslateProviderConfig());
+        ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_VOLCENGINE_AST2, new KizunaAIVolcengineAST2ProviderConfig());
+      }
       ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_SONIOX, new KizunaAISonioxProviderConfig());
     }
 

--- a/src/services/providers/ProviderConfigFactory.ts
+++ b/src/services/providers/ProviderConfigFactory.ts
@@ -132,6 +132,28 @@ export class ProviderConfigFactory {
    * @param providerId - The provider identifier
    * @returns ProviderDescriptor instance
    */
+  /**
+   * The Kizuna-managed provider to put a Basic-mode user on when they sign in,
+   * or null when this build offers none.
+   *
+   * Derived from what is REGISTERED rather than from a feature flag. The
+   * managed providers are gated independently, so `isKizunaAIEnabled()` no
+   * longer implies any particular one exists — a caller that hardcoded the
+   * Translate twin would set a provider `getDescriptor` then throws on.
+   *
+   * The preference order preserves the previous behaviour where the twins are
+   * available (Translate first) and falls through to whatever else is
+   * registered, so a build offering only Soniox lands on Soniox.
+   */
+  static getDefaultManagedProvider(): ProviderType | null {
+    const preferred = [
+      Provider.KIZUNA_AI_OPENAI_TRANSLATE,
+      Provider.KIZUNA_AI_VOLCENGINE_AST2,
+      Provider.KIZUNA_AI_SONIOX,
+    ];
+    return preferred.find((p) => this.configs.has(p)) ?? null;
+  }
+
   static getDescriptor(providerId: ProviderType): ProviderDescriptor {
     const d = this.configs.get(providerId);
     if (!d) throw new Error(`Unsupported provider: ${providerId}`);

--- a/src/services/providers/descriptorRegistry.test.ts
+++ b/src/services/providers/descriptorRegistry.test.ts
@@ -5,6 +5,9 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/providers/kizunaProviderGating.test.ts
+++ b/src/services/providers/kizunaProviderGating.test.ts
@@ -1,0 +1,95 @@
+/**
+ * The three Kizuna-managed providers are released independently, and only
+ * Soniox is released today.
+ *
+ * They used to share one gate, so `VITE_ENABLE_KIZUNA_AI=true` — the switch
+ * that has to be on to ship Soniox at all — offered all three. That matters
+ * beyond tidiness: the relay twins bill per second of session time while
+ * Soniox bills on reported usage, and the wallet page states only Soniox's
+ * rates, so a user who picked Volcengine would be charged at one rate and
+ * shown another.
+ *
+ * Every other suite runs with `import.meta.env.DEV` true, where the relay gate
+ * is deliberately open — so nothing else here exercises the shipped
+ * configuration. This file is the only place that does.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider } from '../../types/Provider';
+
+const RELAY_TWINS = [
+  Provider.KIZUNA_AI_OPENAI_TRANSLATE,
+  Provider.KIZUNA_AI_VOLCENGINE_AST2,
+] as const;
+
+/** Fresh factory per case: the config map is static, so a module reused across
+ *  cases would keep whichever gating ran first. */
+async function providersWith(relayEnabled: boolean): Promise<Provider[]> {
+  vi.resetModules();
+  vi.doMock('../../utils/environment', async (orig) => ({
+    ...(await orig<any>()),
+    isKizunaAIEnabled: () => true,
+    isKizunaRelayProvidersEnabled: () => relayEnabled,
+    isPalabraAIEnabled: () => false,
+    isLocalNativeEnabled: () => false,
+    isElectron: () => true,
+    isExtension: () => false,
+    getRelayWsUrl: () => 'wss://r.example/v1',
+  }));
+  const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+  return ProviderConfigFactory.getAvailableProviders();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.doUnmock('../../utils/environment');
+});
+
+describe('Kizuna managed providers are gated independently', () => {
+  it('offers Soniox but not the relay twins when only Soniox is released', async () => {
+    const providers = await providersWith(false);
+
+    expect(providers).toContain(Provider.KIZUNA_AI_SONIOX);
+    for (const twin of RELAY_TWINS) {
+      expect(providers).not.toContain(twin);
+    }
+  });
+
+  it('offers all three once the relay gate is opened', async () => {
+    const providers = await providersWith(true);
+
+    expect(providers).toContain(Provider.KIZUNA_AI_SONIOX);
+    for (const twin of RELAY_TWINS) {
+      expect(providers).toContain(twin);
+    }
+  });
+
+  // The master gate still governs all of them: a build with Kizuna off offers
+  // none, whatever the relay gate says.
+  it('offers none of them when the master Kizuna gate is off', async () => {
+    vi.resetModules();
+    vi.doMock('../../utils/environment', async (orig) => ({
+      ...(await orig<any>()),
+      isKizunaAIEnabled: () => false,
+      isKizunaRelayProvidersEnabled: () => true,
+      isPalabraAIEnabled: () => false,
+      isLocalNativeEnabled: () => false,
+      isElectron: () => true,
+      isExtension: () => false,
+      getRelayWsUrl: () => 'wss://r.example/v1',
+    }));
+    const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+    const providers = ProviderConfigFactory.getAvailableProviders();
+
+    expect(providers).not.toContain(Provider.KIZUNA_AI_SONIOX);
+    for (const twin of RELAY_TWINS) {
+      expect(providers).not.toContain(twin);
+    }
+  });
+
+  // BYOK Soniox is not gated at all and must stay reachable in every build —
+  // it is the provider a user brings their own key to.
+  it('leaves BYOK Soniox available regardless of either gate', async () => {
+    expect(await providersWith(false)).toContain(Provider.SONIOX);
+    expect(await providersWith(true)).toContain(Provider.SONIOX);
+  });
+});

--- a/src/services/providers/kizunaProviderGating.test.ts
+++ b/src/services/providers/kizunaProviderGating.test.ts
@@ -196,6 +196,36 @@ describe('the legacy kizunaai migration must land on a registered provider', () 
     expect(ProviderConfigFactory.isProviderSupported(migrated)).toBe(true);
   });
 
+  // The likelier case, and the one the first fix missed: a user who ACTUALLY
+  // SELECTED a twin in an earlier build has that exact value persisted, not
+  // the ancient 'kizunaai' string.
+  it('redirects a persisted twin the build no longer registers', async () => {
+    const { migrateLegacyKizunaProvider, ProviderConfigFactory } = await migrateWith(false);
+
+    for (const twin of RELAY_TWINS) {
+      const migrated = migrateLegacyKizunaProvider(twin);
+      expect(migrated).toBe(Provider.KIZUNA_AI_SONIOX);
+      expect(ProviderConfigFactory.isProviderSupported(migrated)).toBe(true);
+    }
+  });
+
+  // Redirecting is only for providers this build cannot offer. A registered
+  // one is the user's actual choice and must survive untouched.
+  it('leaves a registered twin exactly as the user chose it', async () => {
+    const { migrateLegacyKizunaProvider } = await migrateWith(true);
+
+    for (const twin of RELAY_TWINS) {
+      expect(migrateLegacyKizunaProvider(twin)).toBe(twin);
+    }
+  });
+
+  it('leaves managed Soniox alone in both configurations', async () => {
+    const off = await migrateWith(false);
+    const on = await migrateWith(true);
+    expect(off.migrateLegacyKizunaProvider(Provider.KIZUNA_AI_SONIOX)).toBe(Provider.KIZUNA_AI_SONIOX);
+    expect(on.migrateLegacyKizunaProvider(Provider.KIZUNA_AI_SONIOX)).toBe(Provider.KIZUNA_AI_SONIOX);
+  });
+
   it('leaves any other persisted provider untouched', async () => {
     const { migrateLegacyKizunaProvider } = await migrateWith(false);
     expect(migrateLegacyKizunaProvider(Provider.GEMINI)).toBe(Provider.GEMINI);

--- a/src/services/providers/kizunaProviderGating.test.ts
+++ b/src/services/providers/kizunaProviderGating.test.ts
@@ -23,6 +23,22 @@ const RELAY_TWINS = [
 
 /** Fresh factory per case: the config map is static, so a module reused across
  *  cases would keep whichever gating ran first. */
+async function factoryWith(relayEnabled: boolean) {
+  vi.resetModules();
+  vi.doMock('../../utils/environment', async (orig) => ({
+    ...(await orig<any>()),
+    isKizunaAIEnabled: () => true,
+    isKizunaRelayProvidersEnabled: () => relayEnabled,
+    isPalabraAIEnabled: () => false,
+    isLocalNativeEnabled: () => false,
+    isElectron: () => true,
+    isExtension: () => false,
+    getRelayWsUrl: () => 'wss://r.example/v1',
+  }));
+  const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+  return ProviderConfigFactory;
+}
+
 async function providersWith(relayEnabled: boolean): Promise<Provider[]> {
   vi.resetModules();
   vi.doMock('../../utils/environment', async (orig) => ({
@@ -91,5 +107,48 @@ describe('Kizuna managed providers are gated independently', () => {
   it('leaves BYOK Soniox available regardless of either gate', async () => {
     expect(await providersWith(false)).toContain(Provider.SONIOX);
     expect(await providersWith(true)).toContain(Provider.SONIOX);
+  });
+});
+
+describe('the sign-in default must be a provider this build registered', () => {
+  // Codex on #415. MainLayout auto-selects a managed provider when a Basic-mode
+  // user signs in. It used to hardcode the Translate twin, guarded on
+  // isKizunaAIEnabled() — which was sound only while that flag was what
+  // registered the twin. Once the gates split, the shipping build (Kizuna on,
+  // relay off) would set an UNREGISTERED provider, and the getDescriptor calls
+  // throughout MainPanel/ProviderSection throw on the next render: signing in
+  // would break the app outright.
+  it('falls back to managed Soniox when the relay twins are not registered', async () => {
+    const factory = await factoryWith(false);
+    const target = factory.getDefaultManagedProvider();
+
+    expect(target).toBe(Provider.KIZUNA_AI_SONIOX);
+    // The property that actually matters: whatever it returns must resolve.
+    expect(() => factory.getDescriptor(target!)).not.toThrow();
+  });
+
+  it('keeps preferring the Translate twin where it is registered', async () => {
+    const factory = await factoryWith(true);
+    const target = factory.getDefaultManagedProvider();
+
+    expect(target).toBe(Provider.KIZUNA_AI_OPENAI_TRANSLATE);
+    expect(() => factory.getDescriptor(target!)).not.toThrow();
+  });
+
+  it('returns null rather than an unusable provider when none is registered', async () => {
+    vi.resetModules();
+    vi.doMock('../../utils/environment', async (orig) => ({
+      ...(await orig<any>()),
+      isKizunaAIEnabled: () => false,
+      isKizunaRelayProvidersEnabled: () => false,
+      isPalabraAIEnabled: () => false,
+      isLocalNativeEnabled: () => false,
+      isElectron: () => true,
+      isExtension: () => false,
+      getRelayWsUrl: () => 'wss://r.example/v1',
+    }));
+    const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+
+    expect(ProviderConfigFactory.getDefaultManagedProvider()).toBeNull();
   });
 });

--- a/src/services/providers/kizunaProviderGating.test.ts
+++ b/src/services/providers/kizunaProviderGating.test.ts
@@ -152,3 +152,53 @@ describe('the sign-in default must be a provider this build registered', () => {
     expect(ProviderConfigFactory.getDefaultManagedProvider()).toBeNull();
   });
 });
+
+describe('the legacy kizunaai migration must land on a registered provider', () => {
+  // Codex on #415. `migrateLegacyKizunaProvider` rewrote a persisted 'kizunaai'
+  // to the Translate twin, and its own comment promised "stranded users land on
+  // a supported provider". Splitting the gates broke that promise: in a build
+  // that ships Soniox alone the twin is unregistered, `loadSettings` rejects it
+  // at `isProviderSupported`, and the user silently drops to BYOK OpenAI — from
+  // a managed provider to one needing their own API key. Advanced-mode users
+  // are not rescued by the Basic-mode sign-in switch, so nothing corrects it.
+  async function migrateWith(relayEnabled: boolean) {
+    vi.resetModules();
+    vi.doMock('../../utils/environment', async (orig) => ({
+      ...(await orig<any>()),
+      isKizunaAIEnabled: () => true,
+      isKizunaRelayProvidersEnabled: () => relayEnabled,
+      isPalabraAIEnabled: () => false,
+      isLocalNativeEnabled: () => false,
+      isElectron: () => true,
+      isExtension: () => false,
+      getRelayWsUrl: () => 'wss://r.example/v1',
+    }));
+    const { migrateLegacyKizunaProvider } = await import('../../stores/settingsStore');
+    const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+    return { migrateLegacyKizunaProvider, ProviderConfigFactory };
+  }
+
+  it('sends a legacy user to managed Soniox when the twins are not registered', async () => {
+    const { migrateLegacyKizunaProvider, ProviderConfigFactory } = await migrateWith(false);
+    const migrated = migrateLegacyKizunaProvider('kizunaai');
+
+    expect(migrated).toBe(Provider.KIZUNA_AI_SONIOX);
+    // The property that matters: the migration target must survive the
+    // isProviderSupported check that `loadSettings` puts it through.
+    expect(ProviderConfigFactory.isProviderSupported(migrated)).toBe(true);
+  });
+
+  it('still prefers the Translate twin where it is registered', async () => {
+    const { migrateLegacyKizunaProvider, ProviderConfigFactory } = await migrateWith(true);
+    const migrated = migrateLegacyKizunaProvider('kizunaai');
+
+    expect(migrated).toBe(Provider.KIZUNA_AI_OPENAI_TRANSLATE);
+    expect(ProviderConfigFactory.isProviderSupported(migrated)).toBe(true);
+  });
+
+  it('leaves any other persisted provider untouched', async () => {
+    const { migrateLegacyKizunaProvider } = await migrateWith(false);
+    expect(migrateLegacyKizunaProvider(Provider.GEMINI)).toBe(Provider.GEMINI);
+    expect(migrateLegacyKizunaProvider(Provider.SONIOX)).toBe(Provider.SONIOX);
+  });
+});

--- a/src/services/providers/localNativeGating.test.ts
+++ b/src/services/providers/localNativeGating.test.ts
@@ -7,6 +7,9 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isVolcengineSTEnabled: () => true,
   isVolcengineAST2Enabled: () => true,

--- a/src/services/providers/participantConfig.test.ts
+++ b/src/services/providers/participantConfig.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/providers/prepareToStart.kizunaSoniox.test.ts
+++ b/src/services/providers/prepareToStart.kizunaSoniox.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/providers/prepareToStart.local.test.ts
+++ b/src/services/providers/prepareToStart.local.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/providers/sessionResourcesWiring.test.ts
+++ b/src/services/providers/sessionResourcesWiring.test.ts
@@ -6,6 +6,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/providers/speechMode.test.ts
+++ b/src/services/providers/speechMode.test.ts
@@ -3,6 +3,9 @@ import { describe, it, expect, vi } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/services/providers/voicePrepWiring.test.ts
+++ b/src/services/providers/voicePrepWiring.test.ts
@@ -6,6 +6,9 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 vi.mock('../../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isLocalNativeEnabled: () => true,
   isElectron: () => true,

--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -11,6 +11,9 @@ import { buildDefaultLocalPrompt } from '../lib/local-inference/prompts';
 vi.mock('../utils/environment', async (orig) => ({
   ...(await orig<any>()),
   isKizunaAIEnabled: () => true,
+  // Explicit: the relay twins are gated separately now, and this mock's
+  // promise is that EVERY provider gate is forced on.
+  isKizunaRelayProvidersEnabled: () => true,
   isPalabraAIEnabled: () => true,
   isElectron: () => true,
   isExtension: () => false,

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -321,11 +321,26 @@ export interface SettingsStore {
 
 // ==================== Helper Functions ====================
 
-/** Migrate a persisted legacy 'kizunaai' provider value to the relay twin.
- *  The realtime KizunaAI provider was replaced by two relay-managed providers;
- *  default existing users to the Translate twin. */
+/**
+ * Migrate a persisted legacy 'kizunaai' provider value to a managed provider.
+ *
+ * The realtime KizunaAI provider was replaced by relay-managed twins. The
+ * target is whichever managed provider this build REGISTERED, not a fixed one:
+ * the twins are gated independently, so a build that ships Soniox alone does
+ * not offer the Translate twin, and naming it would fail `isProviderSupported`
+ * in `loadSettings` and drop the user to BYOK OpenAI — the opposite of what
+ * this migration exists for, and silent. Advanced-mode users are not rescued
+ * by the Basic-mode sign-in switch either, so nothing downstream would correct
+ * it.
+ *
+ * Falls back to the Translate twin when no managed provider is registered at
+ * all, which preserves the previous behaviour: `loadSettings` rejects it and
+ * lands on OpenAI, the only sensible answer for a build with no managed
+ * providers.
+ */
 export function migrateLegacyKizunaProvider(p: Provider | string): Provider {
-  return (p as string) === 'kizunaai' ? Provider.KIZUNA_AI_OPENAI_TRANSLATE : (p as Provider);
+  if ((p as string) !== 'kizunaai') return p as Provider;
+  return ProviderConfigFactory.getDefaultManagedProvider() ?? Provider.KIZUNA_AI_OPENAI_TRANSLATE;
 }
 
 /** Migrate persisted PalabraAI language codes that the API rejects.

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -322,9 +322,18 @@ export interface SettingsStore {
 // ==================== Helper Functions ====================
 
 /**
- * Migrate a persisted legacy 'kizunaai' provider value to a managed provider.
+ * Redirect a persisted Kizuna-managed provider this build does not offer.
  *
- * The realtime KizunaAI provider was replaced by relay-managed twins. The
+ * Two inputs need it, and the second is the likelier one. The legacy realtime
+ * 'kizunaai' value, replaced long ago by the relay twins; and a twin the user
+ * ACTUALLY SELECTED in an earlier build, which a later build may no longer
+ * register now that the managed providers are gated independently. Both end at
+ * the same place: `loadSettings` runs the result through
+ * `isProviderSupported`, and anything unregistered silently becomes BYOK
+ * OpenAI — a managed user dropped to one who must supply their own API key,
+ * with nothing downstream to correct it in Advanced mode.
+ *
+ * A registered managed provider is left exactly as the user chose it. The
  * target is whichever managed provider this build REGISTERED, not a fixed one:
  * the twins are gated independently, so a build that ships Soniox alone does
  * not offer the Translate twin, and naming it would fail `isProviderSupported`
@@ -339,7 +348,16 @@ export interface SettingsStore {
  * providers.
  */
 export function migrateLegacyKizunaProvider(p: Provider | string): Provider {
-  if ((p as string) !== 'kizunaai') return p as Provider;
+  const isLegacy = (p as string) === 'kizunaai';
+  const isManaged = isLegacy || isKizunaManagedProvider(p as Provider);
+  if (!isManaged) return p as Provider;
+
+  // A managed provider THIS build registered is already fine — keep the user's
+  // actual choice. Only a gated-out one needs redirecting.
+  if (!isLegacy && ProviderConfigFactory.isProviderSupported(p as Provider)) {
+    return p as Provider;
+  }
+
   return ProviderConfigFactory.getDefaultManagedProvider() ?? Provider.KIZUNA_AI_OPENAI_TRANSLATE;
 }
 

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -191,6 +191,31 @@ export function isKizunaAIEnabled(): boolean {
 }
 
 /**
+ * Check if the relay-managed Kizuna twins (OpenAI Translate, Volcengine AST2)
+ * should be offered.
+ *
+ * NARROWER than `isKizunaAIEnabled`, which is the master "this is a Kizuna
+ * build" gate and also drives the account UI, onboarding and MainLayout's
+ * provider defaulting — it cannot be used to hold back individual providers.
+ *
+ * These two exist because the managed providers are released independently:
+ * only Soniox is being released, and turning on the master gate to ship it
+ * would otherwise expose all three. They also bill differently from Soniox
+ * (per second of session time rather than on reported usage) and the wallet
+ * page currently states only Soniox's rates, so offering them would show a
+ * user of those providers a price that is not theirs.
+ *
+ * Development keeps them on, so nothing changes while working locally.
+ */
+export function isKizunaRelayProvidersEnabled(): boolean {
+  if (isDevelopmentMode()) {
+    return true;
+  }
+
+  return import.meta.env.VITE_ENABLE_KIZUNA_RELAY_PROVIDERS === 'true';
+}
+
+/**
  * Check if Palabra AI features should be enabled
  * @returns true if Palabra AI features should be shown
  *


### PR DESCRIPTION
All three Kizuna-managed providers shared one flag:

```ts
if (isKizunaAIEnabled()) {
  configs.set(KIZUNA_AI_OPENAI_TRANSLATE, …)
  configs.set(KIZUNA_AI_VOLCENGINE_AST2, …)
  configs.set(KIZUNA_AI_SONIOX, …)
}
```

`VITE_ENABLE_KIZUNA_AI=true` is the switch that has to be on to ship managed Soniox at all — so turning it on also offers OpenAI Translate and Volcengine AST2. Only Soniox is being released.

## Why this is more than premature exposure

The twins bill on a **different model** from Soniox, and the wallet page does not state their rates.

- `TranslateRelayDO` and `VolcengineAST2RelayDO` charge `billableSeconds` without passing `pricing`, so both take `billing-service`'s default `"time"` — charged **during** the session (`FLUSH_SECONDS = 30` for the former, per usage response for the latter).
- Managed Soniox charges `cost_times_k` on reported usage, **after** the session, at reconciliation.
- `formatRateInfo` renders only `soniox:speech_to_speech` and `soniox:text_only`, even though `/api/wallet/status` publishes all four rates.

Net effect if the twins shipped today: a user who selected Volcengine is charged **$5.00/hr** while the wallet page shows them **$2.50/hr** — Soniox's rate, not theirs.

## The gate

`isKizunaAIEnabled` stays the master "this is a Kizuna build" gate. It cannot be used to hold back individual providers: it also drives the account section, onboarding, and MainLayout's provider defaulting.

The new `isKizunaRelayProvidersEnabled` is narrower, defaults off in production, and stays on in development so local work is unchanged.

## A test gap this exposed

Every existing suite runs with `import.meta.env.DEV` true, where the new gate is deliberately open — so **none of the 2662 existing tests exercise the shipped configuration**. Adding the gate alone changed no test result, which is exactly why it needed its own.

`kizunaProviderGating.test.ts` covers all four states (relay off / relay on / master off / BYOK Soniox unaffected), and was verified to fail when the gate is removed rather than merely passing alongside it.

The eleven suites whose mock claims to "force every provider gate on" now name this gate explicitly, so that claim is true by construction instead of by relying on `DEV`.

2666 tests pass.

## Follow-up, not fixed here

When the twins do ship, `formatRateInfo` must show the rate for the provider in use — the data is already in the status response. Until then the Soniox-only footnote is correct, which is also why the Terms in `kizuna-ai-lab/sokuji-backend#19` describe Soniox's model alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added independent availability controls for relay-managed translation and speech providers.
  - Soniox availability can now be managed separately from other relay providers.
  - Added configuration guidance for enabling relay providers in development and production.
  - Basic Mode now automatically selects an available managed provider when needed.
  - Legacy Kizuna provider settings migrate to an available managed provider.
- **Bug Fixes**
  - Preserved BYOK Soniox configurations regardless of relay-provider settings.
  - Improved provider registration consistency across feature-flag combinations.
- **Tests**
  - Expanded coverage for provider visibility, fallback behavior, migration, and feature-gate combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->