### PR TITLE
fix(auth): reload in place on sign-out instead of navigating to '/'

### DIFF
--- a/src/components/Auth/UserAccountInfo.tsx
+++ b/src/components/Auth/UserAccountInfo.tsx
@@ -335,8 +335,15 @@ export function UserAccountInfo({
                 // Even if backend returns 403 or other errors, clear frontend state
                 // This ensures users can always "log out"
               } finally {
-                // Force page reload to clear all state
-                window.location.href = '/';
+                // Reload in place, never navigate to '/'. Only the dev server
+                // serves the app at the site root: the packaged desktop app is
+                // loaded from file://…/build/index.html, where '/' is the
+                // filesystem root (the window went blank), and the extension
+                // panel is chrome-extension://<id>/fullpage.html, where '/' is
+                // the extension root with no document (ERR_FILE_NOT_FOUND).
+                // reload() re-runs the current document on every surface, which
+                // is all the "clear all state" here ever needed.
+                window.location.reload();
               }
             }}
           >


### PR DESCRIPTION
## Problem

Signing out breaks on both shipped surfaces, and works only in development.

The handler ends with:

```js
} finally {
  // Force page reload to clear all state
  window.location.href = '/';
}
```

`/` is the site root — which only the Vite dev server serves. On the surfaces users actually run:

| Surface | Document | `'/'` resolves to | Symptom |
|---|---|---|---|
| Packaged desktop | `file://…/build/index.html` | filesystem root | window goes blank after sign-out |
| Extension side panel | `chrome-extension://<id>/fullpage.html` | extension root, no document | `ERR_FILE_NOT_FOUND` |
| Dev | `http://localhost:5173/index.html` | the app | works |

Both were reported from real use. Same shape as the `INVALID_ORIGIN` bug filed against the backend today — a dev-only assumption baked into a production path.

## Fix

Reload in place instead of navigating:

```js
window.location.reload();
```

`reload()` re-runs whatever document is current, so it is correct on all three surfaces and never leaves the app on a URL that does not exist.

Session state does not depend on the reload: `useSession()` is better-auth's reactive hook and every consumer already re-renders when `signOut()` clears it. The reload is kept purely to preserve the original comment's belt-and-braces "clear all state" intent for non-auth state, at no cost.

## Scope

One line plus its comment. Grepped for other root navigations (`location.href =`, `location.replace(`, `location.assign(`) across `src/` and `extension/` — this was the only one.

## Testing

`tsc` clean on the touched file. No test covers this handler (there is no `UserAccountInfo` test file); verified by reading the three documents' URLs rather than by adding a jsdom test that would only assert the mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-out behavior by reloading the current page, ensuring compatibility across desktop and browser-extension experiences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->