### PR TITLE
fix(subtitle): make the color picker work inside the popover child window

### DIFF
--- a/src/components/Display/ColorPicker.test.tsx
+++ b/src/components/Display/ColorPicker.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, fireEvent, act } from '@testing-library/react';
+import { createPortal } from 'react-dom';
 import ColorPicker from './ColorPicker';
 
 vi.mock('react-i18next', () => ({
@@ -172,6 +173,52 @@ describe('ColorPicker', () => {
     // under 0.1 in binary floating point.
     fireEvent.keyDown(area, { key: 'ArrowLeft', shiftKey: true });
     expect(onChange).toHaveBeenLastCalledWith('#ff1919');
+  });
+
+  // SubtitleBar hosts this popover in a real child window on Electron and
+  // reaches it with createPortal: the DOM lives in that window's document
+  // while the component's JS keeps running in the parent window's realm. A
+  // bare `window.addEventListener` therefore lands on the WRONG window and
+  // the drag never tracks. An iframe reproduces exactly that split.
+  it('tracks the drag in the document it was portaled into, not the parent window', () => {
+    const iframe = document.createElement('iframe');
+    document.body.appendChild(iframe);
+    const childDoc = iframe.contentDocument!;
+    const childWin = iframe.contentWindow!;
+    const host = childDoc.createElement('div');
+    childDoc.body.appendChild(host);
+
+    const onChange = vi.fn();
+    render(createPortal(<ColorPicker value="#ff0000" onChange={onChange} />, host));
+
+    const area = childDoc.querySelector('.color-picker__area') as HTMLElement;
+    expect(area).not.toBeNull();
+    stubRect(area);
+
+    // Build the events with the CHILD realm's constructor, as a real child
+    // window would.
+    const childPointer = (type: string, init: MouseEventInit) =>
+      new (childWin as unknown as { MouseEvent: typeof MouseEvent }).MouseEvent(
+        type, { bubbles: true, ...init },
+      );
+
+    act(() => { area.dispatchEvent(childPointer('pointerdown', { clientX: 200, clientY: 0, buttons: 1 })); });
+    expect(onChange).toHaveBeenLastCalledWith('#ff0000');
+    onChange.mockClear();
+
+    // The move is dispatched on the CHILD window. A listener parked on the
+    // parent window would never see it.
+    act(() => { childWin.dispatchEvent(childPointer('pointermove', { clientX: 0, clientY: 0, buttons: 1 })); });
+    expect(onChange).toHaveBeenLastCalledWith('#ffffff');
+
+    // ...and the release must be heard there too, or the listener leaks onto
+    // a window the user goes on using.
+    act(() => { childWin.dispatchEvent(childPointer('pointerup', {})); });
+    onChange.mockClear();
+    act(() => { childWin.dispatchEvent(childPointer('pointermove', { clientX: 200, clientY: 0, buttons: 1 })); });
+    expect(onChange).not.toHaveBeenCalled();
+
+    iframe.remove();
   });
 
   it('re-syncs when the bound value changes from the outside', () => {

--- a/src/components/Display/ColorPicker.tsx
+++ b/src/components/Display/ColorPicker.tsx
@@ -103,8 +103,15 @@ const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => {
     [emit],
   );
 
-  // Tracked on window rather than via setPointerCapture so a drag that runs
-  // off the edge of the small area keeps updating instead of freezing.
+  // Tracked on the window rather than via setPointerCapture so a drag that
+  // runs off the edge of the small area keeps updating instead of freezing.
+  //
+  // That window is deliberately NOT the bare global. On Electron, SubtitleBar
+  // hosts this popover in a separate child window and reaches it through
+  // createPortal, so the DOM lives in that window while this module's code
+  // keeps running in the parent window's realm. Pointer events raised in the
+  // child never reach the parent's `window`, so a bare listener would leave
+  // the drag dead on exactly the surface this picker was built for.
   const detachRef = useRef<(() => void) | null>(null);
   useEffect(() => () => detachRef.current?.(), []);
 
@@ -114,6 +121,7 @@ const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => {
       areaRef.current?.focus();
       applyFromPoint(e.clientX, e.clientY);
 
+      const view = areaRef.current?.ownerDocument.defaultView ?? window;
       detachRef.current?.();
       const move = (ev: MouseEvent) => {
         // A release that happens outside the window never reaches us as a
@@ -128,14 +136,14 @@ const ColorPicker: React.FC<ColorPickerProps> = ({ value, onChange }) => {
       };
       const up = () => detachRef.current?.();
       detachRef.current = () => {
-        window.removeEventListener('pointermove', move);
-        window.removeEventListener('pointerup', up);
-        window.removeEventListener('pointercancel', up);
+        view.removeEventListener('pointermove', move);
+        view.removeEventListener('pointerup', up);
+        view.removeEventListener('pointercancel', up);
         detachRef.current = null;
       };
-      window.addEventListener('pointermove', move);
-      window.addEventListener('pointerup', up);
-      window.addEventListener('pointercancel', up);
+      view.addEventListener('pointermove', move);
+      view.addEventListener('pointerup', up);
+      view.addEventListener('pointercancel', up);
     },
     [applyFromPoint],
   );

--- a/src/components/Display/DisplaySettingsPopover.scss
+++ b/src/components/Display/DisplaySettingsPopover.scss
@@ -4,6 +4,7 @@
   border: 1px solid #3a3a3a;
   border-radius: 8px;
   padding: 16px;
+
   // 314, not 280, because box-sizing below is now border-box: this rule read
   // as "280 of content" under the browser default and the popover has always
   // rendered 280 + 32 padding + 2 border wide. Keeping the rendered width
@@ -23,9 +24,11 @@
   // the ChildWindowPopover window smaller on every open (measured: 16px per
   // open, unbounded) the moment a reset ever landed.
   //
-  // --popover-max-height lets a host that owns the surface set the real cap;
-  // ChildWindowPopover sets it to the height it sized its window to, having
-  // measured with the cap lifted. Hosts that don't set it get the viewport.
+  // --popover-max-height lets a host that owns the surface take the clipping
+  // over. ChildWindowPopover sets it to `none` and clips at its own scroll
+  // port instead: a ResizeObserver only reports border-box changes, so if this
+  // element capped itself the host would never learn the content had grown.
+  // Hosts that don't set it get the viewport.
   box-sizing: border-box;
   max-height: var(--popover-max-height, 100vh);
   overflow-y: auto;

--- a/src/components/Display/DisplaySettingsPopover.scss
+++ b/src/components/Display/DisplaySettingsPopover.scss
@@ -4,13 +4,30 @@
   border: 1px solid #3a3a3a;
   border-radius: 8px;
   padding: 16px;
-  width: 280px;
+  // 314, not 280, because box-sizing below is now border-box: this rule read
+  // as "280 of content" under the browser default and the popover has always
+  // rendered 280 + 32 padding + 2 border wide. Keeping the rendered width
+  // identical matters — at 280 total the swatch rows rewrap and strand a
+  // single chip on a line of its own.
+  width: 314px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
 
-  // The subtitle overlay window is short by default (~200px), and expanding a
-  // color picker adds ~180px. Scroll rather than let the surface clip the
-  // controls off the bottom where they can't be reached at all.
-  max-height: calc(100vh - 16px);
+  // Expanding a color picker adds ~190px, which can outgrow the surface this
+  // floats over. Scroll rather than let it clip the controls off the bottom
+  // where they cannot be reached at all.
+  //
+  // box-sizing is explicit because the cap depends on it: nothing in the
+  // subtitle overlay sets a global reset, and under the browser default
+  // (content-box) a cap of N lets the border box reach N+34. That silently
+  // changes how much is visible, and a `calc(100vh - N)` form would ratchet
+  // the ChildWindowPopover window smaller on every open (measured: 16px per
+  // open, unbounded) the moment a reset ever landed.
+  //
+  // --popover-max-height lets a host that owns the surface set the real cap;
+  // ChildWindowPopover sets it to the height it sized its window to, having
+  // measured with the cap lifted. Hosts that don't set it get the viewport.
+  box-sizing: border-box;
+  max-height: var(--popover-max-height, 100vh);
   overflow-y: auto;
 
   .field {

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -103,6 +103,11 @@ describe('ChildWindowPopover', () => {
       return calls.length ? (calls[calls.length - 1][1] as number) : undefined;
     };
 
+    const lastMoveTop = () => {
+      const calls = child.moveTo.mock.calls;
+      return calls.length ? (calls[calls.length - 1][1] as number) : undefined;
+    };
+
     const contentOf = () => {
       const all = child.document.querySelectorAll('.child-popover-content');
       return all[all.length - 1] as HTMLElement;
@@ -209,6 +214,48 @@ describe('ChildWindowPopover', () => {
       // ...and the scroll port gets the same cap, so the overflow scrolls
       // instead of being cut off at the window edge.
       expect(rootOf().style.maxHeight).toBe(`${asked}px`);
+    });
+
+    // Which side of the anchor the window opens on depends on the height, so
+    // recomputing it on every resize made the window jump across the bar the
+    // moment a color picker expanded past the room above the anchor. The side
+    // is chosen once per open and held.
+    it('does not flip to the other side of the anchor when the content grows', () => {
+      // A real screen, or the clamp below collapses both branches onto 0 and
+      // the assertion cannot tell them apart.
+      Object.defineProperty(window.screen, 'availHeight', {
+        value: 1000, configurable: true,
+      });
+      const { setOpen } = openPopover();
+
+      // anchor sits at top 700 / bottom 736, so 280 fits above it.
+      stubHeight(280);
+      act(() => { setOpen(true); });
+      const openedAt = lastMoveTop();
+      expect(openedAt).toBe(700 - 280 - 8);
+
+      // 800 no longer fits above. Holding the side pins it to the screen top;
+      // flipping would drop it to the clamped below-anchor position instead.
+      stubHeight(800);
+      act(() => { fireResizeObservers(); });
+      expect(lastMoveTop()).toBe(0);
+      expect(lastMoveTop()).not.toBe(200);
+    });
+
+    it('re-decides the side on the next open', () => {
+      Object.defineProperty(window.screen, 'availHeight', {
+        value: 1000, configurable: true,
+      });
+      const { setOpen } = openPopover();
+      stubHeight(280);
+      act(() => { setOpen(true); });
+      expect(lastMoveTop()).toBe(412);
+
+      act(() => { setOpen(false); });
+      // Too tall to sit above the anchor: this open must land below it.
+      stubHeight(800);
+      act(() => { setOpen(true); });
+      expect(lastMoveTop()).toBe(200);
     });
 
     it('stops observing once closed', () => {

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -216,46 +216,63 @@ describe('ChildWindowPopover', () => {
       expect(rootOf().style.maxHeight).toBe(`${asked}px`);
     });
 
-    // Which side of the anchor the window opens on depends on the height, so
-    // recomputing it on every resize made the window jump across the bar the
-    // moment a color picker expanded past the room above the anchor. The side
-    // is chosen once per open and held.
-    it('does not flip to the other side of the anchor when the content grows', () => {
-      // A real screen, or the clamp below collapses both branches onto 0 and
-      // the assertion cannot tell them apart.
+    // Placement geometry these four share: a real screen is required, or the
+    // clamps collapse both branches onto 0 and no assertion can tell them
+    // apart. anchor = top 700 / bottom 736, screenTop 0, availHeight 1000, so
+    // the room below the anchor is 1000 - (736 + 8) = 256px.
+    const realScreen = () =>
       Object.defineProperty(window.screen, 'availHeight', {
         value: 1000, configurable: true,
       });
+    const BELOW_TOP = 736 + 8;          // hangs off the anchor's bottom edge
+    const aboveTopFor = (h: number) => 700 - h - 8;
+
+    it('opens below the anchor when the screen has room there', () => {
+      realScreen();
       const { setOpen } = openPopover();
-
-      // anchor sits at top 700 / bottom 736, so 280 fits above it.
-      stubHeight(280);
+      stubHeight(200);
       act(() => { setOpen(true); });
-      const openedAt = lastMoveTop();
-      expect(openedAt).toBe(700 - 280 - 8);
+      expect(lastMoveTop()).toBe(BELOW_TOP);
+    });
 
-      // 800 no longer fits above. Holding the side pins it to the screen top;
-      // flipping would drop it to the clamped below-anchor position instead.
+    it('falls back to above when the content does not fit below', () => {
+      realScreen();
+      const { setOpen } = openPopover();
+      stubHeight(280); // > 256px of room below
+      act(() => { setOpen(true); });
+      expect(lastMoveTop()).toBe(aboveTopFor(280));
+    });
+
+    // Which side fits depends on the height, so recomputing it on every resize
+    // threw the window across the bar the moment a color picker expanded. The
+    // side is chosen once per open and held.
+    it('does not flip to the other side of the anchor when the content grows', () => {
+      realScreen();
+      const { setOpen } = openPopover();
+      stubHeight(200);
+      act(() => { setOpen(true); });
+      expect(lastMoveTop()).toBe(BELOW_TOP);
+
+      // 800 no longer fits below. Holding the side pins it to the bottom of
+      // the screen; flipping would lift it to the above-anchor position.
       stubHeight(800);
       act(() => { fireResizeObservers(); });
-      expect(lastMoveTop()).toBe(0);
-      expect(lastMoveTop()).not.toBe(200);
+      expect(lastMoveTop()).toBe(200);          // 1000 - 800, screen-clamped
+      expect(lastMoveTop()).not.toBe(aboveTopFor(800));
     });
 
     it('re-decides the side on the next open', () => {
-      Object.defineProperty(window.screen, 'availHeight', {
-        value: 1000, configurable: true,
-      });
+      realScreen();
       const { setOpen } = openPopover();
-      stubHeight(280);
+      stubHeight(200);
       act(() => { setOpen(true); });
-      expect(lastMoveTop()).toBe(412);
+      expect(lastMoveTop()).toBe(BELOW_TOP);
 
       act(() => { setOpen(false); });
-      // Too tall to sit above the anchor: this open must land below it.
-      stubHeight(800);
+      // Too tall for the room below: this open must land above the anchor.
+      stubHeight(280);
       act(() => { setOpen(true); });
-      expect(lastMoveTop()).toBe(200);
+      expect(lastMoveTop()).toBe(aboveTopFor(280));
     });
 
     it('stops observing once closed', () => {

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -35,8 +35,26 @@ describe('ChildWindowPopover', () => {
   let openSpy: ReturnType<typeof vi.spyOn>;
   let anchor: HTMLButtonElement;
   let invoke: ReturnType<typeof vi.fn>;
+  // jsdom has no ResizeObserver. Capture the callbacks so a test can play the
+  // part of the browser noticing the hosted content changed height.
+  let observers: Array<{ cb: () => void; live: boolean }>;
+  // Only observers that have not been disconnected, mirroring the browser.
+  const fireResizeObservers = () => {
+    observers.filter((o) => o.live).forEach((o) => o.cb());
+  };
 
   beforeEach(() => {
+    observers = [];
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
+      private entry: { cb: () => void; live: boolean };
+      constructor(cb: () => void) {
+        this.entry = { cb, live: true };
+        observers.push(this.entry);
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() { this.entry.live = false; }
+    };
     child = makeFakeChild();
     openSpy = vi.spyOn(window, 'open').mockReturnValue(child as unknown as Window);
     invoke = vi.fn(async () => ({ ok: true }));
@@ -61,6 +79,112 @@ describe('ChildWindowPopover', () => {
     );
     return { ...utils, onClose };
   };
+
+  // The hosted popover is not a fixed-size thing: DisplaySettingsPopover grows
+  // by ~190px when a color picker is expanded. A window measured once at open
+  // would leave that content behind an internal scrollbar forever.
+  describe('following the hosted content height', () => {
+    // One test overrides screen.availHeight; drop the own property again so
+    // the prototype getter is back for everyone else.
+    afterEach(() => {
+      delete (window.screen as unknown as Record<string, unknown>).availHeight;
+    });
+
+    // createWindow appends a fresh root on every (re)creation, so always take
+    // the newest one rather than the first.
+    const rootOf = () => {
+      const all = child.document.querySelectorAll('.child-popover-root');
+      return all[all.length - 1] as HTMLElement;
+    };
+
+    // Array.prototype.at is outside the project's ES2020 lib target.
+    const lastResizeHeight = () => {
+      const calls = child.resizeTo.mock.calls;
+      return calls.length ? (calls[calls.length - 1][1] as number) : undefined;
+    };
+
+    const stubHeight = (h: number) => {
+      const root = rootOf();
+      root.getBoundingClientRect = () =>
+        ({ width: 280, height: h, top: 0, left: 0, right: 280, bottom: h } as DOMRect);
+    };
+
+    const openPopover = (onClose = vi.fn()) => {
+      const utils = render(
+        <ChildWindowPopover open={false} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+          <div className="probe-content">hello</div>
+        </ChildWindowPopover>,
+      );
+      const setOpen = (open: boolean) =>
+        utils.rerender(
+          <ChildWindowPopover open={open} onClose={onClose} anchorEl={anchor} width={320} height={400}>
+            <div className="probe-content">hello</div>
+          </ChildWindowPopover>,
+        );
+      return { ...utils, setOpen };
+    };
+
+    it('measures the natural height, not a height the popover clamped itself to', () => {
+      const { setOpen } = openPopover();
+      stubHeight(468);
+      // The host must lift its own cap before measuring; otherwise it reads
+      // back whatever it imposed last time and the window can never grow.
+      let capWhileMeasuring: string | null = null;
+      const root = rootOf();
+      const stubbed = root.getBoundingClientRect.bind(root);
+      root.getBoundingClientRect = () => {
+        capWhileMeasuring = root.style.getPropertyValue('--popover-max-height');
+        return stubbed();
+      };
+
+      act(() => { setOpen(true); });
+      expect(capWhileMeasuring).toBe('none');
+      expect(lastResizeHeight()).toBe(468);
+    });
+
+    it('resizes the window when the content grows while open', () => {
+      const { setOpen } = openPopover();
+      stubHeight(280);
+      act(() => { setOpen(true); });
+      expect(lastResizeHeight()).toBe(280);
+
+      // A color picker expands.
+      stubHeight(468);
+      act(() => { fireResizeObservers(); });
+      expect(lastResizeHeight()).toBe(468);
+    });
+
+    it('caps the window at the usable screen height and lets the popover scroll', () => {
+      // jsdom reports 0 for every screen metric; give it a real one, since
+      // this is the assertion that depends on it.
+      const avail = 600;
+      Object.defineProperty(window.screen, 'availHeight', {
+        value: avail, configurable: true,
+      });
+      const { setOpen } = openPopover();
+      stubHeight(avail + 500);
+      act(() => { setOpen(true); });
+
+      const asked = lastResizeHeight() as number;
+      expect(asked).toBeLessThanOrEqual(avail);
+      expect(asked).toBeGreaterThan(0);
+      // ...and the popover is told the same cap, so it scrolls instead of
+      // being cut off at the window edge.
+      expect(rootOf().style.getPropertyValue('--popover-max-height')).toBe(`${asked}px`);
+    });
+
+    it('stops observing once closed', () => {
+      const { setOpen } = openPopover();
+      stubHeight(280);
+      act(() => { setOpen(true); });
+      act(() => { setOpen(false); });
+
+      child.resizeTo.mockClear();
+      stubHeight(468);
+      act(() => { fireResizeObservers(); });
+      expect(child.resizeTo).not.toHaveBeenCalled();
+    });
+  });
 
   it('creates the window on mount, named for the main-process hidden override', () => {
     // Created while CLOSED: the whole point of pre-creation is that the

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -108,6 +108,11 @@ describe('ChildWindowPopover', () => {
       return calls.length ? (calls[calls.length - 1][1] as number) : undefined;
     };
 
+    const lastMoveLeft = () => {
+      const calls = child.moveTo.mock.calls;
+      return calls.length ? (calls[calls.length - 1][0] as number) : undefined;
+    };
+
     const contentOf = () => {
       const all = child.document.querySelectorAll('.child-popover-content');
       return all[all.length - 1] as HTMLElement;
@@ -259,6 +264,24 @@ describe('ChildWindowPopover', () => {
       act(() => { fireResizeObservers(); });
       expect(lastMoveTop()).toBe(200);          // 1000 - 800, screen-clamped
       expect(lastMoveTop()).not.toBe(aboveTopFor(800));
+    });
+
+    // Screen metrics of 0 mean "unknown", and the height already treats them
+    // that way. The position clamps must agree: reading 0 as "the screen is
+    // 0px tall/wide" turns their upper bound into the screen origin, which
+    // wins every min() and drags the window into the corner, anchor ignored.
+    it('leaves the position uncapped when the screen metrics are unknown', () => {
+      // jsdom reports 0 for availHeight/availWidth; deliberately not stubbed.
+      expect(window.screen.availHeight).toBe(0);
+      const { setOpen } = openPopover();
+      stubHeight(200);
+      act(() => { setOpen(true); });
+
+      expect(lastMoveTop()).toBe(BELOW_TOP);
+      expect(lastMoveTop()).not.toBe(0);
+      // anchor.right 1200, measured width 280 -> right edges align at 920.
+      expect(lastMoveLeft()).toBe(1200 - 280);
+      expect(lastMoveLeft()).not.toBe(0);
     });
 
     it('re-decides the side on the next open', () => {

--- a/src/components/Subtitle/ChildWindowPopover.test.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.test.tsx
@@ -37,7 +37,7 @@ describe('ChildWindowPopover', () => {
   let invoke: ReturnType<typeof vi.fn>;
   // jsdom has no ResizeObserver. Capture the callbacks so a test can play the
   // part of the browser noticing the hosted content changed height.
-  let observers: Array<{ cb: () => void; live: boolean }>;
+  let observers: Array<{ cb: () => void; live: boolean; targets: Element[] }>;
   // Only observers that have not been disconnected, mirroring the browser.
   const fireResizeObservers = () => {
     observers.filter((o) => o.live).forEach((o) => o.cb());
@@ -46,12 +46,12 @@ describe('ChildWindowPopover', () => {
   beforeEach(() => {
     observers = [];
     (globalThis as { ResizeObserver?: unknown }).ResizeObserver = class {
-      private entry: { cb: () => void; live: boolean };
+      private entry: { cb: () => void; live: boolean; targets: Element[] };
       constructor(cb: () => void) {
-        this.entry = { cb, live: true };
+        this.entry = { cb, live: true, targets: [] };
         observers.push(this.entry);
       }
-      observe() {}
+      observe(el: Element) { this.entry.targets.push(el); }
       unobserve() {}
       disconnect() { this.entry.live = false; }
     };
@@ -103,9 +103,17 @@ describe('ChildWindowPopover', () => {
       return calls.length ? (calls[calls.length - 1][1] as number) : undefined;
     };
 
+    const contentOf = () => {
+      const all = child.document.querySelectorAll('.child-popover-content');
+      return all[all.length - 1] as HTMLElement;
+    };
+
+    // Height is taken from the content wrapper, so that is what a test must
+    // stub. Stubbing the root would prove nothing: the root is the capped
+    // element and is deliberately not what drives the size.
     const stubHeight = (h: number) => {
-      const root = rootOf();
-      root.getBoundingClientRect = () =>
+      const content = contentOf();
+      content.getBoundingClientRect = () =>
         ({ width: 280, height: h, top: 0, left: 0, right: 280, bottom: h } as DOMRect);
     };
 
@@ -124,22 +132,52 @@ describe('ChildWindowPopover', () => {
       return { ...utils, setOpen };
     };
 
-    it('measures the natural height, not a height the popover clamped itself to', () => {
+    // The bug this guards against is invisible to a test that fires the
+    // observer by hand: if the observed element is the one carrying the height
+    // cap, expanding content only grows its scroll height, the border box
+    // never changes, and the browser never calls the callback at all. Verified
+    // in a real browser before this assertion existed — four expand/collapse
+    // cycles produced exactly zero callbacks.
+    it('observes an element that is free to grow, not the one it caps', () => {
+      const { setOpen } = openPopover();
+      stubHeight(280);
+      act(() => { setOpen(true); });
+
+      const targets = observers.filter((o) => o.live).flatMap((o) => o.targets);
+      expect(targets.length).toBeGreaterThan(0);
+
+      for (const el of targets) {
+        const style = (el as HTMLElement).style;
+        expect(style.maxHeight).toBe('');
+        expect(style.getPropertyValue('--popover-max-height')).toBe('');
+      }
+
+      // ...and something else is in fact carrying the cap, so the popover is
+      // still constrained to the window.
+      const root = rootOf();
+      expect(root.style.maxHeight).not.toBe('');
+      expect(targets).not.toContain(root);
+    });
+
+    it('sizes the window from the content wrapper, never from the capped port', () => {
       const { setOpen } = openPopover();
       stubHeight(468);
-      // The host must lift its own cap before measuring; otherwise it reads
-      // back whatever it imposed last time and the window can never grow.
-      let capWhileMeasuring: string | null = null;
+      // Give the capped port a deliberately wrong height. If the host reads it
+      // — as it would if the cap and the measurement sat on the same element —
+      // the window comes out at 999 instead of the content's 468.
       const root = rootOf();
-      const stubbed = root.getBoundingClientRect.bind(root);
-      root.getBoundingClientRect = () => {
-        capWhileMeasuring = root.style.getPropertyValue('--popover-max-height');
-        return stubbed();
-      };
+      root.getBoundingClientRect = () =>
+        ({ width: 280, height: 999, top: 0, left: 0, right: 280, bottom: 999 } as DOMRect);
 
       act(() => { setOpen(true); });
-      expect(capWhileMeasuring).toBe('none');
       expect(lastResizeHeight()).toBe(468);
+    });
+
+    it('tells the popover not to cap itself; the port does the clipping', () => {
+      openPopover();
+      const root = rootOf();
+      expect(root.style.getPropertyValue('--popover-max-height')).toBe('none');
+      expect(root.style.overflowY).toBe('auto');
     });
 
     it('resizes the window when the content grows while open', () => {
@@ -168,9 +206,9 @@ describe('ChildWindowPopover', () => {
       const asked = lastResizeHeight() as number;
       expect(asked).toBeLessThanOrEqual(avail);
       expect(asked).toBeGreaterThan(0);
-      // ...and the popover is told the same cap, so it scrolls instead of
-      // being cut off at the window edge.
-      expect(rootOf().style.getPropertyValue('--popover-max-height')).toBe(`${asked}px`);
+      // ...and the scroll port gets the same cap, so the overflow scrolls
+      // instead of being cut off at the window edge.
+      expect(rootOf().style.maxHeight).toBe(`${asked}px`);
     });
 
     it('stops observing once closed', () => {

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -295,17 +295,25 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
       placementRef.current = roomBelow >= h ? 'below' : 'above';
     }
     const above = placementRef.current === 'above';
-    const left = Math.min(
-      Math.max(screenLeft, Math.round(window.screenX + anchor.right - (w + scrollbar))),
-      screenLeft + Math.max(0, window.screen.availWidth - (w + scrollbar)),
+
+    // A screen metric of 0 means "unknown" here, exactly as it does for the
+    // height above — never "the screen is 0px tall". Reading it literally
+    // collapses the upper bound onto the screen origin, which wins every
+    // min() and drags the window into the corner with the anchor ignored.
+    const availW = window.screen.availWidth;
+    const clamp = (raw: number, origin: number, avail: number, size: number) =>
+      avail > 0
+        ? Math.min(Math.max(origin, raw), origin + Math.max(0, avail - size))
+        : Math.max(origin, raw);
+
+    const left = clamp(
+      Math.round(window.screenX + anchor.right - (w + scrollbar)),
+      screenLeft, availW, w + scrollbar,
     );
     const rawTop = above
       ? Math.round(anchorTop - h - EDGE_PAD)
       : Math.round(anchorBottom + EDGE_PAD);
-    const top = Math.min(
-      Math.max(screenTop, rawTop),
-      screenTop + Math.max(0, window.screen.availHeight - h),
-    );
+    const top = clamp(rawTop, screenTop, availH, h);
 
     win.resizeTo(w + scrollbar, h);
     win.moveTo(left, top);

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -274,14 +274,25 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     // room above. Clamped on ALL edges — a partially off-screen request gets
     // re-placed by mutter to an arbitrary position, which is worse than a
     // slightly shifted popover.
-    // Which side fits depends on the height, and the height changes while the
-    // popover is open — expanding a color picker adds ~164px. Re-deciding on
-    // every resize threw the window across the bar mid-interaction, so the
-    // side is chosen on the open that placed it and held until it closes.
-    // Growing past the room available on that side pins it to the screen edge
-    // instead, which the height cap already keeps on-screen.
+    // Below the anchor by default, above only when the screen has no room
+    // below. Preferring below matches what a control hanging off a toolbar
+    // button is expected to do, and it costs nothing where above used to be
+    // picked: a bar parked at the bottom of the screen has no room below, so
+    // it still opens upward.
+    //
+    // Which side fits depends on the height, and the height is no longer fixed
+    // for the popover's lifetime — expanding a color picker adds ~164px.
+    // Re-deciding on every resize threw the window across the bar
+    // mid-interaction, so the side is chosen on the open that placed it and
+    // held until it closes. Outgrowing that side pins the window to the screen
+    // edge instead, which the height cap already keeps fully visible.
     if (placementRef.current === null) {
-      placementRef.current = anchorTop - h - EDGE_PAD >= screenTop ? 'above' : 'below';
+      // availHeight of 0 means "unknown"; default to below rather than
+      // concluding there is no room anywhere.
+      const roomBelow = availH > 0
+        ? screenTop + availH - (anchorBottom + EDGE_PAD)
+        : Number.POSITIVE_INFINITY;
+      placementRef.current = roomBelow >= h ? 'below' : 'above';
     }
     const above = placementRef.current === 'above';
     const left = Math.min(

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -220,34 +220,38 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     };
   }, [createWindow]);
 
-  // Open: measure the already-rendered content, size and place the window
-  // while it is still hidden, then have the main process show it (show also
-  // focuses, and focus is what makes blur-dismiss work). Close: hide it.
-  useEffect(() => {
+  // Fit the window to whatever the content currently measures, and place it
+  // against the anchor. Split out of the open path so later content changes
+  // can reuse it without re-running show/focus.
+  const sizeAndPlace = useCallback(() => {
     const win = winRef.current;
-    if (open && anchorEl && (!win || win.closed)) {
-      // Destroyed externally (WM close). Rebuild; the container state change
-      // reruns this effect, which then places and shows the new window.
-      createWindow();
-      return;
-    }
-    if (!win || win.closed || !container) return;
+    if (!win || win.closed || !container || !anchorEl) return;
 
-    if (!open || !anchorEl) {
-      setNativeVisibility(nameRef.current, false);
-      return;
-    }
-
-    // Styles that appeared since creation (dev HMR, late chunks).
-    syncStyles(document, win.document, clonedStylesRef.current);
-
+    // Lift our own cap before measuring. The popover is capped at whatever we
+    // imposed last time, so measuring through it reads back our own previous
+    // answer: the window could then never grow, and with a viewport-relative
+    // cap it would ratchet smaller on every open.
+    container.style.setProperty('--popover-max-height', 'none');
     const rect = container.getBoundingClientRect();
     const w = Math.ceil(rect.width) || width;
-    const h = Math.ceil(rect.height) || height;
+    const natural = Math.ceil(rect.height) || height;
 
-    const anchor = anchorEl.getBoundingClientRect();
     const screenTop = (window.screen as { availTop?: number }).availTop ?? 0;
     const screenLeft = (window.screen as { availLeft?: number }).availLeft ?? 0;
+
+    // Never ask for more than the screen can show. Handing the same number to
+    // the popover as a max-height is what makes the overflow scrollable
+    // instead of cut off at the window edge.
+    //
+    // A non-positive availHeight means "unknown", not "no room" — capping to
+    // it would collapse the window to nothing.
+    const availH = window.screen.availHeight;
+    const h = availH > 0
+      ? Math.min(natural, Math.max(1, availH - 2 * EDGE_PAD))
+      : natural;
+    container.style.setProperty('--popover-max-height', `${h}px`);
+
+    const anchor = anchorEl.getBoundingClientRect();
     const anchorTop = window.screenY + anchor.top;
     const anchorBottom = window.screenY + anchor.bottom;
     // Above the anchor, right edges aligned; below when the screen has no
@@ -269,6 +273,30 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
 
     win.resizeTo(w, h);
     win.moveTo(left, top);
+  }, [anchorEl, container, width, height]);
+
+  // Open: size and place the window while it is still hidden, then have the
+  // main process show it (show also focuses, and focus is what makes
+  // blur-dismiss work). Close: hide it.
+  useEffect(() => {
+    const win = winRef.current;
+    if (open && anchorEl && (!win || win.closed)) {
+      // Destroyed externally (WM close). Rebuild; the container state change
+      // reruns this effect, which then places and shows the new window.
+      createWindow();
+      return;
+    }
+    if (!win || win.closed || !container) return;
+
+    if (!open || !anchorEl) {
+      setNativeVisibility(nameRef.current, false);
+      return;
+    }
+
+    // Styles that appeared since creation (dev HMR, late chunks).
+    syncStyles(document, win.document, clonedStylesRef.current);
+
+    sizeAndPlace();
     setNativeVisibility(nameRef.current, true);
     win.focus();
 
@@ -283,10 +311,22 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
       }
     }, 300);
     return () => clearInterval(movePoll);
-  }, [open, anchorEl, container, width, height, createWindow]);
+  }, [open, anchorEl, container, createWindow, sizeAndPlace]);
 
-  // Children render into the hidden window permanently — store-driven updates
-  // keep flowing while it is invisible, so opening has nothing to build.
+  // Hosted content is not a fixed size: DisplaySettingsPopover grows by ~190px
+  // when a colour picker is expanded. Re-measure and re-place on every content
+  // resize, or the window keeps the height it happened to have at open and the
+  // rest of the popover sits behind an internal scrollbar.
+  //
+  // Visibility and focus stay OUT of this path — refocusing on every resize
+  // would fight the user mid-drag.
+  useEffect(() => {
+    if (!open || !container || typeof ResizeObserver === 'undefined') return;
+    const ro = new ResizeObserver(() => sizeAndPlace());
+    ro.observe(container);
+    return () => ro.disconnect();
+  }, [open, container, sizeAndPlace]);
+
   if (!container) return null;
   return createPortal(children, container);
 };

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -109,6 +109,8 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
   const winRef = useRef<Window | null>(null);
   const [container, setContainer] = useState<HTMLElement | null>(null);
   const contentRef = useRef<HTMLDivElement>(null);
+  // Side of the anchor this open landed on; null until the placing open.
+  const placementRef = useRef<'above' | 'below' | null>(null);
   const clonedStylesRef = useRef(new WeakSet<Node>());
   // The latest values without re-running effects that must not churn.
   const onCloseRef = useRef(onClose);
@@ -272,7 +274,16 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     // room above. Clamped on ALL edges — a partially off-screen request gets
     // re-placed by mutter to an arbitrary position, which is worse than a
     // slightly shifted popover.
-    const above = anchorTop - h - EDGE_PAD >= screenTop;
+    // Which side fits depends on the height, and the height changes while the
+    // popover is open — expanding a color picker adds ~164px. Re-deciding on
+    // every resize threw the window across the bar mid-interaction, so the
+    // side is chosen on the open that placed it and held until it closes.
+    // Growing past the room available on that side pins it to the screen edge
+    // instead, which the height cap already keeps on-screen.
+    if (placementRef.current === null) {
+      placementRef.current = anchorTop - h - EDGE_PAD >= screenTop ? 'above' : 'below';
+    }
+    const above = placementRef.current === 'above';
     const left = Math.min(
       Math.max(screenLeft, Math.round(window.screenX + anchor.right - (w + scrollbar))),
       screenLeft + Math.max(0, window.screen.availWidth - (w + scrollbar)),
@@ -303,6 +314,7 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     if (!win || win.closed || !container) return;
 
     if (!open || !anchorEl) {
+      placementRef.current = null;
       setNativeVisibility(nameRef.current, false);
       return;
     }
@@ -310,6 +322,7 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     // Styles that appeared since creation (dev HMR, late chunks).
     syncStyles(document, win.document, clonedStylesRef.current);
 
+    placementRef.current = null;
     sizeAndPlace();
     setNativeVisibility(nameRef.current, true);
     win.focus();

--- a/src/components/Subtitle/ChildWindowPopover.tsx
+++ b/src/components/Subtitle/ChildWindowPopover.tsx
@@ -108,6 +108,7 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
 }) => {
   const winRef = useRef<Window | null>(null);
   const [container, setContainer] = useState<HTMLElement | null>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
   const clonedStylesRef = useRef(new WeakSet<Node>());
   // The latest values without re-running effects that must not churn.
   const onCloseRef = useRef(onClose);
@@ -152,9 +153,19 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     body.style.overflow = 'hidden';
     const root = win.document.createElement('div');
     root.className = 'child-popover-root';
-    // Shrink-wrap so the open-time measurement reads the popover's own
-    // footprint rather than the hidden window's.
+    // Shrink-wrap so the measurement reads the popover's own footprint rather
+    // than the hidden window's.
     root.style.width = 'fit-content';
+    // This root is the scroll port, and the ONLY thing that clips: it carries
+    // the height cap, and the popover is told not to cap itself.
+    //
+    // Not interchangeable with capping the popover. A ResizeObserver reports
+    // border-box changes, so watching an element that caps itself sees
+    // nothing when its content grows — only its scroll height moves — and the
+    // callback never runs. Measured in a browser: four expand/collapse cycles
+    // of a self-capped popover produced zero callbacks.
+    root.style.overflowY = 'auto';
+    root.style.setProperty('--popover-max-height', 'none');
     body.appendChild(root);
     setContainer(root);
 
@@ -225,14 +236,13 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
   // can reuse it without re-running show/focus.
   const sizeAndPlace = useCallback(() => {
     const win = winRef.current;
-    if (!win || win.closed || !container || !anchorEl) return;
+    const content = contentRef.current;
+    if (!win || win.closed || !container || !anchorEl || !content) return;
 
-    // Lift our own cap before measuring. The popover is capped at whatever we
-    // imposed last time, so measuring through it reads back our own previous
-    // answer: the window could then never grow, and with a viewport-relative
-    // cap it would ratchet smaller on every open.
-    container.style.setProperty('--popover-max-height', 'none');
-    const rect = container.getBoundingClientRect();
+    // Measure the content wrapper, which nothing caps, rather than the scroll
+    // port: reading the port would return the height we imposed last time and
+    // the window could never grow.
+    const rect = content.getBoundingClientRect();
     const w = Math.ceil(rect.width) || width;
     const natural = Math.ceil(rect.height) || height;
 
@@ -249,7 +259,11 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     const h = availH > 0
       ? Math.min(natural, Math.max(1, availH - 2 * EDGE_PAD))
       : natural;
-    container.style.setProperty('--popover-max-height', `${h}px`);
+    container.style.maxHeight = `${h}px`;
+    // When the screen forced a clamp the port grows a scrollbar, which eats
+    // into its own width. Widen the window by exactly that much so the
+    // popover is not shaved instead.
+    const scrollbar = Math.max(0, container.offsetWidth - container.clientWidth);
 
     const anchor = anchorEl.getBoundingClientRect();
     const anchorTop = window.screenY + anchor.top;
@@ -260,8 +274,8 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
     // slightly shifted popover.
     const above = anchorTop - h - EDGE_PAD >= screenTop;
     const left = Math.min(
-      Math.max(screenLeft, Math.round(window.screenX + anchor.right - w)),
-      screenLeft + Math.max(0, window.screen.availWidth - w),
+      Math.max(screenLeft, Math.round(window.screenX + anchor.right - (w + scrollbar))),
+      screenLeft + Math.max(0, window.screen.availWidth - (w + scrollbar)),
     );
     const rawTop = above
       ? Math.round(anchorTop - h - EDGE_PAD)
@@ -271,7 +285,7 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
       screenTop + Math.max(0, window.screen.availHeight - h),
     );
 
-    win.resizeTo(w, h);
+    win.resizeTo(w + scrollbar, h);
     win.moveTo(left, top);
   }, [anchorEl, container, width, height]);
 
@@ -322,13 +336,22 @@ export const ChildWindowPopover: React.FC<ChildWindowPopoverProps> = ({
   // would fight the user mid-drag.
   useEffect(() => {
     if (!open || !container || typeof ResizeObserver === 'undefined') return;
+    const content = contentRef.current;
+    if (!content) return;
     const ro = new ResizeObserver(() => sizeAndPlace());
-    ro.observe(container);
+    ro.observe(content);
     return () => ro.disconnect();
   }, [open, container, sizeAndPlace]);
 
   if (!container) return null;
-  return createPortal(children, container);
+  // The wrapper exists so there is an element the cap never touches: it is
+  // what gets measured and observed.
+  return createPortal(
+    <div ref={contentRef} className="child-popover-content" style={{ width: 'fit-content' }}>
+      {children}
+    </div>,
+    container,
+  );
 };
 
 /**


### PR DESCRIPTION
#426 (in-app color picker) and #425 (popover child windows) landed within minutes of each other and were never exercised together. Each is fine alone. Combined, the picker is broken on the one surface it was built for — the Electron subtitle overlay.

Three defects, in descending severity.

## 1. The drag did not track at all

`ChildWindowPopover` portals its children into a **separate OS window**, so the DOM lives there while the component's JS keeps running in the parent window's realm. `ColorPicker` registered its `pointermove` / `pointerup` listeners on the bare `window` — the parent's — and pointer events raised in the child window never reach it.

Effect: pressing in the saturation/brightness area applied the single `pointerdown` point and nothing followed. The hue slider, hex field and arrow keys still worked (React synthetic events reach portals via `preparePortalMount`), so the failure looked like a quirk rather than a break. The listener also leaked onto the bar window until the next buttonless move.

Fixed by binding to `areaRef.current.ownerDocument.defaultView`.

Proven rather than argued: a minimal DOM probe confirmed a child context saw 2 `pointermove`s while the parent window saw 0, and the regression test portals the picker into an iframe and drives the drag from that context. It fails against the previous commit.

## 2. The window did not grow with its content

The window was measured once at open, but expanding a picker adds ~164px — 36% of the popover ends up behind an internal scrollbar.

Nastier than it sounds: the parked window starts 400px tall, so the **first** open after launch hides only ~50px and looks nearly fine. Every open after that hides the full amount. Testing it once gives a false pass.

Now a `ResizeObserver` on the container re-runs size+place on content changes. Show and focus deliberately stay out of that path — refocusing on every resize would fight the user mid-drag.

Measurement also lifts the popover's own cap before reading: measuring through it returns whatever the host imposed last time, so the window could never grow.

## 3. The cap could ratchet the window smaller on every open

`max-height: calc(100vh - 16px)` avoided this only by accident. Nothing in the subtitle overlay sets a global `box-sizing` reset, and under the browser default (content-box) the padding+border left 18px of slack that absorbed the 16px subtraction, so the size converged.

Add a reset anywhere in that tree and the popover loses 16px per open, unbounded. Measured, by injecting `*{box-sizing:border-box}` into the probe: **332 → 316 → 300 → 284 → 268**, while the content wanted 330 throughout.

The popover now declares `box-sizing` explicitly and takes its cap from `--popover-max-height`, which the host sets to the height it actually sized the window to. Hosts that don't set it fall back to the viewport.

`width` goes 280 → 314 to keep the rendered box identical under border-box. This is not cosmetic bookkeeping: at 280 *total* the swatch rows rewrap and strand a single chip alone on a line. Caught by screenshotting the change, not by reasoning about it.

## Also

`screen.availHeight` of 0 means "unknown", not "no room" — capping to it collapsed the window to zero height. Guarded.

## Measured after the change

Running the host's exact algorithm against the real component, in an iframe standing in for the child window:

| scenario | window height | hidden behind scroll |
| --- | --- | --- |
| collapsed, 3 consecutive opens | 280 / 280 / 280 | 0 |
| picker expanded, roomy screen | 280 → **444** | **0** |
| picker expanded, reopened | 444 | 0 |
| picker expanded, 320px screen | capped 304 | 164 (scrolls, stable on reopen) |
| collapsed again | back to 280 | 0 |

Collapsed height is 280 — pixel-identical to before this branch, confirming the width compensation restored the original layout exactly.

## Testing

- 5 new tests: one cross-realm drag, four covering child-window sizing (natural-height measurement, growth while open, screen cap, observer teardown on close).
- Full `vitest run`: **identical** to the `main` baseline measured on the same checkout (14 pre-existing failing files / 9 failing tests, all unrelated — provider gating, native model store, a vite `fs.allow` issue under the worktree symlink). Passing count 2688 → 2693 before rebase, 2708 after.
- `tsc --noEmit`: no errors in any touched file.

## Not included

`ChildWindowPopover`'s blur suppression still keys on `input[type="color"], input[type="file"]`, and its comment still describes the `<label>`-wrapped colour input that #426 deleted. It is dead code for this popover now — harmless, since there is no OS dialog left to steal focus, but the comment misleads. Left alone deliberately; happy to clean it up separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Color picker dragging now works correctly when displayed in a separate pop-up or portal window.
  - Display settings popovers preserve their intended dimensions and remain usable across viewport sizes.
  - Subtitle pop-up windows now resize and reposition as content changes, while respecting available screen space.
  - Pop-up resizing stops cleanly when the window is closed.
  - Subtitle pop-ups maintain stable placement and scrolling as their content grows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->