### PR TITLE
fix(store): annotate validateApiKey's return type, and delete the dead state it was hiding

### DIFF
--- a/src/stores/settingsStore.test.ts
+++ b/src/stores/settingsStore.test.ts
@@ -55,9 +55,7 @@ describe('settingsStore', () => {
     // Reset the store before each test
     useSettingsStore.setState({
       provider: Provider.OPENAI,
-      isValidated: false,
       isValidating: false,
-      validationError: null,
       cacheTimestamp: null,
     });
     vi.clearAllMocks();
@@ -100,9 +98,12 @@ describe('settingsStore', () => {
         useSettingsStore.setState({ isValidating: true });
         useSettingsStore.setState({
           isValidating: false,
-          isValidated: true,
-          validationError: null,
         });
+        // The real action resolves to a result its callers read. The stub used
+        // to resolve to undefined, which only type-checked because the store's
+        // inference was broken; a caller awaiting this got undefined where the
+        // contract promised an object.
+        return { valid: true, message: '', validating: false };
       });
 
       // Switch to a Kizuna-managed (relay) provider

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -834,10 +834,15 @@ const useSettingsStore = create<SettingsStore>()(
     },
 
     // === Async Actions ===
+    // The return type is annotated deliberately, not decoratively. Without it
+    // this one action's inferred type poisons contextual typing across the
+    // whole create<SettingsStore>() literal, and roughly a third of the
+    // repository's type errors are downstream of that. See the commit that
+    // added this line for the before/after numbers.
     validateApiKey: async (
       getAuthToken?: () => Promise<string | null>,
       isSignedIn: boolean = true,
-    ) => {
+    ): Promise<ApiKeyValidationResult> => {
       const state = get();
       const provider = state.provider;
 
@@ -940,8 +945,6 @@ const useSettingsStore = create<SettingsStore>()(
             availableModels: [],
             validationMessage: displayMessage,
             isValidating: false,
-            isValidated: false,
-            validationError: null
           });
           return {
             valid: false,
@@ -967,8 +970,6 @@ const useSettingsStore = create<SettingsStore>()(
           availableModels: [],
           validationMessage: '',
           isValidating: false,
-          isValidated: false,
-          validationError: null
         });
         return {valid: false, message: '', validating: false};
       }
@@ -983,8 +984,6 @@ const useSettingsStore = create<SettingsStore>()(
           availableModels: cached.models,
           validationMessage: cached.validation.message,
           isValidating: false,
-          isValidated: true,
-          validationError: cached.validation.valid ? null : cached.validation.message,
           cacheTimestamp: cached.timestamp
         });
         return cached.validation;
@@ -1017,8 +1016,6 @@ const useSettingsStore = create<SettingsStore>()(
           validationMessage: result.validation.message,
           validationCache: newCache,
           isValidating: false,
-          isValidated: true,
-          validationError: result.validation.valid ? null : result.validation.message,
           cacheTimestamp: Date.now()
         });
 
@@ -1059,8 +1056,6 @@ const useSettingsStore = create<SettingsStore>()(
           availableModels: [],
           validationMessage: message,
           isValidating: false,
-          isValidated: false,
-          validationError: message
         });
         return {valid: false, message, validating: false};
       }


### PR DESCRIPTION
## What

One missing return-type annotation on `validateApiKey` was poisoning contextual typing across the entire `create<SettingsStore>()` literal. Adding it:

| | before | after |
|---|---|---|
| repo-wide `error TS` | 466 | **331** |
| `src/stores/` | 149 | **27** |

Two files changed, +11/−15.

## What the broken inference was hiding

This is the more interesting half. Two store fields turned out to be pure dead state, identical in shape:

| field | production writes | test writes | reads | declared on the interface |
|---|---|---|---|---|
| `isValidated` | 5 | 2 | **0** | no |
| `validationError` | 5 | 2 | **0** | no |

Ten writes each, never once read, and neither declared on `SettingsStore`. They could persist precisely because TypeScript had no working view of the object they lived in — the annotation is what let it speak up.

Their jobs were already covered by fields that *are* read: `isApiKeyValid` (declared, defaulted, read by `ProviderSection`, `SettingsInitializer` and `MainPanel`) and `validationMessage` (what `ProviderSection` actually renders). So they are deleted rather than declared — adding a declaration would have issued a birth certificate to a field nobody reads.

The same blindness hid a real defect in `settingsStore.test.ts`: its `validateApiKey` stub resolved to `undefined` while the contract promises a result object. It type-checked only because inference was already broken.

## Verification

- `npx vitest run`: **3113 passing**, and the same 11 files / 7 tests failing for the same pre-existing reasons as before this branch (provider gating, store migrations, `ModernBrowserAudioService`, and two vite `Denied ID` worklet resolutions). Zero new failures.
- `src/stores` alone: 293 passing, 6 pre-existing suite-level import failures, unchanged.

## Origin

Found while implementing #437 — an agent noticed the annotation's effect, judged it out of scope for a bugfix task, and left it recorded in that PR's design doc rather than landing a 130-error change inside unrelated work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key validation state handling.
  * Validation results now return consistently across success, failure, cached, and error scenarios.
  * Removed outdated validation status fields to prevent stale or misleading state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->