### PR TITLE
fix(subtitle): restore the text colour settings in subtitle mode

### DIFF
--- a/src/components/Subtitle/SubtitleApp.rootStyle.test.tsx
+++ b/src/components/Subtitle/SubtitleApp.rootStyle.test.tsx
@@ -1,0 +1,101 @@
+// src/components/Subtitle/SubtitleApp.rootStyle.test.tsx
+//
+// SubtitleApp.scss styles `.subtitle-app` with
+//   color: var(--subtitle-source-color, #FFFFFF)
+// but for most of the file's history nothing ever defined that variable at
+// the root, so the declaration silently resolved to its #FFFFFF fallback.
+// This pins the variable to the root style object so the rule means what it
+// says. Every chrome element below the root (idle body, PTT hint, bar) sets
+// its own colour and therefore overrides this, so the value only reaches
+// elements that opt into inheritance.
+//
+// Mocks mirror SubtitleApp.handleStart.test.tsx: SubtitleApp's real import
+// graph reaches the audio worklets, which vitest cannot resolve from a
+// worktree, so every heavy dependency is stubbed.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (_k: string, d?: string) => d ?? _k }),
+}));
+
+vi.mock('../../stores/settingsStore', () => ({
+  __esModule: true,
+  default: { getState: () => ({ __syncSubtitleFullscreen: vi.fn(), subtitleModeActive: false }) },
+  useExitSubtitleMode: () => vi.fn(async () => {}),
+  useProvider: () => 'openai',
+  useCurrentProviderSettings: () => ({ sourceLanguage: 'en', targetLanguage: 'zh' }),
+  useLocalInferenceSettings: () => ({}),
+  useCurrentTurnDetectionMode: () => 'Disabled',
+  useSubtitleFullscreen: () => false,
+  useSetSubtitleFullscreen: () => vi.fn(async () => {}),
+  useNavigateToSettings: () => vi.fn(),
+}));
+
+// A colour nothing else in the tree could produce, so the assertion cannot
+// pass by coincidence with the #FFFFFF fallback.
+const SOURCE_COLOR = '#FF00FF';
+
+vi.mock('../../stores/subtitleStore', () => ({
+  useSubtitleSettings: () => ({
+    bgColor: '#000000', bgOpacity: 80, fontSize: 24, compactMode: false,
+    sourceTextColor: '#FF00FF', translationTextColor: '#00FF00',
+  }),
+  useSaveSubtitleWindowBounds: () => vi.fn(async () => {}),
+  useSubtitlePositionLocked: () => false,
+  useSubtitleSpeakerDisplayMode: () => 'both',
+  useSubtitleParticipantDisplayMode: () => 'both',
+  useSubtitleNewItemHighlightEnabled: () => false,
+}));
+
+vi.mock('../../stores/sessionStore', () => ({
+  useIsSessionActive: () => false,
+  useSessionStartTime: () => null,
+  useItems: () => [],
+  useParticipantItems: () => [],
+  useRequestClearConversation: () => vi.fn(),
+  useLockedMode: () => null,
+  useStartGate: () => ({ canStart: true, reason: null }),
+  useSessionIsInitializing: () => false,
+  useInitProgress: () => null,
+  useRequestSessionStart: () => vi.fn(),
+  useRequestSessionStop: () => vi.fn(),
+}));
+
+vi.mock('../../stores/audioStore', () => ({
+  useMode: () => 'speaker',
+}));
+
+vi.mock('./useOverlayDragResize', () => ({
+  useOverlayDragResize: () => ({ resizeHandleProps: {} }),
+}));
+
+vi.mock('./SubtitleBar', () => ({ default: () => null }));
+vi.mock('./SubtitleStream', () => ({ default: () => null }));
+vi.mock('./SubtitleIdle', () => ({ default: () => null }));
+
+vi.mock('../../services/providers/speechMode', () => ({
+  isPushGatedMode: (_provider: string, mode: string) =>
+    mode === 'Push-to-Talk' || mode === 'Push-to-Translate' || mode === 'Disabled',
+}));
+
+const { default: SubtitleApp } = await import('./SubtitleApp');
+
+beforeEach(() => {
+  cleanup();
+});
+
+describe('SubtitleApp root style', () => {
+  it('defines --subtitle-source-color on the root the stylesheet reads it from', () => {
+    const { container } = render(<SubtitleApp />);
+    const root = container.querySelector('.subtitle-app') as HTMLElement;
+    expect(root.style.getPropertyValue('--subtitle-source-color')).toBe(SOURCE_COLOR);
+  });
+
+  it('still defines the background and highlight-overlay vars it always had', () => {
+    const { container } = render(<SubtitleApp />);
+    const root = container.querySelector('.subtitle-app') as HTMLElement;
+    expect(root.style.background).not.toBe('');
+    expect(root.style.getPropertyValue('--subtitle-highlight-overlay')).not.toBe('');
+  });
+});

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -6,6 +6,9 @@
   width: 100vw;
   border-radius: 8px;
   overflow: hidden;
