### PR TITLE
feat(settings): adopt customizable select for provider, selects, and variant pickers

### DIFF
--- a/shared/index.tsx
+++ b/shared/index.tsx
@@ -5,6 +5,12 @@ import PostHog from 'posthog-js-lite';
 import { ANALYTICS_CONFIG, isDevelopment, getPlatform, getEnvironment, isAnalyticsEnabled } from '../src/config/analytics';
 import { setupErrorTracking } from '../src/lib/errorTracking';
 import { AppProviders } from '../src/components/AppProviders';
+import { installCustomizableSelectWarningMuffler } from '../src/utils/muffleCustomizableSelectWarnings';
+
+// Before anything renders: drop React's two dev-only false positives about
+// customizable-select markup (valid in Chromium 135+, still flagged by
+// validateDOMNesting as of react-dom 19.2.8 — see the muffler's doc comment).
+installCustomizableSelectWarningMuffler();
 
 // Re-export PostHog context from its dedicated side-effect-free module.
 // Keeping the named exports here preserves backward compatibility with

--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -620,3 +620,16 @@
   0%, 100% { opacity: 1; }
   50% { opacity: 0.4; }
 }
+
+// Floating wrapper for the display-settings popover. size() middleware sets
+// max-height inline; the inner popover has to scroll within it, or the clamp
+// would just cut the content off.
+.display-popover-floating {
+  display: flex;
+  min-height: 0;
+
+  .display-settings-popover {
+    overflow-y: auto;
+    min-height: 0;
+  }
+}

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -81,7 +81,7 @@ import { shouldShowItem } from './conversationFilter';
 import ExportButton from './ExportButton';
 import {
   useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, shift, size,
-  FloatingPortal,
+  autoUpdate, FloatingPortal,
 } from '@floating-ui/react';
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 import { usePlaybackStore, usePlaybackHighlight } from '../../stores/playbackStore';
@@ -738,6 +738,9 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     open: displayPopoverOpen,
     onOpenChange: setDisplayPopoverOpen,
     placement: 'bottom-end',
