### PR TITLE
fix(subtitle): stop spending 88px of every line on gutters

### DIFF
--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -1,7 +1,12 @@
 .subtitle-stream {
   flex: 1;
   min-height: 0;
-  padding: 12px 24px 16px;
+  // 12px horizontal matches `.conversation-display` in MainPanel.scss. The
+  // subtitle surface used to carry 24px — double the side panel's rail on a
+  // surface that is narrower (the extension overlay floors at MIN_W = 320px)
+  // and shorter, so the gutter cost far more of the line here than it does
+  // in the panel.
+  padding: 8px 12px 10px;
   display: flex;
   flex-direction: column;
   scroll-behavior: smooth;
@@ -88,6 +93,19 @@
   &.expanded {
     overflow-y: auto;
     justify-content: flex-end;
+
+    // Drop ConversationRow's 30px hanging indent (the avatar column, see
+    // ConversationRow.scss > .row-body). It buys alignment under the header's
+    // name, but on this surface a header only appears when the speaker
+    // switches, and the stream is pinned to its bottom edge in a 140-200px
+    // window — so the header is usually scrolled out of view and the indent
+    // aligns to nothing while costing 30px of every line. The lang badge
+    // still forms the left rail, so the rows stay in a column.
+    // Four classes deep on purpose: `.conversation-row.grouped .row-body`
+    // in ConversationRow.scss ties on specificity at three.
+    .conversation-row .row-body {
+      padding-left: 0;
+    }
   }
 }
 

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -1,6 +1,7 @@
 .subtitle-stream {
   flex: 1;
   min-height: 0;
+
   // 12px horizontal matches `.conversation-display` in MainPanel.scss. The
   // subtitle surface used to carry 24px — double the side panel's rail on a
   // surface that is narrower (the extension overlay floors at MIN_W = 320px)


### PR DESCRIPTION
## Problem

In expanded subtitle mode, the first character of every line sits **88px** in from the window edge:

```
24px  .subtitle-stream horizontal padding
30px  ConversationRow's hanging indent (.row-body padding-left)
~26px lang badge (EN/ZH) + 8px gap
────
88px
```

The extension overlay floors at 320px wide (`MIN_W` in `extension/content/subtitle-overlay-content.js`). At that width only **209px** is left for text — 65% of the window — and a sentence that fits in three lines wraps onto four.

## What the 30px is for

`.row-body { padding-left: 30px }` in `ConversationRow.scss` is the avatar column: 22px avatar + `.row-header`'s `gap: 8px`. It aligns body text under the name in the header, Slack-style.

On this surface it mostly aligns to nothing. A header only renders when the speaker switches (`ConversationRow.tsx:69`, `showHeader = !prevItem || prevItem.source !== source`), and the subtitle window is 140–200px tall with the stream pinned to its bottom edge — so the header has usually scrolled out of view. In a one-sided stretch of speech, ten rows carry a single header at the top and the other nine indent under a name nobody can see.

## Change

Scoped to the subtitle surface (`src/components/Subtitle/SubtitleStream.scss`); MainPanel is untouched:

- `.subtitle-stream` padding `12px 24px 16px` → `8px 12px 10px`. MainPanel's `.conversation-display` rail is 12px; the subtitle surface was carrying double that while being both narrower and shorter.
- Zero out the 30px indent in expanded mode. The lang badge still forms the left rail, so rows stay in a column.

MainPanel keeps its indent — it has the height to keep headers on screen.

> The selector is deliberately four classes deep (`.subtitle-stream.expanded .conversation-row .row-body`): `.conversation-row.grouped .row-body` in `ConversationRow.scss` is three, so it would tie on specificity and win on source order in the compiled output.

## Result

Measured by compiling the real SCSS and probing the rendered chain in headless Chromium:

| Width | Text starts at | Text width | Lines for the same long sentence |
|---|---|---|---|
| 320px before | 88 | 209 | 4 |
| 320px after | **46** | **263** | **3** |
| 560px before | 88 | 449 | 2 |
| 560px after | **46** | **503** | 2 |
| 900px before → after | 88 → **46** | 721 | 1 |

## Verification

- `npx vitest run src/components/Subtitle src/components/MainPanel` → 320 tests pass.
- The one failing suite, `SubtitleApp.test.tsx`, is the pre-existing vite fs-allow problem in worktrees (`Denied ID .../@sapphi-red/web-noise-suppressor/...`). Stashing the change and rerunning on the clean base reproduces the identical failure, so it is unrelated to this diff.
- Compact mode is untouched beyond the container padding — the new rule lives inside `&.expanded`.

## Left out on purpose

- `ConversationRow.scss:70-72`'s `.conversation-row.grouped & { padding-left: 30px; }` restates the base value and is dead code. Not removed here, to keep the diff confined to the subtitle surface.
- MainPanel's side panel carries the same 30px indent and could be tightened too. Not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reduced subtitle stream padding for a more compact layout.
  * Removed the extra left indentation from expanded conversation rows for improved alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->