+  // Defined on this element's inline style by SubtitleApp.tsx (the user's
+  // source-text colour). Only reaches descendants that don't set their own
+  // colour — the idle body, PTT hint and bar all do.
   color: var(--subtitle-source-color, #FFFFFF);
   // Positioning context for the SubtitleBar, which floats above the
   // subtitle area so the bar's footprint isn't permanently reserved.

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -330,6 +330,13 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
     '--bar-opacity': barVisible ? 1 : 0,
     '--bar-pointer-events': barVisible ? 'auto' : 'none',
     '--subtitle-highlight-overlay': getHighlightOverlayForBg(subtitle.bgColor),
+    // SubtitleApp.scss reads this for `.subtitle-app`'s inherited text
+    // colour. It had never been defined at the root, so that declaration
+    // always resolved to its #FFFFFF fallback. Every chrome element below
+    // (idle body, PTT hint, bar) sets its own colour and overrides this, so
+    // defining it changes nothing that is on screen today — it just makes
+    // the rule mean what it says for anything that inherits.
+    '--subtitle-source-color': subtitle.sourceTextColor,
   };
 
   return (

--- a/src/components/Subtitle/SubtitleStream.test.tsx
+++ b/src/components/Subtitle/SubtitleStream.test.tsx
@@ -347,6 +347,30 @@ describe('SubtitleStream — expanded mode (per-item rows)', () => {
     expect(container.querySelectorAll('.conversation-row').length).toBe(4);
     expect(container.querySelector('.subtitle-stream__line')).toBeNull();
   });
+
+  // Expanded mode delegates to ConversationRow, whose stylesheet reads the
+  // --conversation-* custom properties (it was renamed off --subtitle-* when
+  // MainPanel gained its own display settings). The subtitle colours must be
+  // published under BOTH names or the user's text-colour choice silently does
+  // nothing in the subtitle window's default (non-compact) layout.
+  it('publishes the text colours under the --conversation-* names ConversationRow reads', () => {
+    const { container } = render(
+      <SubtitleStream
+        items={items}
+        compact={false}
+        fontSize={36}
+        speakerMode="both"
+        participantMode="both"
+        sourceLanguage="en"
+        targetLanguage="zh"
+        sourceTextColor="#FF0000"
+        translationTextColor="#00FF00"
+      />,
+    );
+    const root = container.querySelector('.subtitle-stream') as HTMLElement;
+    expect(root.style.getPropertyValue('--conversation-source-color')).toBe('#FF0000');
+    expect(root.style.getPropertyValue('--conversation-translation-color')).toBe('#00FF00');
+  });
 });
 
 describe('SubtitleStream — expanded karaoke highlight', () => {

--- a/src/components/Subtitle/SubtitleStream.tsx
+++ b/src/components/Subtitle/SubtitleStream.tsx
@@ -179,14 +179,24 @@ const SubtitleStream: React.FC<Props> = ({
     isFirstRenderRef.current = false;
   });
 
-  // Apply fontSize to both our flat-line styles and the CSS var that
-  // ConversationRow reads in expanded mode.
+  // Apply fontSize and the text colours to both our own compact-band styles
+  // and the CSS vars ConversationRow reads in expanded mode. ConversationRow
+  // is themed via --conversation-* (renamed off --subtitle-* when MainPanel
+  // gained its own display settings), so each value has to be published under
+  // both names — expanded mode is the subtitle window's DEFAULT layout, and
+  // publishing only --subtitle-* leaves the user's colour choice inert there.
   const style: React.CSSProperties & Record<string, string> = {
     fontSize: `${fontSize}px`,
     '--conversation-font-size': `${fontSize}px`,
   };
-  if (sourceTextColor) style['--subtitle-source-color'] = sourceTextColor;
-  if (translationTextColor) style['--subtitle-translation-color'] = translationTextColor;
+  if (sourceTextColor) {
+    style['--subtitle-source-color'] = sourceTextColor;
+    style['--conversation-source-color'] = sourceTextColor;
+  }
+  if (translationTextColor) {
+    style['--subtitle-translation-color'] = translationTextColor;
+    style['--conversation-translation-color'] = translationTextColor;
+  }
 
   return (
     <div className={`subtitle-stream ${compact ? 'compact' : 'expanded'}`} style={style}>


### PR DESCRIPTION
Two colour bugs in the subtitle window, both of the same shape: a stylesheet reads a CSS custom property that nothing ever defines, so the declaration silently falls through to a hardcoded fallback.

## 1. The text colour settings did nothing (the reported bug)

In subtitle mode the source/translation **text colour** settings had no effect. Background colour still worked, which is what made the breakage read as "only the text colour setting broke".

**Root cause.** `ConversationRow.scss` is themed via `--conversation-source-color` / `--conversation-translation-color`. Those were renamed off `--subtitle-*` in e0d8811e, whose commit message reasoned:

> ConversationRow only renders inside MainPanel, so this rename has no other consumers.

That premise is wrong. `SubtitleStream` renders `ConversationRow` in **expanded mode**, and only ever published the `--subtitle-*` names. Nothing sets `--conversation-*` inside the subtitle window, so the text fell through to the hardcoded fallbacks `#9aa0a6` / `#e8e8e8`.

This hit the default configuration: `subtitleStore`'s `compactMode` defaults to **`false`**, so expanded mode *is* the subtitle window's default layout. Compact mode was unaffected — it styles its own bands off `--subtitle-*`.

Background colour survived because `SubtitleApp` applies it inline to the `.subtitle-app` root rather than through a renamed variable.

**Fix.** Publish each colour under both names on the same style object, mirroring what `fontSize` already does with `--conversation-font-size`. That existing font-size path is also the evidence the inheritance chain is sound: the font-size slider has always worked in expanded subtitle mode, through exactly this mechanism.

Applies to both surfaces (Electron subtitle window and extension overlay) — they share `SubtitleApp` → `SubtitleStream`.

## 2. `--subtitle-source-color` was never defined at the root

`SubtitleApp.scss` has always styled `.subtitle-app` with `color: var(--subtitle-source-color, #FFFFFF)`, but that variable was never set at the root — checked the full history of `SubtitleApp.tsx`, it has never been there — so the declaration resolved to its `#FFFFFF` fallback for the rule's entire lifetime.

**Fix.** Feed it the user's source-text colour, so the rule means what it says.

This one is intent restoration rather than a visual change. Every chrome element below the root sets its own colour and overrides the inherited one: `.subtitle-ptt-hint p` and `.subtitle-idle__message` (`rgba(255,255,255,.7)`), `__action` (`#fff`, `.45` disabled), `__hint` (`.45`), `__error` (`#ff6b6b`), `__link` (`.5`), `__return` (`.92`), plus all of `SubtitleBar`. Every class `SubtitleIdle` renders was checked against the stylesheet. Nothing on screen today inherits the root colour, so defining it moves no pixels — it only stops future descendants that opt into inheritance from silently getting hardcoded white.

## Tests

Both fixes are covered by tests written first and confirmed failing before the change:

- `SubtitleStream.test.tsx` — expanded mode publishes the `--conversation-*` names (`expected '' to be '#FF0000'` before the fix)
- `SubtitleApp.rootStyle.test.tsx` (new) — the root defines `--subtitle-source-color` (`expected '' to be '#FF00FF'` before the fix)

Results:

- `src/components/Subtitle/`: **131 passed**
- `ConversationRow` / `DisplaySettingsPopover` / `subtitleStore`: **66 passed**
- `tsc --noEmit`: 342 errors before and after — the repo's pre-existing baseline, none in the touched files

The new root-style test is a separate file rather than an addition to `SubtitleApp.test.tsx` because that file imports `SubtitleApp` unmocked, and its real import graph reaches the audio worklets, which vitest cannot resolve from a worktree. It mirrors the mock set `SubtitleApp.handleStart.test.tsx` already uses to dodge the same problem.

`SubtitleApp.test.tsx` therefore still fails to load in a worktree. A/B-checked against the same worktree with the changes stashed: identical failure, pre-existing and unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Subtitle source and translation color settings now apply consistently in both compact and expanded conversation layouts.
  * Improved compatibility between subtitle styling and conversation display components.
  * Subtitle colors now remain consistent across different subtitle app and conversation presentation modes.
  * Background and highlight styling continue to display correctly alongside customized subtitle colors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->