+    // Re-position and re-clamp while open — without this a window resize
+    // leaves flip/shift/size results stale (same as ModeDevicePopover).
+    whileElementsMounted: autoUpdate,
     middleware: [
       offset(8),
       flip(),

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -80,7 +80,8 @@ import ConversationRow from './ConversationRow';
 import { shouldShowItem } from './conversationFilter';
 import ExportButton from './ExportButton';
 import {
-  useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
+  useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, shift, size,
+  FloatingPortal,
 } from '@floating-ui/react';
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 import { usePlaybackStore, usePlaybackHighlight } from '../../stores/playbackStore';
@@ -737,7 +738,21 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     open: displayPopoverOpen,
     onOpenChange: setDisplayPopoverOpen,
     placement: 'bottom-end',
-    middleware: [offset(8), flip()],
+    middleware: [
+      offset(8),
+      flip(),
+      shift({ padding: 8 }),
+      // Clamp to the viewport so a short window scrolls the popover instead
+      // of cutting it off — same pattern as ModeDevicePopover.
+      size({
+        padding: 8,
+        apply({ availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${Math.max(0, availableHeight)}px`,
+          });
+        },
+      }),
+    ],
   });
   // useRole wires aria-haspopup / aria-expanded / aria-controls on the
   // trigger button and role="dialog" / aria-modal on the floating wrapper.
@@ -4103,6 +4118,7 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             <FloatingPortal>
               <div
                 ref={displayPopoverFloating.refs.setFloating}
+                className="display-popover-floating"
                 style={displayPopoverFloating.floatingStyles}
                 aria-label={t('mainPanel.displaySettings', 'Display settings')}
                 {...displayPopoverInteractions.getFloatingProps()}

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1320,10 +1320,13 @@
         cursor: not-allowed;
       }
 
-      // The checkmark only renders on the selected option; push it to the
-      // row's far end (options are flex rows).
+      // Push the checkmark to the row's far end. It is the option's FIRST
+      // flex item in the UA stylesheet, so `margin-left: auto` alone shoves
+      // the content after it to the right edge instead — `order: 1` has to
+      // move the checkmark box last first.
       &::checkmark {
         color: vars.$color-primary;
+        order: 1;
         margin-left: auto;
       }
     }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1258,84 +1258,125 @@
   }
 }
 
+// ── Customizable select (appearance: base-select, Chromium 135+) ──────────
+// One shared layer replaces every classic select's OS-drawn popup — which
+// ignores our theme beyond option colors — with a themed picker on the
+// in-window top layer. @supports guards it: the extension's floor is Chrome
+// 116, and anything older keeps today's classic popup untouched (rich option
+// markup is likewise gated in TSX — see supportsBaseSelect()).
+@supports (appearance: base-select) {
+  .language-select,
+  .select-dropdown,
+  .provider-select {
+    &,
+    &::picker(select) {
+      appearance: base-select;
+    }
+
+    // base-select renders its own ::picker-icon chevron; the data-URI arrow
+    // from the classic styling would double it.
+    background-image: none;
+
+    &::picker-icon {
+      color: vars.$text-muted;
+    }
+
+    &:open {
+      border-color: vars.$color-primary;
+    }
+
+    &::picker(select) {
+      background: vars.$bg-surface;
+      border: 1px solid vars.$border-default;
+      border-radius: vars.$radius-md;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+      padding: 4px;
+      margin-top: 4px;
+      // Long lists (35+ languages) scroll inside the picker. The top layer
+      // already clamps to the viewport; this keeps the list hand-sized.
+      max-height: 320px;
+      overflow-y: auto;
+      scrollbar-width: thin;
+    }
+
+    option {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 10px;
+      border-radius: vars.$radius-sm;
+      font-size: vars.$font-title;
+      color: vars.$text-primary;
+      background: transparent;
+      cursor: pointer;
+
+      &:hover,
+      &:focus {
+        background: vars.$bg-control;
+      }
+
+      &:disabled {
+        color: vars.$text-disabled;
+        cursor: not-allowed;
+      }
+
+      // The checkmark only renders on the selected option; push it to the
+      // row's far end (options are flex rows).
+      &::checkmark {
+        color: vars.$color-primary;
+        margin-left: auto;
+      }
+    }
+  }
+
+  // Rich provider rows: icon + name-line (name · engine credit) + description.
+  // The option markup lives in ProviderSection.tsx; .provider-name-line and
+  // .powered-by are the shared styles used across the settings panel.
+  .provider-select {
+    // The closed control holds a two-line row, like the old .provider-info.
+    padding: 12px;
+
+    option {
+      align-items: center;
+      gap: 12px;
+    }
+
+    &::picker(select) {
+      // Provider descriptions run long; let rows breathe a little more.
+      max-height: 380px;
+    }
+
+    .provider-select__icon {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      flex: none;
+      color: vars.$text-muted;
+    }
+
+    .provider-select__text {
+      display: flex;
+      flex-direction: column;
+      min-width: 0;
+    }
+
+    .provider-select__name {
+      font-size: vars.$font-title;
+      font-weight: vars.$weight-medium;
+      color: vars.$text-primary;
+    }
+
+    .provider-select__description {
+      font-size: vars.$font-caption;
+      color: vars.$text-muted;
+    }
+  }
+}
+
 // Provider section styles
 .provider-selection-area {
   margin-bottom: vars.$space-2;
   position: relative;
-}
-
-.provider-info {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 12px;
-  background: vars.$bg-control;
-  border-radius: vars.$radius-sm;
-  cursor: pointer;
-  transition: all vars.$transition-fast;
-  user-select: none;
-
-  &:hover:not(.disabled) {
-    background: vars.$bg-hover;
-  }
-
-  &.expanded {
-    background: vars.$bg-hover;
-    border-bottom-left-radius: 0;
-    border-bottom-right-radius: 0;
-  }
-
-  &.disabled {
-    cursor: not-allowed;
-    opacity: 0.6;
-    background: vars.$bg-surface;
-
-    .provider-details .provider-toggle {
-      display: none;
-    }
-  }
-
-  .provider-icon {
-    color: vars.$text-muted;
-
-    svg {
-      width: 24px;
-      height: 24px;
-    }
-  }
-
-  .provider-details {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-
-    .provider-main-info {
-      flex: 1;
-
-      .provider-name {
-        font-size: vars.$font-title;
-        font-weight: 600;
-        margin-bottom: 2px;
-        color: vars.$text-primary;
-      }
-
-      .provider-description {
-        font-size: vars.$font-caption;
-        color: vars.$text-muted;
-        line-height: 1.3;
-      }
-    }
-
-    .provider-toggle {
-      color: vars.$text-muted;
-      transition: color vars.$transition-fast;
-
-      &:hover {
-        color: vars.$text-primary;
-      }
-    }
-  }
 }
 
 /* Provider name + engine credit sharing one line.
@@ -1356,8 +1397,7 @@
   gap: 7px;
   margin-bottom: 2px;
 
-  .provider-name,
-  .provider-option-name {
+  .provider-select__name {
     margin-bottom: 0;
   }
 }
@@ -1378,76 +1418,6 @@
     letter-spacing: 0;
     text-transform: none;
     color: vars.$text-secondary;
-  }
-}
-
-.provider-options {
-  background: vars.$bg-surface;
-  border: 1px solid vars.$bg-hover;
-  border-top: none;
-  border-radius: 0 0 vars.$radius-sm vars.$radius-sm;
-  max-height: 300px;
-  overflow-y: auto;
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  animation: slideDown 0.15s ease-out;
-
-  @keyframes slideDown {
-    from {
-      opacity: 0;
-      transform: translateY(-4px);
-    }
-    to {
-      opacity: 1;
-      transform: translateY(0);
-    }
-  }
-
-  .provider-option {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    padding: 10px 12px;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-    border-bottom: 1px solid vars.$border-subtle;
-
-    &:last-child {
-      border-bottom: none;
-    }
-
-    &:hover {
-      background: vars.$bg-control;
-    }
-
-    &:active {
-      background: vars.$bg-hover;
-    }
-
-    .provider-option-icon {
-      color: vars.$text-muted;
-
-      svg {
-        width: 20px;
-        height: 20px;
-      }
-    }
-
-    .provider-option-details {
-      flex: 1;
-
-      .provider-option-name {
-        font-size: vars.$font-title;
-        font-weight: 500;
-        color: vars.$text-primary;
-        margin-bottom: 1px;
-      }
-
-      .provider-option-description {
-        font-size: vars.$font-caption;
-        color: vars.$text-muted;
-        line-height: 1.2;
-      }
-    }
   }
 }
 

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1344,6 +1344,17 @@
       gap: 12px;
     }
 
+    // The closed control's content is <selectedcontent> — a CLONE of the
+    // chosen option, not an option — so the option flex rule above does not
+    // reach it. Without this the icon stacks on its own line above the name
+    // instead of sitting beside it the way the old .provider-info row did.
+    selectedcontent {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+    }
+
     &::picker(select) {
       // Provider descriptions run long; let rows breathe a little more.
       max-height: 380px;

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -568,9 +568,14 @@
         .model-card__variant-name { color: vars.$color-primary; }
       }
 
+      // order:1 + auto margin park the checkmark at the row end; without the
+      // order it sits first in flex order and the auto margin would shove the
+      // row content right instead (see the shared layer in Settings.scss).
       &::checkmark {
         color: vars.$color-primary;
         font-weight: vars.$weight-semibold;
+        order: 1;
+        margin-left: auto;
       }
 
       // Unsupported: greyed, not selectable (still listed with size + reason).

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -622,10 +622,15 @@
     text-align: right;
   }
 
-  &__variant-cpu-note {
+  // Rendered as a disabled <option> (the select content model admits no
+  // other child shape), but it is a note, not a rejected choice — undo the
+  // option:disabled treatment that reading would be wrong for.
+  &__variant-select option.model-card__variant-cpu-note {
     font-size: 10px;
     color: vars.$text-muted;
-    padding: 2px 4px;
+    padding: 2px 8px;
+    opacity: 1;
+    cursor: default;
   }
 }
 

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -484,14 +484,24 @@
   }
 
   // --- Variant chooser (pre-download quant selection for multi-variant models) ---
+  //
+  // A customizable <select> (appearance: base-select). This section is
+  // Electron-only (Chromium 144), so there is no classic-select fallback to
+  // style. The picker floats on the top layer, so opening it never grows the
+  // card — which is what the old absolutely-positioned menu existed to ensure,
+  // minus its clipping inside the settings panel's scroll container.
 
-  // Dropdown wrapper lives in the header (where the size sits); menu is absolutely
-  // positioned so opening it never grows the card.
   &__variant-dd {
-    position: relative;
+    display: inline-flex;
   }
 
-  &__variant-trigger {
+  &__variant-select {
+    &,
+    &::picker(select) {
+      appearance: base-select;
+    }
+
+    // Closed control: the compact chip the old trigger button was.
     display: inline-flex;
     align-items: center;
     gap: 4px;
@@ -511,74 +521,66 @@
     }
 
     &:disabled { cursor: not-allowed; opacity: 0.6; }
-  }
 
-  // Calm, matches the muted "size" slot on sibling cards; green is reserved for
-  // the chosen row inside the menu, not the always-visible trigger.
-  &__variant-trigger-value {
-    color: vars.$text-secondary;
-    font-weight: vars.$weight-medium;
-    letter-spacing: 0.02em;
-  }
+    &::picker-icon { color: vars.$text-muted; }
 
-  &__variant-menu {
-    position: absolute;
-    top: calc(100% + 4px);
-    right: 0;
-    z-index: 20;
-    min-width: 210px;
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-    padding: 4px;
-    background: #1f2225;
-    border: 1px solid vars.$border-default;
-    border-radius: vars.$radius-sm;
-    // The selectable .model-card sets cursor:pointer, which `cursor` inheritance
-    // leaks onto the menu's plain text (e.g. the CPU note). Reset it here; the
-    // item buttons re-assert their own pointer/not-allowed cursor.
-    cursor: default;
-  }
-
-  &__variant-item {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    padding: 5px 8px;
-    background: transparent;
-    border: 0;
-    border-radius: vars.$radius-sm;
-    cursor: pointer;
-    text-align: left;
-    width: 100%;
-    transition: background vars.$transition-fast;
-
-    // Hover highlight only on selectable rows (unsupported rows use aria-disabled,
-    // not the :disabled pseudo-class, so exclude them by class).
-    &:hover:not(:disabled):not(#{&}--unsupported) { background: rgba(255, 255, 255, 0.06); }
-
-    // Selected variant: filled tint only (no accent-bar shadow, by preference) —
-    // still unmistakable via the green name + check.
-    &--chosen {
-      background: rgba(vars.$color-primary, 0.12);
+    // The closed control mirrors the chosen option; keep only its name + size
+    // there (calm, matches the muted "size" slot on sibling cards — green is
+    // reserved for the picker rows).
+    selectedcontent {
+      .model-card__variant-recommended,
+      .model-card__variant-reason { display: none; }
+      .model-card__variant-name { color: vars.$text-secondary; }
     }
 
-    // Unsupported: greyed, not clickable (still listed with its size + blocked icon).
-    &--unsupported { opacity: 0.5; cursor: not-allowed; }
+    &::picker(select) {
+      min-width: 230px;
+      padding: 4px;
+      background: #1f2225;
+      border: 1px solid vars.$border-default;
+      border-radius: vars.$radius-sm;
+      box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+      margin-top: 4px;
+      // The selectable .model-card sets cursor:pointer, which `cursor`
+      // inheritance leaks onto the picker's plain text (the CPU note).
+      cursor: default;
+    }
 
-    &:disabled { cursor: not-allowed; }
+    option {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 10px;
+      padding: 5px 8px;
+      background: transparent;
+      border-radius: vars.$radius-sm;
+      cursor: pointer;
+      transition: background vars.$transition-fast;
+
+      &:hover:not(:disabled),
+      &:focus:not(:disabled) { background: rgba(255, 255, 255, 0.06); }
+
+      // Selected variant: filled tint only (no accent-bar shadow, by
+      // preference) — still unmistakable via the green name + checkmark.
+      &:checked {
+        background: rgba(vars.$color-primary, 0.12);
+
+        .model-card__variant-name { color: vars.$color-primary; }
+      }
+
+      &::checkmark {
+        color: vars.$color-primary;
+        font-weight: vars.$weight-semibold;
+      }
+
+      // Unsupported: greyed, not selectable (still listed with size + reason).
+      &:disabled { opacity: 0.5; cursor: not-allowed; }
+    }
   }
 
-  &__variant-check {
-    color: vars.$color-primary;
-    font-weight: vars.$weight-semibold;
-  }
-
-  // Compute type is the primary label of the row → bright + tracked; the chosen
-  // row turns green to reinforce selection.
-  // Precision + size is the primary info → never wraps; the secondary reason on the
-  // right wraps instead. flex-shrink:0 protects it from the reason column.
+  // Compute type is the primary label of the row → bright + tracked.
+  // Precision + size never wraps; the secondary reason on the right wraps
+  // instead. flex-shrink:0 protects it from the reason column.
   &__variant-name {
     flex: 0 0 auto;
     white-space: nowrap;
@@ -586,10 +588,6 @@
     color: vars.$text-primary;
     font-weight: vars.$weight-medium;
     letter-spacing: 0.02em;
-
-    .model-card__variant-item--chosen & {
-      color: vars.$color-primary;
-    }
   }
 
   // Secondary metadata: the size trails the compute type, muted and lighter so the
@@ -610,13 +608,13 @@
     white-space: nowrap;
   }
 
-  // Muted "blocked" icon — full reason is in the row's title tooltip. Mirrors the
-  // green "recommended" slot on the opposite end of the state spectrum.
-  &__variant-unavailable {
-    flex: 0 0 auto;
-    display: inline-flex;
-    align-items: center;
+  // Why an unsupported variant can't be picked, inline in the row — the old
+  // hover tooltip can't render above the top-layer picker, and inline beats
+  // hover-only anyway.
+  &__variant-reason {
+    font-size: 10px;
     color: vars.$text-muted;
+    text-align: right;
   }
 
   &__variant-cpu-note {

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -292,52 +292,54 @@ beforeEach(() => {
 });
 
 describe('NativeModelManagementSection — HY-MT2 variant card', () => {
-  it('header dropdown shows the chosen variant + size; opening it lists supported (enabled) and unsupported (disabled) variants', async () => {
+  it('header dropdown is a select whose value is the chosen variant; rows list supported (enabled) and unsupported (disabled) variants', async () => {
     // All statuses absent (default) → pre-download state for hy-mt2-7b.
     render(<NativeModelManagementSection />);
     const q4SizeLabel = formatMemMb(Math.round(8e9 / 1e6));
 
-    // The compact dropdown trigger appears in the header, showing the chosen variant + size.
-    const trigger = await waitFor(() => {
+    // The compact dropdown in the header is a customizable <select>
+    // (appearance: base-select — this section is Electron-only, Chromium 144);
+    // its value is the chosen variant id, and <selectedcontent> mirrors the
+    // chosen option's label + size into the closed control.
+    const dd = await waitFor(() => {
       const card = screen.getByTestId('model-card-hy-mt2-7b');
-      return within(card).getByTestId('variant-dd-hy-mt2-7b');
+      return within(card).getByTestId('variant-dd-hy-mt2-7b') as HTMLSelectElement;
     });
-    expect(trigger).toHaveTextContent('Q4_K_M');
-    expect(trigger).toHaveTextContent(q4SizeLabel);
+    expect(dd.value).toBe('q4_k_m');
 
-    // Variant rows are NOT rendered until the dropdown is opened (keeps the card short).
-    expect(screen.queryByTestId('variant-row-q4_k_m')).not.toBeInTheDocument();
-
-    // Open the menu.
-    fireEvent.click(trigger);
-
+    // Options live inside the select from the start — the picker is a
+    // top-layer popup, so listing them never grows the card (which is what
+    // the old menu's lazy render existed to prevent).
     const card7b = screen.getByTestId('model-card-hy-mt2-7b');
     const q4Row = within(card7b).getByTestId('variant-row-q4_k_m');
+    expect(q4Row).toHaveTextContent('Q4_K_M');
     expect(q4Row).toHaveTextContent(q4SizeLabel);
     expect(within(q4Row).getByText('recommended')).toBeInTheDocument();
     expect(q4Row).toBeEnabled();
 
-    // q8_0 is unsupported → listed (so the user sees the option) but not
-    // selectable. It uses aria-disabled (not the disabled attribute) so the row
-    // stays hoverable for the instant tooltip; a muted "blocked" icon marks it.
+    // q8_0 is unsupported → listed (so the user sees the option) but disabled;
+    // its actual reason is spelled out inline in the row — the old hover
+    // tooltip can't render above the select's top-layer picker, and inline
+    // beats hover-only anyway.
     const q8Row = within(card7b).getByTestId('variant-row-q8_0');
-    expect(q8Row).toHaveAttribute('aria-disabled', 'true');
-    expect(within(q8Row).getByLabelText("Won't fit on this machine")).toBeInTheDocument();
+    expect(q8Row).toBeDisabled();
+    expect(q8Row).toHaveTextContent('GPU memory');
   });
 
-  it('clicking a supported variant in the menu pins it (writes translationVariant)', async () => {
+  it('changing the select to an unsupported variant is a no-op', async () => {
+    // A real picker never lets a disabled option through; this guards the
+    // programmatic/keyboard path — pinning must itself check support, the
+    // way the old menu's click handler no-opped on unsupported rows.
+    // (The positive pin path is covered on the TTS card below, where a
+    // second supported variant exists to change to.)
     render(<NativeModelManagementSection />);
-    const trigger = await waitFor(() =>
+    const dd = await waitFor(() =>
       within(screen.getByTestId('model-card-hy-mt2-7b')).getByTestId('variant-dd-hy-mt2-7b'));
-    fireEvent.click(trigger); // open the menu
 
-    const q4Row = within(screen.getByTestId('model-card-hy-mt2-7b')).getByTestId('variant-row-q4_k_m');
-    fireEvent.click(q4Row);
+    fireEvent.change(dd, { target: { value: 'q8_0' } });
 
-    // The pin reaches settings (single source of truth feeding both download repo and load).
-    expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ translationVariantByModel: { 'hy-mt2-7b': 'q4_k_m' } }));
-    // and it must NOT switch the active model
+    expect(mockUpdate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ translationVariantByModel: expect.anything() }));
     expect(mockUpdate).not.toHaveBeenCalledWith(
       expect.objectContaining({ translationModel: expect.anything() }));
   });
@@ -346,9 +348,9 @@ describe('NativeModelManagementSection — HY-MT2 variant card', () => {
     render(<NativeModelManagementSection />);
     // hy-mt15-7b is a multilingual card always present; its catalog entry carries
     // variantIds too, so it fetches variants and shows the same Q4_K_M dropdown as hy-mt2.
-    const trigger = await waitFor(() =>
-      within(screen.getByTestId('model-card-hy-mt15-7b')).getByTestId('variant-dd-hy-mt15-7b'));
-    expect(trigger).toHaveTextContent('Q4_K_M');
+    const dd = await waitFor(() =>
+      within(screen.getByTestId('model-card-hy-mt15-7b')).getByTestId('variant-dd-hy-mt15-7b')) as HTMLSelectElement;
+    expect(dd.value).toBe('q4_k_m');
   });
 
   it('collapses to resolved variant label after download; no variant chooser buttons', async () => {
@@ -439,22 +441,22 @@ describe('NativeModelManagementSection — TTS multi-variant card (Task 10)', ()
     render(<NativeModelManagementSection />);
     const q4SizeLabel = formatMemMb(Math.round(3.6e9 / 1e6));
 
-    const trigger = await waitFor(() => {
+    const dd = await waitFor(() => {
       const card = screen.getByTestId('model-card-qwen3-tts-1.7b');
-      return within(card).getByTestId('variant-dd-qwen3-tts-1.7b');
+      return within(card).getByTestId('variant-dd-qwen3-tts-1.7b') as HTMLSelectElement;
     });
-    expect(trigger).toHaveTextContent('BF16');
-    expect(trigger).toHaveTextContent(q4SizeLabel);
+    expect(dd.value).toBe('bf16');
+    const bf16Row = within(screen.getByTestId('model-card-qwen3-tts-1.7b')).getByTestId('variant-row-bf16');
+    expect(bf16Row).toHaveTextContent('BF16');
+    expect(bf16Row).toHaveTextContent(q4SizeLabel);
   });
 
   it('pinning a supported variant on a TTS card writes translationVariantByModel (not the download or active model)', async () => {
     render(<NativeModelManagementSection />);
-    const trigger = await waitFor(() =>
+    const dd = await waitFor(() =>
       within(screen.getByTestId('model-card-qwen3-tts-1.7b')).getByTestId('variant-dd-qwen3-tts-1.7b'));
-    fireEvent.click(trigger); // open the menu
 
-    const fp32Row = within(screen.getByTestId('model-card-qwen3-tts-1.7b')).getByTestId('variant-row-fp32');
-    fireEvent.click(fp32Row);
+    fireEvent.change(dd, { target: { value: 'fp32' } });
 
     // The pin reaches settings via the same generic per-model map ASR/translation use.
     expect(mockUpdate).toHaveBeenCalledWith(

--- a/src/components/Settings/sections/NativeModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.test.tsx
@@ -439,7 +439,7 @@ describe('NativeModelManagementSection — TTS multi-variant card (Task 10)', ()
   // variantMap/onPin (the picker was translation/ASR-only before this task).
   it('the picker renders on a multi-variant TTS card (same as ASR/translation)', async () => {
     render(<NativeModelManagementSection />);
-    const q4SizeLabel = formatMemMb(Math.round(3.6e9 / 1e6));
+    const bf16SizeLabel = formatMemMb(Math.round(3.6e9 / 1e6));
 
     const dd = await waitFor(() => {
       const card = screen.getByTestId('model-card-qwen3-tts-1.7b');
@@ -448,7 +448,7 @@ describe('NativeModelManagementSection — TTS multi-variant card (Task 10)', ()
     expect(dd.value).toBe('bf16');
     const bf16Row = within(screen.getByTestId('model-card-qwen3-tts-1.7b')).getByTestId('variant-row-bf16');
     expect(bf16Row).toHaveTextContent('BF16');
-    expect(bf16Row).toHaveTextContent(q4SizeLabel);
+    expect(bf16Row).toHaveTextContent(bf16SizeLabel);
   });
 
   it('pinning a supported variant on a TTS card writes translationVariantByModel (not the download or active model)', async () => {

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -143,7 +143,13 @@ const VariantDropdown: React.FC<{
           );
         })}
         {!gpuFits && (
-          <span className="model-card__variant-cpu-note">No GPU variant fits — runs on CPU.</span>
+          // A disabled option, not a bare <span>: the select content model
+          // (and React's nesting validator) only admits option-shaped
+          // children, and a span here would log the very warning class the
+          // dev muffler exists to avoid adding to.
+          <option disabled className="model-card__variant-cpu-note">
+            {t('models.variantNoGpuFits', 'No GPU variant fits — runs on CPU.')}
+          </option>
         )}
       </select>
     </div>

--- a/src/components/Settings/sections/NativeModelManagementSection.tsx
+++ b/src/components/Settings/sections/NativeModelManagementSection.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp, Ban } from 'lucide-react';
+import { ChevronDown, ChevronRight, Download, CheckCircle, Star, Zap, Trash2, X, AlertTriangle, CircleHelp } from 'lucide-react';
 import Tooltip from '../../Tooltip/Tooltip';
 import { useLocalNativeSettings, useUpdateLocalNative, type LocalNativeSettings } from '../../../stores/settingsStore';
 import {
@@ -78,11 +78,15 @@ type VariantCardProps = {
 };
 
 /**
- * Compact quant-variant picker shown in a card header (in place of the size). A trigger
- * shows the chosen variant + size (e.g. "FP8 · 8.0 GB"); clicking opens a menu listing all
- * variants with sizes — unsupported ones disabled with a reason, plus a "runs on CPU" note
- * when no GPU variant fits. A dropdown (rather than an inline button stack) keeps the card
- * short and scales as more quant formats are added.
+ * Compact quant-variant picker shown in a card header (in place of the size).
+ * A customizable <select> (appearance: base-select): the closed control mirrors
+ * the chosen variant + size (e.g. "FP8 · 8.0 GB") via <selectedcontent>; the
+ * picker lists all variants with sizes — unsupported ones disabled with the
+ * reason inline (a hover tooltip can't render above the top-layer picker) —
+ * plus a "runs on CPU" note when no GPU variant fits.
+ *
+ * No classic-select fallback: local native models are Electron-only, and the
+ * packaged Electron (Chromium 144) always renders base-select.
  */
 const VariantDropdown: React.FC<{
   variantProps: VariantCardProps;
@@ -91,85 +95,57 @@ const VariantDropdown: React.FC<{
   selectId: string;
 }> = ({ variantProps, chosenVariant, disabled, selectId }) => {
   const { t } = useTranslation();
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => { if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false); };
-    document.addEventListener('mousedown', onDoc);
-    return () => document.removeEventListener('mousedown', onDoc);
-  }, [open]);
 
   const gpuFits = variantProps.variants.some((v) => v.supported);
   const chosenId = variantProps.pinnedVariantId ?? variantProps.recommendedVariantId;
-  const triggerLabel = chosenVariant
-    ? `${chosenVariant.computeType.toUpperCase()} · ${formatMemMb(Math.round(chosenVariant.sizeBytes / 1e6))}`
-    : 'CPU';
 
   return (
-    <div className="model-card__variant-dd" ref={ref} onClick={(e) => e.stopPropagation()}>
-      <button
-        type="button"
-        className="model-card__variant-trigger"
+    // stopPropagation: the surrounding .model-card selects the model on click.
+    <div className="model-card__variant-dd" onClick={(e) => e.stopPropagation()}>
+      <select
+        className="model-card__variant-select"
         data-testid={`variant-dd-${selectId}`}
         disabled={disabled}
-        aria-expanded={open}
-        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
+        value={chosenVariant ? chosenId : ''}
+        onChange={(e) => {
+          // The picker never lets a disabled option through; this guards the
+          // programmatic/keyboard path the way the old menu's click handler
+          // no-opped on unsupported rows.
+          const v = variantProps.variants.find((x) => x.id === e.target.value);
+          if (v?.supported) variantProps.onPinVariant(v.id);
+        }}
       >
-        <span className="model-card__variant-trigger-value">{triggerLabel}</span>
-        <ChevronDown size={12} />
-      </button>
-      {open && (
-        <div className="model-card__variant-menu" role="listbox">
-          {variantProps.variants.map((v) => {
-            const isChosen = v.supported && v.id === chosenId;
-            const isRec = v.supported && v.id === variantProps.recommendedVariantId;
-            const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
-            return (
-              <button
-                key={v.id}
-                type="button"
-                role="option"
-                aria-selected={isChosen}
-                data-testid={`variant-row-${v.id}`}
-                className={'model-card__variant-item'
-                  + (isChosen ? ' model-card__variant-item--chosen' : '')
-                  + (!v.supported ? ' model-card__variant-item--unsupported' : '')}
-                // aria-disabled (not the `disabled` attribute) so the row stays
-                // hoverable — a disabled <button> suppresses pointer events for its
-                // whole subtree, which would block the icon's tooltip. The click
-                // handler already no-ops for unsupported variants.
-                aria-disabled={!v.supported}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  if (v.supported) { variantProps.onPinVariant(v.id); setOpen(false); }
-                }}
-              >
-                <span className="model-card__variant-name">
-                  {isChosen && <span className="model-card__variant-check" aria-label="selected">✓ </span>}
-                  {v.computeType.toUpperCase()}
-                  <span className="model-card__variant-size"> · {sizeLabel}</span>
-                </span>
-                {isRec && (
-                  <span className="model-card__variant-recommended">{t('models.recommended', 'Recommended').toLowerCase()}</span>
-                )}
-                {!v.supported && (
-                  // Muted "blocked" glyph mirrors the green "recommended" slot; the full
-                  // reason shows in an instant (0ms) tooltip on hover.
-                  <Tooltip content={v.reason || t('models.wontFit', "Won't fit on this machine")} position="top" icon="none" openDelay={0}>
-                    <span className="model-card__variant-unavailable" aria-label={t('models.wontFit', "Won't fit on this machine")}>
-                      <Ban size={13} />
-                    </span>
-                  </Tooltip>
-                )}
-              </button>
-            );
-          })}
-          {!gpuFits && (
-            <span className="model-card__variant-cpu-note">No GPU variant fits — runs on CPU.</span>
-          )}
-        </div>
-      )}
+        <button type="button"><selectedcontent /></button>
+        {!chosenVariant && (
+          <option value="" disabled hidden>CPU</option>
+        )}
+        {variantProps.variants.map((v) => {
+          const isRec = v.supported && v.id === variantProps.recommendedVariantId;
+          const sizeLabel = formatMemMb(Math.round(v.sizeBytes / 1e6));
+          return (
+            <option
+              key={v.id}
+              value={v.id}
+              disabled={!v.supported}
+              data-testid={`variant-row-${v.id}`}
+            >
+              <span className="model-card__variant-name">
+                {v.computeType.toUpperCase()}
+                <span className="model-card__variant-size"> · {sizeLabel}</span>
+              </span>
+              {isRec && (
+                <span className="model-card__variant-recommended">{t('models.recommended', 'Recommended').toLowerCase()}</span>
+              )}
+              {!v.supported && (
+                <span className="model-card__variant-reason">{v.reason || t('models.wontFit', "Won't fit on this machine")}</span>
+              )}
+            </option>
+          );
+        })}
+        {!gpuFits && (
+          <span className="model-card__variant-cpu-note">No GPU variant fits — runs on CPU.</span>
+        )}
+      </select>
     </div>
   );
 };

--- a/src/components/Settings/sections/ProviderSection.poweredBy.test.tsx
+++ b/src/components/Settings/sections/ProviderSection.poweredBy.test.tsx
@@ -5,12 +5,16 @@
  * descriptions were byte-identical boilerplate, so the list showed three
  * indistinguishable rows.
  *
+ * The selector is a customizable <select> (appearance: base-select) whose
+ * options carry the rich row markup; every provider — including the selected
+ * one — is an option, so "the selected row" is option:checked.
+ *
  * Runs against the real i18n catalog rather than a stubbed t(): the attribution
  * is a <Trans> with a component slot, so a stub that returns keys would assert
  * nothing about whether the sentence actually assembles.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 vi.mock('../../../lib/analytics', () => ({
   useAnalytics: () => ({ trackEvent: vi.fn() }),
@@ -29,9 +33,18 @@ vi.mock('../../../services/ServiceFactory', () => ({
   },
 }));
 
+// jsdom has no layout engine, so CSS.supports says false there; the rich
+// markup path is what these tests are about.
+vi.mock('../../../utils/supportsBaseSelect', () => ({
+  supportsBaseSelect: () => true,
+}));
+
 const { default: useSettingsStore } = await import('../../../stores/settingsStore');
 const { Provider } = await import('../../../types/Provider');
 const { default: ProviderSection } = await import('./ProviderSection');
+
+const selectedOption = () =>
+  document.querySelector('.provider-select option:checked');
 
 describe('ProviderSection — Kizuna-managed rows credit their engine', () => {
   beforeEach(() => {
@@ -41,10 +54,11 @@ describe('ProviderSection — Kizuna-managed rows credit their engine', () => {
   it('names the selected row KizunaAI and credits the engine beside it', () => {
     render(<ProviderSection isSessionActive={false} />);
 
-    const name = document.querySelector('.provider-info .provider-name');
+    const row = selectedOption();
+    const name = row?.querySelector('.provider-select__name');
     expect(name?.textContent).toBe('KizunaAI');
 
-    const credit = document.querySelector('.provider-info .powered-by');
+    const credit = row?.querySelector('.powered-by');
     expect(credit?.textContent).toBe('Powered by Soniox');
     // Same line as the name — a separate line would make every row taller.
     expect(credit?.closest('.provider-name-line')).toBe(name?.closest('.provider-name-line'));
@@ -53,7 +67,7 @@ describe('ProviderSection — Kizuna-managed rows credit their engine', () => {
   it('describes what sets this engine apart instead of the shared boilerplate', () => {
     render(<ProviderSection isSessionActive={false} />);
 
-    const desc = document.querySelector('.provider-info .provider-description');
+    const desc = selectedOption()?.querySelector('.provider-select__description');
     expect(desc?.textContent).toContain('60 languages');
     expect(desc?.textContent).not.toContain('authenticated via your account');
   });
@@ -62,22 +76,21 @@ describe('ProviderSection — Kizuna-managed rows credit their engine', () => {
     useSettingsStore.setState({ provider: Provider.SONIOX } as never);
     render(<ProviderSection isSessionActive={false} />);
 
-    expect(document.querySelector('.provider-info .powered-by')).toBeNull();
-    expect(document.querySelector('.provider-info .provider-name')?.textContent).toBe('Soniox');
+    expect(selectedOption()?.querySelector('.powered-by')).toBeNull();
+    expect(selectedOption()?.querySelector('.provider-select__name')?.textContent).toBe('Soniox');
   });
 
-  it('tells the managed twins apart in the dropdown', () => {
+  it('tells the managed twins apart in the list', () => {
     render(<ProviderSection isSessionActive={false} />);
-    // Open the list: the three twins are all named "KizunaAI" now, so the
-    // credit is the only thing separating them.
-    fireEvent.click(document.querySelector('.provider-info') as HTMLElement);
 
-    const credits = Array.from(document.querySelectorAll('.provider-options .powered-by'))
+    // All three twins are named "KizunaAI", so the credit is the only thing
+    // separating them. Options are always in the DOM on a select — including
+    // the selected one, which the old custom dropdown used to filter out.
+    const credits = Array.from(document.querySelectorAll('.provider-select option .powered-by'))
       .map((el) => el.textContent);
     expect(credits).toContain('Powered by Doubao');
     expect(credits).toContain('Powered by OpenAI');
-    // The selected one is filtered out of the options list.
-    expect(credits).not.toContain('Powered by Soniox');
+    expect(credits).toContain('Powered by Soniox');
     // BYOK Soniox sits in the same list and must stay uncredited.
     expect(screen.getAllByText('Soniox').length).toBeGreaterThan(0);
   });

--- a/src/components/Settings/sections/ProviderSection.select.test.tsx
+++ b/src/components/Settings/sections/ProviderSection.select.test.tsx
@@ -82,6 +82,28 @@ describe('ProviderSection — provider <select>', () => {
     expect(document.querySelector('.provider-select selectedcontent')).not.toBeNull();
   });
 
+  it('survives a persisted provider that is no longer registered and keeps it visible', () => {
+    // e.g. local_native persisted in Electron, then the profile opened in the
+    // extension — or a feature flag turned off since. The registry has no
+    // descriptor for it; before this, the settings-slice selector threw
+    // (getDescriptor) and the whole section crashed. The select must render,
+    // report the stored value, and pin it on a disabled option instead of
+    // silently displaying the first registered provider.
+    useSettingsStore.setState({ provider: Provider.LOCAL_NATIVE } as never);
+    render(<ProviderSection isSessionActive={false} />);
+
+    const select = getSelect();
+    expect(select.value).toBe(Provider.LOCAL_NATIVE);
+    const opt = document.querySelector(
+      `.provider-select option[value="${Provider.LOCAL_NATIVE}"]`,
+    ) as HTMLOptionElement;
+    expect(opt).not.toBeNull();
+    expect(opt.disabled).toBe(true);
+    // Switching AWAY still works.
+    fireEvent.change(select, { target: { value: Provider.GEMINI } });
+    expect(useSettingsStore.getState().provider).toBe(Provider.GEMINI);
+  });
+
   it('falls back to plain text options where base-select is unsupported', () => {
     baseSelectSupported.value = false;
     render(<ProviderSection isSessionActive={false} />);

--- a/src/components/Settings/sections/ProviderSection.select.test.tsx
+++ b/src/components/Settings/sections/ProviderSection.select.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Behavior of the provider selector as a customizable <select>
+ * (appearance: base-select) — and its graceful degradation.
+ *
+ * The rich markup (icons, descriptions, engine credits inside <option>) only
+ * renders where the runtime supports base-select; Chromium ≥135 does (the
+ * packaged Electron is 144), but the extension's floor is Chrome 116, where a
+ * classic select must get plain text options instead — rich children would be
+ * invisible in its OS-drawn popup.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+
+vi.mock('../../../lib/analytics', () => ({
+  useAnalytics: () => ({ trackEvent: vi.fn() }),
+}));
+
+vi.mock('../../../lib/auth/hooks', () => ({
+  useAuth: () => ({ isSignedIn: true, getToken: async () => 'token' }),
+}));
+
+vi.mock('../../../services/ServiceFactory', () => ({
+  ServiceFactory: {
+    getSettingsService: () => ({
+      getSetting: async (_k: string, d: unknown) => d,
+      setSetting: async () => undefined,
+    }),
+  },
+}));
+
+const baseSelectSupported = vi.hoisted(() => ({ value: true }));
+vi.mock('../../../utils/supportsBaseSelect', () => ({
+  supportsBaseSelect: () => baseSelectSupported.value,
+}));
+
+const { default: useSettingsStore } = await import('../../../stores/settingsStore');
+const { Provider } = await import('../../../types/Provider');
+const { default: ProviderSection } = await import('./ProviderSection');
+
+const getSelect = () =>
+  document.querySelector('.provider-select') as HTMLSelectElement;
+
+describe('ProviderSection — provider <select>', () => {
+  beforeEach(() => {
+    baseSelectSupported.value = true;
+    useSettingsStore.setState({ provider: Provider.OPENAI } as never);
+  });
+
+  it('switches provider through the store on change', () => {
+    render(<ProviderSection isSessionActive={false} />);
+
+    fireEvent.change(getSelect(), { target: { value: Provider.GEMINI } });
+
+    expect(useSettingsStore.getState().provider).toBe(Provider.GEMINI);
+  });
+
+  it('reflects the current provider as the selected option', () => {
+    useSettingsStore.setState({ provider: Provider.PALABRA_AI } as never);
+    render(<ProviderSection isSessionActive={false} />);
+
+    expect(getSelect().value).toBe(Provider.PALABRA_AI);
+  });
+
+  it('is disabled while a session is active', () => {
+    // The old custom dropdown refused to expand mid-session; the select
+    // expresses the same rule as the disabled attribute.
+    render(<ProviderSection isSessionActive={true} />);
+
+    expect(getSelect().disabled).toBe(true);
+  });
+
+  it('renders rich option content when base-select is supported', () => {
+    render(<ProviderSection isSessionActive={false} />);
+
+    const option = document.querySelector(
+      `.provider-select option[value="${Provider.OPENAI}"]`,
+    );
+    expect(option?.querySelector('.provider-select__icon svg')).not.toBeNull();
+    expect(option?.querySelector('.provider-select__description')?.textContent)
+      .toContain('GPT');
+    // The closed control mirrors the selected option via <selectedcontent>.
+    expect(document.querySelector('.provider-select selectedcontent')).not.toBeNull();
+  });
+
+  it('falls back to plain text options where base-select is unsupported', () => {
+    baseSelectSupported.value = false;
+    render(<ProviderSection isSessionActive={false} />);
+
+    const option = document.querySelector(
+      `.provider-select option[value="${Provider.OPENAI}"]`,
+    );
+    // A classic select popup renders option text only — element children
+    // would be flattened or invisible, so the markup must not emit them.
+    expect(option?.querySelector('span')).toBeNull();
+    expect(option?.textContent).toBe('OpenAI');
+    expect(document.querySelector('.provider-select selectedcontent')).toBeNull();
+    // Switching still works through the same handler.
+    fireEvent.change(getSelect(), { target: { value: Provider.GEMINI } });
+    expect(useSettingsStore.getState().provider).toBe(Provider.GEMINI);
+  });
+});

--- a/src/components/Settings/sections/ProviderSection.tsx
+++ b/src/components/Settings/sections/ProviderSection.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useCallback, useEffect, useMemo } from 'react';
-import { Cpu, Zap, HelpCircle, ChevronDown, ChevronUp, CheckCircle, AlertCircle, ExternalLink, X } from 'lucide-react';
+import React, { useState, useEffect, useMemo } from 'react';
+import { Cpu, Zap, HelpCircle, CheckCircle, AlertCircle, ExternalLink, X } from 'lucide-react';
+import { supportsBaseSelect } from '../../../utils/supportsBaseSelect';
 import { OpenAIIcon, GeminiIcon, PalabraAIIcon, KizunaAIIcon, VolcengineIcon, ZoomIcon, SonioxIcon, KIZUNA_HOSTED_ICONS } from '../../Icons/ProviderIcons';
 import { PoweredBy } from './PoweredBy';
 import { asSonioxRegion } from '../../../lib/soniox/regions';
@@ -246,7 +247,10 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
     localInferenceSettings.sourceLanguage, localInferenceSettings.targetLanguage,
   ]);
 
-  const [isProviderExpanded, setIsProviderExpanded] = useState(false);
+  // Whether the provider select can render rich option markup (icons,
+  // descriptions, engine credits). Stable for the life of the page, so a
+  // one-shot init is enough.
+  const [richSelect] = useState(() => supportsBaseSelect());
 
   const [dismissedTutorials, setDismissedTutorials] = useState<Set<string>>(() => {
     try {
@@ -358,27 +362,7 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
       to_provider: newProvider,
       during_session: isSessionActive
     });
-
-    setIsProviderExpanded(false);
   };
-
-  // Handle clicking outside the provider selector
-  const handleClickOutside = useCallback((event: MouseEvent) => {
-    const target = event.target as Element;
-    if (!target.closest('.provider-selection-area')) {
-      setIsProviderExpanded(false);
-    }
-  }, []);
-
-  // Add click outside listener
-  useEffect(() => {
-    if (isProviderExpanded) {
-      document.addEventListener('mousedown', handleClickOutside);
-      return () => {
-        document.removeEventListener('mousedown', handleClickOutside);
-      };
-    }
-  }, [isProviderExpanded, handleClickOutside]);
 
   // Get provider info by ID. Name/description resolve through the descriptor's
   // i18n key (defaults to the provider id itself — see i18nKey on
@@ -403,7 +387,6 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
     };
   };
 
-  const providerInfo = getProviderInfoById(provider);
   const currentApiKey = getCurrentApiKey();
 
   return (
@@ -433,58 +416,52 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
       </h3>
 
       <div className="provider-selection-area">
-        <div
-          className={`provider-info ${isProviderExpanded ? 'expanded' : ''} ${isSessionActive ? 'disabled' : ''}`}
-          onClick={() => !isSessionActive && availableProviders.length > 1 && setIsProviderExpanded(!isProviderExpanded)}
+        {/* A customizable <select> (appearance: base-select): keyboard
+            navigation, ARIA and the disabled rule come with the element, and
+            the picker floats on the top layer instead of pushing the settings
+            below it down the way the old in-flow expander did. Where the
+            runtime lacks base-select (extension on Chrome <135), options fall
+            back to plain text — rich children would be flattened or invisible
+            in the classic OS-drawn popup. */}
+        <select
+          className="select-dropdown provider-select"
+          value={provider}
+          onChange={(e) => handleProviderChange(e.target.value as ProviderType)}
+          disabled={isSessionActive}
+          aria-label={t('simpleSettings.provider', 'Provider')}
         >
-          <div className="provider-icon">{React.createElement(providerInfo.icon, { size: 24 })}</div>
-          <div className="provider-details">
-            <div className="provider-main-info">
-              {/* Name and engine credit share one line: the managed twins are all
-                  named "KizunaAI", so the vendor is what tells them apart, and
-                  giving it its own line would make every row a line taller. */}
-              <div className="provider-name-line">
-                <span className="provider-name">{providerInfo.name}</span>
-                <PoweredBy provider={provider} />
-              </div>
-              <div className="provider-description">{providerInfo.description}</div>
-            </div>
-            {!isSessionActive && availableProviders.length > 1 && (
-              <div className="provider-toggle">
-                {isProviderExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
-              </div>
-            )}
-          </div>
-        </div>
-
-        {isProviderExpanded && !isSessionActive && (
-          <div className="provider-options">
-            {availableProviders
-              .filter(p => p.id !== provider)
-              .map((p) => {
-                const optionInfo = getProviderInfoById(p.id as ProviderType);
-
-                return (
-                  <div
-                    key={p.id}
-                    className="provider-option"
-                    onClick={() => { handleProviderChange(p.id as ProviderType); setIsProviderExpanded(false); }}
-                  >
-                    <div className="provider-option-icon">
-                      {React.createElement(optionInfo.icon, { size: 20 })}
-                    </div>
-                    <div className="provider-option-details">
-                      <div className="provider-name-line">
-                        <span className="provider-option-name">{optionInfo.name}</span>
-                        <PoweredBy provider={p.id as ProviderType} />
-                      </div>
-                      <div className="provider-option-description">{optionInfo.description}</div>
-                    </div>
-                  </div>
-                );
-              })}
-          </div>
-        )}
+          {richSelect && (
+            // The closed control mirrors the selected option's markup;
+            // CSS trims it down (see .provider-select selectedcontent).
+            <button type="button"><selectedcontent /></button>
+          )}
+          {availableProviders.map((p) => {
+            const optionInfo = getProviderInfoById(p.id as ProviderType);
+            if (!richSelect) {
+              return (
+                <option key={p.id} value={p.id}>{optionInfo.name}</option>
+              );
+            }
+            return (
+              <option key={p.id} value={p.id}>
+                <span className="provider-select__icon">
+                  {React.createElement(optionInfo.icon, { size: 20 })}
+                </span>
+                <span className="provider-select__text">
+                  {/* Name and engine credit share one line: the managed twins
+                      are all named "KizunaAI", so the vendor is what tells
+                      them apart, and giving it its own line would make every
+                      row a line taller. */}
+                  <span className="provider-name-line">
+                    <span className="provider-select__name">{optionInfo.name}</span>
+                    <PoweredBy provider={p.id as ProviderType} />
+                  </span>
+                  <span className="provider-select__description">{optionInfo.description}</span>
+                </span>
+              </option>
+            );
+          })}
+        </select>
       </div>
 
       {/* API Endpoint Input - Only for OpenAI Compatible */}

--- a/src/components/Settings/sections/ProviderSection.tsx
+++ b/src/components/Settings/sections/ProviderSection.tsx
@@ -283,6 +283,13 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
     return ProviderConfigFactory.getAllConfigs();
   }, []);
 
+  // The persisted provider can be one the registry no longer carries — a
+  // feature flag turned off since, or a selection made in Electron opened in
+  // the extension (local_native, volcengine_ast2). getDescriptor throws for
+  // those, and this component must survive them: the select renders the
+  // stored value on a disabled placeholder option instead.
+  const providerRegistered = ProviderConfigFactory.isProviderSupported(provider);
+
   // Get current API key based on provider — delegates to the descriptor's
   // peekPrimaryCredential so the per-provider credential shape lives in one
   // place instead of being hand-copied here (see also settingsStore.validateApiKey).
@@ -291,9 +298,12 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
   // user types (OpenAI/Gemini/OpenAI Translate no longer have their own
   // dedicated settings hooks called here after the switch collapsed).
   const currentProviderSettingsSlice = useSettingsStore(
-    (state) => state[ProviderConfigFactory.getDescriptor(provider).settingsSliceKey as keyof SettingsStore]
+    (state) => providerRegistered
+      ? state[ProviderConfigFactory.getDescriptor(provider).settingsSliceKey as keyof SettingsStore]
+      : undefined
   );
   const getCurrentApiKey = (): string => {
+    if (!providerRegistered) return '';
     return ProviderConfigFactory.getDescriptor(provider).peekPrimaryCredential(currentProviderSettingsSlice);
   };
 
@@ -389,6 +399,35 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
 
   const currentApiKey = getCurrentApiKey();
 
+  // One renderer for every provider option — the registered list and the
+  // unregistered-placeholder both go through it, so the rich/plain split
+  // (see richSelect) lives in exactly one place.
+  const renderProviderOption = (id: ProviderType, disabled = false) => {
+    const optionInfo = getProviderInfoById(id);
+    if (!richSelect) {
+      return (
+        <option key={id} value={id} disabled={disabled}>{optionInfo.name}</option>
+      );
+    }
+    return (
+      <option key={id} value={id} disabled={disabled}>
+        <span className="provider-select__icon">
+          {React.createElement(optionInfo.icon, { size: 20 })}
+        </span>
+        <span className="provider-select__text">
+          {/* Name and engine credit share one line: the managed twins are all
+              named "KizunaAI", so the vendor is what tells them apart, and
+              giving it its own line would make every row a line taller. */}
+          <span className="provider-name-line">
+            <span className="provider-select__name">{optionInfo.name}</span>
+            <PoweredBy provider={id} />
+          </span>
+          <span className="provider-select__description">{optionInfo.description}</span>
+        </span>
+      </option>
+    );
+  };
+
   return (
     <div className={`config-section provider-section ${className}`} id="provider-section">
       <h3>
@@ -435,32 +474,14 @@ const ProviderSection: React.FC<ProviderSectionProps> = ({
             // CSS trims it down (see .provider-select selectedcontent).
             <button type="button"><selectedcontent /></button>
           )}
-          {availableProviders.map((p) => {
-            const optionInfo = getProviderInfoById(p.id as ProviderType);
-            if (!richSelect) {
-              return (
-                <option key={p.id} value={p.id}>{optionInfo.name}</option>
-              );
-            }
-            return (
-              <option key={p.id} value={p.id}>
-                <span className="provider-select__icon">
-                  {React.createElement(optionInfo.icon, { size: 20 })}
-                </span>
-                <span className="provider-select__text">
-                  {/* Name and engine credit share one line: the managed twins
-                      are all named "KizunaAI", so the vendor is what tells
-                      them apart, and giving it its own line would make every
-                      row a line taller. */}
-                  <span className="provider-name-line">
-                    <span className="provider-select__name">{optionInfo.name}</span>
-                    <PoweredBy provider={p.id as ProviderType} />
-                  </span>
-                  <span className="provider-select__description">{optionInfo.description}</span>
-                </span>
-              </option>
-            );
-          })}
+          {!providerRegistered && (
+            // A persisted provider whose registration is gone gets its own
+            // disabled option — without it a controlled select with an
+            // unmatched value silently displays the first registered provider
+            // while the store still holds this one.
+            renderProviderOption(provider, true)
+          )}
+          {availableProviders.map((p) => renderProviderOption(p.id as ProviderType))}
         </select>
       </div>
 

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "يحتاج إلى ~{{need}} من ذاكرة GPU — هذا الجهاز لديه {{have}}",
     "variantWontFitNoMem": "يحتاج إلى ~{{need}} من ذاكرة GPU",
     "wontFit": "لن يناسب هذا الجهاز",
+    "variantNoGpuFits": "لا توجد نسخة تناسب وحدة معالجة الرسومات — سيعمل على المعالج.",
     "hwFramework": "المحرك",
     "hwDevice": "الجهاز",
     "hwApi": "التسريع",

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "~{{need}} GPU মেমরি প্রয়োজন — এই মেশিনে আছে {{have}}",
     "variantWontFitNoMem": "~{{need}} GPU মেমরি প্রয়োজন",
     "wontFit": "এই মেশিনে জায়গা হবে না",
+    "variantNoGpuFits": "কোনো GPU ভ্যারিয়েন্ট মানানসই নয় — CPU-তে চলবে।",
     "hwFramework": "ইঞ্জিন",
     "hwDevice": "ডিভাইস",
     "hwApi": "অ্যাক্সিলারেশন",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Benötigt ~{{need}} GPU-Speicher — dieser Rechner hat {{have}}",
     "variantWontFitNoMem": "Benötigt ~{{need}} GPU-Speicher",
     "wontFit": "Passt nicht auf diesen Rechner",
+    "variantNoGpuFits": "Keine GPU-Variante passt — läuft auf der CPU.",
     "hwFramework": "Engine",
     "hwDevice": "Gerät",
     "hwApi": "Beschleunigung",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Needs ~{{need}} of GPU memory — this machine has {{have}}",
     "variantWontFitNoMem": "Needs ~{{need}} of GPU memory",
     "wontFit": "Won't fit on this machine",
+    "variantNoGpuFits": "No GPU variant fits — runs on CPU.",
     "hwFramework": "Engine",
     "hwDevice": "Device",
     "hwApi": "Acceleration",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Necesita ~{{need}} de memoria GPU — este equipo tiene {{have}}",
     "variantWontFitNoMem": "Necesita ~{{need}} de memoria GPU",
     "wontFit": "No cabe en este equipo",
+    "variantNoGpuFits": "Ninguna variante cabe en la GPU — se ejecuta en la CPU.",
     "hwFramework": "Motor",
     "hwDevice": "Dispositivo",
     "hwApi": "Aceleración",

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "به حدود {{need}} حافظه GPU نیاز دارد — این دستگاه {{have}} دارد",
     "variantWontFitNoMem": "به حدود {{need}} حافظه GPU نیاز دارد",
     "wontFit": "روی این دستگاه جا نمی‌شود",
+    "variantNoGpuFits": "هیچ نسخه‌ای در GPU جا نمی‌شود — روی CPU اجرا می‌شود.",
     "hwFramework": "موتور",
     "hwDevice": "دستگاه",
     "hwApi": "شتاب‌دهی",

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Vaatii ~{{need}} GPU-muistia — tässä koneessa on {{have}}",
     "variantWontFitNoMem": "Vaatii ~{{need}} GPU-muistia",
     "wontFit": "Ei mahdu tähän koneeseen",
+    "variantNoGpuFits": "Mikään GPU-versio ei mahdu — suoritetaan CPU:lla.",
     "hwFramework": "Moottori",
     "hwDevice": "Laite",
     "hwApi": "Kiihdytys",

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Kailangan ng ~{{need}} na GPU memory — {{have}} lang ang makinang ito",
     "variantWontFitNoMem": "Kailangan ng ~{{need}} na GPU memory",
     "wontFit": "Hindi kasya sa makinang ito",
+    "variantNoGpuFits": "Walang GPU variant na kasya — tatakbo sa CPU.",
     "hwFramework": "Engine",
     "hwDevice": "Device",
     "hwApi": "Acceleration",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Nécessite ~{{need}} de mémoire GPU — cette machine en a {{have}}",
     "variantWontFitNoMem": "Nécessite ~{{need}} de mémoire GPU",
     "wontFit": "Ne tient pas sur cette machine",
+    "variantNoGpuFits": "Aucune variante ne tient sur le GPU — exécution sur le CPU.",
     "hwFramework": "Moteur",
     "hwDevice": "Périphérique",
     "hwApi": "Accélération",

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "דורש ~{{need}} מזיכרון GPU — במחשב זה יש {{have}}",
     "variantWontFitNoMem": "דורש ~{{need}} מזיכרון GPU",
     "wontFit": "לא יתאים למחשב זה",
+    "variantNoGpuFits": "אף גרסה לא מתאימה ל-GPU — יופעל על המעבד.",
     "hwFramework": "מנוע",
     "hwDevice": "התקן",
     "hwApi": "האצה",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "~{{need}} GPU मेमोरी चाहिए — इस मशीन में {{have}} है",
     "variantWontFitNoMem": "~{{need}} GPU मेमोरी चाहिए",
     "wontFit": "इस मशीन पर फ़िट नहीं होगा",
+    "variantNoGpuFits": "कोई GPU वैरिएंट फ़िट नहीं होता — CPU पर चलेगा।",
     "hwFramework": "इंजन",
     "hwDevice": "डिवाइस",
     "hwApi": "त्वरण",

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Perlu ~{{need}} memori GPU — mesin ini memiliki {{have}}",
     "variantWontFitNoMem": "Perlu ~{{need}} memori GPU",
     "wontFit": "Tidak muat di mesin ini",
+    "variantNoGpuFits": "Tidak ada varian GPU yang muat — berjalan di CPU.",
     "hwFramework": "Mesin",
     "hwDevice": "Perangkat",
     "hwApi": "Akselerasi",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Richiede ~{{need}} di memoria GPU — questa macchina ne ha {{have}}",
     "variantWontFitNoMem": "Richiede ~{{need}} di memoria GPU",
     "wontFit": "Troppo grande per questa macchina",
+    "variantNoGpuFits": "Nessuna variante entra nella GPU — verrà eseguito su CPU.",
     "hwFramework": "Motore",
     "hwDevice": "Dispositivo",
     "hwApi": "Accelerazione",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "約 {{need}} のGPUメモリが必要 — このマシンは {{have}}",
     "variantWontFitNoMem": "約 {{need}} のGPUメモリが必要",
     "wontFit": "このマシンでは実行できません",
+    "variantNoGpuFits": "GPU に収まるバリアントがありません — CPU で実行します。",
     "hwFramework": "エンジン",
     "hwDevice": "デバイス",
     "hwApi": "アクセラレーション",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "약 {{need}}의 GPU 메모리가 필요 — 이 컴퓨터는 {{have}}",
     "variantWontFitNoMem": "약 {{need}}의 GPU 메모리가 필요",
     "wontFit": "이 컴퓨터에서는 실행할 수 없습니다",
+    "variantNoGpuFits": "GPU에 맞는 버전이 없습니다 — CPU에서 실행됩니다.",
     "hwFramework": "엔진",
     "hwDevice": "장치",
     "hwApi": "가속",

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Memerlukan ~{{need}} memori GPU — mesin ini mempunyai {{have}}",
     "variantWontFitNoMem": "Memerlukan ~{{need}} memori GPU",
     "wontFit": "Tidak muat pada mesin ini",
+    "variantNoGpuFits": "Tiada varian GPU yang muat — berjalan pada CPU.",
     "hwFramework": "Enjin",
     "hwDevice": "Peranti",
     "hwApi": "Pemecutan",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Vereist ~{{need}} GPU-geheugen — deze machine heeft {{have}}",
     "variantWontFitNoMem": "Vereist ~{{need}} GPU-geheugen",
     "wontFit": "Past niet op deze machine",
+    "variantNoGpuFits": "Geen GPU-variant past — draait op de CPU.",
     "hwFramework": "Engine",
     "hwDevice": "Apparaat",
     "hwApi": "Versnelling",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Wymaga ~{{need}} pamięci GPU — ta maszyna ma {{have}}",
     "variantWontFitNoMem": "Wymaga ~{{need}} pamięci GPU",
     "wontFit": "Nie zmieści się na tej maszynie",
+    "variantNoGpuFits": "Żaden wariant nie mieści się na GPU — działa na CPU.",
     "hwFramework": "Silnik",
     "hwDevice": "Urządzenie",
     "hwApi": "Akceleracja",

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Precisa de ~{{need}} de memória da GPU — esta máquina tem {{have}}",
     "variantWontFitNoMem": "Precisa de ~{{need}} de memória da GPU",
     "wontFit": "Não cabe nesta máquina",
+    "variantNoGpuFits": "Nenhuma variante cabe na GPU — será executado na CPU.",
     "hwFramework": "Motor",
     "hwDevice": "Dispositivo",
     "hwApi": "Aceleração",

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Precisa de ~{{need}} de memória da GPU — esta máquina tem {{have}}",
     "variantWontFitNoMem": "Precisa de ~{{need}} de memória da GPU",
     "wontFit": "Não cabe nesta máquina",
+    "variantNoGpuFits": "Nenhuma variante cabe na GPU — será executado na CPU.",
     "hwFramework": "Motor",
     "hwDevice": "Dispositivo",
     "hwApi": "Aceleração",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Требуется ~{{need}} памяти GPU — на этом компьютере {{have}}",
     "variantWontFitNoMem": "Требуется ~{{need}} памяти GPU",
     "wontFit": "Не поместится на этом компьютере",
+    "variantNoGpuFits": "Ни один вариант не помещается в GPU — будет работать на CPU.",
     "hwFramework": "Движок",
     "hwDevice": "Устройство",
     "hwApi": "Ускорение",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Kräver ~{{need}} GPU-minne — den här maskinen har {{have}}",
     "variantWontFitNoMem": "Kräver ~{{need}} GPU-minne",
     "wontFit": "Får inte plats på den här maskinen",
+    "variantNoGpuFits": "Ingen GPU-variant får plats — körs på CPU.",
     "hwFramework": "Motor",
     "hwDevice": "Enhet",
     "hwApi": "Acceleration",

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "~{{need}} GPU நினைவகம் தேவை — இந்த கணினியில் {{have}} உள்ளது",
     "variantWontFitNoMem": "~{{need}} GPU நினைவகம் தேவை",
     "wontFit": "இந்த கணினியில் பொருந்தாது",
+    "variantNoGpuFits": "எந்த GPU வகையும் பொருந்தவில்லை — CPU-இல் இயங்கும்.",
     "hwFramework": "இயந்திரம்",
     "hwDevice": "சாதனம்",
     "hwApi": "முடுக்கம்",

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "~{{need}} GPU మెమొరీ అవసరం — ఈ మెషిన్‌లో {{have}} ఉంది",
     "variantWontFitNoMem": "~{{need}} GPU మెమొరీ అవసరం",
     "wontFit": "ఈ మెషిన్‌లో సరిపోదు",
+    "variantNoGpuFits": "ఏ GPU వేరియంట్ సరిపోదు — CPU పై నడుస్తుంది.",
     "hwFramework": "ఇంజిన్",
     "hwDevice": "పరికరం",
     "hwApi": "యాక్సిలరేషన్",

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "ต้องการหน่วยความจำ GPU ~{{need}} — เครื่องนี้มี {{have}}",
     "variantWontFitNoMem": "ต้องการหน่วยความจำ GPU ~{{need}}",
     "wontFit": "ไม่พอดีกับเครื่องนี้",
+    "variantNoGpuFits": "ไม่มีเวอร์ชันที่พอดีกับ GPU — จะทำงานบน CPU",
     "hwFramework": "เอนจิน",
     "hwDevice": "อุปกรณ์",
     "hwApi": "การเร่งความเร็ว",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "~{{need}} GPU belleği gerekir — bu makinede {{have}} var",
     "variantWontFitNoMem": "~{{need}} GPU belleği gerekir",
     "wontFit": "Bu makineye sığmaz",
+    "variantNoGpuFits": "GPU’ya sığan bir sürüm yok — CPU üzerinde çalışır.",
     "hwFramework": "Motor",
     "hwDevice": "Cihaz",
     "hwApi": "Hızlandırma",

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Потребує ~{{need}} пам'яті GPU — на цьому комп'ютері {{have}}",
     "variantWontFitNoMem": "Потребує ~{{need}} пам'яті GPU",
     "wontFit": "Не вміститься на цьому комп'ютері",
+    "variantNoGpuFits": "Жоден варіант не вміщується в GPU — працюватиме на CPU.",
     "hwFramework": "Рушій",
     "hwDevice": "Пристрій",
     "hwApi": "Прискорення",

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "Cần ~{{need}} bộ nhớ GPU — máy này chỉ có {{have}}",
     "variantWontFitNoMem": "Cần ~{{need}} bộ nhớ GPU",
     "wontFit": "Không vừa với máy này",
+    "variantNoGpuFits": "Không có biến thể nào vừa với GPU — sẽ chạy trên CPU.",
     "hwFramework": "Công cụ",
     "hwDevice": "Thiết bị",
     "hwApi": "Tăng tốc",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "需要约 {{need}} 显存 — 本机为 {{have}}",
     "variantWontFitNoMem": "需要约 {{need}} 显存",
     "wontFit": "本机无法运行",
+    "variantNoGpuFits": "没有适配 GPU 的版本 — 将在 CPU 上运行。",
     "hwFramework": "推理引擎",
     "hwDevice": "设备",
     "hwApi": "加速 API",

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -855,6 +855,7 @@
     "variantWontFit": "需要約 {{need}} 顯示記憶體 — 本機為 {{have}}",
     "variantWontFitNoMem": "需要約 {{need}} 顯示記憶體",
     "wontFit": "本機無法執行",
+    "variantNoGpuFits": "沒有適合 GPU 的版本 — 將在 CPU 上執行。",
     "hwFramework": "推理引擎",
     "hwDevice": "裝置",
     "hwApi": "加速 API",

--- a/src/types/customizable-select.d.ts
+++ b/src/types/customizable-select.d.ts
@@ -1,0 +1,12 @@
+// Customizable <select> (appearance: base-select, Chromium 135+) introduces
+// the <selectedcontent> element, which mirrors the selected option's rich
+// markup into the select's closed control. @types/react doesn't know it yet.
+import 'react';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      selectedcontent: React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>;
+    }
+  }
+}

--- a/src/utils/muffleCustomizableSelectWarnings.test.ts
+++ b/src/utils/muffleCustomizableSelectWarnings.test.ts
@@ -49,6 +49,22 @@ describe('installCustomizableSelectWarningMuffler', () => {
     expect(sink).toHaveBeenCalledTimes(1);
   });
 
+  it('still reports a real error whose component stack happens to mention muffled tags', () => {
+    // React appends the component stack as the last format argument, and a
+    // stack routinely contains lines like "<span className=..." — so matching
+    // the WHOLE rendered text would let a real <div>-in-<option> error be
+    // swallowed whenever any <span> appears in the stack. Only the first line
+    // carries the actual verdict.
+    console.error(
+      'In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
+      '<div>', 'option', '',
+      // Prop-less elements render bare in React stacks ("<span>", "<option>"),
+      // exactly matching the muffled pair strings.
+      '\n  ...\n    <span>\n    <option>\n',
+    );
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
   it('leaves unrelated errors alone', () => {
     console.error('boom', new Error('x'));
     expect(sink).toHaveBeenCalledTimes(1);

--- a/src/utils/muffleCustomizableSelectWarnings.test.ts
+++ b/src/utils/muffleCustomizableSelectWarnings.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installCustomizableSelectWarningMuffler } from './muffleCustomizableSelectWarnings';
+
+// vitest runs with DEV=true, so the muffler installs — which is also the only
+// environment where React's validateDOMNesting (the source of the false
+// positives) exists.
+
+describe('installCustomizableSelectWarningMuffler', () => {
+  let original: typeof console.error;
+  let sink: ReturnType<typeof vi.fn<(...args: unknown[]) => void>>;
+
+  beforeEach(() => {
+    original = console.error;
+    sink = vi.fn<(...args: unknown[]) => void>();
+    console.error = sink;
+    installCustomizableSelectWarningMuffler();
+  });
+
+  afterEach(() => {
+    console.error = original;
+  });
+
+  it('drops the button-in-select false positive in React\'s exact live format', () => {
+    // Captured verbatim from a live window via CDP: the child arg carries
+    // brackets, the parent arg does NOT (the format supplies them as <%s>).
+    // The first muffler version missed this and matched nothing.
+    console.error(
+      'In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
+      '<button>', 'select', '', '\n  ...\n    <MainLayout>\n',
+    );
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it('drops the span-in-option false positive', () => {
+    console.error(
+      'In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
+      '<span>', 'option', '', '',
+    );
+    expect(sink).not.toHaveBeenCalled();
+  });
+
+  it('still reports a genuinely wrong nesting', () => {
+    // <div> in <option> is not part of our select markup — if it ever shows
+    // up it is a real bug and must stay visible.
+    console.error(
+      'In HTML, %s cannot be a child of <%s>.%s\nThis will cause a hydration error.%s',
+      '<div>', 'option', '', '',
+    );
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+
+  it('leaves unrelated errors alone', () => {
+    console.error('boom', new Error('x'));
+    expect(sink).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/muffleCustomizableSelectWarnings.ts
+++ b/src/utils/muffleCustomizableSelectWarnings.ts
@@ -1,0 +1,59 @@
+/**
+ * Dev-only console filter for two React false positives.
+ *
+ * The customizable-select markup (<button><selectedcontent/></button> inside
+ * <select>, rich spans inside <option>) is valid HTML in Chromium 135+ — the
+ * select parser relaxation and appearance: base-select shipped together — but
+ * React's validateDOMNesting still enforces the pre-relaxation content model.
+ * Verified against react-dom 19.2.8 (latest stable) and the newest 19.3
+ * canary (2026-05-29): the `case "select"` whitelist still ends at
+ * option/optgroup/hr/script/template/#text and neither build mentions
+ * <selectedcontent> at all. Until React catches up, every render of the
+ * provider or variant select logs two alarming-but-false errors.
+ *
+ * The "will cause a hydration error" part of the message does not apply
+ * either: this app client-renders through createRoot, so no hydration ever
+ * happens.
+ *
+ * validateDOMNesting only exists in development builds — production is
+ * untouched — so this filter is dev-only too, and matches as narrowly as the
+ * message format allows: exactly the two parent/child pairs our select markup
+ * uses on purpose. A genuinely wrong nesting (say, <div> in <option>) still
+ * logs. Delete this file when React learns the new select content model.
+ */
+
+const MUFFLED_PAIRS: Array<[child: string, parent: string]> = [
+  ['<button>', '<select>'],
+  ['<span>', '<option>'],
+];
+
+/**
+ * React logs through a printf-style format string, captured verbatim from a
+ * live window: `"In HTML, %s cannot be a child of <%s>.%s\n..."` with the
+ * child bracketed ('<button>') but the parent bare ('select') — so naive
+ * argument joining never contains '<select>'. Render the format first, then
+ * match.
+ */
+function renderConsoleFormat(args: unknown[]): string {
+  const [first, ...rest] = args;
+  if (typeof first === 'string' && first.includes('%s')) {
+    let i = 0;
+    return first.replace(/%s/g, () => String(rest[i++] ?? ''));
+  }
+  return args.map(String).join(' ');
+}
+
+export function installCustomizableSelectWarningMuffler(): void {
+  if (!import.meta.env.DEV) return;
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    const text = renderConsoleFormat(args);
+    if (
+      text.includes('cannot be a child of') &&
+      MUFFLED_PAIRS.some(([child, parent]) => text.includes(child) && text.includes(parent))
+    ) {
+      return;
+    }
+    original.apply(console, args as never[]);
+  };
+}

--- a/src/utils/muffleCustomizableSelectWarnings.ts
+++ b/src/utils/muffleCustomizableSelectWarnings.ts
@@ -47,7 +47,11 @@ export function installCustomizableSelectWarningMuffler(): void {
   if (!import.meta.env.DEV) return;
   const original = console.error;
   console.error = (...args: unknown[]) => {
-    const text = renderConsoleFormat(args);
+    // Only the first line carries the verdict ("In HTML, <x> cannot be a
+    // child of <y>."). The component stack that follows routinely contains
+    // bare tags like "<span>" or "<option>", which would make a REAL error
+    // (say, <div> in <option>) match a muffled pair by accident.
+    const text = renderConsoleFormat(args).split('\n', 1)[0];
     if (
       text.includes('cannot be a child of') &&
       MUFFLED_PAIRS.some(([child, parent]) => text.includes(child) && text.includes(parent))

--- a/src/utils/supportsBaseSelect.ts
+++ b/src/utils/supportsBaseSelect.ts
@@ -1,0 +1,20 @@
+/**
+ * Whether this runtime renders customizable selects (appearance: base-select,
+ * Chromium 135+). The packaged Electron (Chromium 144) always does; the
+ * extension's floor is Chrome 116, where selects keep the classic OS-drawn
+ * popup and rich option markup would be flattened or invisible — callers use
+ * this to decide between rich and plain option content.
+ *
+ * A function, not a module-level constant, so tests can mock it per case.
+ */
+export function supportsBaseSelect(): boolean {
+  try {
+    return (
+      typeof CSS !== 'undefined' &&
+      typeof CSS.supports === 'function' &&
+      CSS.supports('appearance', 'base-select')
+    );
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What

Adopts Chromium's customizable select (`appearance: base-select`, Chromium 135+; the packaged Electron 40 is Chromium 144) across the settings UI, in three slices:

1. **Provider selector becomes a real `<select>`** with rich options — icon, name + engine credit on one line, description. The picker floats on the in-window top layer, so choosing a provider no longer pushes the whole settings column down the way the old in-flow expander did. Keyboard navigation, ARIA, and the mid-session disabled rule now come from the element; the hand-rolled expander and its click-outside listener are deleted.
2. **Every classic select in the app (25 call sites — language, model, voice, …) gets a themed picker** from one shared `@supports (appearance: base-select)` layer on `.select-dropdown`/`.language-select`: dark panel, hover rows, green end-of-row checkmark, internal scrolling. One CSS block, no TSX changes.
3. **The quant-variant picker on model cards becomes a customizable select** too, replacing the hand-rolled `role="listbox"` menu (and its absolute-position clipping inside the settings scroll container). Two deliberate UX changes: the selected row uses the native `::checkmark`, and an unsupported variant's reason now shows inline in the row instead of a hover tooltip — a tooltip portal can't render above the top-layer picker, and inline beats hover-only anyway.

Also: the MainPanel display-settings popover gains `shift()` + `size()` clamping (same pattern as ModeDevicePopover) so a short window scrolls it instead of cutting it off.

## Compatibility

- **Electron**: Chromium 144, always renders base-select.
- **Extension**: manifest floor is Chrome 116. `supportsBaseSelect()` gates the provider select's markup down to plain-text options there, and the shared CSS layer is `@supports`-guarded, so pre-135 Chrome keeps today's classic OS popup untouched. (The OS popup only honors option colors and nothing else — that limitation is what motivated this change; see the comparison artifact from the design round.)
- The variant picker is Electron-only (local native models), so it has no fallback branch.

## React dev-warning note

React's `validateDOMNesting` has not caught up with the relaxed select content model — verified against react-dom 19.2.8 (latest stable) and the newest 19.3 canary: `<select>`'s whitelist still ends at option/optgroup/hr/script/template/#text, and `<selectedcontent>` appears nowhere. The two resulting errors are dev-only false positives (production strips the validator; the app client-renders via `createRoot`, so the threatened "hydration error" cannot occur). A narrowly-scoped dev-only console filter (`muffleCustomizableSelectWarnings.ts`) drops exactly the two parent/child pairs our markup uses on purpose — a genuinely wrong nesting still logs. Delete it when React learns the new content model.

## Verification

- Unit: 2630 passed; the 9 failures are the known worktree baseline, identical on `main` (A/B'd) — zero regressions.
- Live Electron window (CDP-driven): `CSS.supports("appearance: base-select") = true`, provider picker opens with icons/credits/descriptions, checked row carries the green end-of-row checkmark, closed control lays out icon-beside-text (measured `sideBySide: true`, compared side-by-side against the pre-refactor UI), the 35-item UI-language picker themes and scrolls, and the console shows **zero** errors through a full settings render.

## Manual test checklist (paths not covered above)

- [ ] Pick a provider **with the mouse** in the picker (verification drove changes programmatically): picker closes, provider switches, the settings below swap (API key / endpoint), switching back keeps state
- [ ] Variant picker on multi-variant model cards (needs the native sidecar + variant data — not visually verified): chip shows name+size only; unsupported rows disabled with the reason inline; picking a variant does not select the card itself; CPU note renders
- [ ] Extension side panel on Chrome ≥135 (rich picker) and, if available, 116–134 (plain-text fallback)
- [ ] Settings panel at its 300px minimum width; RTL locales (ar/fa) — flex rows + `order:1` checkmark flip direction in RTL
- [ ] Simple mode and onboarding (`UserTypeSelection`) selects — they inherit the shared layer
- [ ] Keyboard: Tab → Enter/Space opens, arrows navigate, Esc closes; provider select disabled during an active session
- [ ] Packaged build sanity (all verification above ran in dev mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated provider, language, and model variant pickers with native controls and richer option details.
  * Added clearer indicators for selected, unavailable, and resource-limited model variants.
  * Improved settings popover sizing, positioning, and scrolling within the available screen space.
  * Added compatibility fallbacks for environments without advanced native select support.
  * Added localized messaging when model variants cannot fit available GPU memory.

* **Bug Fixes**
  * Prevented unsupported model selections from being applied.
  * Improved handling of development warnings without affecting production behavior.
  * Preserved settings when a previously selected provider is no longer available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->