### PR TITLE
feat(providers): reorder the provider list to lead with the curated eight

### DIFF
--- a/src/services/providers/ProviderConfigFactory.ts
+++ b/src/services/providers/ProviderConfigFactory.ts
@@ -26,18 +26,20 @@ export class ProviderConfigFactory {
     // its own environment / feature-flag guard.
 
     ProviderConfigFactory.configs.set(Provider.OPENAI, new OpenAIProviderConfig());
+
+    // Kizuna-managed Soniox — behind the master Kizuna gate plus its own gate.
+    // Each managed provider carries its OWN gate: they are released
+    // independently, and they bill on different models whose rates the wallet
+    // page publishes one at a time. A shared gate could not express "ship this
+    // one alone", which is what independent release means.
+    if (isKizunaAIEnabled() && isKizunaSonioxEnabled()) {
+      ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_SONIOX, new KizunaAISonioxProviderConfig());
+    }
+
     ProviderConfigFactory.configs.set(Provider.OPENAI_TRANSLATE, new OpenAITranslateProviderConfig());
 
     // Local inference is always available (no API key or feature flag required)
     ProviderConfigFactory.configs.set(Provider.LOCAL_INFERENCE, new LocalInferenceProviderConfig());
-
-    // Native (Electron sidecar) local inference — Electron only, behind feature flag
-    if (isElectron() && isLocalNativeEnabled()) {
-      ProviderConfigFactory.configs.set(Provider.LOCAL_NATIVE, new LocalNativeProviderConfig());
-    }
-
-    // Soniox speech-to-speech translation — always available (BYOK)
-    ProviderConfigFactory.configs.set(Provider.SONIOX, new SonioxProviderConfig());
 
     // Volcengine AST 2.0 — always available, but only in Electron (IPC proxy) and
     // Extension (declarativeNetRequest header injection), which it technically requires
