### PR TITLE
feat(subtitle): host bar popovers in pre-created hidden child windows

### DIFF
--- a/electron/ipc-channels.js
+++ b/electron/ipc-channels.js
@@ -86,6 +86,8 @@ export const INVOKE_CHANNELS = [
   'subtitle:set-locked',
   'subtitle:set-fullscreen',
   'subtitle:get-screen-bounds',
+  // Popover child-window visibility (see popover-windows.js)
+  'popover-window:set-visible',
   // Externally-registered (electron-audio-loopback)
   ...EXTERNAL_INVOKE_CHANNELS,
 ];

--- a/electron/main.js
+++ b/electron/main.js
@@ -2,6 +2,7 @@ const { app, BrowserWindow, ipcMain, Menu, dialog, shell, session, systemPrefere
 const path = require('path');
 const { betterAuthAdapter } = require('./better-auth-adapter');
 const { setupSubtitleHandlers } = require('./subtitle-window.js');
+const { setupPopoverWindowHandlers } = require('./popover-windows.js');
 const { applyLinuxGpuFlags } = require('./linux-gpu-flags');
 
 // Handle Squirrel events for Windows
@@ -342,6 +343,7 @@ function createWindow() {
   });
 
   setupSubtitleHandlers(mainWindow);
+  setupPopoverWindowHandlers(mainWindow);
 
   // Set custom User Agent for the window
   mainWindow.webContents.setUserAgent(customUserAgent);

--- a/electron/popover-windows.js
+++ b/electron/popover-windows.js
@@ -1,0 +1,65 @@
+// electron/popover-windows.js
+//
+// Visibility bridge for the subtitle bar's popover child windows.
+//
+// The renderer hosts those popovers in frameless child windows it opens with
+// window.open (see src/components/Subtitle/ChildWindowPopover.tsx). They are
+// created once and reused, so opening a popover costs a show + move instead
+// of a native window creation — but a DOM Window has no visibility API, and
+// "parking" windows off-screen does not survive the window manager: mutter
+// clamps both the initial position and runtime moveTo back onto the screen
+// (measured: a window parked at (-10000, 0) sat at (0, 32), fully visible).
+// So the main process owns visibility: popover windows are created hidden
+// via a setWindowOpenHandler override — show:false from the very first
+// frame — and shown/hidden over IPC.
+const { ipcMain } = require('electron');
+
+// The renderer names its popover windows with this window.open target prefix.
+const POPOVER_PREFIX = 'sokuji-popover:';
+
+// Live popover windows by frame name. Module scope for the same reason as
+// subtitle-window.js: createWindow() can run more than once per app lifetime,
+// and ipcMain.handle throws on a second registration of the same channel, so
+// handlers register once at module load and resolve windows at call time.
+const popoverWindows = new Map();
+
+ipcMain.handle('popover-window:set-visible', (_event, payload) => {
+  const name = payload?.name;
+  const win = popoverWindows.get(name);
+  if (!win || win.isDestroyed()) return { ok: false };
+  if (payload?.visible) {
+    // show() also focuses the window — which the renderer wants: focus is
+    // what makes its blur-to-dismiss behavior work.
+    win.show();
+  } else {
+    win.hide();
+  }
+  return { ok: true };
+});
+
+function setupPopoverWindowHandlers(mainWindow) {
+  mainWindow.webContents.setWindowOpenHandler((details) => {
+    if (details.frameName?.startsWith(POPOVER_PREFIX)) {
+      return {
+        action: 'allow',
+        overrideBrowserWindowOptions: { show: false },
+      };
+    }
+    // Everything else keeps Electron's default window.open behavior.
+    return { action: 'allow' };
+  });
+
+  mainWindow.webContents.on('did-create-window', (childWindow, details) => {
+    const name = details.frameName;
+    if (!name?.startsWith(POPOVER_PREFIX)) return;
+    popoverWindows.set(name, childWindow);
+    childWindow.on('closed', () => {
+      // Only forget the window if it is still the registered one — a name
+      // can be reused after a close, and the stale closed event must not
+      // evict its successor.
+      if (popoverWindows.get(name) === childWindow) popoverWindows.delete(name);
+    });
+  });
+}
+
+module.exports = { setupPopoverWindowHandlers };

--- a/electron/popover-windows.js
+++ b/electron/popover-windows.js
@@ -12,7 +12,7 @@
 // So the main process owns visibility: popover windows are created hidden
 // via a setWindowOpenHandler override — show:false from the very first
 // frame — and shown/hidden over IPC.
-const { ipcMain } = require('electron');
+const { ipcMain, shell } = require('electron');
 
 // The renderer names its popover windows with this window.open target prefix.
 const POPOVER_PREFIX = 'sokuji-popover:';
@@ -45,8 +45,14 @@ function setupPopoverWindowHandlers(mainWindow) {
         overrideBrowserWindowOptions: { show: false },
       };
     }
