### PR TITLE
fix(wallet): adapt money display precision to magnitude, floor balances

### DIFF
--- a/src/components/Auth/UserAccountInfo.tsx
+++ b/src/components/Auth/UserAccountInfo.tsx
@@ -17,7 +17,7 @@ import {
   UserCog,
   Wallet
 } from 'lucide-react';
-import {formatUsd} from '../../utils/formatters';
+import {formatUsd, formatUsdFloor} from '../../utils/formatters';
 import {useTranslation} from 'react-i18next';
 import {useAnalytics} from '../../lib/analytics';
 import {isElectron, getBackendUrl, getApiUrl} from '../../utils/environment';
@@ -376,7 +376,9 @@ export function UserAccountInfo({
             <div className="quota-compact-line">
               <Wallet size={14} className="wallet-icon"/>
               <span className="balance-section">
-                {formatUsd(quota.balance || quota.remaining)}
+                {/* Floored, not rounded: a balance must never display more
+                    money than the wallet holds. See `formatUsdFloor`. */}
+                {formatUsdFloor(quota.balance || quota.remaining)}
               </span>
               <span className="divider">|</span>
               <span className="usage-section">

--- a/src/components/MainPanel/sessionStartGate.test.ts
+++ b/src/components/MainPanel/sessionStartGate.test.ts
@@ -367,7 +367,11 @@ describe('reasonToI18n', () => {
     const entry = reasonToI18n('insufficient-balance', 9_999);
     expect(entry.defaultValue).toBe('Insufficient balance: {{balance}}');
     expect(entry.defaultValue).not.toMatch(/token/i);
-    expect(entry.values).toEqual({ balance: '$0.01' });
+    // Sub-cent, so it renders at full micro-USD precision and is FLOORED.
+    // This used to read "$0.01" — a fixed 2dp rounded 9,999 µUSD up to a cent
+    // the wallet does not hold, in the one message whose entire job is to say
+    // the balance is too low. See `formatUsdFloor`.
+    expect(entry.values).toEqual({ balance: '$0.009999' });
   });
 
   it('renders a missing balance as $0.00 rather than an empty slot', () => {

--- a/src/components/MainPanel/sessionStartGate.ts
+++ b/src/components/MainPanel/sessionStartGate.ts
@@ -13,7 +13,7 @@ import { Provider, isKizunaManagedProvider, type ProviderType } from '../../type
 // re-exports it: this file is also loaded by the subtitle window, and that
 // barrel pulls in SonioxClient and the i18n bootstrap behind it.
 import { sonioxManagedMinBalanceMicroUsd } from '../../services/providers/sonioxManagedMinBalance';
-import { formatUsd } from '../../utils/formatters';
+import { formatUsdFloor } from '../../utils/formatters';
 
 export type StartBlockReason =
   | 'missing-device'
@@ -294,10 +294,14 @@ export function reasonToI18n(
       // speaks in "tokens", so the raw value would render as a 7-digit
       // integer. Formatted here — the one place every surface reads its
       // blocker message from — rather than at each call site.
+      //
+      // Floored, like every other balance: this message appears precisely when
+      // the balance is too low to start, so rounding it UP to a friendlier
+      // number is the worst possible moment to overstate it.
       return {
         key: 'mainPanel.insufficientBalance',
         defaultValue: 'Insufficient balance: {{balance}}',
-        values: { balance: formatUsd(balanceMicroUsd ?? 0) },
+        values: { balance: formatUsdFloor(balanceMicroUsd ?? 0) },
       };
     case 'quota-unknown':
       return { key: 'tokenUsage.unableToLoadQuota', defaultValue: 'Unable to load quota information' };

--- a/src/components/Subtitle/SubtitleIdle.test.tsx
+++ b/src/components/Subtitle/SubtitleIdle.test.tsx
@@ -107,8 +107,19 @@ describe('SubtitleIdle blocked state', () => {
     render(
       <SubtitleIdle state={{ kind: 'blocked', reason: 'insufficient-balance', balance: 9_999 }} {...handlers()} />,
     );
-    expect(screen.getByRole('button', { name: /\$0\.01/ })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /9999/ })).not.toBeInTheDocument();
+    // 9,999 µUSD is $0.009999 — under a cent, so it renders at full micro-USD
+    // precision and floored. This used to read "$0.01", rounding UP to a cent
+    // the wallet does not hold, in the one message whose whole job is to say
+    // the balance is short. See `formatUsdFloor`.
+    const button = screen.getByRole('button', { name: /\$0\.009999/ });
+    expect(button).toBeInTheDocument();
+    // The original guard here was `not.toMatch(/9999/)`, which no longer
+    // expresses the intent: at full precision the formatted amount CONTAINS
+    // the integer's own digits — "$0.009999" is 9,999 µUSD written correctly.
+    // What must never appear is those digits as a bare integer, so pin that
+    // instead: the run may only occur after a "$0." decimal point.
+    expect(button.textContent).toContain('$0.009999');
+    expect(button.textContent).not.toMatch(/(^|[^.\d])9999(\D|$)/);
   });
 
   // loading-models has no settings destination, so there is nothing to click.

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -1,20 +1,90 @@
 import { describe, it, expect } from 'vitest';
-import { formatUsd, formatRemainingTime } from './formatters';
+import { formatUsd, formatUsdFloor, formatRemainingTime } from './formatters';
 
+/**
+ * MIRROR OF the backend's adaptive-precision case table
+ * (`sokuji-backend/src/services/money-format.ts` and its browser twin
+ * `sokuji-backend/web/src/lib/money-format.ts`). sokuji-react, the Worker and
+ * the dashboard are three separate TypeScript projects that cannot import each
+ * other, so the rule necessarily exists three times; restating the SAME
+ * micro-USD inputs and decimal counts here means a change to one copy surfaces
+ * as a failure on the others.
+ *
+ * Two conventions deliberately differ on this side and are pinned below:
+ *   - the minus sits INSIDE the currency symbol ("$-1.50"), where the backend
+ *     emits "-$1.50";
+ *   - unusable input renders "$0.00", where the dashboard renders an em dash.
+ * Both predate the shared precision rule, so only the precision rule is
+ * mirrored, not the whole formatter.
+ */
 describe('formatUsd', () => {
-  it('renders micro-USD as a 2dp dollar string', () => {
+  // Dollar-magnitude amounts - balances and top-ups - keep the familiar 2dp.
+  it('formats amounts >= $1 to 2 decimals', () => {
     expect(formatUsd(3_420_000)).toBe('$3.42');
-    expect(formatUsd(0)).toBe('$0.00');
+    expect(formatUsd(12_500_000)).toBe('$12.50');
     expect(formatUsd(1_000_000)).toBe('$1.00');
+    expect(formatUsd(1_500_000)).toBe('$1.50');
   });
 
-  it('keeps negative balances signed', () => {
+  // Cent-magnitude amounts get 4dp: 2dp already discards most of the value.
+  it('formats amounts >= $0.01 to 4 decimals', () => {
+    expect(formatUsd(26_499)).toBe('$0.0265');
+    expect(formatUsd(10_000)).toBe('$0.0100');
+  });
+
+  // Below a cent, render the full micro-USD precision: nothing is lost,
+  // because micro-USD IS the stored atom.
+  it('formats amounts under $0.01 to 6 decimals, losing nothing', () => {
+    // The measured case that motivated the whole rule: a 10.08s Soniox stream
+    // with translation cost $0.000776, charged at K=2.0 -> 1552 micro-USD. At a
+    // fixed 2dp the 30-day usage line read "$0.00" for every short session.
+    expect(formatUsd(1_552)).toBe('$0.001552');
+    expect(formatUsd(9_999)).toBe('$0.009999');
+    expect(formatUsd(1)).toBe('$0.000001');
+  });
+
+  // Zero is carved OUT of the magnitude table, which never really applied to
+  // it: zero has no magnitude to select a bucket by. An empty balance reads as
+  // "$0.00"; "$0.000000" would read as a precision artifact rather than as
+  // "nothing".
+  it('renders an exact zero at 2 decimals, outside the magnitude table', () => {
+    expect(formatUsd(0)).toBe('$0.00');
+  });
+
+  // The asymmetry with the case above is deliberate: "$0.00" means no money
+  // moved, "$0.000000" means a very small amount did, and those must not look
+  // alike.
+  it('distinguishes a sub-micro-USD amount from an exact zero', () => {
+    expect(formatUsd(0.4)).toBe('$0.000000');
+    expect(formatUsd(0.4)).not.toBe(formatUsd(0));
+  });
+
+  // Rounding happens within the bucket the RAW magnitude selected, so a value
+  // just under a bucket edge can round up to it. Pinned so the behaviour is
+  // deliberate rather than incidental - and so the contrast with
+  // `formatUsdFloor`, which cannot round up, stays visible.
+  it('rounds within the bucket its magnitude selected', () => {
+    expect(formatUsd(999_999)).toBe('$1.0000');
+    expect(formatUsd(9_999_999)).toBe('$10.00');
+  });
+
+  it('keeps negative amounts signed at every precision bucket', () => {
     expect(formatUsd(-1_500_000)).toBe('$-1.50');
+    expect(formatUsd(-26_499)).toBe('$-0.0265');
+    expect(formatUsd(-1_552)).toBe('$-0.001552');
+  });
+
+  // A negative magnitude too small to survive its own bucket would render
+  // "$-0.000000", which reads as a rendering bug rather than as a balance a
+  // fraction of a micro-USD overdrawn.
+  it('drops the sign when the magnitude rounds away entirely', () => {
+    expect(formatUsd(-0.4)).toBe('$0.000000');
+    expect(formatUsd(-0)).toBe('$0.00');
   });
 
   // QuotaData is built from an untyped JSON payload, and the call sites
   // (`quota.balance ?? 0`, `quota.balance || quota.remaining`) do not stop a
-  // NaN — without the guard the balance UI rendered the literal "$NaN".
+  // NaN - without the guard the balance UI rendered the literal "$NaN".
   it('renders non-finite input as $0.00 rather than $NaN', () => {
     expect(formatUsd(NaN)).toBe('$0.00');
     expect(formatUsd(Infinity)).toBe('$0.00');
@@ -28,6 +98,73 @@ describe('formatUsd', () => {
 
   it('rejects a non-number that would coerce (a string balance from bad JSON)', () => {
     expect(formatUsd('3420000' as unknown as number)).toBe('$0.00');
+  });
+});
+
+/**
+ * `formatUsdFloor` picks its precision bucket exactly as `formatUsd` does, then
+ * truncates toward negative infinity instead of rounding to nearest. It exists
+ * for the ONE quantity where rounding to nearest is actively misleading: a
+ * balance, which must never be displayed as more money than the wallet holds.
+ */
+describe('formatUsdFloor', () => {
+  // The reported symptom, exactly. Top up $5, run one short session charged
+  // 1552 micro-USD, and the true balance is $4.998448. `toFixed(2)` renders
+  // that as "$5.00" - so the balance appeared frozen at the top-up amount and
+  // the session looked free. Truncation shows the money moved.
+  it('never renders a balance as more money than the wallet holds', () => {
+    expect(formatUsdFloor(5_000_000 - 1_552)).toBe('$4.99');
+    expect(formatUsd(5_000_000 - 1_552)).toBe('$5.00');
+  });
+
+  // Truncation must not shave a cent off an amount that already sits exactly on
+  // the grid. Done in float dollars this fails: 4.95 * 100 is 494.99999999999994
+  // in IEEE 754, so `Math.floor` would render "$4.94". The floor therefore
+  // happens in integer micro-USD, where the grid points are exact.
+  it('leaves an amount already on the displayed grid untouched', () => {
+    expect(formatUsdFloor(4_950_000)).toBe('$4.95');
+    expect(formatUsdFloor(12_500_000)).toBe('$12.50');
+    expect(formatUsdFloor(1_000_000)).toBe('$1.00');
+    expect(formatUsdFloor(10_000)).toBe('$0.0100');
+  });
+
+  // Same magnitude buckets as `formatUsd`: a sub-cent balance still shows its
+  // full micro-USD precision, where truncation is a no-op because micro-USD is
+  // the stored atom.
+  it('uses the same magnitude buckets, losing nothing below a cent', () => {
+    expect(formatUsdFloor(26_499)).toBe('$0.0264');
+    expect(formatUsdFloor(1_552)).toBe('$0.001552');
+    expect(formatUsdFloor(1)).toBe('$0.000001');
+  });
+
+  // The bucket comes from the RAW magnitude, and truncation can only move the
+  // value down, so - unlike `formatUsd` - a balance can never round up across
+  // a bucket edge into a number the user does not have.
+  it('cannot round up across a bucket edge', () => {
+    expect(formatUsdFloor(999_999)).toBe('$0.9999');
+    expect(formatUsdFloor(9_999_999)).toBe('$9.99');
+  });
+
+  // Balances may go negative (charging is post-paid, so a session can overrun
+  // the balance). Truncating toward negative infinity moves a debt AWAY from
+  // zero, which is the same conservative direction: never show less debt than
+  // is owed.
+  it('never renders a negative balance as less debt than is owed', () => {
+    expect(formatUsdFloor(-1_234_000)).toBe('$-1.24');
+    expect(formatUsdFloor(-1_500_000)).toBe('$-1.50');
+  });
+
+  it('renders an exact zero at 2 decimals, as formatUsd does', () => {
+    expect(formatUsdFloor(0)).toBe('$0.00');
+    expect(formatUsdFloor(-0)).toBe('$0.00');
+  });
+
+  it('renders unusable input as $0.00 rather than $NaN', () => {
+    expect(formatUsdFloor(NaN)).toBe('$0.00');
+    expect(formatUsdFloor(Infinity)).toBe('$0.00');
+    expect(formatUsdFloor(null)).toBe('$0.00');
+    expect(formatUsdFloor(undefined)).toBe('$0.00');
+    expect(formatUsdFloor('3420000' as unknown as number)).toBe('$0.00');
   });
 });
 

--- a/src/utils/formatters.test.ts
+++ b/src/utils/formatters.test.ts
@@ -68,6 +68,25 @@ describe('formatUsd', () => {
     expect(formatUsd(9_999_999)).toBe('$10.00');
   });
 
+  // Rounding happens on the exact integer micro-USD, NOT on the float dollars,
+  // so an amount sitting exactly half a display unit from its neighbours lands
+  // by rule instead of by IEEE 754 accident. 10,050 µUSD is
+  // 0.010049999999999999906 as a double, so `(m / 1e6).toFixed(4)` rounds it
+  // DOWN to "$0.0100"; 1,005,000 µUSD does the same at 2dp. Neither direction
+  // was a decision: a sweep of the 4dp bucket's 9,900 exact ties splits 4,943
+  // down and 4,957 up purely on how each value happens to be representable.
+  it('resolves an exact tie by rule rather than by float representation', () => {
+    expect(formatUsd(10_050)).toBe('$0.0101');
+    expect(formatUsd(1_005_000)).toBe('$1.01');
+  });
+
+  // Ties resolve away from zero on both sides, because the magnitude is what
+  // gets rounded - the same magnitude the sign is then applied to.
+  it('resolves ties symmetrically for negative amounts', () => {
+    expect(formatUsd(-10_050)).toBe('$-0.0101');
+    expect(formatUsd(-1_005_000)).toBe('$-1.01');
+  });
+
   it('keeps negative amounts signed at every precision bucket', () => {
     expect(formatUsd(-1_500_000)).toBe('$-1.50');
     expect(formatUsd(-26_499)).toBe('$-0.0265');

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -2,10 +2,72 @@
  * Utility functions for formatting data display
  */
 
+/** Conversion anchor: 1 USD = 1,000,000 micro-USD. */
+const MICRO_USD_PER_USD = 1_000_000;
+
+/** A formatted magnitude carrying no value at all: "0.00", "0.000000". */
+const ALL_ZEROS = /^0(?:\.0+)?$/;
+
 /**
- * Format a micro-USD wallet amount (1 USD = 1,000,000 micro-USD) as a display
- * currency string. Mirrors the `formatUsd` helper in the backend web dashboard
- * (sokuji-backend/web/src/pages/dashboard/Wallet.tsx).
+ * Decimal places for a NON-NEGATIVE USD magnitude, chosen by its size.
+ *
+ * WHY THE DECIMAL COUNT ADAPTS. A fixed 2 decimals is right for a balance and
+ * catastrophic for a usage row. At the magnitudes this product actually bills
+ * at, `toFixed(2)` does not round an amount — it deletes it. A measured
+ * example: a 10.08-second Soniox stream with translation cost $0.000776 from
+ * the provider, charged at `cost × K` (K = 2.0) = 1552 µUSD. Two decimals
+ * render that as "$0.00", so the account panel's "30D" line read as zero for
+ * every short session, and the balance beside it — $4.998448 after a $5
+ * top-up — rounded straight back to "$5.00". Both numbers said no money had
+ * moved when it had.
+ *
+ *   |x| >= $1      2 decimals   "$12.50"
+ *   |x| >= $0.01   4 decimals   "$0.0265"
+ *   otherwise      6 decimals   "$0.001552"   (the full µUSD atom, lossless)
+ *
+ * Exact zero is carved OUT of the table, which never really applied to it:
+ * zero has no magnitude to select a bucket by, and "$0.000000" reads as a
+ * precision artifact rather than as "nothing". That leaves 0 rendering "$0.00"
+ * while 1 µUSD renders "$0.000001", which looks asymmetric but is the point:
+ * one means no money moved, the other means a very small amount did.
+ *
+ * MIRRORED IN `sokuji-backend/src/services/money-format.ts` (the Worker) and
+ * `sokuji-backend/web/src/lib/money-format.ts` (the dashboard). Those two and
+ * this one are separate TypeScript projects built by different toolchains, so
+ * none can import another and the rule exists three times; the case table in
+ * `formatters.test.ts` restates the backend's so a change to one copy fails
+ * the others. The backend copies emit "-$1.50" and render unusable input as an
+ * em dash; this one keeps "$-1.50" and "$0.00" (see below). Only the precision
+ * rule is shared.
+ */
+function usdDecimals(absUsd: number): 2 | 4 | 6 {
+  if (absUsd === 0) return 2;
+  if (absUsd >= 1) return 2;
+  if (absUsd >= 0.01) return 4;
+  return 6;
+}
+
+/**
+ * Assemble the final string from an already-scaled µUSD amount.
+ *
+ * The sign is applied to the FORMATTED magnitude, not the raw number, so an
+ * amount too small to survive its own precision bucket cannot render as
+ * "$-0.000000" — which reads as a rendering bug rather than as a balance a
+ * fraction of a micro-USD overdrawn. A representable negative stays signed.
+ */
+function render(microUsd: number, decimals: 2 | 4 | 6): string {
+  const magnitude = Math.abs(microUsd / MICRO_USD_PER_USD).toFixed(decimals);
+  const sign = microUsd < 0 && !ALL_ZEROS.test(magnitude) ? '-' : '';
+  return `$${sign}${magnitude}`;
+}
+
+/**
+ * Format a micro-USD amount (1 USD = 1,000,000 micro-USD) as a display currency
+ * string, rounded to nearest at a precision that adapts to its magnitude (see
+ * `usdDecimals`).
+ *
+ * For a BALANCE use `formatUsdFloor` instead: rounding to nearest can render
+ * more money than the wallet holds.
  *
  * The argument comes from `QuotaData`, which is built from an untyped JSON
  * payload, so null/undefined/NaN can reach here — callers pass things like
@@ -14,11 +76,45 @@
  * "$NaN" appearing in the balance UI.
  *
  * @param microUsd Amount in micro-USD
- * @returns Formatted string (e.g., "$3.42")
+ * @returns Formatted string (e.g., "$3.42", "$0.001552")
  */
 export function formatUsd(microUsd: number | null | undefined): string {
   if (typeof microUsd !== 'number' || !Number.isFinite(microUsd)) return '$0.00';
-  return `$${(microUsd / 1_000_000).toFixed(2)}`;
+  return render(microUsd, usdDecimals(Math.abs(microUsd / MICRO_USD_PER_USD)));
+}
+
+/**
+ * Format a micro-USD amount as `formatUsd` does, but TRUNCATING toward negative
+ * infinity instead of rounding to nearest.
+ *
+ * For a balance, rounding to nearest is not merely imprecise, it is wrong in a
+ * specific direction: it can claim the wallet holds money it does not. Half a
+ * cent of usage against a $5 balance leaves $4.995, which rounds back up to
+ * "$5.00" — the display says the session was free. Truncation can only ever
+ * understate, so what the user sees is money they are certain to have.
+ *
+ * A negative balance is reachable (charging is post-paid, so a session can
+ * overrun the balance) and truncating toward negative infinity moves a debt
+ * away from zero — the same conservative direction: never show less debt than
+ * is owed.
+ *
+ * THE TRUNCATION HAPPENS IN INTEGER µUSD, not in float dollars, because the
+ * grid points are exact there and are not in IEEE 754: `4.95 * 100` is
+ * 494.99999999999994, so flooring in dollars would render an exact $4.95
+ * balance as "$4.94". Every amount in this system is an integer number of
+ * micro-USD, which makes `step` an exact divisor.
+ *
+ * @param microUsd Amount in micro-USD
+ * @returns Formatted string (e.g., "$4.99" for a balance of $4.998448)
+ */
+export function formatUsdFloor(microUsd: number | null | undefined): string {
+  if (typeof microUsd !== 'number' || !Number.isFinite(microUsd)) return '$0.00';
+  // Bucket chosen from the RAW magnitude, exactly as `formatUsd` does, so the
+  // two agree on precision and differ only in direction.
+  const decimals = usdDecimals(Math.abs(microUsd / MICRO_USD_PER_USD));
+  // µUSD per displayed unit: 10,000 (a cent) at 2dp, 100 at 4dp, 1 at 6dp.
+  const step = 10 ** (6 - decimals);
+  return render(Math.floor(microUsd / step) * step, decimals);
 }
 
 /**

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -48,7 +48,16 @@ function usdDecimals(absUsd: number): 2 | 4 | 6 {
 }
 
 /**
- * Assemble the final string from an already-scaled µUSD amount.
+ * µUSD per displayed unit at a given precision: 10,000 (a cent) at 2dp, 100 at
+ * 4dp, 1 at 6dp. Exact, because both operands are powers of ten.
+ */
+function stepMicroUsd(decimals: 2 | 4 | 6): number {
+  return 10 ** (6 - decimals);
+}
+
+/**
+ * Assemble the final string from an amount ALREADY quantized onto the display
+ * grid by `quantize`.
  *
  * The sign is applied to the FORMATTED magnitude, not the raw number, so an
  * amount too small to survive its own precision bucket cannot render as
@@ -59,6 +68,32 @@ function render(microUsd: number, decimals: 2 | 4 | 6): string {
   const magnitude = Math.abs(microUsd / MICRO_USD_PER_USD).toFixed(decimals);
   const sign = microUsd < 0 && !ALL_ZEROS.test(magnitude) ? '-' : '';
   return `$${sign}${magnitude}`;
+}
+
+/**
+ * Snap an exact integer µUSD amount onto the display grid.
+ *
+ * BOTH ROUNDING MODES QUANTIZE IN INTEGER µUSD RATHER THAN IN FLOAT DOLLARS,
+ * for the same reason: the grid points are exact there and are not in IEEE 754.
+ *
+ *   - `round`: dividing first and letting `toFixed` round decides ties on
+ *     representation accident. 10,050 µUSD is exactly half a 4dp unit, but as a
+ *     double it is 0.010049999999999999906, so `toFixed(4)` rounds it DOWN to
+ *     "0.0100". That is not a rule — sweeping the 9,900 exact ties in the 4dp
+ *     bucket splits 4,943 down and 4,957 up. Rounding `|micro| / step` instead
+ *     resolves every tie away from zero, symmetrically for either sign.
+ *   - `floor`: `4.95 * 100` is 494.99999999999994, so flooring in dollars would
+ *     render an exact $4.95 balance as "$4.94".
+ *
+ * The magnitude is what gets quantized — the same magnitude `render` then
+ * applies the sign to — so the two agree on which side of a tie an amount sits
+ * regardless of sign.
+ */
+function quantize(microUsd: number, decimals: 2 | 4 | 6, mode: 'round' | 'floor'): number {
+  const step = stepMicroUsd(decimals);
+  if (mode === 'floor') return Math.floor(microUsd / step) * step;
+  const magnitude = Math.round(Math.abs(microUsd) / step) * step;
+  return microUsd < 0 ? -magnitude : magnitude;
 }
 
 /**
@@ -80,7 +115,8 @@ function render(microUsd: number, decimals: 2 | 4 | 6): string {
  */
 export function formatUsd(microUsd: number | null | undefined): string {
   if (typeof microUsd !== 'number' || !Number.isFinite(microUsd)) return '$0.00';
-  return render(microUsd, usdDecimals(Math.abs(microUsd / MICRO_USD_PER_USD)));
+  const decimals = usdDecimals(Math.abs(microUsd / MICRO_USD_PER_USD));
+  return render(quantize(microUsd, decimals, 'round'), decimals);
 }
 
 /**
@@ -98,11 +134,8 @@ export function formatUsd(microUsd: number | null | undefined): string {
  * away from zero — the same conservative direction: never show less debt than
  * is owed.
  *
- * THE TRUNCATION HAPPENS IN INTEGER µUSD, not in float dollars, because the
- * grid points are exact there and are not in IEEE 754: `4.95 * 100` is
- * 494.99999999999994, so flooring in dollars would render an exact $4.95
- * balance as "$4.94". Every amount in this system is an integer number of
- * micro-USD, which makes `step` an exact divisor.
+ * Like `formatUsd`, it quantizes in integer µUSD rather than float dollars —
+ * see `quantize` for why each mode needs that.
  *
  * @param microUsd Amount in micro-USD
  * @returns Formatted string (e.g., "$4.99" for a balance of $4.998448)
@@ -112,9 +145,7 @@ export function formatUsdFloor(microUsd: number | null | undefined): string {
   // Bucket chosen from the RAW magnitude, exactly as `formatUsd` does, so the
   // two agree on precision and differ only in direction.
   const decimals = usdDecimals(Math.abs(microUsd / MICRO_USD_PER_USD));
-  // µUSD per displayed unit: 10,000 (a cent) at 2dp, 100 at 4dp, 1 at 6dp.
-  const step = 10 ** (6 - decimals);
-  return render(Math.floor(microUsd / step) * step, decimals);
+  return render(quantize(microUsd, decimals, 'floor'), decimals);
 }
 
 /**


### PR DESCRIPTION
## The bug

Top up $5, run one short session, and the account panel says the session was free:

| | before | after |
|---|---|---|
| balance after a 10.08s session (4,998,448 µUSD) | `$5.00` | **`$4.99`** |
| that session's 30-day usage (1,552 µUSD) | `$0.00` | **`$0.001552`** |

Both numbers were rendered with a fixed `toFixed(2)`. At the magnitudes this product bills at, two decimals do not *round* an amount — they **delete** it. A 10.08-second Soniox stream with translation costs $0.000776 from the provider, charged at `cost × K` (K = 2.0) = 1,552 µUSD, which reads as `$0.00`; and the $4.998448 balance beside it rounds straight back up to `$5.00`.

The money itself was never wrong. Every amount is an exact integer micro-USD end to end — DB column, ledger row, and the `Math.ceil`-to-µUSD in `pricing.ts`. This was display only, and it stays display only: **storage and arithmetic are untouched by this PR.**

## The fix

**1. Adopt the backend's magnitude-adaptive precision rule.** It already exists twice — `sokuji-backend/src/services/money-format.ts` (the Worker) and `sokuji-backend/web/src/lib/money-format.ts` (the dashboard) — and was mirrored by nothing on this side. The comment in `formatters.ts` claiming to mirror the dashboard's `formatUsd` had been stale since the dashboard moved off 2dp.

```
|x| >= $1      2 decimals   "$12.50"
|x| >= $0.01   4 decimals   "$0.0265"
otherwise      6 decimals   "$0.001552"   (the full µUSD atom, lossless)
exact zero     "$0.00"                    (carved out: zero has no magnitude)
```

The case table in `formatters.test.ts` restates the backend's µUSD inputs and decimal counts verbatim, so a change to any one of the three copies fails the others. Two conventions deliberately differ on this side and are pinned rather than silently diverging: the minus sits inside the currency symbol (`$-1.50`), and unusable input renders `$0.00` rather than an em dash.

**2. Add `formatUsdFloor` for balances.** For a balance, rounding to nearest is not merely imprecise — it is wrong in a specific direction: it can claim the wallet holds money it does not. It picks the same magnitude bucket, then truncates toward negative infinity, so the displayed figure is always money the user is certain to have. A negative balance is reachable (charging is post-paid, so a session can overrun the balance) and truncating toward −∞ moves a debt *away* from zero — the same conservative direction: never show less debt than is owed.

> The truncation happens in **integer micro-USD**, not float dollars. `4.95 * 100` is `494.99999999999994` in IEEE 754, so flooring in dollars would render an exact $4.95 balance as `$4.94`. Pinned by a test.

**3. Both balance surfaces switch to it** — the account panel, and the insufficient-balance blocker. That second one matters: it used to round 9,999 µUSD up to `$0.01`, overstating the balance in the one message whose entire job is to say the balance is short. It now reads `$0.009999`.

The 30-day usage line keeps rounding to nearest, which is lossless in its 6-decimal bucket and matches what the backend ledger shows.

## Verification

- `formatters.test.ts`: 22/22, case table aligned with the backend's
- the 6 affected test files: 120/120
- **full suite A/B**: 20 failing files on this branch, 20 on the clean base, `diff` **identical** — nothing here is new
- **`tsc --noEmit` A/B**: 342 errors on this branch, 342 on the clean base; the 2 in `UserAccountInfo.tsx` (analytics event name, lucide `title` prop) pre-date this change

The full-suite run also caught a test this change invalidates: `SubtitleIdle.test.tsx` asserted `/9999/` never appears on the button, guarding against rendering a raw wallet integer. At full precision the formatted amount *necessarily* contains the integer's own digits — `$0.009999` **is** 9,999 µUSD, correctly written. The assertion can no longer be expressed as digit absence, so it is now structural: those digits may only appear after a `$0.` decimal point.

## Known, not addressed here

A second cause of "usage moved but the balance didn't", entirely backend-side and out of scope for this PR: the balance is read through a KV cache (invalidated on charge, but KV deletion is eventually consistent), while the 30-day usage is read live from D1. For a short window after a session ends, usage can move while the balance lags. Distinguishable from this bug by the amount — if the balance is stale by more than the display precision, it is the cache, not the rounding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wallet balances now display with adaptive precision, showing up to six decimal places when needed.
  - Balance values are truncated rather than rounded for more accurate small-amount displays.

- **Bug Fixes**
  - Insufficient-balance messages now match the precision and truncation used in wallet balance displays.
  - Prevented misleading rounded values for very small balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->