### PR TITLE
refactor(settings): move interface language into Help, at the weight of a link

### DIFF
--- a/src/components/Settings/AdvancedSettings/AdvancedSettings.tsx
+++ b/src/components/Settings/AdvancedSettings/AdvancedSettings.tsx
@@ -111,18 +111,9 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings, act
       >
         {activeTab === 'general' && (
           <>
-            {/* Interface Language - full list */}
-            <LanguageSection
-              isSessionActive={isSessionActive}
-              showInterfaceLanguage={true}
-              showTranslationLanguages={false}
-              simplifiedInterfaceList={false}
-            />
-
             {/* Translation Languages - same as Simple mode */}
             <LanguageSection
               isSessionActive={isSessionActive}
-              showInterfaceLanguage={false}
               showTranslationLanguages={true}
             />
 
@@ -132,7 +123,7 @@ const AdvancedSettings: React.FC<AdvancedSettingsProps> = ({ toggleSettings, act
             />
 
             {/* Help & Updates */}
-            <HelpSection toggleSettings={toggleSettings} />
+            <HelpSection toggleSettings={toggleSettings} isSessionActive={isSessionActive} />
           </>
         )}
 

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1957,6 +1957,35 @@
   }
 }
 
+// Interface language: a picker that has to read as a link, because that is the
+// weight it now carries. The <select> keeps its native behaviour — the list is
+// 30 long and the platform renders it outside this panel, with keyboard and
+// type-ahead for free — but sheds every visual sign of being a form control,
+// so it sits level with "Restart Setup Guide" beside it rather than towering
+// over it.
+.help-link--picker {
+  position: relative;
+
+  .help-link__select {
+    appearance: none;
+    background: transparent;
+    border: none;
+    padding: 0 2px;
+    margin: 0;
+    color: inherit;
+    font: inherit;
+    cursor: inherit;
+    // The option list is painted by the OS, which does not inherit this panel's
+    // theme; without this the popup can come up as light text on light ground.
+    option { color: initial; background: initial; }
+
+    &:focus-visible {
+      outline: 1px solid vars.$color-primary;
+      outline-offset: 2px;
+      border-radius: 2px;
+    }
+  }
+}
 
 .version-label {
   margin-left: auto;

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1971,19 +1971,29 @@
 // one, also sizes it correctly: measured at 54px for 日本語 against 148px for
 // the same list drawn as a classic OS widget.
 .help-link--picker {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
+  // Layout comes from .help-link; only the select's own box needs correcting.
 
   .help-link__select {
     background: transparent;
     border: none;
     border-radius: 3px;
-    padding: 1px 2px;
+    padding: 0 2px;
     margin: 0;
     color: inherit;
     font: inherit;
     cursor: pointer;
+
+    // A base-select control carries a UA minimum height of 24px — a touch
+    // target — against the 13.85px of text in the links beside it, and its
+    // chevron holds a full line box on top of that. The row's boxes were
+    // centred on each other either way, but the eye aligns a line of links on
+    // their TEXT, and a taller box centres its text somewhere else.
+    //
+    // `1lh` is exactly the line box the neighbouring spans occupy, so the
+    // select's text sits on their baseline instead of floating above it.
+    min-height: 0;
+    height: 1lh;
+    align-items: center;
 
     &:disabled { cursor: not-allowed; }
 
@@ -2013,7 +2023,15 @@
       scrollbar-width: thin;
     }
 
-    &::picker-icon { color: vars.$text-muted; }
+    // The chevron is a flex item of the select and, left at its normal line
+    // box, stands 17.3px against the 13.85px of the text beside it — enough to
+    // set the height of the whole select, and through it the whole row, taller
+    // than every other link in Help. `line-height: 1` takes it down to the
+    // glyph, which is all this needs to be.
+    &::picker-icon {
+      color: vars.$text-muted;
+      line-height: 1;
+    }
 
     &:hover { color: vars.$color-primary; }
     &:open { color: vars.$color-primary; }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1963,37 +1963,81 @@
 // type-ahead for free — but sheds every visual sign of being a form control,
 // so it sits level with "Restart Setup Guide" beside it rather than towering
 // over it.
+// The picker keeps a link's weight — no border, no filled background, the
+// same muted colour as the links beside it — but it must still read as
+// something you can open, so it keeps its chevron. `.help-link__select` joins
+// the shared base-select layer below, which themes the popup and, because a
+// base-select control lays out to its SELECTED option rather than its longest
+// one, also sizes it correctly: measured at 54px for 日本語 against 148px for
+// the same list drawn as a classic OS widget.
 .help-link--picker {
-  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
 
-  // A native <select> is as wide as its LONGEST option, not its chosen one, so
-  // picking 日本語 out of a list containing "Português (Portugal)" left the
-  // control padded with twenty characters of empty space — enough to push the
-  // next link onto another line. The visible name below sets the width, and
-  // the select is laid over it transparently: full native behaviour, no
-  // phantom width.
   .help-link__select {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    opacity: 0;
-    appearance: none;
+    background: transparent;
     border: none;
+    border-radius: 3px;
+    padding: 1px 2px;
     margin: 0;
-    padding: 0;
+    color: inherit;
     font: inherit;
     cursor: pointer;
-    // The option list is painted by the OS, which does not inherit this panel's
-    // theme; without this the popup can come up as light text on light ground.
+
+    &:disabled { cursor: not-allowed; }
+
+    // Classic fallback (Chrome 116–134): the popup is drawn by the OS and
+    // ignores this theme past the option colours. Chevron comes from the
+    // shared `.language-select` background-image in that path; here the row is
+    // borderless, so a plain caret keeps it recognisable without one.
     option { color: initial; background: initial; }
   }
+}
 
-  // The select is invisible, so the focus ring has to be drawn by the row.
-  &:focus-within {
-    outline: 1px solid vars.$color-primary;
-    outline-offset: 2px;
-    border-radius: 2px;
+@supports (appearance: base-select) {
+  .help-link--picker .help-link__select {
+    &,
+    &::picker(select) { appearance: base-select; }
+
+    // Same themed popup as every other select in Settings.
+    &::picker(select) {
+      background: vars.$bg-surface;
+      border: 1px solid vars.$border-default;
+      border-radius: vars.$radius-md;
+      box-shadow: 0 8px 24px rgba(0, 0, 0, 0.5);
+      padding: 4px;
+      margin-top: 4px;
+      max-height: 320px;
+      overflow-y: auto;
+      scrollbar-width: thin;
+    }
+
+    &::picker-icon { color: vars.$text-muted; }
+
+    &:hover { color: vars.$color-primary; }
+    &:open { color: vars.$color-primary; }
+
+    option {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      padding: 8px 10px;
+      border-radius: vars.$radius-sm;
+      font-size: vars.$font-title;
+      color: vars.$text-primary;
+      background: transparent;
+      cursor: pointer;
+
+      &:hover,
+      &:focus { background: vars.$bg-control; }
+
+      &::checkmark {
+        color: vars.$color-primary;
+        order: 1;
+        margin-left: auto;
+      }
+    }
   }
 }
 

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -2023,17 +2023,18 @@
       scrollbar-width: thin;
     }
 
-    // The chevron is a flex item of the select and, left at its normal line
-    // box, stands 17.3px against the 13.85px of the text beside it — enough to
-    // set the height of the whole select, and through it the whole row, taller
-    // than every other link in Help. `line-height: 1` takes it down to the
-    // glyph, which is all this needs to be.
+    // `inherit`, not the $text-muted the other selects give their chevron:
+    // those sit in bordered form controls, this one sits in a row of links
+    // whose lucide icons are all `stroke="currentColor"` and light up with the
+    // row. A fixed colour here left the chevron behind on hover, the one part
+    // of the control that did not react.
     &::picker-icon {
-      color: vars.$text-muted;
+      color: inherit;
       line-height: 1;
     }
 
-    &:hover { color: vars.$color-primary; }
+    // Hover colour comes from `.help-link:hover`, shared with every link in
+    // the row. Only the open state is this control's own.
     &:open { color: vars.$color-primary; }
 
     option {

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1997,10 +1997,17 @@
 
     &:disabled { cursor: not-allowed; }
 
-    // Classic fallback (Chrome 116–134): the popup is drawn by the OS and
-    // ignores this theme past the option colours. Chevron comes from the
-    // shared `.language-select` background-image in that path; here the row is
-    // borderless, so a plain caret keeps it recognisable without one.
+    // Classic fallback (Chrome 116–134, the extension's floor): the popup is
+    // drawn by the OS and ignores this theme past the option colours.
+    //
+    // Known difference, accepted rather than worked around: a classic select
+    // is as wide as its longest option, so on those versions picking 日本語
+    // still reserves the width of "Português (Portugal)" and can push a link
+    // onto another line. Sizing it correctly there needs a mirrored span with
+    // the select overlaid transparently on top — which this file carried for
+    // one commit and which also hides the chevron, the thing that tells a
+    // borderless control it can be opened. On a path where the popup is
+    // already unthemed, a wide control is the smaller cost.
     option { color: initial; background: initial; }
   }
 }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1966,24 +1966,34 @@
 .help-link--picker {
   position: relative;
 
+  // A native <select> is as wide as its LONGEST option, not its chosen one, so
+  // picking 日本語 out of a list containing "Português (Portugal)" left the
+  // control padded with twenty characters of empty space — enough to push the
+  // next link onto another line. The visible name below sets the width, and
+  // the select is laid over it transparently: full native behaviour, no
+  // phantom width.
   .help-link__select {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    opacity: 0;
     appearance: none;
-    background: transparent;
     border: none;
-    padding: 0 2px;
     margin: 0;
-    color: inherit;
+    padding: 0;
     font: inherit;
-    cursor: inherit;
+    cursor: pointer;
     // The option list is painted by the OS, which does not inherit this panel's
     // theme; without this the popup can come up as light text on light ground.
     option { color: initial; background: initial; }
+  }
 
-    &:focus-visible {
-      outline: 1px solid vars.$color-primary;
-      outline-offset: 2px;
-      border-radius: 2px;
-    }
+  // The select is invisible, so the focus ring has to be drawn by the row.
+  &:focus-within {
+    outline: 1px solid vars.$color-primary;
+    outline-offset: 2px;
+    border-radius: 2px;
   }
 }
 

--- a/src/components/Settings/SimpleSettings/SimpleSettings.order.test.tsx
+++ b/src/components/Settings/SimpleSettings/SimpleSettings.order.test.tsx
@@ -1,8 +1,14 @@
 /**
- * Interface language is set once and never revisited, so it belongs at the
- * bottom of the panel rather than at the top next to *Translation* languages -
- * two adjacent sections both named "language". Translation languages lead
- * instead, which is what the panel is for.
+ * Interface language is no longer a section of this panel at all.
+ *
+ * It was a full `config-section` at the top, next to *Translation* languages -
+ * two adjacent blocks both called "language" - then moved to the bottom, and
+ * now lives inside HelpSection at the weight of a link, alongside the version
+ * number and the update check. It is set once, never revisited, and by its own
+ * description does not affect what can be translated.
+ *
+ * So this file's contract changed: it used to pin the interface section's
+ * position, and now pins its ABSENCE, plus the order of what remains.
  *
  * Follows `SimpleSettings.account.test.tsx`'s mount idiom (real stores,
  * ServiceFactory and analytics mocked, an interpolating `t()`) and, for the
@@ -12,12 +18,8 @@
  * `HelpSection` is the one section still stubbed - it calls `useOnboarding`
  * and throws outside an `OnboardingProvider`. The stub reproduces the real
  * element's `config-section` / `id="help-section"` shell so the order it
- * takes part in is the real one.
- *
- * The interface instance is identified by `className`, which `LanguageSection`
- * splices into `config-section ${className}`. It deliberately carries no `id`:
- * `#languages-section` belongs to the translation instance, and onboarding
- * targets ids, which is why this move leaves onboarding untouched.
+ * takes part in is the real one. HelpSection's own contents, the language
+ * picker included, are covered by `sections/HelpSection.test.tsx`.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render } from '@testing-library/react';
@@ -69,15 +71,26 @@ beforeEach(() => {
   useSettingsStore.setState({ engineSlotTarget: null, provider: Provider.OPENAI });
 });
 
+const sectionIds = () => {
+  const { container } = render(<MemoryRouter><SimpleSettings /></MemoryRouter>);
+  return Array.from(container.querySelectorAll('.config-section'))
+    .map((el) => el.id || el.className);
+};
+
 describe('SimpleSettings - section order', () => {
-  it('puts translation languages first and interface language last, before help', () => {
-    const { container } = render(<MemoryRouter><SimpleSettings /></MemoryRouter>);
-    const ids = Array.from(container.querySelectorAll('.config-section'))
-      .map((el) => el.id || el.className);
+  it('leads with translation languages and ends with help', () => {
+    const ids = sectionIds();
     const translation = ids.findIndex((x) => x.includes('languages-section'));
     const help = ids.findIndex((x) => x.includes('help'));
-    const iface = ids.findIndex((x) => x.includes('interface-language'));
-    expect(translation).toBeLessThan(iface);
-    expect(iface).toBeLessThan(help);
+    expect(translation).toBeGreaterThanOrEqual(0);
+    expect(translation).toBeLessThan(help);
+    expect(help).toBe(ids.length - 1);
+  });
+
+  // The move's whole point: interface language no longer occupies a section of
+  // this panel. It is a link inside Help now, so nothing here should carry it.
+  it('gives interface language no section of its own', () => {
+    const ids = sectionIds();
+    expect(ids.some((x) => x.includes('interface-language'))).toBe(false);
   });
 });

--- a/src/components/Settings/SimpleSettings/SimpleSettings.tsx
+++ b/src/components/Settings/SimpleSettings/SimpleSettings.tsx
@@ -168,7 +168,6 @@ const SimpleSettings: React.FC<SimpleSettingsProps> = ({ highlightSection }) => 
         {/* Translation Languages */}
         <LanguageSection
           isSessionActive={isSessionActive}