@@ -47,20 +49,22 @@ export class ProviderConfigFactory {
 
     ProviderConfigFactory.configs.set(Provider.GEMINI, new GeminiProviderConfig());
 
+    // Soniox speech-to-speech translation — always available (BYOK)
+    ProviderConfigFactory.configs.set(Provider.SONIOX, new SonioxProviderConfig());
+
     // Only register Palabra AI if the feature flag is enabled
     if (isPalabraAIEnabled()) {
       ProviderConfigFactory.configs.set(Provider.PALABRA_AI, new PalabraAIProviderConfig());
     }
 
-    // Only register Kizuna AI if the feature flag is enabled
+    // Native (Electron sidecar) local inference — Electron only, behind feature flag
+    if (isElectron() && isLocalNativeEnabled()) {
+      ProviderConfigFactory.configs.set(Provider.LOCAL_NATIVE, new LocalNativeProviderConfig());
+    }
+
+    // The remaining Kizuna-managed providers, each behind the master gate plus
+    // its own gate (see the Kizuna Soniox registration above).
     if (isKizunaAIEnabled()) {
-      // Each managed provider carries its OWN gate: they are released
-      // independently, and they bill on different models whose rates the wallet
-      // page publishes one at a time. A shared gate could not express "ship this
-      // one alone", which is what independent release means.
-      if (isKizunaSonioxEnabled()) {
-        ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_SONIOX, new KizunaAISonioxProviderConfig());
-      }
       if (isKizunaOpenAITranslateEnabled()) {
         ProviderConfigFactory.configs.set(Provider.KIZUNA_AI_OPENAI_TRANSLATE, new KizunaAIOpenAITranslateProviderConfig());
       }

--- a/src/services/providers/providerOrder.test.ts
+++ b/src/services/providers/providerOrder.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { Provider } from '../../types/Provider';
+
+// Registration order in ProviderConfigFactory's static block IS the UI list
+// order (the configs Map preserves insertion order, and ProviderSection
+// renders getAllConfigs() as-is). This pins the curated head of that list.
+async function allProviders(): Promise<Provider[]> {
+  vi.resetModules();
+  vi.doMock('../../utils/environment', async (orig) => ({
+    ...(await orig<any>()),
+    isKizunaAIEnabled: () => true,
+    isKizunaSonioxEnabled: () => true,
+    isKizunaOpenAITranslateEnabled: () => true,
+    isKizunaVolcengineAST2Enabled: () => true,
+    isPalabraAIEnabled: () => true,
+    isLocalNativeEnabled: () => true,
+    isElectron: () => true,
+    isExtension: () => false,
+    getRelayWsUrl: () => 'wss://r.example/v1',
+  }));
+  const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+  return ProviderConfigFactory.getAvailableProviders();
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  vi.doUnmock('../../utils/environment');
+});
+
+describe('provider list order', () => {
+  it('leads with the curated eight, in order, before everything else', async () => {
+    const ids = await allProviders();
+
+    expect(ids.slice(0, 8)).toEqual([
+      Provider.OPENAI,
+      Provider.KIZUNA_AI_SONIOX,
+      Provider.OPENAI_TRANSLATE,
+      Provider.LOCAL_INFERENCE,
+      Provider.VOLCENGINE_AST2,
+      Provider.GEMINI,
+      Provider.SONIOX,
+      Provider.PALABRA_AI,
+    ]);
+  });
+
+  // When a gated provider in the head is absent, the remaining head providers
+  // must still lead the list in the same relative order — the gate removes an
+  // entry, it must not reshuffle the others.
+  it('keeps the head order stable when gated entries drop out', async () => {
+    vi.resetModules();
+    vi.doMock('../../utils/environment', async (orig) => ({
+      ...(await orig<any>()),
+      isKizunaAIEnabled: () => false,
+      isKizunaSonioxEnabled: () => false,
+      isKizunaOpenAITranslateEnabled: () => false,
+      isKizunaVolcengineAST2Enabled: () => false,
+      isPalabraAIEnabled: () => false,
+      isLocalNativeEnabled: () => false,
+      isElectron: () => false,
+      isExtension: () => false,
+      getRelayWsUrl: () => 'wss://r.example/v1',
+    }));
+    const { ProviderConfigFactory } = await import('./ProviderConfigFactory');
+    const ids = ProviderConfigFactory.getAvailableProviders();
+
+    expect(ids.slice(0, 5)).toEqual([
+      Provider.OPENAI,
+      Provider.OPENAI_TRANSLATE,
+      Provider.LOCAL_INFERENCE,
+      Provider.GEMINI,
+      Provider.SONIOX,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Registration order in `ProviderConfigFactory` is the UI list order (the configs Map preserves insertion order and `ProviderSection` renders `getAllConfigs()` as-is). This reorders the registrations so the list leads with:

1. OpenAI
2. Kizuna AI Soniox
3. OpenAI Translate
4. Local Inference
5. Volcengine AST2
6. Gemini
7. Soniox (BYOK)
8. Palabra AI

Everything else (Local Native, the other two Kizuna-managed providers, OpenAI Compatible, Volcengine ST, Zoom AI) follows in its previous relative order.

Every environment / feature-flag guard is preserved. The only structural change: the Kizuna Soniox registration moves out of the shared `isKizunaAIEnabled` block and guards itself with `isKizunaAIEnabled() && isKizunaSonioxEnabled()`, so it can sit second while the other two managed providers stay gated together further down — semantics unchanged.

## Test plan

- New `providerOrder.test.ts` (written first, red → green) pins the curated head of the list with all gates open, and checks that closed gates drop entries without reshuffling the rest.
- Full `src/services/providers/` suite: the 7 pre-existing failures (`kizunaProviderGating` ×6, `descriptorRegistry` ×1) fail identically on the clean base — worktree node_modules resolution issue, unrelated to this change (A/B verified via stash).
- `tsc --noEmit` error count identical before/after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the ordering of available AI providers so commonly used options appear in the intended sequence.
  * Ensured provider availability gates are applied consistently, including Soniox and local-native options.

* **Tests**
  * Added coverage to verify provider ordering and confirm disabled providers are removed without disrupting the remaining sequence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->