### PR TITLE
fix(electron): enforce a single instance on Windows and Linux

### DIFF
--- a/electron/entry-map.consistency.test.js
+++ b/electron/entry-map.consistency.test.js
@@ -1,0 +1,79 @@
+// electron/entry-map.consistency.test.js
+//
+// The main-process build has a hand-written entry map in vite.config.ts, and a
+// companion `external: [/^\.\/[a-z0-9-]+$/]` rule that keeps every relative
+// sibling require a runtime require instead of inlining it (rolldown mangles
+// CJS exports when it inlines an entry — see the comment on that rule).
+//
+// Those two halves must agree. Add a module under electron/, require it from
+// another main-process file, and forget the entry line, and the failure is
+// silent in every place you would look: `npm run build` succeeds with no
+// warning, dist-electron/main.js still emits require("./your-module"), and the
+// whole vitest suite stays green because tests require the *source* file and
+// never touch the bundle. The only symptom is the packaged app dying at
+// startup with MODULE_NOT_FOUND. This test is the missing signal.
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const electronDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(electronDir, '..');
+
+/**
+ * The `entry: { ... }` map of the electron() plugin's `main` config, read out
+ * of vite.config.ts as text. Importing the config instead would drag in the
+ * whole plugin chain for what is a flat list of string literals.
+ */
+function readEntryMap() {
+  const config = readFileSync(path.join(repoRoot, 'vite.config.ts'), 'utf8');
+  const block = config.match(/main:\s*\{\s*(?:\/\/[^\n]*\n\s*)*entry:\s*\{([^}]*)\}/);
+  if (!block) throw new Error('could not locate the main-process entry map in vite.config.ts');
+
+  const entries = [...block[1].matchAll(/'([^']+)':\s*'electron\/([^']+)'/g)]
+    .map(([, name, file]) => ({ name, file }));
+  if (entries.length === 0) throw new Error('parsed the entry map but found no entries');
+  return entries;
+}
+
+/**
+ * Relative sibling modules a main-process file pulls in. Covers both the plain
+ * `require('./x')` form and the bare `'./x'` literal that main.js hands to a
+ * platform-selected `require(helper)`, which no require-shaped regex would see.
+ */
+function siblingRefs(source) {
+  const refs = new Set();
+  for (const [, spec] of source.matchAll(/require\(\s*['"](\.\/[^'"]+)['"]\s*\)/g)) {
+    refs.add(spec);
+  }
+  for (const [, spec] of source.matchAll(/['"](\.\/[a-z0-9-]+)['"]/g)) {
+    // Only literals that name a real sibling module -- './build/index.html' and
+    // friends are paths, not module specifiers.
+    if (existsSync(path.join(electronDir, `${spec.slice(2)}.js`))) refs.add(spec);
+  }
+  return [...refs];
+}
+
+const entries = readEntryMap();
+const entryFiles = new Set(entries.map((e) => e.file));
+
+describe('main-process entry map', () => {
+  it.each(entries)('$name points at a file that exists', ({ file }) => {
+    expect(existsSync(path.join(electronDir, file))).toBe(true);
+  });
+
+  it.each(entries)('$name requires nothing that is missing from the map', ({ file }) => {
+    const source = readFileSync(path.join(electronDir, file), 'utf8');
+    const missing = siblingRefs(source)
+      .map((spec) => (spec.endsWith('.js') ? spec.slice(2) : `${spec.slice(2)}.js`))
+      .filter((target) => !entryFiles.has(target));
+
+    // Every miss here is a require that survives into dist-electron pointing at
+    // a chunk the build never emits.
+    expect(
+      missing,
+      `electron/${file} requires ${missing.join(', ')}, which vite.config.ts does not build. ` +
+        `Add them to the electron() main entry map.`
+    ).toEqual([]);
+  });
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,7 +5,7 @@ const { setupSubtitleHandlers } = require('./subtitle-window.js');
 const { setupCaptionDoubleClick } = require('./window-caption-dblclick.js');
 const { setupPopoverWindowHandlers } = require('./popover-windows.js');
 const { applyLinuxGpuFlags } = require('./linux-gpu-flags');
-const { acquireSingleInstanceLock, focusWindow } = require('./single-instance');
+const { acquireSingleInstanceLock, createFocusRelay } = require('./single-instance');
 
 // Handle Squirrel events for Windows
 if (process.platform === 'win32') {
@@ -81,10 +81,13 @@ app.commandLine.appendSwitch('jack-name', 'sokuji');
 // install/uninstall helpers, which legitimately run while the app is open,
 // have already exited by this point.
 let isDuplicateInstance = false;
+// Holds a focus request that lands before createWindow() has run -- see
+// createFocusRelay for why that is the common case rather than the rare one.
+const focusRelay = createFocusRelay(() => mainWindow);
 if (!acquireSingleInstanceLock(app, {
   onSecondInstance: () => {
     console.log('[Sokuji] [Main] Second launch detected; focusing the existing window');
-    focusWindow(mainWindow);
+    focusRelay.onSecondInstance();
   },
 })) {
   isDuplicateInstance = true;
@@ -374,6 +377,10 @@ function createWindow() {
       backgroundThrottling: false
     }
   });
+
+  // A second launch during the ~half second between claiming the lock and
+  // getting here left its focus request waiting; honour it now.
+  focusRelay.windowCreated();
 
   setupSubtitleHandlers(mainWindow);
   // Windows only: frame:false + transparent:true above costs the window its

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,6 +5,7 @@ const { setupSubtitleHandlers } = require('./subtitle-window.js');
 const { setupCaptionDoubleClick } = require('./window-caption-dblclick.js');
 const { setupPopoverWindowHandlers } = require('./popover-windows.js');
 const { applyLinuxGpuFlags } = require('./linux-gpu-flags');
+const { acquireSingleInstanceLock, focusWindow } = require('./single-instance');
 
 // Handle Squirrel events for Windows
 if (process.platform === 'win32') {
@@ -70,6 +71,37 @@ const {
 app.setName('sokuji');
 app.commandLine.appendSwitch('application-name', 'sokuji');
 app.commandLine.appendSwitch('jack-name', 'sokuji');
+
+// Single instance. Sokuji was only ever single-instance on macOS, and that was
+// Launch Services refusing to start a second copy of the .app bundle rather
+// than anything we did -- on Windows and Linux every Start-menu click started
+// another process that then fought the first one over the PulseAudio modules
+// and the sidecar's file locks. Claimed here because the lock lives under
+// userData (so it must follow app.setName above) and because the Squirrel
+// install/uninstall helpers, which legitimately run while the app is open,
+// have already exited by this point.
+let isDuplicateInstance = false;
+if (!acquireSingleInstanceLock(app, {
+  onSecondInstance: () => {
+    console.log('[Sokuji] [Main] Second launch detected; focusing the existing window');
+    focusWindow(mainWindow);
+  },
+})) {
+  isDuplicateInstance = true;
+  console.log('[Sokuji] [Main] Another instance is already running; focusing it and exiting');
+  // app.quit(), not app.exit(): app.exit() before the message loop is up takes
+  // Chromium's early exit() path, which aborts -- measured on Linux, a duplicate
+  // launch died with SIGABRT and dumped core every time.
+  //
+  // quit() is clean but not immediate, and it emits before-quit/will-quit, where
+  // cleanupAndExit() is wired up. That teardown must NOT run here:
+  // removeVirtualAudioDevices() ends in cleanupModulesByName(), which unloads
+  // every sokuji_* PulseAudio module regardless of who created it, so quitting
+  // this process would tear down the audio of the instance we just handed over
+  // to. The isDuplicateInstance guards in cleanupAndExit() and in whenReady()
+  // below are what make that safe -- they are load-bearing, not decorative.
+  app.quit();
+}
 
 // Enable WebGPU for ONNX Runtime acceleration
 app.commandLine.appendSwitch('enable-unsafe-webgpu');
@@ -408,6 +440,7 @@ function createWindow() {
 
 // Create window when Electron is ready
 app.whenReady().then(async () => {
+  if (isDuplicateInstance) return;
   // Windows sandbox recovery (issue #352): if a prior run left a crash marker,
   // scan ACLs and show the native recovery dialog BEFORE creating the (transparent)
   // main window. May relaunch or exit; if so, do not proceed to createWindow().
@@ -507,6 +540,7 @@ app.whenReady().then(async () => {
 
 // Ensure cleanup happens before app exits
 const cleanupAndExit = () => {
+  if (isDuplicateInstance) return;
   console.log('[Sokuji] [Main] Cleaning up virtual audio devices before exit...');
   removeVirtualAudioDevices();
   nativeHost.stop();

--- a/electron/single-instance.js
+++ b/electron/single-instance.js
@@ -1,0 +1,80 @@
+// Single-instance enforcement.
+//
+// Sokuji looked single-instance on macOS and nowhere else, and the macOS
+// behaviour was never ours: Launch Services refuses to start a second copy of
+// the same .app bundle (`open -n` bypasses it and does start two). Windows and
+// Linux have no equivalent, so every Start-menu click and every .desktop
+// activation started another full process.
+//
+// That is not a cosmetic duplicate-window problem here, because the state a
+// second process touches is system-global rather than per-process:
+//
+//   - PulseAudio virtual devices. Both processes run cleanupOrphanedDevices()
+//     and createVirtualAudioDevices() over the same named modules.
+//   - The native sidecar, whose Windows file locks are exclusive.
+//
+// The teardown path is worse than the startup path. removeVirtualAudioDevices()
+// ends in cleanupModulesByName(), which unloads every module matching the
+// sokuji_* names regardless of who created it -- so *quitting* a second
+// instance tears down the first instance's audio. That is why the caller must
+// drop a losing instance with app.exit(), not app.quit(): app.quit() emits
+// before-quit/will-quit, which is exactly where that cleanup is wired up.
+
+/** Set to "1" to allow several instances side by side. See below. */
+const OPT_OUT_ENV = 'SOKUJI_ALLOW_MULTIPLE_INSTANCES';
+
+/**
+ * Claim the single-instance lock for this process.
+ *
+ * Must be called after app.setName() -- the lock lives under userData, whose
+ * path is derived from the app name -- and after the Squirrel install/uninstall
+ * handling, whose short-lived helper processes legitimately run alongside a
+ * live app and must not be turned away.
+ *
+ * @param {Electron.App} app
+ * @param {{ onSecondInstance?: () => void, env?: NodeJS.ProcessEnv }} [deps]
+ * @returns {boolean} true if this process owns the instance and may start up;
+ *   false if another instance already has it and this one must exit.
+ */
+function acquireSingleInstanceLock(app, { onSecondInstance, env = process.env } = {}) {
+  // The dev build and the installed build both call app.setName('sokuji'), so
+  // they share one userData directory and therefore one lock: without an escape
+  // hatch, `npm run electron:dev` would exit on the spot whenever the installed
+  // Sokuji happened to be open. Opt-in only -- two instances still fight over
+  // the virtual audio devices, so this is a debugging tool, not a supported mode.
+  if (env[OPT_OUT_ENV] === '1') {
+    return true;
+  }
+
+  if (!app.requestSingleInstanceLock()) {
+    // Electron has already handed our argv to the first instance by the time
+    // this returns, which is what fires 'second-instance' over there. Nothing
+    // left to register here -- this process is about to go away.
+    return false;
+  }
+
+  app.on('second-instance', () => {
+    // The user asked for Sokuji again; the honest answer to that is the window
+    // they already have, brought to the front.
+    if (onSecondInstance) onSecondInstance();
+  });
+
+  return true;
+}
+
+/**
+ * Bring an existing window to the user, whatever state it was left in.
+ * Null-safe: between window-all-closed and the next launch there is none.
+ *
+ * @param {Electron.BrowserWindow | null | undefined} win
+ */
+function focusWindow(win) {
+  if (!win || win.isDestroyed()) return;
+  // focus() on a minimized window is a no-op on Windows -- it stays in the
+  // taskbar and the second launch looks like it did nothing.
+  if (win.isMinimized()) win.restore();
+  if (!win.isVisible()) win.show();
+  win.focus();
+}
+
+module.exports = { acquireSingleInstanceLock, focusWindow, OPT_OUT_ENV };

--- a/electron/single-instance.js
+++ b/electron/single-instance.js
@@ -42,7 +42,13 @@ function acquireSingleInstanceLock(app, { onSecondInstance, env = process.env } 
   // hatch, `npm run electron:dev` would exit on the spot whenever the installed
   // Sokuji happened to be open. Opt-in only -- two instances still fight over
   // the virtual audio devices, so this is a debugging tool, not a supported mode.
-  if (env[OPT_OUT_ENV] === '1') {
+  //
+  // Honoured in development builds only. A packaged Sokuji that inherited the
+  // variable -- from a shell profile, a hand-edited .desktop Exec line -- would
+  // resurrect the exact failure this lock exists to prevent, for a user who
+  // never asked to debug anything. Gating on isPackaged costs the dev case
+  // nothing: the process running `npm run electron:dev` is the unpackaged one.
+  if (env[OPT_OUT_ENV] === '1' && !app.isPackaged) {
     return true;
   }
 
@@ -63,6 +69,47 @@ function acquireSingleInstanceLock(app, { onSecondInstance, env = process.env } 
 }
 
 /**
+ * Focus handling for second launches, including the ones that arrive before
+ * there is a window to focus.
+ *
+ * The lock is claimed at module load, but mainWindow is assigned deep inside
+ * whenReady -- after Better Auth init, orphan-device cleanup, and the pactl
+ * round-trip that creates the virtual devices. Measured on Linux that gap is
+ * ~530ms, and a duplicate launch fired 200-500ms after the first reproducibly
+ * lands inside it. Passing the not-yet-created window to focusWindow() there
+ * drops the request silently -- and that is the likeliest duplicate launch of
+ * all: the user clicking the icon again because nothing has appeared yet.
+ *
+ * So an early request is held and honoured the moment the window exists.
+ *
+ * @param {() => Electron.BrowserWindow | null | undefined} getWindow
+ * @returns {{ onSecondInstance: () => void, windowCreated: () => void }}
+ */
+function createFocusRelay(getWindow) {
+  let pending = false;
+
+  return {
+    onSecondInstance() {
+      const win = getWindow();
+      if (!win) {
+        pending = true;
+        return;
+      }
+      focusWindow(win);
+    },
+
+    /** Call right after the main window is assigned. */
+    windowCreated() {
+      // No request pending means an ordinary first launch: a fresh window
+      // already comes up focused, and raising it again would be noise.
+      if (!pending) return;
+      pending = false;
+      focusWindow(getWindow());
+    },
+  };
+}
+
+/**
  * Bring an existing window to the user, whatever state it was left in.
  * Null-safe: between window-all-closed and the next launch there is none.
  *
@@ -77,4 +124,4 @@ function focusWindow(win) {
   win.focus();
 }
 
-module.exports = { acquireSingleInstanceLock, focusWindow, OPT_OUT_ENV };
+module.exports = { acquireSingleInstanceLock, focusWindow, createFocusRelay, OPT_OUT_ENV };

--- a/electron/single-instance.test.js
+++ b/electron/single-instance.test.js
@@ -1,0 +1,113 @@
+// electron/single-instance.test.js
+//
+// Sokuji was single-instance on macOS only, and only by accident: Launch
+// Services refuses to start a second copy of the same .app bundle, so the app
+// never needed a lock of its own. On Windows and Linux nothing plays that role
+// -- every Start-menu click and every .desktop activation spawned a fully
+// independent process that then fought the first one over system-global state
+// (PulseAudio modules, the sidecar's file locks).
+import { describe, it, expect, vi } from 'vitest';
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(import.meta.url);
+const { acquireSingleInstanceLock, focusWindow } = nodeRequire('./single-instance.js');
+
+/** Minimal stand-in for Electron's `app`, recording what got registered. */
+const fakeApp = (lockGranted) => {
+  const handlers = {};
+  return {
+    requestSingleInstanceLock: vi.fn(() => lockGranted),
+    on: vi.fn((event, handler) => { handlers[event] = handler; }),
+    handlers,
+  };
+};
+
+describe('acquireSingleInstanceLock', () => {
+  it('claims the lock and returns true for the first instance', () => {
+    const app = fakeApp(true);
+    expect(acquireSingleInstanceLock(app, { env: {} })).toBe(true);
+    expect(app.requestSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+
+  it('returns false for a duplicate launch', () => {
+    const app = fakeApp(false);
+    expect(acquireSingleInstanceLock(app, { env: {} })).toBe(false);
+  });
+
+  it('routes second-instance launches to the existing window', () => {
+    const app = fakeApp(true);
+    const onSecondInstance = vi.fn();
+    acquireSingleInstanceLock(app, { env: {}, onSecondInstance });
+
+    expect(app.on).toHaveBeenCalledWith('second-instance', expect.any(Function));
+    app.handlers['second-instance']();
+    expect(onSecondInstance).toHaveBeenCalledOnce();
+  });
+
+  it('does not register second-instance on the loser, whose event loop is about to die', () => {
+    const app = fakeApp(false);
+    acquireSingleInstanceLock(app, { env: {}, onSecondInstance: vi.fn() });
+    expect(app.on).not.toHaveBeenCalled();
+  });
+
+  it('opts out entirely when SOKUJI_ALLOW_MULTIPLE_INSTANCES is set', () => {
+    // The dev build and the installed build share one userData directory
+    // (app.setName('sokuji') in both), so they would otherwise share one lock
+    // and `npm run electron:dev` would exit instantly while Sokuji is running.
+    const app = fakeApp(false);
+    expect(
+      acquireSingleInstanceLock(app, { env: { SOKUJI_ALLOW_MULTIPLE_INSTANCES: '1' } })
+    ).toBe(true);
+    expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
+  });
+
+  it('ignores an empty or unset opt-out value rather than treating it as truthy', () => {
+    const app = fakeApp(true);
+    acquireSingleInstanceLock(app, { env: { SOKUJI_ALLOW_MULTIPLE_INSTANCES: '' } });
+    expect(app.requestSingleInstanceLock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('focusWindow', () => {
+  const fakeWindow = (state = {}) => ({
+    isDestroyed: () => state.destroyed ?? false,
+    isMinimized: () => state.minimized ?? false,
+    isVisible: () => state.visible ?? true,
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
+  });
+
+  it('un-minimizes before focusing, since focus() alone leaves it in the taskbar', () => {
+    const win = fakeWindow({ minimized: true });
+    focusWindow(win);
+    expect(win.restore).toHaveBeenCalledOnce();
+    expect(win.focus).toHaveBeenCalledOnce();
+  });
+
+  it('shows a hidden window instead of only raising it', () => {
+    const win = fakeWindow({ visible: false });
+    focusWindow(win);
+    expect(win.show).toHaveBeenCalledOnce();
+    expect(win.focus).toHaveBeenCalledOnce();
+  });
+
+  it('only focuses a window that is already up', () => {
+    const win = fakeWindow();
+    focusWindow(win);
+    expect(win.restore).not.toHaveBeenCalled();
+    expect(win.show).not.toHaveBeenCalled();
+    expect(win.focus).toHaveBeenCalledOnce();
+  });
+
+  it('tolerates no window at all, the gap between quit and the next launch', () => {
+    expect(() => focusWindow(null)).not.toThrow();
+    expect(() => focusWindow(undefined)).not.toThrow();
+  });
+
+  it('tolerates a destroyed window, whose methods would throw', () => {
+    const win = fakeWindow({ destroyed: true });
+    focusWindow(win);
+    expect(win.focus).not.toHaveBeenCalled();
+  });
+});

--- a/electron/single-instance.test.js
+++ b/electron/single-instance.test.js
@@ -10,12 +10,13 @@ import { describe, it, expect, vi } from 'vitest';
 import { createRequire } from 'node:module';
 
 const nodeRequire = createRequire(import.meta.url);
-const { acquireSingleInstanceLock, focusWindow } = nodeRequire('./single-instance.js');
+const { acquireSingleInstanceLock, focusWindow, createFocusRelay } = nodeRequire('./single-instance.js');
 
 /** Minimal stand-in for Electron's `app`, recording what got registered. */
-const fakeApp = (lockGranted) => {
+const fakeApp = (lockGranted, { packaged = false } = {}) => {
   const handlers = {};
   return {
+    isPackaged: packaged,
     requestSingleInstanceLock: vi.fn(() => lockGranted),
     on: vi.fn((event, handler) => { handlers[event] = handler; }),
     handlers,
@@ -54,11 +55,23 @@ describe('acquireSingleInstanceLock', () => {
     // The dev build and the installed build share one userData directory
     // (app.setName('sokuji') in both), so they would otherwise share one lock
     // and `npm run electron:dev` would exit instantly while Sokuji is running.
-    const app = fakeApp(false);
+    const app = fakeApp(false, { packaged: false });
     expect(
       acquireSingleInstanceLock(app, { env: { SOKUJI_ALLOW_MULTIPLE_INSTANCES: '1' } })
     ).toBe(true);
     expect(app.requestSingleInstanceLock).not.toHaveBeenCalled();
+  });
+
+  it('ignores the opt-out in a packaged build, where two instances only break each other', () => {
+    // A packaged Sokuji that inherits the variable -- from a shell profile, a
+    // hand-edited .desktop Exec line -- would resurrect exactly the bug this
+    // lock exists to fix: two processes fighting over the same PulseAudio
+    // modules, either one's exit unloading the other's devices.
+    const app = fakeApp(false, { packaged: true });
+    expect(
+      acquireSingleInstanceLock(app, { env: { SOKUJI_ALLOW_MULTIPLE_INSTANCES: '1' } })
+    ).toBe(false);
+    expect(app.requestSingleInstanceLock).toHaveBeenCalledOnce();
   });
 
   it('ignores an empty or unset opt-out value rather than treating it as truthy', () => {
@@ -109,5 +122,79 @@ describe('focusWindow', () => {
     const win = fakeWindow({ destroyed: true });
     focusWindow(win);
     expect(win.focus).not.toHaveBeenCalled();
+  });
+});
+
+describe('createFocusRelay', () => {
+  // The lock is claimed at module load, but mainWindow is only assigned deep
+  // inside whenReady -- after Better Auth init, orphan-device cleanup and the
+  // pactl round-trip that creates the virtual devices. Measured on Linux that
+  // gap is ~530ms, and a duplicate launch fired 200-500ms after the first
+  // reproducibly lands inside it. Handing focusWindow an undefined window
+  // there drops the request silently, which is the one case the user is most
+  // likely to produce: clicking the icon again because nothing appeared yet.
+  const fakeWindow = () => ({
+    isDestroyed: () => false,
+    isMinimized: () => false,
+    isVisible: () => true,
+    restore: vi.fn(),
+    show: vi.fn(),
+    focus: vi.fn(),
+  });
+
+  it('focuses straight away once the window is up', () => {
+    const win = fakeWindow();
+    const relay = createFocusRelay(() => win);
+    relay.onSecondInstance();
+    expect(win.focus).toHaveBeenCalledOnce();
+  });
+
+  it('holds a request that arrives before the window exists, then honours it', () => {
+    let win = null;
+    const relay = createFocusRelay(() => win);
+    relay.onSecondInstance();
+
+    win = fakeWindow();
+    relay.windowCreated();
+    expect(win.focus).toHaveBeenCalledOnce();
+  });
+
+  it('collapses several early requests into one focus', () => {
+    let win = null;
+    const relay = createFocusRelay(() => win);
+    relay.onSecondInstance();
+    relay.onSecondInstance();
+    relay.onSecondInstance();
+
+    win = fakeWindow();
+    relay.windowCreated();
+    expect(win.focus).toHaveBeenCalledOnce();
+  });
+
+  it('does not raise the window on an ordinary first launch', () => {
+    const win = fakeWindow();
+    const relay = createFocusRelay(() => win);
+    relay.windowCreated();
+    expect(win.focus).not.toHaveBeenCalled();
+  });
+
+  it('clears the request once honoured, so a later window is not raised again', () => {
+    let win = null;
+    const relay = createFocusRelay(() => win);
+    relay.onSecondInstance();
+
+    win = fakeWindow();
+    relay.windowCreated();
+
+    const replacement = fakeWindow();
+    win = replacement;
+    relay.windowCreated();
+    expect(replacement.focus).not.toHaveBeenCalled();
+  });
+
+  it('survives a window that never arrives', () => {
+    const relay = createFocusRelay(() => null);
+    relay.onSecondInstance();
+    expect(() => relay.windowCreated()).not.toThrow();
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -145,6 +145,7 @@ export default defineConfig(({ command, mode }) => {
             'linux-window-titles': 'electron/linux-window-titles.js',
             'linux-gpu-flags': 'electron/linux-gpu-flags.js',
             'sandbox-recovery': 'electron/sandbox-recovery.js',
+            'single-instance': 'electron/single-instance.js',
             'windows-audio-utils': 'electron/windows-audio-utils.js',
             'audio-host': 'electron/audio-host.js',
             'audio-host-path': 'electron/audio-host-path.js',


### PR DESCRIPTION
## The bug

Sokuji only ever behaved as a single instance on macOS, and that was Launch Services refusing to start a second copy of the `.app` bundle rather than anything the app did (`open -n` starts two there as well). Windows and Linux have no equivalent guard: `app.requestSingleInstanceLock()` appears nowhere in the tree, so every Start-menu click and every `.desktop` activation started another full process.

## Why it is worse than duplicate windows

The state a second process touches is system-global, not per-process:

- **PulseAudio virtual devices** — both processes run `cleanupOrphanedDevices()` and `createVirtualAudioDevices()` over the same named modules.
- **The native sidecar**, whose Windows file locks are exclusive.

The teardown path is the worse half. `removeVirtualAudioDevices()` ends in `cleanupModulesByName()`, which unloads every `sokuji_*` module regardless of who created it — so *quitting* a second instance tore down the **first** instance's audio while its window kept running, with no visible symptom beyond the microphone going quiet.

## The fix

Claim the lock in `main.js` after `app.setName()` (the lock lives under `userData`) and after the Squirrel install/uninstall branch (those helpers legitimately run alongside a live app). A duplicate launch hands its argv over, focuses the existing window, and quits.

Two details that are easy to get wrong and are commented in place:

- **The loser quits with `app.quit()`, not `app.exit()`.** `app.exit()` before the message loop is up takes Chromium's early `exit()` path and aborts — measured on Linux, every duplicate launch died with SIGABRT and dumped core (exit code 134). On Windows that would likely surface as a crash dialog.
- **`app.quit()` emits `before-quit`/`will-quit`, where `cleanupAndExit()` is wired up.** The `isDuplicateInstance` guards in `cleanupAndExit()` and `whenReady()` are therefore load-bearing, not defensive: without them the loser performs exactly the teardown described above.

`SOKUJI_ALLOW_MULTIPLE_INSTANCES=1` opts out. The dev build and the installed build both call `app.setName('sokuji')`, so they share one `userData` directory and therefore one lock; without an escape hatch `npm run electron:dev` would exit on the spot whenever Sokuji happens to be open. Debug-only — two instances still fight over the virtual devices.

## The extra test

`electron/entry-map.consistency.test.js` guards a separate silent-failure class this change ran into first-hand.

The main-process build lists its entries by hand in `vite.config.ts`, alongside an `external: [/^\.\/[a-z0-9-]+$/]` rule that keeps every relative sibling require a runtime require. Add a module, require it, forget the entry line, and:

- `npm run build` succeeds with **no warning**;
- `dist-electron/main.js` still emits `require("./your-module")`;
- `dist-electron/your-module.js` is never emitted;
- the whole vitest suite stays green, because tests require the *source* file and never touch the bundle.

The only symptom is the packaged app dying at startup with `MODULE_NOT_FOUND`. Adding `single-instance.js` hit exactly this. The test checks both drift directions (entry points at a missing file / entry requires something unlisted) and was mutation-tested: removing the `single-instance` line fails with `electron/main.js requires single-instance.js, which vite.config.ts does not build.`

It also matches `'./x'` bare string literals, not just `require('./x')` — `main.js` selects two audio helpers by platform and passes the result to `require(helper)`, which a require-shaped pattern alone would miss.

## Verification

Real runs on Linux, not reasoning:

| Check | Result |
|---|---|
| 3 duplicate launches, exit code | `0` / `0` / `0`, no core dump |
| `second-instance` events received by instance 1 | 3, each followed by a focus |
| `Cleaning up virtual audio` in instance 1's log | 0 occurrences |
| `pactl list short modules \| grep -c sokuji` before/after | 2 → 2 (winner's devices intact) |
| After instance 1 quits | 0 modules left; a fresh launch reacquires the lock |
| `SOKUJI_ALLOW_MULTIPLE_INSTANCES=1` | both instances coexist |

Tests: `electron/` 23 files, 360 passing. Full suite 240 passing; the one failure (`src/components/MainLayout/MainLayout.keepAlive.test.tsx`) is pre-existing — it fails identically with all of these changes stashed, and nothing here touches `src/`.

Not verified on real Windows or macOS hardware — the lock API is platform-agnostic and the macOS behaviour is unchanged either way, but a Windows check that duplicate launches no longer produce a crash dialog would be worth doing before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added single-instance protection for packaged app builds to prevent duplicate launches.
  * Relaunching the app now restores, shows, and focuses the existing window, including when the main window is still starting.
  * Added an opt-out for unpackaged development builds.

* **Tests**
  * Added coverage for instance handling, deferred focus behavior, and Electron entry-point consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->