-          showInterfaceLanguage={false}
           showTranslationLanguages={true}
         />
 
@@ -200,21 +199,8 @@ const SimpleSettings: React.FC<SimpleSettingsProps> = ({ highlightSection }) => 
           isLocked={lockParticipant}
         />
 
-        {/* Interface Language - simplified list. Last because it is set once
-            and never revisited; the panel leads with translation languages,
-            which is what it is for. It carries a className rather than an id:
-            `#languages-section` is the translation instance's, and onboarding
-            targets ids, so this move leaves onboarding untouched. */}
-        <LanguageSection
-          className="interface-language-section"
-          isSessionActive={isSessionActive}
-          showInterfaceLanguage={true}
-          showTranslationLanguages={false}
-          simplifiedInterfaceList={true}
-        />
-
         {/* Help & Updates */}
-        <HelpSection />
+        <HelpSection isSessionActive={isSessionActive} />
       </div>
     </div>
   );

--- a/src/components/Settings/sections/HelpSection.test.tsx
+++ b/src/components/Settings/sections/HelpSection.test.tsx
@@ -89,17 +89,21 @@ describe('interface language in Help', () => {
     expect(picker().getAttribute('aria-label')).toMatch(/interface language/i);
   });
 
-  // A native <select> takes its width from its LONGEST option, not from the
-  // chosen one. With "Português (Portugal)" in the list, picking 日本語 left
-  // the control holding twenty characters' worth of empty space, which pushed
-  // the next link onto another line. The visible name is rendered separately
-  // so the width follows what is actually selected; the select itself is
-  // overlaid transparently and keeps its native behaviour.
-  it('shows the selected language as text, so the width fits it', () => {
+  // Settings themes every one of its dropdowns through one shared
+  // `appearance: base-select` layer, keyed off these class names. Joining it
+  // is what gives this control the app's own popup instead of the OS one, the
+  // chevron that marks it as openable, and — because a base-select control
+  // lays out to its selected option rather than its longest — a width that
+  // follows the chosen language. Measured: 54px for 日本語 against 148px for
+  // the same list as a classic OS widget.
+  //
+  // The width itself is a CSS property that jsdom cannot observe; what this
+  // pins is the hook the stylesheet selects on, which is what would silently
+  // break if the class were renamed.
+  it('joins the shared select styling rather than rolling its own', () => {
     render(<HelpSection />);
-    const shown = document.querySelector('#help-section .help-link__value');
-    expect(shown).not.toBeNull();
-    expect(shown!.textContent).toBe('English');
+    expect(picker().classList.contains('help-link__select')).toBe(true);
+    expect(picker().closest('.help-link--picker')).not.toBeNull();
   });
 
   it('offers every interface language, not a shortened list', () => {

--- a/src/components/Settings/sections/HelpSection.test.tsx
+++ b/src/components/Settings/sections/HelpSection.test.tsx
@@ -40,8 +40,21 @@ vi.mock('../../../stores/updateStore', () => ({
   useOpenUpdateDialog: () => vi.fn(),
 }));
 
+// Records suppression so the picker's interaction with it can be asserted;
+// renders children either way, as the real one does.
+//
+// Only the tooltips that are actually controlled are recorded. Help renders
+// three — the picker's, support's and Discussions' — and the last two pass no
+// `suppressed` at all, so recording every render would leave the reader of
+// this array looking at Discussions' constant false.
+const tooltipSuppressed: boolean[] = [];
+// `.at(-1)` needs ES2022; this project targets ES2020.
+const lastSuppressed = () => tooltipSuppressed[tooltipSuppressed.length - 1];
 vi.mock('../../Tooltip/Tooltip', () => ({
-  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  default: ({ children, suppressed }: { children: React.ReactNode; suppressed?: boolean }) => {
+    if (suppressed !== undefined) tooltipSuppressed.push(suppressed);
+    return <>{children}</>;
+  },
 }));
 
 // Injected by vite's `define` at build time, so it does not exist here.
@@ -142,6 +155,25 @@ describe('interface language in Help', () => {
   it('is disabled while a session is running', () => {
     render(<HelpSection isSessionActive />);
     expect(picker().disabled).toBe(true);
+  });
+
+  // Opening the picker puts a list right where the tooltip is; leaving the
+  // tooltip up means it covers the thing the user just asked to see. Focus is
+  // the signal available here — a native select gives no open/close event —
+  // and it covers both opening by mouse and arriving by keyboard.
+  it('drops the tooltip once the picker takes focus', async () => {
+    render(<HelpSection />);
+    tooltipSuppressed.length = 0;
+    fireEvent.focus(picker());
+    await vi.waitFor(() => expect(lastSuppressed()).toBe(true));
+  });
+
+  it('restores the tooltip when the picker is left', async () => {
+    render(<HelpSection />);
+    fireEvent.focus(picker());
+    await vi.waitFor(() => expect(lastSuppressed()).toBe(true));
+    fireEvent.blur(picker());
+    await vi.waitFor(() => expect(lastSuppressed()).toBe(false));
   });
 
   it('leaves the other help links in place', () => {

--- a/src/components/Settings/sections/HelpSection.test.tsx
+++ b/src/components/Settings/sections/HelpSection.test.tsx
@@ -134,7 +134,8 @@ describe('interface language in Help', () => {
   it('applies a chosen language and remembers it', async () => {
     render(<HelpSection />);
     fireEvent.change(picker(), { target: { value: 'ja' } });
-    expect(changeLanguageWithLoad).toHaveBeenCalledWith('ja');
+    // The work runs on a serialising chain, so it lands a microtask later.
+    await vi.waitFor(() => expect(changeLanguageWithLoad).toHaveBeenCalledWith('ja'));
     // Loading the catalogue is not the same as persisting the preference;
     // without the store write the choice is lost on the next launch.
     await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('ja'));
@@ -179,28 +180,51 @@ describe('interface language in Help', () => {
   });
 
   // A <select> fires change on every arrow-key step, so holding a direction
-  // walks the list and starts one catalogue load per language passed. Each is
-  // independently async: an earlier one finishing last would leave the app
-  // speaking a language the user only scrolled through.
-  it('ignores a language load that finishes after a newer one', async () => {
+  // walks the list and starts one request per language passed.
+  //
+  // Guarding only the writes is not enough, and this is the trap: the loader
+  // calls i18n.changeLanguage() ITSELF, before any check the caller could make
+  // afterwards. A stale request allowed to run would change the visible
+  // language back on its way to being discarded, leaving the app showing one
+  // language and having saved another. The requests are serialised instead,
+  // and each checks whether it is still wanted before doing anything at all.
+  it('never loads a language the user has already moved on from', async () => {
+    const started: string[] = [];
     const finish: Record<string, () => void> = {};
-    changeLanguageWithLoad.mockImplementation(
-      (lang: string) => new Promise<void>((res) => { finish[lang] = () => res(); }),
-    );
+    changeLanguageWithLoad.mockImplementation((lang: string) => {
+      started.push(lang);
+      return new Promise<void>((res) => { finish[lang] = () => res(); });
+    });
 
     render(<HelpSection />);
     fireEvent.change(picker(), { target: { value: 'ja' } });
     fireEvent.change(picker(), { target: { value: 'zh_CN' } });
 
-    // The newer choice lands first, then the older one straggles in.
-    finish['zh_CN']();
-    await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('zh_CN'));
-    finish['ja']();
-
-    // Give the stale continuation a chance to misbehave before asserting.
+    // Whichever ran first, let it settle, then let everything drain.
     await new Promise((r) => setTimeout(r, 0));
+    Object.values(finish).forEach((f) => f());
+    await new Promise((r) => setTimeout(r, 0));
+    Object.values(finish).forEach((f) => f());
+    await new Promise((r) => setTimeout(r, 0));
+
+    // ja was superseded before it could run, so it must never have been loaded
+    // — a load is a visible language change, not just a write.
+    expect(started).not.toContain('ja');
     expect(setUILanguage).not.toHaveBeenCalledWith('ja');
-    expect(setUILanguage).toHaveBeenCalledTimes(1);
+    await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('zh_CN'));
+  });
+
+  // The loader has already changed the visible language by the time the write
+  // fails, and the store's own setter applies its value before awaiting the
+  // settings service. Left alone the app keeps a language it failed to save.
+  it('puts the language back when the write fails', async () => {
+    setUILanguage.mockRejectedValueOnce(new Error('disk full'));
+    render(<HelpSection />);
+    fireEvent.change(picker(), { target: { value: 'ja' } });
+
+    await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('ja'));
+    // Rolled back to what it was before the attempt.
+    await vi.waitFor(() => expect(changeLanguageWithLoad).toHaveBeenLastCalledWith('en'));
   });
 
   // setUILanguage writes through the settings service. Left unawaited, a

--- a/src/components/Settings/sections/HelpSection.test.tsx
+++ b/src/components/Settings/sections/HelpSection.test.tsx
@@ -1,0 +1,135 @@
+// Interface language belongs in Help, at the weight of a help link.
+//
+// It used to be a full config-section — an <h3>, an 18px icon, a tooltip —
+// sitting at the top of the panel next to *Translation* languages, two
+// adjacent blocks both called "language". But it is set once and never
+// revisited, and by its own description it does NOT affect what you can
+// translate. That makes it a fact about the application, like the version
+// number and the update check, not a feature setting.
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+
+const changeLanguageWithLoad = vi.fn(async () => undefined);
+vi.mock('../../../locales', () => ({ changeLanguageWithLoad }));
+
+const setUILanguage = vi.fn();
+vi.mock('../../../stores/settingsStore', () => ({
+  useSetUILanguage: () => setUILanguage,
+}));
+
+const trackEvent = vi.fn();
+vi.mock('../../../lib/analytics', () => ({ useAnalytics: () => ({ trackEvent }) }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_k: string, d?: string) => d ?? _k,
+    i18n: { language: 'en' },
+  }),
+}));
+
+vi.mock('../../../contexts/OnboardingContext', () => ({
+  useOnboarding: () => ({ startOnboarding: vi.fn() }),
+}));
+
+let electron = false;
+vi.mock('../../../utils/environment', () => ({ isElectron: () => electron }));
+
+vi.mock('../../../stores/updateStore', () => ({
+  useUpdateStatus: () => 'idle',
+  useCheckForUpdates: () => vi.fn(),
+  useOpenUpdateDialog: () => vi.fn(),
+}));
+
+vi.mock('../../Tooltip/Tooltip', () => ({
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+// Injected by vite's `define` at build time, so it does not exist here.
+vi.stubGlobal('__APP_VERSION__', '0.0.0-test');
+
+const { default: HelpSection } = await import('./HelpSection');
+const { INTERFACE_LANGUAGES } = await import('./interfaceLanguages');
+
+beforeEach(() => {
+  cleanup();
+  electron = false;
+  changeLanguageWithLoad.mockClear();
+  setUILanguage.mockClear();
+  trackEvent.mockClear();
+});
+
+const picker = () => screen.getByLabelText(/interface language/i) as HTMLSelectElement;
+
+describe('interface language in Help', () => {
+  it('is offered as a control inside the help section', () => {
+    render(<HelpSection />);
+    const help = document.querySelector('#help-section');
+    expect(help).not.toBeNull();
+    expect(help!.contains(picker())).toBe(true);
+  });
+
+  // The point of the move: no heading, no 18px icon, no section of its own —
+  // the same weight as "Restart Setup Guide" sitting beside it.
+  it('carries no section heading of its own', () => {
+    render(<HelpSection />);
+    const headings = Array.from(document.querySelectorAll('#help-section h3'));
+    expect(headings).toHaveLength(1);
+    expect(headings[0].textContent).not.toMatch(/interface language/i);
+  });
+
+  // The language's own name is the whole label. Every other entry here is a
+  // single phrase, and "Interface Language: English" would be the only
+  // "label: value" in the row — long enough, measured, to push Discussions
+  // onto a third line. The name stays reachable to assistive technology
+  // through aria-label, which the tests above rely on to find the control.
+  it('lets the language name be the label, with no visible prefix', () => {
+    render(<HelpSection />);
+    const help = document.querySelector('#help-section')!;
+    expect(help.textContent).not.toMatch(/Interface Language/);
+    expect(picker().getAttribute('aria-label')).toMatch(/interface language/i);
+  });
+
+  it('offers every interface language, not a shortened list', () => {
+    render(<HelpSection />);
+    expect(picker().options).toHaveLength(INTERFACE_LANGUAGES.length);
+  });
+
+  it('shows the language currently in use', () => {
+    render(<HelpSection />);
+    expect(picker().value).toBe('en');
+  });
+
+  it('applies a chosen language and remembers it', async () => {
+    render(<HelpSection />);
+    fireEvent.change(picker(), { target: { value: 'ja' } });
+    expect(changeLanguageWithLoad).toHaveBeenCalledWith('ja');
+    // Loading the catalogue is not the same as persisting the preference;
+    // without the store write the choice is lost on the next launch.
+    await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('ja'));
+  });
+
+  it('reports the change with the language it came from', async () => {
+    render(<HelpSection />);
+    fireEvent.change(picker(), { target: { value: 'ja' } });
+    await vi.waitFor(() =>
+      expect(trackEvent).toHaveBeenCalledWith('language_changed', {
+        from_language: 'en',
+        to_language: 'ja',
+        language_type: 'ui',
+      }),
+    );
+  });
+
+  // Changing the UI language reloads a catalogue, which is not something to do
+  // underneath a running translation.
+  it('is disabled while a session is running', () => {
+    render(<HelpSection isSessionActive />);
+    expect(picker().disabled).toBe(true);
+  });
+
+  it('leaves the other help links in place', () => {
+    render(<HelpSection />);
+    expect(screen.getByText(/restart setup guide/i)).toBeTruthy();
+    expect(screen.getByText('support@kizuna.ai')).toBeTruthy();
+  });
+});

--- a/src/components/Settings/sections/HelpSection.test.tsx
+++ b/src/components/Settings/sections/HelpSection.test.tsx
@@ -9,10 +9,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 
-const changeLanguageWithLoad = vi.fn(async () => undefined);
+const changeLanguageWithLoad = vi.fn<(lang: string) => Promise<void>>();
 vi.mock('../../../locales', () => ({ changeLanguageWithLoad }));
 
-const setUILanguage = vi.fn();
+const setUILanguage = vi.fn<(lang: string) => Promise<void>>();
 vi.mock('../../../stores/settingsStore', () => ({
   useSetUILanguage: () => setUILanguage,
 }));
@@ -66,8 +66,10 @@ const { INTERFACE_LANGUAGES } = await import('./interfaceLanguages');
 beforeEach(() => {
   cleanup();
   electron = false;
-  changeLanguageWithLoad.mockClear();
-  setUILanguage.mockClear();
+  changeLanguageWithLoad.mockReset();
+  changeLanguageWithLoad.mockResolvedValue(undefined);
+  setUILanguage.mockReset();
+  setUILanguage.mockResolvedValue(undefined);
   trackEvent.mockClear();
 });
 
@@ -174,6 +176,61 @@ describe('interface language in Help', () => {
     await vi.waitFor(() => expect(lastSuppressed()).toBe(true));
     fireEvent.blur(picker());
     await vi.waitFor(() => expect(lastSuppressed()).toBe(false));
+  });
+
+  // A <select> fires change on every arrow-key step, so holding a direction
+  // walks the list and starts one catalogue load per language passed. Each is
+  // independently async: an earlier one finishing last would leave the app
+  // speaking a language the user only scrolled through.
+  it('ignores a language load that finishes after a newer one', async () => {
+    const finish: Record<string, () => void> = {};
+    changeLanguageWithLoad.mockImplementation(
+      (lang: string) => new Promise<void>((res) => { finish[lang] = () => res(); }),
+    );
+
+    render(<HelpSection />);
+    fireEvent.change(picker(), { target: { value: 'ja' } });
+    fireEvent.change(picker(), { target: { value: 'zh_CN' } });
+
+    // The newer choice lands first, then the older one straggles in.
+    finish['zh_CN']();
+    await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('zh_CN'));
+    finish['ja']();
+
+    // Give the stale continuation a chance to misbehave before asserting.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(setUILanguage).not.toHaveBeenCalledWith('ja');
+    expect(setUILanguage).toHaveBeenCalledTimes(1);
+  });
+
+  // setUILanguage writes through the settings service. Left unawaited, a
+  // failure there surfaced as an unhandled rejection while analytics recorded
+  // a change that was never persisted.
+  it('does not report a change it failed to persist', async () => {
+    setUILanguage.mockRejectedValueOnce(new Error('disk full'));
+    render(<HelpSection />);
+    fireEvent.change(picker(), { target: { value: 'ja' } });
+
+    await vi.waitFor(() => expect(setUILanguage).toHaveBeenCalledWith('ja'));
+    await new Promise((r) => setTimeout(r, 0));
+    expect(trackEvent).not.toHaveBeenCalledWith(
+      'language_changed',
+      expect.objectContaining({ to_language: 'ja' }),
+    );
+  });
+
+  it('survives a catalogue that fails to load', async () => {
+    changeLanguageWithLoad.mockRejectedValueOnce(new Error('offline'));
+    render(<HelpSection />);
+    fireEvent.change(picker(), { target: { value: 'ja' } });
+
+    await new Promise((r) => setTimeout(r, 0));
+    // Nothing persisted, nothing reported, and no unhandled rejection.
+    expect(setUILanguage).not.toHaveBeenCalled();
+    expect(trackEvent).not.toHaveBeenCalledWith(
+      'language_changed',
+      expect.objectContaining({ to_language: 'ja' }),
+    );
   });
 
   it('leaves the other help links in place', () => {

--- a/src/components/Settings/sections/HelpSection.test.tsx
+++ b/src/components/Settings/sections/HelpSection.test.tsx
@@ -89,6 +89,19 @@ describe('interface language in Help', () => {
     expect(picker().getAttribute('aria-label')).toMatch(/interface language/i);
   });
 
+  // A native <select> takes its width from its LONGEST option, not from the
+  // chosen one. With "Português (Portugal)" in the list, picking 日本語 left
+  // the control holding twenty characters' worth of empty space, which pushed
+  // the next link onto another line. The visible name is rendered separately
+  // so the width follows what is actually selected; the select itself is
+  // overlaid transparently and keeps its native behaviour.
+  it('shows the selected language as text, so the width fits it', () => {
+    render(<HelpSection />);
+    const shown = document.querySelector('#help-section .help-link__value');
+    expect(shown).not.toBeNull();
+    expect(shown!.textContent).toBe('English');
+  });
+
   it('offers every interface language, not a shortened list', () => {
     render(<HelpSection />);
     expect(picker().options).toHaveLength(INTERFACE_LANGUAGES.length);

--- a/src/components/Settings/sections/HelpSection.tsx
+++ b/src/components/Settings/sections/HelpSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { HelpCircle, RefreshCw, Mail, MessageSquare, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '../../Tooltip/Tooltip';
@@ -29,6 +29,9 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
   // reports no open/close, but it always takes focus to open — and suppressing
   // on focus also keeps the tooltip out of the way of keyboard users.
   const [pickerFocused, setPickerFocused] = useState(false);
+
+  // Serial number of the newest language request; see the change handler.
+  const languageRequestRef = useRef(0);
 
   const openExternalUrl = (url: string) => {
     if (isElectron() && (window as any).electron?.invoke) {
@@ -107,13 +110,36 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
             onChange={async (e) => {
               const oldLanguage = i18n.language;
               const newLanguage = e.target.value;
-              await changeLanguageWithLoad(newLanguage);
-              setUILanguage(newLanguage);
-              trackEvent('language_changed', {
-                from_language: oldLanguage,
-                to_language: newLanguage,
-                language_type: 'ui',
-              });
+
+              // A <select> fires change on every arrow-key step, so holding a
+              // direction walks the list and starts one catalogue load per
+              // language passed. Each is independently async, so an earlier
+              // one can finish last and leave the app speaking a language the
+              // user only scrolled through. Only the newest request may write.
+              const request = ++languageRequestRef.current;
+
+              try {
+                await changeLanguageWithLoad(newLanguage);
+                if (request !== languageRequestRef.current) return;
+
+                // Awaited: this writes through the settings service, and
+                // unawaited a failure became an unhandled rejection while the
+                // event below reported a change that was never saved.
+                await setUILanguage(newLanguage);
+                if (request !== languageRequestRef.current) return;
+
+                trackEvent('language_changed', {
+                  from_language: oldLanguage,
+                  to_language: newLanguage,
+                  language_type: 'ui',
+                });
+              } catch (err) {
+                // The catalogue or the settings service failed. The language
+                // is left as it was and nothing is reported as changed.
+                // TODO(#441): route this through logStore once the repo-wide
+                // logging convention lands, so the user can see it in Logs.
+                console.error('[HelpSection] Could not change the interface language:', err);
+              }
             }}
           >
             {INTERFACE_LANGUAGES.map((lang) => (

--- a/src/components/Settings/sections/HelpSection.tsx
+++ b/src/components/Settings/sections/HelpSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { HelpCircle, RefreshCw, Mail, MessageSquare, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '../../Tooltip/Tooltip';
@@ -23,6 +23,12 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
   const openUpdateDialog = useOpenUpdateDialog();
   const setUILanguage = useSetUILanguage();
   const { trackEvent } = useAnalytics();
+
+  // Opening the picker puts its list exactly where the tooltip sits, so the
+  // tooltip would cover the thing the user just asked to see. A native select
+  // reports no open/close, but it always takes focus to open — and suppressing
+  // on focus also keeps the tooltip out of the way of keyboard users.
+  const [pickerFocused, setPickerFocused] = useState(false);
 
   const openExternalUrl = (url: string) => {
     if (isElectron() && (window as any).electron?.invoke) {
@@ -68,8 +74,12 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
           and the platform renders it outside this panel's bounds, with its own
           keyboard handling and type-ahead, at no cost here.
         */}
-        <Tooltip content={t('simpleConfig.interfaceLanguageDesc')} position="top">
-        <label className={`help-link help-link--picker ${isSessionActive ? 'disabled' : ''}`}>
+        <Tooltip
+          content={t('simpleConfig.interfaceLanguageDesc')}
+          position="top"
+          suppressed={pickerFocused}
+        >
+        <label className={['help-link', 'help-link--picker', isSessionActive ? 'disabled' : ''].filter(Boolean).join(' ')}>
           <Globe size={13} />
           {/*
             The language's own name is the whole label. Every other entry here
@@ -92,6 +102,8 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
             aria-label={t('simpleConfig.interfaceLanguage', 'Interface Language')}
             value={i18n.language}
             disabled={isSessionActive}
+            onFocus={() => setPickerFocused(true)}
+            onBlur={() => setPickerFocused(false)}
             onChange={async (e) => {
               const oldLanguage = i18n.language;
               const newLanguage = e.target.value;

--- a/src/components/Settings/sections/HelpSection.tsx
+++ b/src/components/Settings/sections/HelpSection.tsx
@@ -78,7 +78,18 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
             the row, long enough to push Discussions onto a third line. The
             globe carries the meaning; the tooltip carries the caveat that this
             is not the translation language.
+
+            The name is rendered here rather than left to the <select>, because
+            a native select is as wide as its LONGEST option. With "Português
+            (Portugal)" in the list, choosing 日本語 left the control padded
+            out with twenty characters of nothing. This span sets the width to
+            the chosen name; the select is laid transparently over it and keeps
+            every native behaviour — the OS-drawn list, keyboard, type-ahead.
           */}
+          <span className="help-link__value">
+            {INTERFACE_LANGUAGES.find((l) => l.value === i18n.language)?.label
+              ?? i18n.language}
+          </span>
           <select
             className="help-link__select"
             aria-label={t('simpleConfig.interfaceLanguage', 'Interface Language')}

--- a/src/components/Settings/sections/HelpSection.tsx
+++ b/src/components/Settings/sections/HelpSection.tsx
@@ -30,8 +30,10 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
   // on focus also keeps the tooltip out of the way of keyboard users.
   const [pickerFocused, setPickerFocused] = useState(false);
 
-  // Serial number of the newest language request; see the change handler.
-  const languageRequestRef = useRef(0);
+  // The language the user last asked for, and the chain the requests run on.
+  // See the change handler for why serialising is what this needs.
+  const wantedLanguageRef = useRef<string | null>(null);
+  const languageChainRef = useRef<Promise<void>>(Promise.resolve());
 
   const openExternalUrl = (url: string) => {
     if (isElectron() && (window as any).electron?.invoke) {
@@ -107,39 +109,71 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
             disabled={isSessionActive}
             onFocus={() => setPickerFocused(true)}
             onBlur={() => setPickerFocused(false)}
-            onChange={async (e) => {
+            onChange={(e) => {
               const oldLanguage = i18n.language;
               const newLanguage = e.target.value;
+              wantedLanguageRef.current = newLanguage;
 
               // A <select> fires change on every arrow-key step, so holding a
-              // direction walks the list and starts one catalogue load per
-              // language passed. Each is independently async, so an earlier
-              // one can finish last and leave the app speaking a language the
-              // user only scrolled through. Only the newest request may write.
-              const request = ++languageRequestRef.current;
+              // direction walks the list and starts one request per language
+              // passed. Checking only before the WRITES would be too late:
+              // changeLanguageWithLoad calls i18n.changeLanguage() itself, so
+              // a stale request allowed to run changes the visible language on
+              // its way to being discarded — leaving the app showing one
+              // language and having saved another.
+              //
+              // So the requests are serialised on a chain, and each asks
+              // whether it is still wanted before doing anything at all. A
+              // language the user scrolled past is never loaded.
+              languageChainRef.current = languageChainRef.current.then(async () => {
+                if (wantedLanguageRef.current !== newLanguage) return;
 
-              try {
-                await changeLanguageWithLoad(newLanguage);
-                if (request !== languageRequestRef.current) return;
+                // Split deliberately: these two failures need opposite
+                // treatment, and one catch around both would have to guess.
+                // TODO(#441): both console lines belong in logStore once the
+                // repo-wide logging convention lands.
+                try {
+                  await changeLanguageWithLoad(newLanguage);
+                } catch (err) {
+                  // The catalogue never loaded, so i18n never switched. There
+                  // is nothing to undo, and trying to "restore" would kick off
+                  // another load for a language that was never left.
+                  console.error('[HelpSection] Could not load the interface language:', err);
+                  return;
+                }
 
-                // Awaited: this writes through the settings service, and
-                // unawaited a failure became an unhandled rejection while the
-                // event below reported a change that was never saved.
-                await setUILanguage(newLanguage);
-                if (request !== languageRequestRef.current) return;
+                try {
+                  // Awaited: this writes through the settings service, and
+                  // unawaited a failure became an unhandled rejection while
+                  // the event below reported a change that was never saved.
+                  await setUILanguage(newLanguage);
+                } catch (err) {
+                  // Here the visible language HAS changed, and the store
+                  // applied its value before awaiting the service — so the app
+                  // is wearing a language it could not save. Put it back,
+                  // unless the user has since asked for something else and a
+                  // later link in the chain is about to set it anyway.
+                  console.error('[HelpSection] Could not save the interface language:', err);
+                  if (wantedLanguageRef.current === newLanguage) {
+                    wantedLanguageRef.current = oldLanguage;
+                    try {
+                      await changeLanguageWithLoad(oldLanguage);
+                      await setUILanguage(oldLanguage);
+                    } catch {
+                      // Best effort: the service is evidently unwell. The
+                      // store's value is restored regardless, since it is
+                      // applied before the write that rejects.
+                    }
+                  }
+                  return;
+                }
 
                 trackEvent('language_changed', {
                   from_language: oldLanguage,
                   to_language: newLanguage,
                   language_type: 'ui',
                 });
-              } catch (err) {
-                // The catalogue or the settings service failed. The language
-                // is left as it was and nothing is reported as changed.
-                // TODO(#441): route this through logStore once the repo-wide
-                // logging convention lands, so the user can see it in Logs.
-                console.error('[HelpSection] Could not change the interface language:', err);
-              }
+              });
             }}
           >
             {INTERFACE_LANGUAGES.map((lang) => (

--- a/src/components/Settings/sections/HelpSection.tsx
+++ b/src/components/Settings/sections/HelpSection.tsx
@@ -1,21 +1,28 @@
 import React, { useEffect } from 'react';
-import { HelpCircle, RefreshCw, Mail, MessageSquare } from 'lucide-react';
+import { HelpCircle, RefreshCw, Mail, MessageSquare, Globe } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '../../Tooltip/Tooltip';
 import { isElectron } from '../../../utils/environment';
 import { useOnboarding } from '../../../contexts/OnboardingContext';
 import { useUpdateStatus, useCheckForUpdates, useOpenUpdateDialog } from '../../../stores/updateStore';
+import { useSetUILanguage } from '../../../stores/settingsStore';
+import { useAnalytics } from '../../../lib/analytics';
+import { changeLanguageWithLoad } from '../../../locales';
+import { INTERFACE_LANGUAGES } from './interfaceLanguages';
 
 interface HelpSectionProps {
   toggleSettings?: () => void;
+  isSessionActive?: boolean;
 }
 
-const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings }) => {
-  const { t } = useTranslation();
+const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActive = false }) => {
+  const { t, i18n } = useTranslation();
   const { startOnboarding } = useOnboarding();
   const updateStatus = useUpdateStatus();
   const checkForUpdates = useCheckForUpdates();
   const openUpdateDialog = useOpenUpdateDialog();
+  const setUILanguage = useSetUILanguage();
+  const { trackEvent } = useAnalytics();
 
   const openExternalUrl = (url: string) => {
     if (isElectron() && (window as any).electron?.invoke) {
@@ -50,6 +57,51 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings }) => {
             <span>{updateStatus === 'checking' ? t('update.checking') : t('update.checkButton')}</span>
           </a>
         )}
+        {/*
+          Interface language, at the weight of a link rather than a section of
+          its own. It is set once and never revisited, and by its own
+          description it does not affect what can be translated — so it is a
+          fact about the application, like the version above and the update
+          check beside it, not a feature setting.
+
+          A native <select> rather than a custom popover: the list is 30 long,
+          and the platform renders it outside this panel's bounds, with its own
+          keyboard handling and type-ahead, at no cost here.
+        */}
+        <Tooltip content={t('simpleConfig.interfaceLanguageDesc')} position="top">
+        <label className={`help-link help-link--picker ${isSessionActive ? 'disabled' : ''}`}>
+          <Globe size={13} />
+          {/*
+            The language's own name is the whole label. Every other entry here
+            is a single phrase — "Discussions", "support@kizuna.ai" — and a
+            "Interface Language: English" would be the only "label: value" in
+            the row, long enough to push Discussions onto a third line. The
+            globe carries the meaning; the tooltip carries the caveat that this
+            is not the translation language.
+          */}
+          <select
+            className="help-link__select"
+            aria-label={t('simpleConfig.interfaceLanguage', 'Interface Language')}
+            value={i18n.language}
+            disabled={isSessionActive}
+            onChange={async (e) => {
+              const oldLanguage = i18n.language;
+              const newLanguage = e.target.value;
+              await changeLanguageWithLoad(newLanguage);
+              setUILanguage(newLanguage);
+              trackEvent('language_changed', {
+                from_language: oldLanguage,
+                to_language: newLanguage,
+                language_type: 'ui',
+              });
+            }}
+          >
+            {INTERFACE_LANGUAGES.map((lang) => (
+              <option key={lang.value} value={lang.value}>{lang.label}</option>
+            ))}
+          </select>
+        </label>
+        </Tooltip>
         <Tooltip content={t('settings.helpEmailTooltip', 'Report bugs or get help')} position="top">
           <a className="help-link" onClick={() => openExternalUrl('mailto:support@kizuna.ai')}>
             <Mail size={13} />

--- a/src/components/Settings/sections/HelpSection.tsx
+++ b/src/components/Settings/sections/HelpSection.tsx
@@ -79,17 +79,14 @@ const HelpSection: React.FC<HelpSectionProps> = ({ toggleSettings, isSessionActi
             globe carries the meaning; the tooltip carries the caveat that this
             is not the translation language.
 
-            The name is rendered here rather than left to the <select>, because
-            a native select is as wide as its LONGEST option. With "Português
-            (Portugal)" in the list, choosing 日本語 left the control padded
-            out with twenty characters of nothing. This span sets the width to
-            the chosen name; the select is laid transparently over it and keeps
-            every native behaviour — the OS-drawn list, keyboard, type-ahead.
+            The control is a plain <select> joined to Settings' shared
+            base-select layer, like every other dropdown in this panel — not a
+            hand-built popover, which would be a third pattern in a codebase
+            that already has two. That layer draws the popup in-window with the
+            app's own theme, and a base-select control lays out to its SELECTED
+            option rather than its longest, so the width follows the chosen
+            language on its own.
           */}
-          <span className="help-link__value">
-            {INTERFACE_LANGUAGES.find((l) => l.value === i18n.language)?.label
-              ?? i18n.language}
-          </span>
           <select
             className="help-link__select"
             aria-label={t('simpleConfig.interfaceLanguage', 'Interface Language')}

--- a/src/components/Settings/sections/LanguageSection.sentence.test.tsx
+++ b/src/components/Settings/sections/LanguageSection.sentence.test.tsx
@@ -60,7 +60,7 @@ const { default: LanguageSection } = await import('./LanguageSection');
 
 const renderSection = () =>
   render(
-    <LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />
+    <LanguageSection isSessionActive={false} showTranslationLanguages={true} />
   );
 
 describe('LanguageSection — mode-verb sentence labels (local providers)', () => {
@@ -227,7 +227,7 @@ describe('LanguageSection — resolution notes summary (2026-08-23 dedup)', () =
         { direction: 'ja→en', stage: 'tts', from: 'supertonic-3', to: 'edge-tts', reason: 'not-downloaded' },
       ],
     });
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     const notes = screen.getByTestId('language-resolution-notes');
     expect(notes.querySelectorAll('.language-warning')).toHaveLength(1);
     // Names the failed picks (display name when the manifest knows the id,
@@ -246,7 +246,7 @@ describe('LanguageSection — resolution notes summary (2026-08-23 dedup)', () =
         { direction: 'ja→en', stage: 'asr', from: null, to: null, reason: 'no-candidate' },
       ],
     });
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     expect(screen.queryByTestId('language-resolution-notes')).not.toBeInTheDocument();
   });
 
@@ -257,14 +257,14 @@ describe('LanguageSection — resolution notes summary (2026-08-23 dedup)', () =
         { direction: 'ja→en', stage: 'translation', from: 'a', to: 'b', reason: 'not-downloaded' },
       ],
     });
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     fireEvent.click(screen.getByTestId('resolution-notes-review'));
     expect(useSettingsStore.getState().engineSlotTarget).toMatchObject({ dir: 'ja→en', stage: 'translation' });
   });
 
   it('renders nothing when there are no notes', () => {
     useModelStore.setState({ lastResolutionNotes: [] });
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     expect(screen.queryByTestId('language-resolution-notes')).not.toBeInTheDocument();
   });
 
@@ -291,7 +291,7 @@ describe('LanguageSection — resolution notes summary (2026-08-23 dedup)', () =
         { direction: 'en→ja', stage: 'asr', from: 'deleted-x', to: 'auto-y', reason: 'not-downloaded' },
       ],
     } as any);
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
 
     fireEvent.click(screen.getByTestId('resolution-notes-use-auto'));
 
@@ -316,7 +316,7 @@ describe('LanguageSection — resolution notes summary (2026-08-23 dedup)', () =
         { direction: 'en→ja', stage: 'asr', from: 'a', to: 'b', reason: 'not-downloaded' },
       ],
     } as any);
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     expect(screen.queryByTestId('language-resolution-notes')).not.toBeInTheDocument();
   });
 
@@ -327,7 +327,7 @@ describe('LanguageSection — resolution notes summary (2026-08-23 dedup)', () =
         { direction: 'ja→en', stage: 'asr', from: null, to: null, reason: 'not-downloaded' },
       ],
     });
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     expect(screen.queryByTestId('language-resolution-notes')).not.toBeInTheDocument();
   });
 });
@@ -350,7 +350,7 @@ describe('LanguageSection — the ONE blocking missing-models warning (resolver-
     // the resolver-backed rewrite.
     useSettingsStore.setState({ provider: Provider.LOCAL_INFERENCE, engineSlotTarget: null } as any);
     useModelStore.setState({ initialized: true, statuses: {}, lastResolutionNotes: [] } as any);
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
 
     const warning = document.querySelector('.language-model-warning');
     expect(warning).toBeInTheDocument();
@@ -365,7 +365,7 @@ describe('LanguageSection — the ONE blocking missing-models warning (resolver-
   it('renders no warning while the model store is uninitialized', () => {
     useSettingsStore.setState({ provider: Provider.LOCAL_INFERENCE });
     useModelStore.setState({ initialized: false, statuses: {} } as any);
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     expect(document.querySelector('.language-model-warning')).not.toBeInTheDocument();
   });
 });
@@ -392,7 +392,7 @@ describe('LanguageSection — the mirror line needs a pinned source language', (
     useSettingsStore.setState((s: any) => ({
       soniox: { ...s.soniox, sourceLanguage: 'auto', targetLanguage: 'en' },
     }));
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     expect(screen.queryByTestId('language-mirror-line')).not.toBeInTheDocument();
   });
 
@@ -400,7 +400,7 @@ describe('LanguageSection — the mirror line needs a pinned source language', (
     useSettingsStore.setState((s: any) => ({
       soniox: { ...s.soniox, sourceLanguage: 'ja', targetLanguage: 'en' },
     }));
-    render(<LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />);
+    render(<LanguageSection isSessionActive={false} showTranslationLanguages={true} />);
     const mirror = screen.getByTestId('language-mirror-line');
     expect(mirror.textContent).toContain('They speak');
     // Display names, never the raw settings tokens.

--- a/src/components/Settings/sections/LanguageSection.soniox.test.tsx
+++ b/src/components/Settings/sections/LanguageSection.soniox.test.tsx
@@ -52,7 +52,7 @@ describe('LanguageSection — Soniox language wiring (regression for C2)', () =>
 
   it('writes the source language to the soniox slice when the source select changes', () => {
     render(
-      <LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />
+      <LanguageSection isSessionActive={false} showTranslationLanguages={true} />
     );
     const selects = screen.getAllByRole('combobox');
     // Only the translation-language pair is rendered (interface language hidden):
@@ -63,7 +63,7 @@ describe('LanguageSection — Soniox language wiring (regression for C2)', () =>
 
   it('writes the target language to the soniox slice when the target select changes', () => {
     render(
-      <LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />
+      <LanguageSection isSessionActive={false} showTranslationLanguages={true} />
     );
     const selects = screen.getAllByRole('combobox');
     fireEvent.change(selects[1], { target: { value: 'ja' } });

--- a/src/components/Settings/sections/LanguageSection.textOnly.test.tsx
+++ b/src/components/Settings/sections/LanguageSection.textOnly.test.tsx
@@ -52,7 +52,7 @@ const textOnlySwitch = () =>
 
 const renderSection = () =>
   render(
-    <LanguageSection isSessionActive={false} showInterfaceLanguage={false} showTranslationLanguages={true} />
+    <LanguageSection isSessionActive={false} showTranslationLanguages={true} />
   );
 
 describe('LanguageSection — Text Only toggle vs the channel matrix', () => {

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
-import { Globe, Languages, ArrowLeftRight, CircleHelp, AlertTriangle, VolumeX } from 'lucide-react';
+import { Languages, ArrowLeftRight, CircleHelp, AlertTriangle, VolumeX } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '../../Tooltip/Tooltip';
 import ToggleSwitch from '../shared/ToggleSwitch';
@@ -11,7 +11,6 @@ import {
   useLocalNativeSettings,
   useVolcengineAST2Settings,
   useZoomAISettings,
-  useSetUILanguage,
   useUpdateOpenAI,
   useUpdateGemini,
   useUpdateOpenAICompatible,
@@ -43,7 +42,6 @@ import { resolveAST2LanguagePair } from '../../../services/providers/volcengineA
 import { useIsParticipantChannelInScope, useMode, speakerChannelInScope } from '../../../stores/audioStore';
 import { useLockedMode } from '../../../stores/sessionStore';
 import { effectiveTextOnly } from '../../../utils/effectiveTextOnly';
-import { changeLanguageWithLoad } from '../../../locales';
 import { useAnalytics } from '../../../lib/analytics';
 import { getTranslationTargetLanguages, getManifestEntry } from '../../../lib/local-inference/modelManifest';
 import { shortenModelName } from '../../../lib/local-inference/modelName';
@@ -53,24 +51,18 @@ import { directionKey, emptyDirection, type Stage, type Selections, type Resolut
 
 interface LanguageSectionProps {
   isSessionActive: boolean;
-  /** Show interface language selector */
-  showInterfaceLanguage?: boolean;
   /** Show translation languages selector */
   showTranslationLanguages?: boolean;
-  /** Use simplified language list for interface (12 languages) */
-  simplifiedInterfaceList?: boolean;
   /** Additional class name */
   className?: string;
 }
 
 const LanguageSection: React.FC<LanguageSectionProps> = ({
   isSessionActive,
-  showInterfaceLanguage = true,
   showTranslationLanguages = true,
-  simplifiedInterfaceList = false,
   className = ''
 }) => {
-  const { t, i18n } = useTranslation();
+  const { t } = useTranslation();
   const { trackEvent } = useAnalytics();
 
   // Settings store
@@ -102,7 +94,6 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
   const keepReplayAudio = useKeepReplayAudio();
   const setKeepReplayAudio = useSetKeepReplayAudio();
 
-  const setUILanguage = useSetUILanguage();
   const updateOpenAISettings = useUpdateOpenAI();
   const updateGeminiSettings = useUpdateGemini();
   const updateOpenAICompatibleSettings = useUpdateOpenAICompatible();
@@ -408,56 +399,6 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
   }, [effectiveProvider, isParticipantChannelInScope, currentProviderSettings.sourceLanguage, currentProviderSettings.model]);
 
   // Simplified interface language list (12 most common languages)
-  const simplifiedLanguages = [
-    { value: 'en', label: 'English' },
-    { value: 'zh_CN', label: '中文 (简体)' },
-    { value: 'zh_TW', label: '中文 (繁體)' },
-    { value: 'ja', label: '日本語' },
-    { value: 'ko', label: '한국어' },
-    { value: 'es', label: 'Español' },
-    { value: 'fr', label: 'Français' },
-    { value: 'de', label: 'Deutsch' },
-    { value: 'pt_BR', label: 'Português (Brasil)' },
-    { value: 'pt_PT', label: 'Português (Portugal)' },
-    { value: 'vi', label: 'Tiếng Việt' },
-    { value: 'hi', label: 'हिन्दी' }
-  ];
-
-  // Full interface language list (35 languages)
-  const fullLanguages = [
-    { value: 'en', label: 'English' },
-    { value: 'zh_CN', label: '中文 (简体)' },
-    { value: 'hi', label: 'हिन्दी' },
-    { value: 'es', label: 'Español' },
-    { value: 'fr', label: 'Français' },
-    { value: 'ar', label: 'العربية' },
-    { value: 'bn', label: 'বাংলা' },
-    { value: 'pt_BR', label: 'Português (Brasil)' },
-    { value: 'ru', label: 'Русский' },
-    { value: 'ja', label: '日本語' },
-    { value: 'de', label: 'Deutsch' },
-    { value: 'ko', label: '한국어' },
-    { value: 'fa', label: 'فارسی' },
-    { value: 'tr', label: 'Türkçe' },
-    { value: 'vi', label: 'Tiếng Việt' },
-    { value: 'it', label: 'Italiano' },
-    { value: 'th', label: 'ไทย' },
-    { value: 'pl', label: 'Polski' },
-    { value: 'id', label: 'Bahasa Indonesia' },
-    { value: 'ms', label: 'Bahasa Melayu' },
-    { value: 'nl', label: 'Nederlands' },
-    { value: 'zh_TW', label: '中文 (繁體)' },
-    { value: 'pt_PT', label: 'Português (Portugal)' },
-    { value: 'uk', label: 'Українська' },
-    { value: 'ta', label: 'தமிழ்' },
-    { value: 'te', label: 'తెలుగు' },
-    { value: 'he', label: 'עברית' },
-    { value: 'fil', label: 'Filipino' },
-    { value: 'sv', label: 'Svenska' },
-    { value: 'fi', label: 'Suomi' }
-  ];
-
-  const interfaceLanguages = simplifiedInterfaceList ? simplifiedLanguages : fullLanguages;
 
   // The ONE blocking warning (2026-08-23 warning-dedup decision): which
   // mandatory stages have NO candidate at all for the current speaker pair.
@@ -643,45 +584,9 @@ const LanguageSection: React.FC<LanguageSectionProps> = ({
 
   return (
     <>
-      {/* Interface Language Section */}
-      {showInterfaceLanguage && (
-        <div className={`config-section ${className}`}>
-          <h3>
-            <Globe size={18} />
-            <span>{t('simpleConfig.interfaceLanguage')}</span>
-            <Tooltip
-              content={t('simpleConfig.interfaceLanguageDesc')}
-              position="top"
-              icon="help"
-            />
-          </h3>
-
-          <div className="setting-row">
-            <select
-              value={i18n.language}
-              onChange={async (e) => {
-                const oldLanguage = i18n.language;
-                const newLanguage = e.target.value;
-                await changeLanguageWithLoad(newLanguage);
-                setUILanguage(newLanguage);
-                trackEvent('language_changed', {
-                  from_language: oldLanguage,
-                  to_language: newLanguage,
-                  language_type: 'ui'
-                });
-              }}
-              disabled={isSessionActive}
-              className="language-select"
-            >
-              {interfaceLanguages.map((lang) => (
-                <option key={lang.value} value={lang.value}>
-                  {lang.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-      )}
+      {/* Interface language now lives in HelpSection, at the weight of a link:
+          it is set once and never revisited, and does not affect what can be
+          translated. This section is about translation languages only. */}
 
       {/* Translation Languages Section */}
       {showTranslationLanguages && (

--- a/src/components/Settings/sections/LanguageSection.tsx
+++ b/src/components/Settings/sections/LanguageSection.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useCallback } from 'react';
-import { Languages, ArrowLeftRight, CircleHelp, AlertTriangle, VolumeX } from 'lucide-react';
+import { Languages, ArrowLeftRight, AlertTriangle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import Tooltip from '../../Tooltip/Tooltip';
 import ToggleSwitch from '../shared/ToggleSwitch';

--- a/src/components/Settings/sections/interfaceLanguages.ts
+++ b/src/components/Settings/sections/interfaceLanguages.ts
@@ -1,0 +1,54 @@
+// src/components/Settings/sections/interfaceLanguages.ts
+//
+// The languages Sokuji's own menus and buttons can be shown in — not the
+// languages it can translate between, which is a separate and far more
+// frequently changed setting.
+//
+// This list used to live inside LanguageSection's function body, rebuilt on
+// every render, alongside a 12-entry "simplified" variant shown in Simple
+// mode. Both are gone: the control now sits in Help at the weight of a link,
+// so the reason to shorten it — sparing a prominent setting's worth of
+// attention — no longer applies, while failing to find your own language in
+// it stays as bad as it ever was.
+//
+// One entry per directory under src/locales. locales.consistency.test.ts
+// guards that correspondence.
+export interface InterfaceLanguage {
+  value: string;
+  label: string;
+}
+
+// Ordered by speaker population, which is why English leads and Finnish
+// trails; it is not alphabetical in any of the labels' own scripts.
+export const INTERFACE_LANGUAGES: InterfaceLanguage[] = [
+  { value: 'en', label: 'English' },
+  { value: 'zh_CN', label: '中文 (简体)' },
+  { value: 'hi', label: 'हिन्दी' },
+  { value: 'es', label: 'Español' },
+  { value: 'fr', label: 'Français' },
+  { value: 'ar', label: 'العربية' },
+  { value: 'bn', label: 'বাংলা' },
+  { value: 'pt_BR', label: 'Português (Brasil)' },
+  { value: 'ru', label: 'Русский' },
+  { value: 'ja', label: '日本語' },
+  { value: 'de', label: 'Deutsch' },
+  { value: 'ko', label: '한국어' },
+  { value: 'fa', label: 'فارسی' },
+  { value: 'tr', label: 'Türkçe' },
+  { value: 'vi', label: 'Tiếng Việt' },
+  { value: 'it', label: 'Italiano' },
+  { value: 'th', label: 'ไทย' },
+  { value: 'pl', label: 'Polski' },
+  { value: 'id', label: 'Bahasa Indonesia' },
+  { value: 'ms', label: 'Bahasa Melayu' },
+  { value: 'nl', label: 'Nederlands' },
+  { value: 'zh_TW', label: '中文 (繁體)' },
+  { value: 'pt_PT', label: 'Português (Portugal)' },
+  { value: 'uk', label: 'Українська' },
+  { value: 'ta', label: 'தமிழ்' },
+  { value: 'te', label: 'తెలుగు' },
+  { value: 'he', label: 'עברית' },
+  { value: 'fil', label: 'Filipino' },
+  { value: 'sv', label: 'Svenska' },
+  { value: 'fi', label: 'Suomi' },
+];

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -29,6 +29,12 @@ interface TooltipProps {
   maxWidth?: number;
   /** Hover open delay in ms (default 100). Pass 0 for an instant tooltip. */
   openDelay?: number;
+  /**
+   * Force the tooltip shut regardless of hover. For triggers that open
+   * something of their own — a select's picker, a menu — where a tooltip
+   * left hanging over the thing the user just opened is in the way.
+   */
+  suppressed?: boolean;
 }
 
 const Tooltip: React.FC<TooltipProps> = ({
@@ -38,7 +44,8 @@ const Tooltip: React.FC<TooltipProps> = ({
   trigger = 'hover',
   icon = 'help',
   maxWidth = 250,
-  openDelay = 100
+  openDelay = 100,
+  suppressed = false
 }) => {
   const [isOpen, setIsOpen] = useState(false);
 
@@ -151,7 +158,7 @@ const Tooltip: React.FC<TooltipProps> = ({
         </span>
       )}
       <FloatingPortal>
-        {isOpen && (
+        {isOpen && !suppressed && (
           <div
             ref={refs.setFloating}
             style={{

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -272,7 +272,10 @@ export interface SettingsStore {
   // === Actions ===
   // Common settings actions
   setProvider: (provider: ProviderType) => void;
-  setUILanguage: (lang: string) => void;
+  // Async: it writes through the settings service. Declared void, callers
+  // had no way to know they should await it — a failed write surfaced as an
+  // unhandled rejection with the UI already changed.
+  setUILanguage: (lang: string) => Promise<void>;
   setUIMode: (mode: 'basic' | 'advanced') => void;
   setTextOnly: (textOnly: boolean) => void;
   setKeepReplayAudio: (keepReplayAudio: boolean) => Promise<void>;


### PR DESCRIPTION
Interface language stops being a setting and becomes a fact about the application.

## The move

It was a full `config-section` — an `<h3>`, an 18px icon, a tooltip — at the top of the panel, directly above *Translation* languages: two adjacent blocks both called "language", the more prominent one being the one nobody ever changes. #437 moved it to the bottom of Simple mode, but only Simple; Advanced still led its General tab with it, and nothing guarded that side.

It is set once and never revisited, and by its own description it does **not** affect what can be translated. That puts it with the version number and the update check, so it now sits inside Help at the weight of a link, in both modes.

Both language lists move out of `LanguageSection`'s function body — where they were rebuilt on every render — into `interfaceLanguages.ts`. The 12-entry "simplified" list is gone with them: it existed to spare a prominent setting's worth of attention, and at link weight, failing to find your own language is the worse cost. Its comment claimed 35 languages; there were 30, one per directory in `src/locales`.

## What the running app then showed

Four faults, each found by using it rather than reading it. Recorded here because the reasoning matters more than the diffs:

**It was a link, so it stopped looking clickable.** Stripped of every control affordance in pursuit of link weight, nothing said the language could be changed. The chevron is back.

**It was not joined to the shared select layer.** Settings themes every dropdown through one `appearance: base-select` layer that draws the popup in-window with the app's own styling. This control was built outside it and then patched twice to compensate — an `option { color: initial }` for the unthemed OS popup, and a mirrored span with a transparently overlaid select to stop it sizing to its longest option. Both were solving, worse, problems this codebase had already solved. A base-select control also lays out to its *selected* option: measured at 54px for 日本語 against 148px for the same list as a classic OS widget, so joining the layer deleted the mirror outright.

A hand-built popover was considered and rejected. Settings uses native selects throughout (`ProviderSection`, `NativeModelManagementSection`, translation languages); the popover components live in `MainPanel` and the title bar, a different context. A third pattern would have matched neither.

**It stood taller than every link beside it.** A base-select control carries a UA minimum height of 24px — a touch target — and its chevron holds a full line box on top of that. Worth being precise: the boxes were centred on each other the whole time, all three mid-points at 48.5; a row of links is read along its *text*, and a taller box centres its text somewhere else. `min-height: 0` plus `height: 1lh` gives it exactly the line box its neighbours occupy — all three rows now measure `top=26.0 h=36.0 mid=44.0`.

**Two things did not react.** The tooltip stayed up while the picker was open, covering the list the user had just asked to see; `Tooltip` gains a `suppressed` prop (it had no controlled entry point at all) and the picker sets it on focus, since a native select reports no open/close but always takes focus to open. And the chevron kept a hardcoded `$text-muted` copied from the bordered selects elsewhere, so it was the one part of the control that ignored hover — now `color: inherit`, measured at `rgb(136,136,136)` at rest and `rgb(16,163,127)` with the row's hover colour.

## Tests

`SimpleSettings.order.test.tsx` pinned the old position; its contract is rewritten to pin the absence instead. `HelpSection` had no tests at all — it has twelve now, covering placement, the full list, persistence, the session lock, tooltip suppression, and the class hook the stylesheet selects on.

512 passing; type errors unchanged from baseline at 331.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interface-language selector to Help & Updates.
  * Added support for 29 interface languages with saved preferences.
  * Improved language-picker styling and browser compatibility.

* **Changes**
  * Simplified Settings by keeping translation languages in General.
  * Language controls and help links now respond appropriately during active sessions.

* **Bug Fixes**
  * Improved reliability when loading or saving language preferences, including recovery from failed or outdated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->