-    // Everything else keeps Electron's default window.open behavior.
-    return { action: 'allow' };
+    // Everything else is denied: the renderer's own window.open('http…')
+    // calls (help links, update downloads) belong in the system browser,
+    // and a compromised renderer must not be able to conjure arbitrary
+    // Electron windows. Only web URLs reach the OS.
+    if (/^https?:\/\//i.test(details.url ?? '')) {
+      void shell.openExternal(details.url);
+    }
+    return { action: 'deny' };
   });
 
   mainWindow.webContents.on('did-create-window', (childWindow, details) => {

--- a/electron/popover-windows.js
+++ b/electron/popover-windows.js
@@ -17,6 +17,17 @@ const { ipcMain, shell } = require('electron');
 // The renderer names its popover windows with this window.open target prefix.
 const POPOVER_PREFIX = 'sokuji-popover:';
 
+/**
+ * Popover windows only ever host DOM the parent portals into them, so their
+ * document stays blank for life. Anything else is a renderer trying to point
+ * a frameless, transparent, always-on-top window at a page — the frame name
+ * is renderer-controlled, so matching the prefix cannot be a licence to load
+ * arbitrary content.
+ */
+function isBlankUrl(url) {
+  return !url || url === 'about:blank';
+}
+
 // Live popover windows by frame name. Module scope for the same reason as
 // subtitle-window.js: createWindow() can run more than once per app lifetime,
 // and ipcMain.handle throws on a second registration of the same channel, so
@@ -40,6 +51,7 @@ ipcMain.handle('popover-window:set-visible', (_event, payload) => {
 function setupPopoverWindowHandlers(mainWindow) {
   mainWindow.webContents.setWindowOpenHandler((details) => {
     if (details.frameName?.startsWith(POPOVER_PREFIX)) {
+      if (!isBlankUrl(details.url)) return { action: 'deny' };
       return {
         action: 'allow',
         overrideBrowserWindowOptions: { show: false },
@@ -59,6 +71,19 @@ function setupPopoverWindowHandlers(mainWindow) {
     const name = details.frameName;
     if (!name?.startsWith(POPOVER_PREFIX)) return;
     popoverWindows.set(name, childWindow);
+
+    // setWindowOpenHandler governs creation only. Re-opening an existing
+    // window NAME navigates the live window instead of making a new one, and
+    // in-page navigation would likewise swap the popover for a web page in
+    // an always-on-top frame. Pin the document to blank for the window's
+    // life. (`url` is the second argument on the legacy signature and a
+    // field on the newer event object; read both.)
+    const blockNavigation = (event, url) => {
+      if (isBlankUrl(url ?? event?.url)) return;
+      event.preventDefault();
+    };
+    childWindow.webContents.on('will-navigate', blockNavigation);
+    childWindow.webContents.on('will-redirect', blockNavigation);
     childWindow.on('closed', () => {
       // Only forget the window if it is still the registered one — a name
       // can be reused after a close, and the stale closed event must not

--- a/electron/popover-windows.test.js
+++ b/electron/popover-windows.test.js
@@ -16,9 +16,13 @@ const electronPath = nodeRequire.resolve('electron');
 const modulePath = nodeRequire.resolve('./popover-windows.js');
 
 const ipcHandlers = new Map();
+const openExternal = vi.fn();
 const fakeElectron = {
   ipcMain: {
     handle: (channel, fn) => ipcHandlers.set(channel, fn),
+  },
+  shell: {
+    openExternal: (...a) => openExternal(...a),
   },
 };
 
@@ -63,7 +67,7 @@ function makeFakeMainWindow() {
       },
     },
     // test helpers
-    __open: (frameName) => openHandler({ frameName, url: 'about:blank' }),
+    __open: (frameName, url = 'about:blank') => openHandler({ frameName, url }),
     __emitCreated: (child, frameName) => {
       for (const fn of wcListeners.get('did-create-window') ?? []) fn(child, { frameName });
     },
@@ -98,10 +102,25 @@ describe('popover child-window visibility bridge', () => {
     expect(decision.overrideBrowserWindowOptions).toMatchObject({ show: false });
   });
 
-  it('leaves non-popover window.opens untouched', () => {
-    const decision = main.__open('some-other-window');
-    expect(decision.action).toBe('allow');
-    expect(decision.overrideBrowserWindowOptions).toBeUndefined();
+  it('denies non-popover window.opens, routing http(s) URLs to the system browser', () => {
+    // The app's own window.open('http…', '_blank') calls (help links, update
+    // downloads) belong in the system browser, and a compromised renderer
+    // must not be able to conjure arbitrary Electron windows.
+    openExternal.mockClear();
+    const web = main.__open('some-other-window', 'https://sokuji.kizuna.ai/docs');
+    expect(web.action).toBe('deny');
+    expect(openExternal).toHaveBeenCalledWith('https://sokuji.kizuna.ai/docs');
+
+    openExternal.mockClear();
+    const blank = main.__open('', 'about:blank');
+    expect(blank.action).toBe('deny');
+    expect(openExternal).not.toHaveBeenCalled();
+
+    // Non-web schemes never reach the OS.
+    openExternal.mockClear();
+    const weird = main.__open('', 'file:///etc/passwd');
+    expect(weird.action).toBe('deny');
+    expect(openExternal).not.toHaveBeenCalled();
   });
 
   it('shows and hides a registered popover window on demand', () => {

--- a/electron/popover-windows.test.js
+++ b/electron/popover-windows.test.js
@@ -39,6 +39,7 @@ function loadModule() {
 
 function makeFakeChildWindow() {
   const listeners = new Map();
+  const wcListeners = new Map();
   const win = {
     destroyed: false,
     show: vi.fn(),
@@ -49,6 +50,19 @@ function makeFakeChildWindow() {
       listeners.get(event).push(fn);
     },
     emit: (event) => { for (const fn of listeners.get(event) ?? []) fn(); },
+    webContents: {
+      on: (event, fn) => {
+        if (!wcListeners.has(event)) wcListeners.set(event, []);
+        wcListeners.get(event).push(fn);
+      },
+    },
+    // test helper: fire a navigation attempt, return whether it was blocked
+    __navigate: (event, url) => {
+      const e = { preventDefault: vi.fn(), url };
+      for (const fn of wcListeners.get(event) ?? []) fn(e, url);
+      return e.preventDefault.mock.calls.length > 0;
+    },
+    __hasNavListeners: () => wcListeners.has('will-navigate') && wcListeners.has('will-redirect'),
   };
   return win;
 }
@@ -100,6 +114,35 @@ describe('popover child-window visibility bridge', () => {
     // show:false in the override is what prevents even a single visible
     // frame before the first explicit show.
     expect(decision.overrideBrowserWindowOptions).toMatchObject({ show: false });
+
+    // The renderer opens with '' (Electron resolves it to about:blank).
+    expect(main.__open('sokuji-popover:1', '').action).toBe('allow');
+  });
+
+  it('refuses a popover window asked to load a real URL', () => {
+    // frameName is renderer-controlled, so the prefix alone must not be a
+    // licence to load anything: a compromised renderer could otherwise get a
+    // frameless, transparent, always-on-top window pointed at its own page.
+    // Popover windows only ever host DOM portaled in from the parent.
+    openExternal.mockClear();
+    const decision = main.__open('sokuji-popover:1', 'https://evil.example/');
+    expect(decision.action).toBe('deny');
+    // Nor is it an external-link path — this shape is not a link click.
+    expect(openExternal).not.toHaveBeenCalled();
+  });
+
+  it('blocks navigation and redirects inside a popover window', () => {
+    // setWindowOpenHandler only governs creation. Reusing an existing window
+    // name navigates the live window instead, and any in-page navigation
+    // would replace the popover with a web page in an always-on-top frame.
+    const child = makeFakeChildWindow();
+    main.__emitCreated(child, 'sokuji-popover:1');
+    expect(child.__hasNavListeners()).toBe(true);
+
+    expect(child.__navigate('will-navigate', 'https://evil.example/')).toBe(true);
+    expect(child.__navigate('will-redirect', 'https://evil.example/')).toBe(true);
+    // The document's own blank URL must not be blocked.
+    expect(child.__navigate('will-navigate', 'about:blank')).toBe(false);
   });
 
   it('denies non-popover window.opens, routing http(s) URLs to the system browser', () => {

--- a/electron/popover-windows.test.js
+++ b/electron/popover-windows.test.js
@@ -1,0 +1,150 @@
+// electron/popover-windows.test.js
+//
+// Main-process tests for the popover child-window visibility bridge.
+//
+// The subtitle bar hosts its popovers in frameless child windows the renderer
+// opens via window.open. They must be created HIDDEN and shown/hidden on
+// demand: the renderer has no visibility API on a DOM Window, and parking
+// windows off-screen does not work — mutter clamps both the initial position
+// and runtime moveTo back onto the screen (measured: a window "parked" at
+// (-10000, 0) sat at (0, 32), fully visible).
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(import.meta.url);
+const electronPath = nodeRequire.resolve('electron');
+const modulePath = nodeRequire.resolve('./popover-windows.js');
+
+const ipcHandlers = new Map();
+const fakeElectron = {
+  ipcMain: {
+    handle: (channel, fn) => ipcHandlers.set(channel, fn),
+  },
+};
+
+function loadModule() {
+  nodeRequire.cache[electronPath] = {
+    id: electronPath,
+    filename: electronPath,
+    loaded: true,
+    exports: fakeElectron,
+  };
+  delete nodeRequire.cache[modulePath];
+  return nodeRequire(modulePath);
+}
+
+function makeFakeChildWindow() {
+  const listeners = new Map();
+  const win = {
+    destroyed: false,
+    show: vi.fn(),
+    hide: vi.fn(),
+    isDestroyed: () => win.destroyed,
+    on: (event, fn) => {
+      if (!listeners.has(event)) listeners.set(event, []);
+      listeners.get(event).push(fn);
+    },
+    emit: (event) => { for (const fn of listeners.get(event) ?? []) fn(); },
+  };
+  return win;
+}
+
+function makeFakeMainWindow() {
+  const wcListeners = new Map();
+  let openHandler = null;
+  const win = {
+    destroyed: false,
+    isDestroyed: () => win.destroyed,
+    webContents: {
+      setWindowOpenHandler: (fn) => { openHandler = fn; },
+      on: (event, fn) => {
+        if (!wcListeners.has(event)) wcListeners.set(event, []);
+        wcListeners.get(event).push(fn);
+      },
+    },
+    // test helpers
+    __open: (frameName) => openHandler({ frameName, url: 'about:blank' }),
+    __emitCreated: (child, frameName) => {
+      for (const fn of wcListeners.get('did-create-window') ?? []) fn(child, { frameName });
+    },
+  };
+  return win;
+}
+
+describe('popover child-window visibility bridge', () => {
+  let main;
+  let setupPopoverWindowHandlers;
+
+  const setVisible = (name, visible) =>
+    ipcHandlers.get('popover-window:set-visible')({}, { name, visible });
+
+  beforeEach(() => {
+    ipcHandlers.clear();
+    ({ setupPopoverWindowHandlers } = loadModule());
+    main = makeFakeMainWindow();
+    setupPopoverWindowHandlers(main);
+  });
+
+  afterEach(() => {
+    delete nodeRequire.cache[electronPath];
+    delete nodeRequire.cache[modulePath];
+  });
+
+  it('creates popover windows hidden via the open handler override', () => {
+    const decision = main.__open('sokuji-popover:1');
+    expect(decision.action).toBe('allow');
+    // show:false in the override is what prevents even a single visible
+    // frame before the first explicit show.
+    expect(decision.overrideBrowserWindowOptions).toMatchObject({ show: false });
+  });
+
+  it('leaves non-popover window.opens untouched', () => {
+    const decision = main.__open('some-other-window');
+    expect(decision.action).toBe('allow');
+    expect(decision.overrideBrowserWindowOptions).toBeUndefined();
+  });
+
+  it('shows and hides a registered popover window on demand', () => {
+    const child = makeFakeChildWindow();
+    main.__emitCreated(child, 'sokuji-popover:1');
+
+    expect(setVisible('sokuji-popover:1', true)).toMatchObject({ ok: true });
+    expect(child.show).toHaveBeenCalledTimes(1);
+
+    expect(setVisible('sokuji-popover:1', false)).toMatchObject({ ok: true });
+    expect(child.hide).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports ok:false for an unknown or closed window instead of throwing', () => {
+    expect(setVisible('sokuji-popover:99', true)).toMatchObject({ ok: false });
+
+    const child = makeFakeChildWindow();
+    main.__emitCreated(child, 'sokuji-popover:2');
+    child.emit('closed');
+    expect(setVisible('sokuji-popover:2', true)).toMatchObject({ ok: false });
+
+    const child2 = makeFakeChildWindow();
+    main.__emitCreated(child2, 'sokuji-popover:3');
+    child2.destroyed = true;
+    expect(setVisible('sokuji-popover:3', true)).toMatchObject({ ok: false });
+    expect(child2.show).not.toHaveBeenCalled();
+  });
+
+  it('ignores created windows without the popover prefix', () => {
+    const child = makeFakeChildWindow();
+    main.__emitCreated(child, 'unrelated');
+    expect(setVisible('unrelated', true)).toMatchObject({ ok: false });
+  });
+
+  it('survives setup being called again for a recreated main window', () => {
+    // ipcMain.handle throws on duplicate registration; handlers must be
+    // registered at module load, not per setup call (the subtitle-window
+    // module documents the same trap).
+    const main2 = makeFakeMainWindow();
+    expect(() => setupPopoverWindowHandlers(main2)).not.toThrow();
+
+    const child = makeFakeChildWindow();
+    main2.__emitCreated(child, 'sokuji-popover:9');
+    expect(setVisible('sokuji-popover:9', true)).toMatchObject({ ok: true });
+  });
+});

--- a/src/components/MainPanel/ExportButton.scss
+++ b/src/components/MainPanel/ExportButton.scss
@@ -58,3 +58,10 @@
     outline: none;
   }
 }
+
+// The floating host's size() clamp writes max-height inline; scroll inside it
+// rather than clipping. Harmless for the child-window host, whose window is
+// sized to the content.
+.export-menu {
+  overflow-y: auto;
+}

--- a/src/components/MainPanel/ExportButton.tsx
+++ b/src/components/MainPanel/ExportButton.tsx
@@ -230,7 +230,11 @@ const ExportButton: React.FC<ExportButtonProps> = ({
         >
           {/* Plain buttons: the child window's native focus handles keyboard
               use; floating-ui's roving tabindex belongs to the inline host. */}
-          <div className="export-menu" role="menu">
+          <div
+            className="export-menu"
+            role="menu"
+            aria-label={t('mainPanel.toolbar.export', 'Export conversation')}
+          >
             {items.map((it) => {
               const { Icon } = it;
               return (

--- a/src/components/MainPanel/ExportButton.tsx
+++ b/src/components/MainPanel/ExportButton.tsx
@@ -7,6 +7,7 @@ import {
   offset,
   flip,
   shift,
+  size,
   useClick,
   useDismiss,
   useRole,
@@ -30,6 +31,7 @@ import {
   type TxtI18n,
 } from '../../utils/conversationExport';
 import { useToast } from '../Toast';
+import { ChildWindowPopover, useChildPopoverToggle } from '../Subtitle/ChildWindowPopover';
 import './ExportButton.scss';
 
 interface ExportButtonProps {
@@ -49,6 +51,12 @@ interface ExportButtonProps {
   sourceLanguage: string;
   /** Target language code from current provider settings. Used as a fallback when the conversation carries no per-item language snapshots (e.g. empty conversation). */
   targetLanguage: string;
+  /**
+   * Where the menu renders. 'floating' (default) is the in-window floating-ui
+   * menu. 'child-window' hosts it in its own frameless OS window — for the
+   * Electron subtitle bar, whose 200px window cannot contain the menu.
+   */
+  popoverHost?: 'floating' | 'child-window';
 }
 
 const ExportButton: React.FC<ExportButtonProps> = ({
@@ -58,9 +66,13 @@ const ExportButton: React.FC<ExportButtonProps> = ({
   localInferenceSettings,
   sourceLanguage,
   targetLanguage,
+  popoverHost = 'floating',
 }) => {
   const { t } = useTranslation();
   const { showToast } = useToast();
+  const childHosted = popoverHost === 'child-window';
+  const childMenu = useChildPopoverToggle();
+  const childBtnRef = React.useRef<HTMLButtonElement>(null);
   const [isOpen, setIsOpen] = useState(false);
   const [activeIndex, setActiveIndex] = useState<number | null>(null);
   const listRef = React.useRef<Array<HTMLElement | null>>([]);
@@ -85,7 +97,20 @@ const ExportButton: React.FC<ExportButtonProps> = ({
     open: isOpen,
     onOpenChange: setIsOpen,
     placement: 'bottom-end',
-    middleware: [offset(4), flip(), shift({ padding: 8 })],
+    middleware: [
+      offset(4),
+      flip(),
+      shift({ padding: 8 }),
+      // A short window scrolls the menu instead of cutting it off.
+      size({
+        padding: 8,
+        apply({ availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${Math.max(0, availableHeight)}px`,
+          });
+        },
+      }),
+    ],
     whileElementsMounted: autoUpdate,
     strategy: 'fixed',
   });
@@ -117,6 +142,12 @@ const ExportButton: React.FC<ExportButtonProps> = ({
     headerNote: t('mainPanel.export.headerNote', 'Note: settings reflect current state at export, not mid-session changes.'),
   }), [t]);
 
+  // Close whichever host is active; each call no-ops for the inactive one.
+  const closeMenu = useCallback(() => {
+    setIsOpen(false);
+    childMenu.onClose('action');
+  }, [childMenu]);
+
   /** Compute a fresh export payload at click time. */
   const buildPayload = useCallback(() => {
     const models = getActiveModelInfo(provider, currentProviderSettings, localInferenceSettings);
@@ -139,7 +170,7 @@ const ExportButton: React.FC<ExportButtonProps> = ({
   }, [normalizedMessages, provider, currentProviderSettings, localInferenceSettings, sourceLanguage, targetLanguage]);
 
   const handleCopy = useCallback(async () => {
-    setIsOpen(false);
+    closeMenu();
     const { messages, metadata } = buildPayload();
     const text = formatAsTxt(messages, metadata, txtI18n, { includeHeader: false });
     const ok = await copyToClipboard(text);
@@ -148,29 +179,78 @@ const ExportButton: React.FC<ExportButtonProps> = ({
     } else {
       showToast(t('mainPanel.export.copyFailed', 'Failed to copy. Check browser permissions.'), { variant: 'error', durationMs: 4000 });
     }
-  }, [buildPayload, showToast, t, txtI18n]);
+  }, [buildPayload, showToast, t, txtI18n, closeMenu]);
 
   const handleDownloadTxt = useCallback(() => {
-    setIsOpen(false);
+    closeMenu();
     const { messages, metadata } = buildPayload();
     const content = formatAsTxt(messages, metadata, txtI18n, { includeHeader: true });
     const filename = `sokuji-conversation-${formatTimestampForFilename(Date.now())}.txt`;
     downloadFile(content, filename, 'text/plain;charset=utf-8');
-  }, [buildPayload, txtI18n]);
+  }, [buildPayload, txtI18n, closeMenu]);
 
   const handleDownloadJson = useCallback(() => {
-    setIsOpen(false);
+    closeMenu();
     const { messages, metadata } = buildPayload();
     const content = formatAsJson(messages, metadata);
     const filename = `sokuji-conversation-${formatTimestampForFilename(Date.now())}.json`;
     downloadFile(content, filename, 'application/json');
-  }, [buildPayload]);
+  }, [buildPayload, closeMenu]);
 
   const items = useMemo(() => ([
     { key: 'copy', label: t('mainPanel.export.copyToClipboard', 'Copy to clipboard'), Icon: Copy, onClick: handleCopy },
     { key: 'txt',  label: t('mainPanel.export.downloadTxt',     'Download as .txt'),    Icon: FileText, onClick: handleDownloadTxt },
     { key: 'json', label: t('mainPanel.export.downloadJson',    'Download as .json'),   Icon: FileJson, onClick: handleDownloadJson },
   ]), [t, handleCopy, handleDownloadTxt, handleDownloadJson]);
+
+  if (childHosted) {
+    return (
+      <>
+        <button
+          ref={childBtnRef}
+          className="export-btn"
+          type="button"
+          disabled={!hasContent}
+          onClick={childMenu.toggle}
+          title={t('mainPanel.toolbar.export', 'Export conversation')}
+          aria-label={t('mainPanel.toolbar.export', 'Export conversation')}
+          aria-haspopup="menu"
+          aria-expanded={childMenu.open}
+        >
+          <Download size={14} />
+          <ChevronDown size={12} className="export-btn-chevron" />
+        </button>
+
+        <ChildWindowPopover
+          open={childMenu.open}
+          onClose={childMenu.onClose}
+          anchorEl={childBtnRef.current}
+          width={240}
+          height={140}
+        >
+          {/* Plain buttons: the child window's native focus handles keyboard
+              use; floating-ui's roving tabindex belongs to the inline host. */}
+          <div className="export-menu" role="menu">
+            {items.map((it) => {
+              const { Icon } = it;
+              return (
+                <button
+                  key={it.key}
+                  role="menuitem"
+                  type="button"
+                  className="export-menu-item"
+                  onClick={it.onClick}
+                >
+                  <Icon size={14} />
+                  <span>{it.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </ChildWindowPopover>
+      </>
+    );
+  }
 
   return (
     <>

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -174,6 +174,52 @@ describe('ChildWindowPopover', () => {
     expect(onClose).toHaveBeenCalledWith('escape');
   });
 
+  it('recreates the window when the native one was closed externally', () => {
+    // Alt+F4 / a WM close command destroys the native window without React
+    // knowing. The next open must rebuild it instead of toggling a corpse.
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <ChildWindowPopover open={false} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div className="probe-content">x</div>
+      </ChildWindowPopover>,
+    );
+    expect(openSpy).toHaveBeenCalledTimes(1);
+
+    child.closed = true; // the WM killed it
+    const child2 = makeFakeChild();
+    openSpy.mockReturnValue(child2 as unknown as Window);
+
+    rerender(
+      <ChildWindowPopover open={true} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div className="probe-content">x</div>
+      </ChildWindowPopover>,
+    );
+    expect(openSpy).toHaveBeenCalledTimes(2);
+    // The rebuilt window carries the content and gets shown.
+    expect(child2.document.querySelector('.probe-content')).not.toBeNull();
+    const name2 = String(openSpy.mock.calls[1][1]);
+    expect(invoke).toHaveBeenCalledWith('popover-window:set-visible', { name: name2, visible: true });
+    expect(child2.focus).toHaveBeenCalled();
+  });
+
+  it('does not dismiss on the blur a native picker (color input) causes', () => {
+    // Opening <input type="color"> hands focus to the OS chooser; that blur
+    // must not close the settings popover mid-interaction. Focus returning
+    // to the child re-arms normal blur dismissal.
+    const { onClose } = renderPopover(true);
+    const colorInput = child.document.createElement('input');
+    colorInput.type = 'color';
+    child.document.body.appendChild(colorInput);
+
+    act(() => { child.dispatch('mousedown', { target: colorInput }); });
+    act(() => { child.dispatch('blur'); });
+    expect(onClose).not.toHaveBeenCalled();
+
+    act(() => { child.dispatch('focus'); });
+    act(() => { child.dispatch('blur'); });
+    expect(onClose).toHaveBeenCalledWith('blur');
+  });
+
   it('closes the OS window only on unmount', () => {
     const { unmount } = renderPopover(true);
     expect(child.close).not.toHaveBeenCalled();

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -220,6 +220,39 @@ describe('ChildWindowPopover', () => {
     expect(onClose).toHaveBeenCalledWith('blur');
   });
 
+  it('suppresses the blur for a KEYBOARD-activated picker (no mousedown at all)', () => {
+    // Space/Enter on a focused color input runs the activation behavior,
+    // which dispatches click directly — mousedown never happens, so arming
+    // on mousedown alone would let the picker's focus grab close the popover.
+    const { onClose } = renderPopover(true);
+    const colorInput = child.document.createElement('input');
+    colorInput.type = 'color';
+    child.document.body.appendChild(colorInput);
+
+    act(() => { child.dispatch('click', { target: colorInput }); });
+    act(() => { child.dispatch('blur'); });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the blur when the picker is reached through its wrapping label', () => {
+    // DisplaySettingsPopover wraps its color input in a <label> holding an
+    // icon. A mouse press lands on the label/icon, whose closest() finds no
+    // input — the matching target only appears on the click the label
+    // forwards to the control.
+    const { onClose } = renderPopover(true);
+    const label = child.document.createElement('label');
+    const icon = child.document.createElement('span');
+    const colorInput = child.document.createElement('input');
+    colorInput.type = 'color';
+    label.append(icon, colorInput);
+    child.document.body.appendChild(label);
+
+    act(() => { child.dispatch('mousedown', { target: icon }); });   // no match
+    act(() => { child.dispatch('click', { target: colorInput }); }); // forwarded
+    act(() => { child.dispatch('blur'); });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
   it('closes the OS window only on unmount', () => {
     const { unmount } = renderPopover(true);
     expect(child.close).not.toHaveBeenCalled();

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -1,0 +1,241 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render, act, renderHook } from '@testing-library/react';
+import { ChildWindowPopover, useChildPopoverToggle } from './ChildWindowPopover';
+
+// A stand-in for the frameless child window window.open() returns in Electron.
+// jsdom's own window.open returns null, so the component under test gets this
+// instead; the document is a real jsdom Document so React can portal into it.
+function makeFakeChild() {
+  const doc = document.implementation.createHTMLDocument('popover');
+  const listeners = new Map<string, Set<(e: unknown) => void>>();
+  const child = {
+    closed: false,
+    document: doc,
+    addEventListener(type: string, fn: (e: unknown) => void) {
+      if (!listeners.has(type)) listeners.set(type, new Set());
+      listeners.get(type)!.add(fn);
+    },
+    removeEventListener(type: string, fn: (e: unknown) => void) {
+      listeners.get(type)?.delete(fn);
+    },
+    dispatch(type: string, event: unknown = {}) {
+      for (const fn of listeners.get(type) ?? []) fn(event);
+    },
+    close: vi.fn(function (this: { closed: boolean }) { child.closed = true; }),
+    resizeTo: vi.fn(),
+    moveTo: vi.fn(),
+    focus: vi.fn(),
+  };
+  return child;
+}
+
+
+describe('ChildWindowPopover', () => {
+  let child: ReturnType<typeof makeFakeChild>;
+  let openSpy: ReturnType<typeof vi.spyOn>;
+  let anchor: HTMLButtonElement;
+  let invoke: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    child = makeFakeChild();
+    openSpy = vi.spyOn(window, 'open').mockReturnValue(child as unknown as Window);
+    invoke = vi.fn(async () => ({ ok: true }));
+    (window as { electron?: unknown }).electron = { invoke };
+    anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    anchor.getBoundingClientRect = () =>
+      ({ top: 700, bottom: 736, left: 900, right: 1200, width: 300, height: 36 } as DOMRect);
+  });
+
+  afterEach(() => {
+    openSpy.mockRestore();
+    anchor.remove();
+    delete (window as { electron?: unknown }).electron;
+  });
+
+  const renderPopover = (open: boolean, onClose = vi.fn()) => {
+    const utils = render(
+      <ChildWindowPopover open={open} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div className="probe-content">hello</div>
+      </ChildWindowPopover>,
+    );
+    return { ...utils, onClose };
+  };
+
+  it('creates the window on mount, named for the main-process hidden override', () => {
+    // Created while CLOSED: the whole point of pre-creation is that the
+    // click pays none of the native-window / stylesheet / first-paint cost.
+    // The target name is what electron/popover-windows.js keys its
+    // show:false override and the visibility IPC on.
+    renderPopover(false);
+
+    expect(openSpy).toHaveBeenCalledTimes(1);
+    expect(String(openSpy.mock.calls[0][1])).toMatch(/^sokuji-popover:/);
+    const features = String(openSpy.mock.calls[0][2]);
+    for (const f of ['frame=false', 'transparent=true', 'alwaysOnTop=true', 'skipTaskbar=true']) {
+      expect(features).toContain(f);
+    }
+  });
+
+  it('carries the Linux toolbar type hint so GNOME skips its map animation', () => {
+    // GNOME animates NORMAL windows on map (~200ms fade) and skips every
+    // other type; type=toolbar is how the popover opts out. Linux-only —
+    // macOS rejects the value and Windows has no fade to suppress.
+    Object.defineProperty(navigator, 'platform', { configurable: true, value: 'Linux x86_64' });
+    try {
+      renderPopover(false);
+      expect(String(openSpy.mock.calls[0][2])).toContain('type=toolbar');
+    } finally {
+      delete (navigator as { platform?: string }).platform;
+    }
+  });
+
+  it('omits the type hint off Linux', () => {
+    Object.defineProperty(navigator, 'platform', { configurable: true, value: 'MacIntel' });
+    try {
+      renderPopover(false);
+      expect(String(openSpy.mock.calls[0][2])).not.toContain('type=');
+    } finally {
+      delete (navigator as { platform?: string }).platform;
+    }
+  });
+
+  it('renders the children into the hidden window even while closed', () => {
+    // Content lives in the child permanently, updating off-screen, so
+    // opening has nothing left to build.
+    renderPopover(false);
+    expect(child.document.querySelector('.probe-content')?.textContent).toBe('hello');
+  });
+
+  it('copies the parent stylesheets into the child head', () => {
+    const style = document.createElement('style');
+    style.textContent = '.probe-content{color:red}';
+    document.head.appendChild(style);
+    try {
+      renderPopover(false);
+      const copied = Array.from(child.document.head.querySelectorAll('style'))
+        .some((s) => s.textContent?.includes('.probe-content'));
+      expect(copied).toBe(true);
+    } finally {
+      style.remove();
+    }
+  });
+
+  it('opening places the window then shows it over IPC; closing hides it', () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <ChildWindowPopover open={false} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div>x</div>
+      </ChildWindowPopover>,
+    );
+    const name = String(openSpy.mock.calls[0][1]);
+    invoke.mockClear();
+
+    rerender(
+      <ChildWindowPopover open={true} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div>x</div>
+      </ChildWindowPopover>,
+    );
+    // Sized and positioned while still hidden, then shown by the main
+    // process (show also focuses; focus is what makes blur-dismiss work).
+    expect(child.resizeTo).toHaveBeenCalled();
+    expect(child.moveTo).toHaveBeenCalled();
+    expect(invoke).toHaveBeenCalledWith('popover-window:set-visible', { name, visible: true });
+    expect(child.focus).toHaveBeenCalled();
+
+    invoke.mockClear();
+    rerender(
+      <ChildWindowPopover open={false} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div>x</div>
+      </ChildWindowPopover>,
+    );
+    expect(invoke).toHaveBeenCalledWith('popover-window:set-visible', { name, visible: false });
+    // Hidden, NOT closed — the next open must not pay creation again.
+    expect(child.close).not.toHaveBeenCalled();
+  });
+
+  it('closes with reason "blur" when the OPEN child loses focus', () => {
+    const { onClose } = renderPopover(true);
+    act(() => { child.dispatch('blur'); });
+    expect(onClose).toHaveBeenCalledWith('blur');
+  });
+
+  it('ignores blur while hidden', () => {
+    // Hidden windows can emit stray blurs (e.g. during creation); those must
+    // not count as dismissals.
+    const { onClose } = renderPopover(false);
+    act(() => { child.dispatch('blur'); });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('closes with reason "escape" on Escape in the open child', () => {
+    const { onClose } = renderPopover(true);
+    act(() => { child.dispatch('keydown', { key: 'Escape' }); });
+    expect(onClose).toHaveBeenCalledWith('escape');
+  });
+
+  it('closes the OS window only on unmount', () => {
+    const { unmount } = renderPopover(true);
+    expect(child.close).not.toHaveBeenCalled();
+    unmount();
+    expect(child.close).toHaveBeenCalled();
+  });
+
+  it('survives window.open being refused', () => {
+    openSpy.mockReturnValue(null as unknown as Window);
+    // No crash on mount, open, or unmount; the popover is simply unavailable.
+    const onClose = vi.fn();
+    const { rerender, unmount } = render(
+      <ChildWindowPopover open={false} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div>x</div>
+      </ChildWindowPopover>,
+    );
+    rerender(
+      <ChildWindowPopover open={true} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+        <div>x</div>
+      </ChildWindowPopover>,
+    );
+    unmount();
+  });
+});
+
+describe('useChildPopoverToggle', () => {
+  it('toggles open and closed', () => {
+    const { result } = renderHook(() => useChildPopoverToggle());
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(true);
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(false);
+  });
+
+  it('swallows the toggle that immediately follows a blur-close', () => {
+    // Clicking the trigger while the popover is open steals focus from the
+    // child FIRST: blur fires, the popover closes, and then the trigger's own
+    // click would reopen it — the button would never close anything. The
+    // window after a blur-close absorbs that click.
+    vi.useFakeTimers();
+    try {
+      const { result } = renderHook(() => useChildPopoverToggle());
+      act(() => result.current.toggle());
+      act(() => result.current.onClose('blur'));
+      expect(result.current.open).toBe(false);
+
+      act(() => result.current.toggle());       // the same click that caused the blur
+      expect(result.current.open).toBe(false);  // swallowed
+
+      act(() => { vi.advanceTimersByTime(400); });
+      act(() => result.current.toggle());       // a genuine later click
+      expect(result.current.open).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not swallow after a non-blur close', () => {
+    const { result } = renderHook(() => useChildPopoverToggle());
+    act(() => result.current.toggle());
+    act(() => result.current.onClose('escape'));
+    act(() => result.current.toggle());
+    expect(result.current.open).toBe(true);
+  });
+});

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -1,6 +1,7 @@
 // src/components/Subtitle/ChildWindowPopover.tsx
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import useLogStore from '../../stores/logStore';
 
 /**
  * Hosts a popover in its own frameless, transparent OS window instead of
@@ -16,9 +17,10 @@ import { createPortal } from 'react-dom';
  * React DOM.
  *
  * Mechanics: Electron parses BrowserWindow options straight out of
- * window.open's feature string (main registers no setWindowOpenHandler), so
- * the renderer can open a frameless transparent always-on-top window without
- * main-process help. The children render into it through createPortal — they
+ * window.open's feature string, so the renderer picks the frameless,
+ * transparent, always-on-top shape itself; the main process only overrides
+ * `show` and owns visibility (electron/popover-windows.js). The children
+ * render into it through createPortal — they
  * stay part of THIS React tree, so handlers and context work unchanged — and
  * the parent's stylesheets are cloned into the child head so the same
  * component styles apply (the react-new-window copyStyles pattern).
@@ -60,8 +62,20 @@ const POPOVER_PREFIX = 'sokuji-popover:';
 let popoverSerial = 0;
 
 function setNativeVisibility(name: string, visible: boolean): void {
-  void (window as { electron?: { invoke: (c: string, p: unknown) => Promise<unknown> } })
-    .electron?.invoke('popover-window:set-visible', { name, visible });
+  void (async () => {
+    try {
+      await (window as { electron?: { invoke: (c: string, p: unknown) => Promise<unknown> } })
+        .electron?.invoke('popover-window:set-visible', { name, visible });
+    } catch (error) {
+      // A rejection leaves the popover in the wrong visibility state; there
+      // is no recovery beyond the user toggling again, but it must not be
+      // silent (and never an unhandled rejection).
+      useLogStore.getState().addLog(
+        `[ChildWindowPopover] set-visible(${visible}) failed for ${name}: ${String(error)}`,
+        'error',
+      );
+    }
+  })();
 }
 
 /**
@@ -101,15 +115,24 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
   const openRef = useRef(open);
   openRef.current = open;
 
-  // Create the hidden window once, for the component's lifetime.
+  // Create the hidden window. Callable more than once: the native window can
+  // be destroyed under React by a WM close command (Alt+F4 and friends), and
+  // the next open rebuilds it instead of toggling a corpse.
   const nameRef = useRef('');
-  useEffect(() => {
+  const teardownRef = useRef<(() => void) | null>(null);
+  const createWindow = useCallback(() => {
+    teardownRef.current?.();
+    teardownRef.current = null;
+
     const name = `${POPOVER_PREFIX}${++popoverSerial}`;
     nameRef.current = name;
     const features = [
       `width=${width}`, `height=${height}`,
       'frame=false', 'transparent=true', 'alwaysOnTop=true', 'skipTaskbar=true',
       'resizable=false', 'minimizable=false', 'maximizable=false', 'hasShadow=false',
+      // Best-effort shield against WM close commands; the rebuild path above
+      // still covers whatever gets through.
+      'closable=false',
       'focusable=true',
       ...platformWindowTypeFeature(),
     ].join(',');
@@ -130,37 +153,70 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     const root = win.document.createElement('div');
     root.className = 'child-popover-root';
     // Shrink-wrap so the open-time measurement reads the popover's own
-    // footprint rather than the parked window's.
+    // footprint rather than the hidden window's.
     root.style.width = 'fit-content';
     body.appendChild(root);
     setContainer(root);
 
     // Dismissal listeners live for the window's lifetime; they no-op while
     // hidden (a hidden window never has focus to lose).
-    const handleBlur = () => { if (openRef.current) onCloseRef.current('blur'); };
+    //
+    // suppressBlur: opening a native picker owned by this window (the color
+    // chooser behind <input type="color">, a file dialog) steals focus and
+    // fires blur — closing then would tear the popover away mid-interaction.
+    // A pointerdown on such an input arms the suppression; focus returning to
+    // the window re-arms normal blur dismissal.
+    let suppressBlur = false;
+    const handleMousedown = (e: unknown) => {
+      const target = (e as { target?: Element | null }).target;
+      if (target && typeof target.closest === 'function'
+          && target.closest('input[type="color"], input[type="file"]')) {
+        suppressBlur = true;
+      }
+    };
+    const handleFocus = () => { suppressBlur = false; };
+    const handleBlur = () => {
+      if (suppressBlur) return;
+      if (openRef.current) onCloseRef.current('blur');
+    };
     const handleKeydown = (e: unknown) => {
       if (openRef.current && (e as KeyboardEvent).key === 'Escape') onCloseRef.current('escape');
     };
+    win.addEventListener('mousedown', handleMousedown as EventListener, true);
+    win.addEventListener('focus', handleFocus);
     win.addEventListener('blur', handleBlur);
     win.addEventListener('keydown', handleKeydown as EventListener);
 
-    return () => {
+    teardownRef.current = () => {
+      win.removeEventListener('mousedown', handleMousedown as EventListener, true);
+      win.removeEventListener('focus', handleFocus);
       win.removeEventListener('blur', handleBlur);
       win.removeEventListener('keydown', handleKeydown as EventListener);
       setContainer(null);
       winRef.current = null;
       if (!win.closed) win.close();
     };
-    // The parked window is sized/positioned per open; creation params are
-    // deliberately captured once.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [width, height]);
+
+  useEffect(() => {
+    createWindow();
+    return () => {
+      teardownRef.current?.();
+      teardownRef.current = null;
+    };
+  }, [createWindow]);
 
   // Open: measure the already-rendered content, size and place the window
   // while it is still hidden, then have the main process show it (show also
   // focuses, and focus is what makes blur-dismiss work). Close: hide it.
   useEffect(() => {
     const win = winRef.current;
+    if (open && anchorEl && (!win || win.closed)) {
+      // Destroyed externally (WM close). Rebuild; the container state change
+      // reruns this effect, which then places and shows the new window.
+      createWindow();
+      return;
+    }
     if (!win || win.closed || !container) return;
 
     if (!open || !anchorEl) {
@@ -181,12 +237,21 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     const anchorTop = window.screenY + anchor.top;
     const anchorBottom = window.screenY + anchor.bottom;
     // Above the anchor, right edges aligned; below when the screen has no
-    // room above.
+    // room above. Clamped on ALL edges — a partially off-screen request gets
+    // re-placed by mutter to an arbitrary position, which is worse than a
+    // slightly shifted popover.
     const above = anchorTop - h - EDGE_PAD >= screenTop;
-    const left = Math.max(screenLeft, Math.round(window.screenX + anchor.right - w));
-    const top = above
+    const left = Math.min(
+      Math.max(screenLeft, Math.round(window.screenX + anchor.right - w)),
+      screenLeft + Math.max(0, window.screen.availWidth - w),
+    );
+    const rawTop = above
       ? Math.round(anchorTop - h - EDGE_PAD)
       : Math.round(anchorBottom + EDGE_PAD);
+    const top = Math.min(
+      Math.max(screenTop, rawTop),
+      screenTop + Math.max(0, window.screen.availHeight - h),
+    );
 
     win.resizeTo(w, h);
     win.moveTo(left, top);
@@ -204,7 +269,7 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
       }
     }, 300);
     return () => clearInterval(movePoll);
-  }, [open, anchorEl, container, width, height]);
+  }, [open, anchorEl, container, width, height, createWindow]);
 
   // Children render into the hidden window permanently — store-driven updates
   // keep flowing while it is invisible, so opening has nothing to build.

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -1,0 +1,241 @@
+// src/components/Subtitle/ChildWindowPopover.tsx
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+/**
+ * Hosts a popover in its own frameless, transparent OS window instead of
+ * inside the parent window's DOM.
+ *
+ * Why: subtitle mode shrinks the main window to a ~200px bar, and any
+ * in-window popover is clipped at its edge. The earlier fix grew the window
+ * for the popover's lifetime, but resizing a transparent window flashes at
+ * the compositor level (frame-sampled: the DOM stays continuous, the flash
+ * is below it — un-fixable from the renderer). A child window sidesteps the
+ * whole class: the subtitle window is never touched, the popover paints in
+ * its own surface above everything, and it remains ordinary, fully-styleable
+ * React DOM.
+ *
+ * Mechanics: Electron parses BrowserWindow options straight out of
+ * window.open's feature string (main registers no setWindowOpenHandler), so
+ * the renderer can open a frameless transparent always-on-top window without
+ * main-process help. The children render into it through createPortal — they
+ * stay part of THIS React tree, so handlers and context work unchanged — and
+ * the parent's stylesheets are cloned into the child head so the same
+ * component styles apply (the react-new-window copyStyles pattern).
+ *
+ * The window is created ONCE — hidden, via a main-process
+ * setWindowOpenHandler override keyed on the window.open target name (see
+ * electron/popover-windows.js) — and kept for the component's lifetime.
+ * Opening is resize + move + a show over IPC. Creating on demand paid the
+ * whole native-window + stylesheet-parse + first-composite bill inside the
+ * click (a perceptible 100–250ms lag); creating hidden up front pays it on
+ * subtitle-mode entry, where nobody is waiting on it.
+ *
+ * Electron-only by design: the extension overlay lives in an iframe with no
+ * OS window to open, and keeps its in-window floating-ui popover.
+ */
+
+export type ChildPopoverCloseReason = 'blur' | 'escape' | 'moved' | 'failed' | 'action';
+
+interface ChildWindowPopoverProps {
+  open: boolean;
+  onClose: (reason: ChildPopoverCloseReason) => void;
+  /** The toolbar button the popover hangs off. */
+  anchorEl: HTMLElement | null;
+  /** Size the parked window is created at; the real size is measured from
+   *  the rendered content on every open. */
+  width: number;
+  height: number;
+  children: React.ReactNode;
+}
+
+const EDGE_PAD = 8;
+
+// window.open target prefix the main process recognizes (popover-windows.js):
+// windows named this way are created hidden and shown/hidden over IPC.
+// Off-screen "parking" is not an option — mutter clamps both the initial
+// position and runtime moveTo back onto the screen (measured: a window
+// parked at (-10000, 0) sat at (0, 32), fully visible).
+const POPOVER_PREFIX = 'sokuji-popover:';
+let popoverSerial = 0;
+
+function setNativeVisibility(name: string, visible: boolean): void {
+  void (window as { electron?: { invoke: (c: string, p: unknown) => Promise<unknown> } })
+    .electron?.invoke('popover-window:set-visible', { name, visible });
+}
+
+/**
+ * GNOME's compositor plays a ~200ms fade/zoom "map" animation for NORMAL
+ * windows, which reads as an unwanted popover-open animation. It skips the
+ * animation entirely for non-NORMAL types, and Electron accepts
+ * `type: 'toolbar'` (_NET_WM_WINDOW_TYPE_TOOLBAR) on Linux — verified with
+ * xprop on a live window. Linux-only: macOS uses a different value set for
+ * `type` and would reject it, and Windows shows new windows instantly with
+ * no system fade to suppress in the first place. navigator.platform rather
+ * than the UA string — the app ships a custom user agent.
+ */
+function platformWindowTypeFeature(): string[] {
+  return /linux/i.test(navigator.platform) ? ['type=toolbar'] : [];
+}
+
+/** Clone parent stylesheets the child doesn't have yet. Runs on every open,
+ *  not just at creation, so styles added later (dev HMR, lazy chunks) reach
+ *  the parked window too. */
+function syncStyles(from: Document, to: Document, cloned: WeakSet<Node>) {
+  from.querySelectorAll('style, link[rel="stylesheet"]').forEach((node) => {
+    if (cloned.has(node)) return;
+    cloned.add(node);
+    to.head.appendChild(to.importNode(node, true));
+  });
+}
+
+export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
+  open, onClose, anchorEl, width, height, children,
+}) => {
+  const winRef = useRef<Window | null>(null);
+  const [container, setContainer] = useState<HTMLElement | null>(null);
+  const clonedStylesRef = useRef(new WeakSet<Node>());
+  // The latest values without re-running effects that must not churn.
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+  const openRef = useRef(open);
+  openRef.current = open;
+
+  // Create the hidden window once, for the component's lifetime.
+  const nameRef = useRef('');
+  useEffect(() => {
+    const name = `${POPOVER_PREFIX}${++popoverSerial}`;
+    nameRef.current = name;
+    const features = [
+      `width=${width}`, `height=${height}`,
+      'frame=false', 'transparent=true', 'alwaysOnTop=true', 'skipTaskbar=true',
+      'resizable=false', 'minimizable=false', 'maximizable=false', 'hasShadow=false',
+      'focusable=true',
+      ...platformWindowTypeFeature(),
+    ].join(',');
+    const win = window.open('', name, features);
+    if (!win) {
+      // Outside Electron (or blocked) — nothing to host the popover in.
+      console.warn('[ChildWindowPopover] window.open refused; popover unavailable');
+      return;
+    }
+    winRef.current = win;
+
+    clonedStylesRef.current = new WeakSet();
+    syncStyles(document, win.document, clonedStylesRef.current);
+    const body = win.document.body;
+    body.style.margin = '0';
+    body.style.background = 'transparent';
+    body.style.overflow = 'hidden';
+    const root = win.document.createElement('div');
+    root.className = 'child-popover-root';
+    // Shrink-wrap so the open-time measurement reads the popover's own
+    // footprint rather than the parked window's.
+    root.style.width = 'fit-content';
+    body.appendChild(root);
+    setContainer(root);
+
+    // Dismissal listeners live for the window's lifetime; they no-op while
+    // hidden (a hidden window never has focus to lose).
+    const handleBlur = () => { if (openRef.current) onCloseRef.current('blur'); };
+    const handleKeydown = (e: unknown) => {
+      if (openRef.current && (e as KeyboardEvent).key === 'Escape') onCloseRef.current('escape');
+    };
+    win.addEventListener('blur', handleBlur);
+    win.addEventListener('keydown', handleKeydown as EventListener);
+
+    return () => {
+      win.removeEventListener('blur', handleBlur);
+      win.removeEventListener('keydown', handleKeydown as EventListener);
+      setContainer(null);
+      winRef.current = null;
+      if (!win.closed) win.close();
+    };
+    // The parked window is sized/positioned per open; creation params are
+    // deliberately captured once.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Open: measure the already-rendered content, size and place the window
+  // while it is still hidden, then have the main process show it (show also
+  // focuses, and focus is what makes blur-dismiss work). Close: hide it.
+  useEffect(() => {
+    const win = winRef.current;
+    if (!win || win.closed || !container) return;
+
+    if (!open || !anchorEl) {
+      setNativeVisibility(nameRef.current, false);
+      return;
+    }
+
+    // Styles that appeared since creation (dev HMR, late chunks).
+    syncStyles(document, win.document, clonedStylesRef.current);
+
+    const rect = container.getBoundingClientRect();
+    const w = Math.ceil(rect.width) || width;
+    const h = Math.ceil(rect.height) || height;
+
+    const anchor = anchorEl.getBoundingClientRect();
+    const screenTop = (window.screen as { availTop?: number }).availTop ?? 0;
+    const screenLeft = (window.screen as { availLeft?: number }).availLeft ?? 0;
+    const anchorTop = window.screenY + anchor.top;
+    const anchorBottom = window.screenY + anchor.bottom;
+    // Above the anchor, right edges aligned; below when the screen has no
+    // room above.
+    const above = anchorTop - h - EDGE_PAD >= screenTop;
+    const left = Math.max(screenLeft, Math.round(window.screenX + anchor.right - w));
+    const top = above
+      ? Math.round(anchorTop - h - EDGE_PAD)
+      : Math.round(anchorBottom + EDGE_PAD);
+
+    win.resizeTo(w, h);
+    win.moveTo(left, top);
+    setNativeVisibility(nameRef.current, true);
+    win.focus();
+
+    // The bar window can move under the popover (its whole surface is a drag
+    // region). There is no DOM event for a window move; poll and close —
+    // repositioning live would fight the WM mid-drag.
+    const startX = window.screenX;
+    const startY = window.screenY;
+    const movePoll = setInterval(() => {
+      if (window.screenX !== startX || window.screenY !== startY) {
+        onCloseRef.current('moved');
+      }
+    }, 300);
+    return () => clearInterval(movePoll);
+  }, [open, anchorEl, container, width, height]);
+
+  // Children render into the hidden window permanently — store-driven updates
+  // keep flowing while it is invisible, so opening has nothing to build.
+  if (!container) return null;
+  return createPortal(children, container);
+};
+
+/**
+ * Open/close state for a ChildWindowPopover driven by a toggle button.
+ *
+ * Owns the one interaction quirk of window-hosted popovers: clicking the
+ * trigger while the popover is open steals focus from the child FIRST, so
+ * blur closes it before the trigger's click lands — and the click would
+ * immediately reopen it, making the button unable to ever close. A short
+ * window after a blur-close absorbs that click.
+ */
+export function useChildPopoverToggle() {
+  const [open, setOpen] = useState(false);
+  const blockUntilRef = useRef(0);
+
+  const onClose = useCallback((reason: ChildPopoverCloseReason) => {
+    setOpen(false);
+    if (reason === 'blur') blockUntilRef.current = Date.now() + 250;
+  }, []);
+
+  const toggle = useCallback(() => {
+    setOpen((o) => {
+      if (!o && Date.now() < blockUntilRef.current) return o;
+      return !o;
+    });
+  }, []);
+
+  return { open, toggle, onClose };
+}

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -164,10 +164,22 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     // suppressBlur: opening a native picker owned by this window (the color
     // chooser behind <input type="color">, a file dialog) steals focus and
     // fires blur — closing then would tear the popover away mid-interaction.
-    // A pointerdown on such an input arms the suppression; focus returning to
-    // the window re-arms normal blur dismissal.
+    // Activating such an input arms the suppression; focus returning to the
+    // window re-arms normal blur dismissal.
+    //
+    // Both mousedown AND a capturing click are needed, and click is the one
+    // that does the real work: keyboard activation (Space/Enter) dispatches
+    // click with no mousedown at all, and DisplaySettingsPopover wraps its
+    // colour input in a <label> — a mouse press there targets the label or
+    // its icon, where closest() finds no input; the input only becomes the
+    // target on the click the label forwards to it. mousedown stays as the
+    // earliest possible arming point for a direct press on the control.
+    //
+    // Residual edge, accepted: if the user abandons the picker by focusing a
+    // different application entirely, suppression stays armed until focus
+    // returns here. The trigger button still closes the popover.
     let suppressBlur = false;
-    const handleMousedown = (e: unknown) => {
+    const handlePickerActivation = (e: unknown) => {
       const target = (e as { target?: Element | null }).target;
       if (target && typeof target.closest === 'function'
           && target.closest('input[type="color"], input[type="file"]')) {
@@ -182,13 +194,15 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     const handleKeydown = (e: unknown) => {
       if (openRef.current && (e as KeyboardEvent).key === 'Escape') onCloseRef.current('escape');
     };
-    win.addEventListener('mousedown', handleMousedown as EventListener, true);
+    win.addEventListener('mousedown', handlePickerActivation as EventListener, true);
+    win.addEventListener('click', handlePickerActivation as EventListener, true);
     win.addEventListener('focus', handleFocus);
     win.addEventListener('blur', handleBlur);
     win.addEventListener('keydown', handleKeydown as EventListener);
 
     teardownRef.current = () => {
-      win.removeEventListener('mousedown', handleMousedown as EventListener, true);
+      win.removeEventListener('mousedown', handlePickerActivation as EventListener, true);
+      win.removeEventListener('click', handlePickerActivation as EventListener, true);
       win.removeEventListener('focus', handleFocus);
       win.removeEventListener('blur', handleBlur);
       win.removeEventListener('keydown', handleKeydown as EventListener);

--- a/src/components/Subtitle/SubtitleBar.scss
+++ b/src/components/Subtitle/SubtitleBar.scss
@@ -167,3 +167,18 @@
   from { transform: rotate(0deg); }
   to { transform: rotate(360deg); }
 }
+
+// Floating wrapper for the settings popover on the EXTENSION OVERLAY surface
+// (Electron hosts it in a child window instead — see ChildWindowPopover).
+// floating-ui's size() middleware writes max-height inline; the popover
+// inside has to scroll rather than overflow it, or the clamp would just cut
+// the content off.
+.subtitle-bar__settings-popover {
+  display: flex;
+  min-height: 0;
+
+  .display-settings-popover {
+    overflow-y: auto;
+    min-height: 0;
+  }
+}

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -1,5 +1,5 @@
 // src/components/Subtitle/SubtitleBar.tsx
-import React, { useCallback, useState } from 'react';
+import React, { useCallback, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   AArrowDown, AArrowUp, ChevronsDownUp, ChevronsUpDown,
@@ -7,7 +7,8 @@ import {
   Play, Square, Loader,
 } from 'lucide-react';
 import {
-  useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, FloatingPortal,
+  useFloating, useClick, useDismiss, useRole, useInteractions, offset, flip, shift, size,
+  autoUpdate, FloatingPortal,
 } from '@floating-ui/react';
 import DisplayModeButton from '../MainPanel/DisplayModeButton';
 import ExportButton from '../MainPanel/ExportButton';
@@ -32,6 +33,7 @@ import {
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 import type { SubtitleSurfaceKind } from './SubtitleApp';
 import { useOverlayDragResize } from './useOverlayDragResize';
+import { ChildWindowPopover, useChildPopoverToggle } from './ChildWindowPopover';
 import './SubtitleBar.scss';
 
 interface Props {
@@ -107,12 +109,36 @@ const SubtitleBar: React.FC<Props> = ({
   // edges, not the bar's 36px footprint.
   const { dragHandleProps } = useOverlayDragResize({ surface });
 
+  // Electron: the settings popover lives in its own frameless transparent
+  // child window — the 200px bar window cannot contain it, and resizing the
+  // bar window for it flashes at the compositor level. The extension overlay
+  // has no OS window to open (it's an iframe) and keeps the in-window
+  // floating popover below.
+  const childWindowHost = surface === 'electron';
+  const settingsChild = useChildPopoverToggle();
+  const settingsBtnRef = useRef<HTMLButtonElement>(null);
+
   const [popoverOpen, setPopoverOpen] = useState(false);
   const { refs, floatingStyles, context } = useFloating({
     open: popoverOpen,
     onOpenChange: setPopoverOpen,
     placement: 'bottom-end',
-    middleware: [offset(8), flip()],
+    whileElementsMounted: autoUpdate,
+    middleware: [
+      offset(8),
+      flip(),
+      shift({ padding: 8 }),
+      // The overlay iframe can be shorter than the popover; clamp so it
+      // scrolls internally instead of being cut off at the iframe edge.
+      size({
+        padding: 8,
+        apply({ availableHeight, elements }) {
+          Object.assign(elements.floating.style, {
+            maxHeight: `${Math.max(0, availableHeight)}px`,
+          });
+        },
+      }),
+    ],
   });
   const click = useClick(context);
   const dismiss = useDismiss(context);
@@ -208,7 +234,7 @@ const SubtitleBar: React.FC<Props> = ({
             messages. The side panel holds the full conversation and is the
             export source of truth — only offer export on the Electron surface,
             where the overlay shares the full session store. */}
-        {surface === 'electron' && <ExportButton {...exportProps} />}
+        {surface === 'electron' && <ExportButton {...exportProps} popoverHost="child-window" />}
         <button
           type="button"
           className="subtitle-bar__btn"
@@ -221,16 +247,31 @@ const SubtitleBar: React.FC<Props> = ({
 
         <span className="subtitle-bar__divider" />
 
-        <button
-          type="button"
-          className="subtitle-bar__btn"
-          ref={refs.setReference}
-          {...getReferenceProps()}
-          title={t('subtitle.bar.settings', 'Subtitle settings')}
-          aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
-        >
-          <Settings size={14} />
-        </button>
+        {childWindowHost ? (
+          <button
+            type="button"
+            className={`subtitle-bar__btn ${settingsChild.open ? 'active' : ''}`}
+            ref={settingsBtnRef}
+            onClick={settingsChild.toggle}
+            aria-haspopup="dialog"
+            aria-expanded={settingsChild.open}
+            title={t('subtitle.bar.settings', 'Subtitle settings')}
+            aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
+          >
+            <Settings size={14} />
+          </button>
+        ) : (
+          <button
+            type="button"
+            className="subtitle-bar__btn"
+            ref={refs.setReference}
+            {...getReferenceProps()}
+            title={t('subtitle.bar.settings', 'Subtitle settings')}
+            aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
+          >
+            <Settings size={14} />
+          </button>
+        )}
         {surface === 'electron' && (
           <button
             type="button"
@@ -273,17 +314,30 @@ const SubtitleBar: React.FC<Props> = ({
         </button>
       </div>
 
-      {popoverOpen && (
-        <FloatingPortal>
-          <div
-            ref={refs.setFloating}
-            style={floatingStyles}
-            aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
-            {...getFloatingProps()}
-          >
-            <DisplaySettingsPopover source="subtitle" />
-          </div>
-        </FloatingPortal>
+      {childWindowHost ? (
+        <ChildWindowPopover
+          open={settingsChild.open}
+          onClose={settingsChild.onClose}
+          anchorEl={settingsBtnRef.current}
+          width={320}
+          height={400}
+        >
+          <DisplaySettingsPopover source="subtitle" />
+        </ChildWindowPopover>
+      ) : (
+        popoverOpen && (
+          <FloatingPortal>
+            <div
+              ref={refs.setFloating}
+              className="subtitle-bar__settings-popover"
+              style={floatingStyles}
+              aria-label={t('subtitle.bar.settings', 'Subtitle settings')}
+              {...getFloatingProps()}
+            >
+              <DisplaySettingsPopover source="subtitle" />
+            </div>
+          </FloatingPortal>
+        )
       )}
     </div>
   );

--- a/src/components/Subtitle/SubtitleBar.tsx
+++ b/src/components/Subtitle/SubtitleBar.tsx
@@ -322,7 +322,12 @@ const SubtitleBar: React.FC<Props> = ({
           width={320}
           height={400}
         >
-          <DisplaySettingsPopover source="subtitle" />
+          {/* The floating branch gets role="dialog" + a name from useRole;
+              the child-window host has to supply the same semantics itself,
+              matching the trigger's aria-haspopup="dialog". */}
+          <div role="dialog" aria-label={t('subtitle.bar.settings', 'Subtitle settings')}>
+            <DisplaySettingsPopover source="subtitle" />
+          </div>
         </ChildWindowPopover>
       ) : (
         popoverOpen && (

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -151,6 +151,7 @@ export default defineConfig(({ command, mode }) => {
             'vb-cable-installer': 'electron/vb-cable-installer.js',
             'squirrel-events': 'electron/squirrel-events.js',
             'subtitle-window': 'electron/subtitle-window.js',
+            'popover-windows': 'electron/popover-windows.js',
             'update-manager': 'electron/update-manager.js'
           },
           onstart(args) {


### PR DESCRIPTION
## Problem

Subtitle mode shrinks the main window to a ~200px bar. Both popovers opened from the bar — display settings (~343px tall) and the export menu — are ordinary DOM, so the window edge clips them no matter what floating-ui does.

## Approach — and the dead ends that shaped it

Each popover now lives in its own **frameless, transparent, always-on-top child window**, opened by the renderer via `window.open` (Electron parses BrowserWindow options straight from the feature string). The popover components render into it through `createPortal` — same React tree, same handlers, same context — with the parent's stylesheets cloned into the child head (the react-new-window copyStyles pattern, re-synced on every open so dev-HMR styles arrive too). The subtitle window is never touched.

Every design decision below was forced by a measured defect, each found on a live window (none visible to the unit suite):

1. **Growing the bar window instead** (`archive/subtitle-reserve-space`) worked geometrically, but resizing a transparent window flashes at the compositor level — frame sampling showed the DOM continuous while the flash sat below it, unreachable from the renderer. Hence: a separate window, so nothing resizes.
2. **Creating the window on click** cost 100–250ms of button-to-popover lag (native window + stylesheet parse + first composite), and opening at a guessed size painted a visible shrink-and-move ~230ms in. Hence: create once on subtitle-mode entry, open = resize + move + show.
3. **Parking the idle window off-screen** did not survive the window manager: mutter clamps both the initial position and runtime `moveTo` back onto the screen — measured, a window "parked" at (-10000, 0) sat at (0, 32), fully visible. Hence: visibility is owned by the main process (`electron/popover-windows.js`): `window.open` targets named `sokuji-popover:*` get `show: false` through a `setWindowOpenHandler` override — hidden from the very first frame — and are shown/hidden over one IPC channel.
4. **GNOME's ~200ms map animation** made every open feel animated. The compositor only plays it for NORMAL/dialog windows, so on Linux the feature string carries `type=toolbar` (`_NET_WM_WINDOW_TYPE_TOOLBAR`, xprop-verified). Linux-only: macOS uses a different `type` value set, and Windows shows new windows instantly with no system fade to suppress.

`ChildWindowPopover` owns the renderer mechanics (placement above the anchor with below-fallback, sizing from the already-rendered content while hidden, dismissal on child blur / Escape / bar-window move via a 300ms position poll, close-on-unmount). `useChildPopoverToggle` absorbs the toggle-vs-blur race: clicking the trigger while open blurs the child first, so a short block after any blur-close keeps the button able to close.

The **extension overlay is untouched** in behavior — an iframe has no OS window to open — but its in-window floating popover gains `autoUpdate` + `shift` + `size` clamping so a short overlay scrolls it instead of clipping. The export menu gets a `popoverHost` prop: `'child-window'` on the Electron subtitle bar, the floating menu (now also size-clamped) everywhere else.

## Verified live (X11 / mutter, CDP-driven)

- Bar window untouched: frame-sampled across open/close, bar position and window height bit-identical throughout
- Click-to-visible under one frame (0.3ms to issue, next frame on screen)
- `xwininfo` Map State: `IsUnMapped` while closed (absent from screenshots, no click interception), `IsViewable` at the anchor while open, `IsUnMapped` after close; both child windows destroyed on subtitle-mode exit (0 → 2 → 0 targets)
- Escape, synthetic blur, and a real `setBounds` window move each dismiss it
- Full suite: 2652 passed; the 9 failures are the known worktree baseline, identical on `main`

## Manual test checklist

- [x] Open/close feel: instant, no animation, no flash *(verified by @jiangzhuo on X11/GNOME)*
- [x] Full-screen screenshot shows no stray popover windows while closed
- [ ] Real OS-focus blur: click outside the popover → closes; click the toggle while open → closes and stays closed (the 250ms blur-race block)
- [ ] Export menu in subtitle mode with an actual conversation (menu content + item actions)
- [ ] Windows / macOS smoke test: popovers open hidden→shown, no fade assumptions broken (`type=toolbar` is Linux-gated)
- [ ] Alt-Tab / taskbar: no extra entries while in subtitle mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Electron child-window popovers for subtitle settings and export menus.
  * Popovers reposition, dismiss on focus changes or Escape, and recover after being closed.
  * Export menus scroll when content exceeds available space.
  * In-app popovers adjust position and height to fit available space.
  * Added accessible labels and dialog semantics to popover controls.

* **Bug Fixes**
  * Prevented unintended popover reopening after dismissal.
  * Improved handling of unavailable or destroyed popover windows.
  * Blocked unintended navigation from popover windows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->