### PR TITLE
feat(macos): in-app auto-update via a stable self-signed identity

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,12 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    # `secrets` cannot be referenced from a step-level `if`; hoisting it here
+    # makes the macOS signing steps conditional without tripping the workflow
+    # validator (an invalid file fails the whole run before anything executes).
+    env:
+      HAS_MAC_CERT: ${{ secrets.MACOS_CSC_LINK != '' }}
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -195,7 +201,7 @@ jobs:
       # to give the app a signing identity that stays the same between builds, which
       # is what Squirrel.Mac and TCC key on.
       - name: Trust the self-signed signing certificate (macOS)
-        if: runner.os == 'macOS' && secrets.MACOS_CSC_LINK != ''
+        if: runner.os == 'macOS' && env.HAS_MAC_CERT == 'true'
         env:
           MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           MACOS_CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
@@ -250,7 +256,7 @@ jobs:
       # An ad-hoc signature yields a cdhash DR, which is exactly what stops
       # Squirrel.Mac from ever accepting an update -- fail loudly instead.
       - name: Verify the app carries a stable signing identity (macOS)
-        if: runner.os == 'macOS' && secrets.MACOS_CSC_LINK != ''
+        if: runner.os == 'macOS' && env.HAS_MAC_CERT == 'true'
         run: |
           set -euo pipefail
           APP=$(find out/make-mac -name 'Sokuji.app' -maxdepth 3 | head -1)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -217,8 +217,28 @@ jobs:
             -passin "pass:$MACOS_CSC_KEY_PASSWORD" -out "$RUNNER_TEMP/signing.pem"
           sudo security add-trusted-cert -d -r trustRoot -p codeSign \
             -k /Library/Keychains/System.keychain "$RUNNER_TEMP/signing.pem"
+          # Prove the trust actually took, in the same shape electron-builder
+          # will see it: import into a scratch keychain and ask for VALID
+          # identities. Checking the default search list here would always say
+          # "0 valid identities found" -- nothing is imported into it, since
+          # electron-builder makes its own keychain from CSC_LINK at build time.
+          SCRATCH="$RUNNER_TEMP/trust-check.keychain"
+          security create-keychain -p check "$SCRATCH"
+          security unlock-keychain -p check "$SCRATCH"
+          security set-keychain-settings "$SCRATCH"
+          security import "$RUNNER_TEMP/signing.p12" -k "$SCRATCH" \
+            -P "$MACOS_CSC_KEY_PASSWORD" -T /usr/bin/codesign >/dev/null
+          security set-key-partition-list -S apple-tool:,apple:,codesign: \
+            -s -k check "$SCRATCH" >/dev/null 2>&1
+          echo "valid identities visible to electron-builder:"
+          security find-identity -v -p codesigning "$SCRATCH" | sed 's/^/  /'
+          if ! security find-identity -v -p codesigning "$SCRATCH" | grep -q "Sokuji Code Signing"; then
+            echo "FAIL: the certificate is still not a valid identity after trusting it." >&2
+            security delete-keychain "$SCRATCH" || true
+            exit 1
+          fi
+          security delete-keychain "$SCRATCH"
           rm -f "$RUNNER_TEMP/signing.p12" "$RUNNER_TEMP/signing.pem"
-          security find-identity -v -p codesigning | sed 's/^/  /'
 
       - name: Build macOS PKG (electron-builder)
         if: runner.os == 'macOS'
@@ -238,6 +258,13 @@ jobs:
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.MACOS_CSC_LINK != '' && 'true' || 'false' }}
           CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          # electron-builder refuses to sign pull-request builds unless this is
+          # set, so that untrusted forks cannot get at signing credentials. That
+          # protection is redundant here -- GitHub does not pass secrets to fork
+          # PRs at all, so HAS_MAC_CERT is false and CSC_LINK is empty there --
+          # while leaving it off means no PR can ever verify the signing chain,
+          # which is the whole point of running this on a PR.
+          CSC_FOR_PULL_REQUEST: ${{ env.HAS_MAC_CERT }}
           VITE_BACKEND_URL: ${{ vars.VITE_BACKEND_URL || 'https://sokuji-api.kizuna.ai' }}
           VITE_ENVIRONMENT: production
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,7 +240,7 @@ jobs:
           security delete-keychain "$SCRATCH"
           rm -f "$RUNNER_TEMP/signing.p12" "$RUNNER_TEMP/signing.pem"
 
-      - name: Build macOS PKG (electron-builder)
+      - name: Build macOS artifacts (electron-builder)
         if: runner.os == 'macOS'
         # --publish never: release job uploads artifacts via softprops/action-gh-release
         # to avoid duplicate releases.
@@ -248,7 +248,11 @@ jobs:
         # globally set to out/make-linux for the Linux build).
         # The afterPack hook (scripts/electron-builder-fuses.js) ad-hoc signs the .app
         # since CSC_IDENTITY_AUTO_DISCOVERY=false skips signing entirely.
-        run: npx electron-builder --mac pkg --${{ matrix.arch }} --publish never -c.directories.output=out/make-mac
+        # Targets must be listed here: a target on the CLI overrides build.mac.target
+        # entirely, so `--mac pkg` alone would silently drop the zip -- and with it
+        # latest-mac.yml and the blockmap, leaving auto-update dead while everything
+        # still looks green. The zip is what electron-updater actually installs.
+        run: npx electron-builder --mac pkg zip --${{ matrix.arch }} --publish never -c.directories.output=out/make-mac
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false
@@ -282,7 +286,7 @@ jobs:
       # cannot find an identity, so an unsigned release would look like a success.
       # An ad-hoc signature yields a cdhash DR, which is exactly what stops
       # Squirrel.Mac from ever accepting an update -- fail loudly instead.
-      - name: Verify the app carries a stable signing identity (macOS)
+      - name: Verify the macOS update artifacts (signature + zip + manifest)
         if: runner.os == 'macOS' && env.HAS_MAC_CERT == 'true'
         run: |
           set -euo pipefail
@@ -306,6 +310,20 @@ jobs:
           esac
           codesign --verify --deep --strict "$APP"
           echo "OK: bundle passes strict nested validation."
+
+          # MacUpdater installs the zip and nothing else -- it rejects pkg and dmg
+          # outright -- and only the zip target emits latest-mac.yml plus the
+          # blockmap. Missing either one leaves auto-update dead with a green build.
+          ZIP=$(find out/make-mac -maxdepth 1 -name '*.zip' | head -1)
+          YML=out/make-mac/latest-mac.yml
+          [ -n "$ZIP" ] || { echo "FAIL: no macOS .zip produced; electron-updater has nothing to install." >&2; exit 1; }
+          [ -f "$YML" ] || { echo "FAIL: no latest-mac.yml produced." >&2; exit 1; }
+          echo "OK: $(basename "$ZIP")"
+          echo "--- latest-mac.yml ---"
+          cat "$YML"
+          grep -q "$(basename "$ZIP")" "$YML" || {
+            echo "FAIL: latest-mac.yml does not reference $(basename "$ZIP")." >&2; exit 1; }
+          echo "OK: manifest references the zip."
 
       - name: Build Chrome Extension
         if: matrix.os == 'ubuntu-latest' && matrix.arch != 'arm64'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,34 @@ jobs:
           VITE_ENABLE_ZOOM_AI: ${{ vars.VITE_ENABLE_ZOOM_AI }}
           VITE_ENABLE_LOCAL_NATIVE: ${{ vars.VITE_ENABLE_LOCAL_NATIVE }}
 
+      # electron-builder discovers signing identities with `security find-identity -v`,
+      # and a self-signed certificate is reported CSSMERR_TP_NOT_TRUSTED, so it would
+      # be invisible and signing would be silently skipped. Trusting it makes it
+      # discoverable. Verified on macOS 26.6.1; see docs/build/macos-auto-update.md.
+      #
+      # This is NOT notarization and buys nothing with Gatekeeper. Its only job is
+      # to give the app a signing identity that stays the same between builds, which
+      # is what Squirrel.Mac and TCC key on.
+      - name: Trust the self-signed signing certificate (macOS)
+        if: runner.os == 'macOS' && secrets.MACOS_CSC_LINK != ''
+        env:
+          MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          MACOS_CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          echo "$MACOS_CSC_LINK" | base64 --decode > "$RUNNER_TEMP/signing.p12"
+          # Extract the certificate alone (no private key) for the trust store.
+          # OpenSSL 3 needs -legacy to read a p12 exported with legacy algorithms;
+          # LibreSSL does not have the flag, so try plain first.
+          openssl pkcs12 -in "$RUNNER_TEMP/signing.p12" -clcerts -nokeys \
+            -passin "pass:$MACOS_CSC_KEY_PASSWORD" -out "$RUNNER_TEMP/signing.pem" 2>/dev/null || \
+          openssl pkcs12 -legacy -in "$RUNNER_TEMP/signing.p12" -clcerts -nokeys \
+            -passin "pass:$MACOS_CSC_KEY_PASSWORD" -out "$RUNNER_TEMP/signing.pem"
+          sudo security add-trusted-cert -d -r trustRoot -p codeSign \
+            -k /Library/Keychains/System.keychain "$RUNNER_TEMP/signing.pem"
+          rm -f "$RUNNER_TEMP/signing.p12" "$RUNNER_TEMP/signing.pem"
+          security find-identity -v -p codesigning | sed 's/^/  /'
+
       - name: Build macOS PKG (electron-builder)
         if: runner.os == 'macOS'
         # --publish never: release job uploads artifacts via softprops/action-gh-release
@@ -198,7 +226,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false
-          CSC_IDENTITY_AUTO_DISCOVERY: false
+          # With no certificate configured the build stays ad-hoc signed and
+          # macOS auto-update stays off; scripts/electron-builder-fuses.js
+          # ad-hoc signs in that case.
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.MACOS_CSC_LINK != '' && 'true' || 'false' }}
+          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
           VITE_BACKEND_URL: ${{ vars.VITE_BACKEND_URL || 'https://sokuji-api.kizuna.ai' }}
           VITE_ENVIRONMENT: production
           VITE_POSTHOG_KEY: ${{ secrets.VITE_POSTHOG_KEY }}
@@ -303,6 +336,9 @@ jobs:
           name: ${{ matrix.artifact_name }}-artifacts
           path: |
             out/make-mac/*.pkg
+            out/make-mac/*.zip
+            out/make-mac/*.blockmap
+            out/make-mac/latest-mac.yml
 
   sign-windows:
     name: Sign Windows artifacts
@@ -426,6 +462,13 @@ jobs:
           find windows-nupkg -name "*.nupkg" -exec cp {} release-assets/ \;
           find macos-arm64-artifacts -name "*.pkg" -exec cp {} release-assets/ \;
           find macos-x64-artifacts -name "*.pkg" -exec cp {} release-assets/ \;
+          # The zip is what electron-updater installs on macOS: MacUpdater accepts
+          # only a zip and rejects pkg/dmg outright. The blockmap next to it is what
+          # makes subsequent updates differential.
+          find macos-arm64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
+          find macos-x64-artifacts -name "*.zip" -exec cp {} release-assets/ \;
+          find macos-arm64-artifacts -name "*.blockmap" -exec cp {} release-assets/ \;
+          find macos-x64-artifacts -name "*.blockmap" -exec cp {} release-assets/ \;
           # Squirrel generates filenames with spaces (e.g. "Sokuji-0.15.12 Setup.exe").
           # Rename to use dots so asset names are consistent and latest.yml URLs match.
           cd release-assets
@@ -466,51 +509,40 @@ jobs:
           echo "=== latest.yml ==="
           cat release-assets/latest.yml
 
-      - name: Generate latest-mac.yml for auto-updater
-        # electron-builder's PKG target does not emit latest-mac.yml on its own
-        # (only zip/dmg targets set isWriteUpdateInfo=true), so generate it the
-        # same way Windows latest.yml is built above. Notify-only context:
-        # update-manager.js darwin branch only reads `version` and constructs
-        # its own pkgUrl, so files[] just enumerates the per-arch PKGs.
-        # electron-updater on macOS always fetches a single latest-mac.yml
-        # (no arch suffix), hence one combined file with both arches in files[].
+      - name: Merge the per-arch latest-mac.yml files
+        # The zip target sets isWriteUpdateInfo, so electron-builder now writes a
+        # correct latest-mac.yml itself -- no hand-rolled sha512 loop any more.
+        # But each arch runner writes its own, and electron-updater fetches a
+        # single latest-mac.yml (no arch suffix), so the two files[] lists have
+        # to be combined. MacUpdater then picks the entry matching process.arch.
         run: |
-          PKGS=()
-          while IFS= read -r p; do PKGS+=("$p"); done < <(find release-assets -name "Sokuji-*-*.pkg" | sort)
-          if [ ${#PKGS[@]} -eq 0 ]; then
-            echo "Warning: No .pkg found, skipping latest-mac.yml generation"
+          set -euo pipefail
+          ARM=$(find macos-arm64-artifacts -name latest-mac.yml | head -1)
+          X64=$(find macos-x64-artifacts -name latest-mac.yml | head -1)
+          if [ -z "$ARM" ] && [ -z "$X64" ]; then
+            echo "No latest-mac.yml produced -- macOS auto-update will not work."
+            echo "That is expected when MACOS_CSC_LINK is unset (unsigned build)."
             exit 0
           fi
-
-          VERSION=${GITHUB_REF_NAME#v}
-          DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
-
-          # Prefer arm64 for the legacy top-level path/sha512 fields, matching
-          # the previous PyYAML merge behavior.
-          PRIMARY=""
-          for PKG in "${PKGS[@]}"; do
-            case "$PKG" in *-arm64.pkg) PRIMARY="$PKG"; break ;; esac
-          done
-          [ -z "$PRIMARY" ] && PRIMARY="${PKGS[0]}"
-          PRIMARY_NAME=$(basename "$PRIMARY")
-          PRIMARY_SHA=$(openssl dgst -sha512 -binary "$PRIMARY" | openssl base64 -A)
-
-          {
-            echo "version: ${VERSION}"
-            echo "files:"
-            for PKG in "${PKGS[@]}"; do
-              NAME=$(basename "$PKG")
-              SHA=$(openssl dgst -sha512 -binary "$PKG" | openssl base64 -A)
-              SIZE=$(stat -c%s "$PKG")
-              echo "  - url: ${NAME}"
-              echo "    sha512: ${SHA}"
-              echo "    size: ${SIZE}"
-            done
-            echo "path: ${PRIMARY_NAME}"
-            echo "sha512: ${PRIMARY_SHA}"
-            echo "releaseDate: '${DATE}'"
-          } > release-assets/latest-mac.yml
-
+          python3 -c "import yaml" 2>/dev/null || pip3 install --quiet pyyaml
+          python3 - "$ARM" "$X64" <<'PY'
+          import sys, yaml
+          paths = [p for p in sys.argv[1:3] if p]
+          docs = [yaml.safe_load(open(p)) for p in paths]
+          # Prefer arm64 for the top-level path/sha512 fields, matching what the
+          # previous hand-rolled step produced.
+          primary = next((d for p, d in zip(paths, docs) if 'arm64' in p), docs[0])
+          seen, files = set(), []
+          for d in docs:
+              for f in d.get('files', []):
+                  if f['url'] not in seen:
+                      seen.add(f['url'])
+                      files.append(f)
+          merged = dict(primary)
+          merged['files'] = files
+          with open('release-assets/latest-mac.yml', 'w') as fh:
+              yaml.safe_dump(merged, fh, default_flow_style=False, sort_keys=False)
+          PY
           echo "=== latest-mac.yml ==="
           cat release-assets/latest-mac.yml
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -245,6 +245,35 @@ jobs:
           VITE_ENABLE_ZOOM_AI: ${{ vars.VITE_ENABLE_ZOOM_AI }}
           VITE_ENABLE_LOCAL_NATIVE: ${{ vars.VITE_ENABLE_LOCAL_NATIVE }}
 
+      # electron-builder logs "skipped macOS code signing" and carries on when it
+      # cannot find an identity, so an unsigned release would look like a success.
+      # An ad-hoc signature yields a cdhash DR, which is exactly what stops
+      # Squirrel.Mac from ever accepting an update -- fail loudly instead.
+      - name: Verify the app carries a stable signing identity (macOS)
+        if: runner.os == 'macOS' && secrets.MACOS_CSC_LINK != ''
+        run: |
+          set -euo pipefail
+          APP=$(find out/make-mac -name 'Sokuji.app' -maxdepth 3 | head -1)
+          if [ -z "$APP" ]; then
+            echo "No Sokuji.app found under out/make-mac" >&2
+            exit 1
+          fi
+          DR=$(codesign -d -r- "$APP" 2>&1 | grep 'designated =>' | sed 's/^#* *designated => //')
+          echo "designated requirement: $DR"
+          case "$DR" in
+            *"certificate root = H"*|*"certificate leaf = H"*)
+              echo "OK: stable, certificate-pinned designated requirement." ;;
+            *cdhash*)
+              echo "FAIL: ad-hoc signature (cdhash DR). Signing was skipped --" >&2
+              echo "the certificate was probably not discoverable via find-identity -v." >&2
+              exit 1 ;;
+            *)
+              echo "FAIL: unrecognised designated requirement." >&2
+              exit 1 ;;
+          esac
+          codesign --verify --deep --strict "$APP"
+          echo "OK: bundle passes strict nested validation."
+
       - name: Build Chrome Extension
         if: matrix.os == 'ubuntu-latest' && matrix.arch != 'arm64'
         run: |

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -1018,7 +1018,7 @@ not ship together.
 - **Gatekeeper is unchanged.** The PKG is still not notarized, so the
   `xattr` step stays exactly as it is today.
 
-### 7.2 Signing the driver — safe, and required anyway
+### 7.2 Signing the driver — safe, and not actually required
 
 The device UID is a compile-time macro. Upstream `BlackHole.c` defines:
 
@@ -1051,28 +1051,58 @@ entirely and ship it as a separate PKG payload. Code under `Resources/` is
 precisely what strict validation is unhappy about, and the app only ever uses
 that copy as installer payload — nothing loads it from there.
 
-### 7.3 Bumping the BlackHole version — the actually risky one, and unnecessary
+### 7.3 Bumping the BlackHole version — verified, and the answer is "not now"
 
-Do not fold this into the signing change. It is a separate decision with its own
-failure modes, and nothing about auto-update requires it — the driver has been
-frozen at BlackHole 0.6.1 / build 596 since 2025-09-17 and works.
+Researched against upstream directly (2026-08-28). The pinned submodule commit
+`4fdd55ca` **is** tag `v0.6.1` (2025-02-06); upstream is at `v0.7.1` plus 4
+commits, **21 commits and ~18 months ahead**.
 
-- **The device UID could change.** It is derived from `kDriver_Name` plus the
-  channel count. Our build script pins both, so a straight version bump should
-  keep `SokujiVirtualAudio2ch_UID` — but if upstream ever reshapes the
-  `kDevice_UID` macro, or if the channel count changes, the UID changes with it.
-  The symptom is nasty and silent: every app that had the device selected falls
-  back to its default, and users report "translation audio stopped reaching
-  Zoom" with nothing in our logs. Diff the macros before bumping.
-- **`killall coreaudiod` interrupts audio system-wide**, in every running app.
-  The PKG does this on every install today. Doing it mid-meeting is bad; a
-  driver update should be something the user opts into, not a side effect.
-- **Auto-update will not carry the driver.** Squirrel replaces the app bundle;
-  `/Library/Audio/Plug-Ins/HAL/` is outside it and needs root. So once Option S
-  ships, an app update and a driver update are different events — and nothing
-  currently detects the skew, because no code reads the driver's
-  `Contents/Resources/VERSION`. Add that version check *before* you ever need to
-  bump the driver, not after.
+**The UID risk I originally flagged does not exist.** Fetching
+`BlackHole/BlackHole.c` at both revisions and diffing the macro block shows it
+byte-for-byte identical, at the same line numbers (152–197):
+`kDriver_Name_Format "%ich"`, `kDevice_UID`, `kDevice2_UID`, `kBox_UID`,
+`kDevice_ModelUID`, `kDevice_Name`, and the `#ifndef`-guarded
+`kNumber_Of_Channels = 2`. So `SokujiVirtualAudio2ch_UID` survives a bump and
+device selections in Zoom/Meet/Teams would not drop. `BlackHole.plist` is
+untouched, and `project.pbxproj` differs only by three `MARKETING_VERSION`
+lines — `scripts/build-sokuji-driver.sh` would work unmodified, PlistBuddy
+targets included.
+
+**But the ledger still says don't.** The entire functional diff over 18 months
+is: 24 kHz added to `kSampleRates`, an `#ifndef` guard around
+`kLatency_Frame_Size`, and firmware version read from the plist. Nothing about
+clock drift, latency, crashes, Apple Silicon or macOS 15/26 — issue #889
+("Broken on macOS 26 Tahoe") was closed by its reporter with no fix shipped.
+
+And 0.7.1 **adds** a regression: commit `60374d35` reads
+`CFBundleGetBundleWithIdentifier(...)` and `CFBundleGetValueForInfoDictionaryKey(...)`
+and passes the result straight to `CFRetain` with no null check
+(`BlackHole.c:1946-1950` on master). `CFRetain(NULL)` crashes *inside
+`coreaudiod`*, taking all system audio down until launchd restarts it, and
+Audio MIDI Setup reads the firmware version on a normal user path. Upstream
+PR #901 guards it and is **still unmerged**. Our exposure is probably lower
+than upstream's own — the crash likely arises because upstream's default
+`kPlugIn_BundleID` does not match its `PRODUCT_BUNDLE_IDENTIFIER`, whereas our
+build script sets both to `com.sokuji.virtualaudio` — but "probably" is not a
+reason to take on an unfixed `coreaudiod` crash.
+
+**The one gain is available without bumping.** `kSampleRates` is
+`#ifndef`-guarded in the pinned revision too, so 24 kHz can be added through
+the existing `GCC_PREPROCESSOR_DEFINITIONS` in `scripts/build-sokuji-driver.sh`.
+That is worth doing on its own merits: Sokuji's entire audio pipeline runs at
+24000 Hz (`ModernAudioPlayer.js:18`, which even errors on a sample-rate
+mismatch at `:253`), while the 0.6.1 device advertises 8000/16000/44100/48000
+and up — so the output leg into the virtual device is being resampled for no
+reason. Escaping the comma-separated list through `xcodebuild` needs care.
+
+**Revisit when PR #901 merges.** If bumping then, keep `kPlugIn_BundleID` and
+`PRODUCT_BUNDLE_IDENTIFIER` in sync (we already do) and re-run the UID check,
+since the UID is assembled at runtime from `kDriver_Name` + channel count.
+
+One non-technical note: upstream added a trademark clarification to `LICENSE`
+(commit `fd5190ca`) asking third-party builds not to use the BlackHole name or
+branding. Sokuji already complies by rebranding wholesale. The GPLv3
+source-offer obligation for the shipped driver binary is unchanged either way.
 
 ## 8. Open questions
 

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -19,6 +19,10 @@ app updates itself". Signing is a prerequisite for that, not the whole of it.
 Squirrel.Mac actually demands is a *stable* signature, not an *Apple* one. See
 §2.5, which is the section to read if you read only one.
 
+**This has been verified on real hardware** (macOS 26.6.1, arm64, 2026-08-24) —
+not just derived from Apple's sources. See §6 for what ran and the one test that
+is still outstanding.
+
 Three things stand in the way today, and all three must go:
 
 1. **The signature is ad-hoc, so it is not stable.** Squirrel.Mac (the engine
@@ -347,6 +351,22 @@ This is the finding that changes the decision. Squirrel.Mac needs a signature
 that is **stable and self-consistent**, not one that chains to Apple. A
 certificate you generate yourself provides exactly that.
 
+> **Verified on hardware, 2026-08-24 — macOS 26.6.1, arm64.** Two deliberately
+> different builds signed with one self-signed certificate produced an identical
+> designated requirement, and the second satisfied the first's DR — the exact
+> check Squirrel.Mac performs:
+>
+> ```
+> v1 DR: identifier "ai.kizunaai.sokuji.verify" and certificate root = H"fc3ac6d0…"
+> v2 DR: identifier "ai.kizunaai.sokuji.verify" and certificate root = H"fc3ac6d0…"
+> codesign --verify --strict -R="<v1 DR>" v2.app   → rc=0
+> codesign --verify --strict v2.app  → "valid on disk", "satisfies its Designated Requirement"
+> spctl -a -vv v2.app                → "rejected"      (Gatekeeper, as expected)
+> ```
+>
+> An ad-hoc-signed control pair correctly failed the same check. Reproduce with
+> `scripts/verify-macos-selfsigned.sh` (9 passed, 0 failed on that machine).
+
 #### 2.5a Verification does not require a trusted anchor
 
 Apple's Code Signing Guide, [Code Signing Tasks](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html):
@@ -446,20 +466,51 @@ when no "Developer ID Application" identity is found it searches for a
 of electron-builder issue #458 — signing with a self-signed certificate is a
 supported configuration, not a hack.
 
-Two CI details to watch:
+Two integration details, both now settled on hardware:
 
-- `createKeychain` (`:120`) runs `security import` but **never**
-  `security add-trusted-cert`, and identity discovery uses
-  `security find-identity -v -p codesigning` — "-v" meaning valid. Whether a
-  self-signed leaf lists as valid without an explicit trust setting is hardware
-  test #6; if not, add `security add-trusted-cert -d -r trustRoot -k <keychain>`
-  before the build.
-- `kSecCSCheckNestedCode | kSecCSStrictValidate` means **all** nested Mach-O
-  must be signed with the same identity — including
-  `Contents/Resources/resources/drivers/SokujiVirtualAudio.driver`, a universal
-  binary currently built with `CODE_SIGNING_REQUIRED=NO`. Code living under
-  `Resources/` is also exactly what strict validation dislikes. This is a
-  prerequisite for *any* signing route, paid or free.
+**(a) The certificate is untrusted, and electron-builder's discovery hides it.**
+A self-signed cert reports `CSSMERR_TP_NOT_TRUSTED`, so
+`security find-identity -v -p codesigning` returns "0 valid identities found".
+`codesign` signs with it regardless — verified — but electron-builder discovers
+identities with exactly that command (`getValidIdentities` runs
+`find-identity -v` and `find-identity -v -p codesigning`), so it would find
+nothing and silently skip signing. Two ways round it:
+
+- Trust the certificate before building:
+  `sudo security add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain cert.pem`.
+  Passwordless on GitHub Actions runners; needs a GUI prompt on a local Mac
+  (it fails over SSH with "the authorization was denied since no user
+  interaction was possible"). Trust does not change the DR.
+- Or sign in the `afterPack` hook, which is what
+  `scripts/electron-builder-fuses.js` already does — swap `--sign -` for the
+  identity and skip electron-builder's own signing entirely. This sidesteps
+  discovery, at the cost of doing inside-out signing yourself.
+
+**(b) The HAL driver does *not* have to be signed.** This contradicts an earlier
+draft of this document, and the correction matters because it removes a
+prerequisite. Tested with the real
+`SokujiVirtualAudio.driver` (Info.plist + universal Mach-O) copied into a host
+bundle and its signature explicitly removed:
+
+```
+codesign --remove-signature …/SokujiVirtualAudio.driver   → "code object is not signed at all"
+codesign --force --sign "<self-signed>" host.app          (outer app only)
+codesign --verify --deep --strict host.app                → rc=0, "valid on disk"
+codesign --verify --deep --strict -R="<own DR>" host.app  → rc=0
+```
+
+`kSecCSCheckNestedCode` looks in the nested-code locations — `Frameworks/`,
+`PlugIns/`, `XPCServices/`, `Helpers/` — whereas anything under
+`Contents/Resources/` is sealed as *data*. Signing the driver is still good
+hygiene (and electron-builder's inside-out signing will do it for free), but it
+is not a blocker for the updater.
+
+*Incidental discovery worth writing down:* OpenSSL 3.x exports PKCS#12 with
+AES-256/SHA-256, which macOS's Security framework cannot import — `security
+import` fails with "MAC verification failed during PKCS12 import (wrong
+password?)", and the misleading message costs an hour. Export with
+`openssl pkcs12 -export -legacy`, or use the system LibreSSL at
+`/usr/bin/openssl`.
 
 ---
 
@@ -498,16 +549,20 @@ steps replaced by a certificate you issue yourself (§2.5). Concretely:
    defaults", with a very long validity. Export as `.p12`. Treat it as a
    permanent project secret — rotating it breaks the update chain and resets
    TCC (§2.5d).
+   Export the `.p12` with `openssl pkcs12 -export -legacy` — the OpenSSL 3
+   default cannot be imported by macOS (§2.5e).
 2. **CI**: store as `CSC_LINK` (base64 `.p12`) + `CSC_KEY_PASSWORD`. Drop
    `CSC_IDENTITY_AUTO_DISCOVERY: false` and `mac.identity: null`; set
    `mac.identity` to the certificate's common name. Do **not** set
-   `mac.notarize`. Add `security add-trusted-cert` before the build if hardware
-   test #6 says it is needed (§2.5e).
+   `mac.notarize`. **Add a trust step before the build** —
+   `sudo security add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain cert.pem`
+   — because electron-builder discovers identities with `find-identity -v`,
+   which does not list an untrusted certificate (verified; §2.5e(a)).
 3. **Signing**: replace the ad-hoc `codesign --force --deep --sign -` in
    `scripts/electron-builder-fuses.js` with electron-builder's normal
-   inside-out signing, and sign the HAL driver with the same identity (§2.5e).
-   Pin the DR with `codesign -r` using a requirement dumped from
-   `codesign -d -r-`.
+   inside-out signing. Pin the DR with `codesign -r` using a requirement dumped
+   from `codesign -d -r-`. The HAL driver does not need signing for the updater
+   to work (§2.5e(b)), though inside-out signing will cover it anyway.
 4. **Artifacts**: add `zip` alongside `pkg` in `build.mac.target` — required by
    `MacUpdater`, and it makes `latest-mac.yml` machine-generated (§0).
 5. **Ownership**: resolve per hardware test #2 — either `pkgbuild --ownership
@@ -827,15 +882,38 @@ the browser and Terminal from the update loop without any certificate at all.
 
 ---
 
-## 6. Hardware tests (all need a Mac; ranked by what they decide)
+## 6. Hardware tests — run 2026-08-24 on macOS 26.6.1 (arm64)
 
-Everything in §2.5 was verified by reading Apple's own Security sources, but
-reading source is not running it. These are ordered so the two that could sink
-Option S come first.
+Everything in §2.5 was first verified by reading Apple's own Security sources;
+it has since been run. `scripts/verify-macos-selfsigned.sh` reproduces tests
+2–6 on any Mac or from a `macos-26` CI job — 9 passed, 0 failed.
 
-**Tests 2–6 are scripted** in `scripts/verify-macos-selfsigned.sh` — run it on
-any Mac, or from a `macos-26` CI job. Test 1 needs a human, because granting
-microphone access requires clicking the dialog.
+| # | What it decides | Result |
+|---|---|---|
+| 1 | Does TCC keep the microphone grant across a re-sign? | **NOT RUN** — needs a human to click the permission dialog |
+| 2 | Can a write-disabled bundle in `/Applications` be renamed? | **PASS** — yes, so `rename(2)`'s CONFORMANCE clause does not bite on APFS here. The root-owned variant still needs a passworded sudo; see the caveat below |
+| 3 | Is the self-signed DR stable, and does build N+1 satisfy build N's DR? | **PASS** — identical DR, `-R` check rc=0, ad-hoc control correctly fails |
+| 4 | Does a non-LaunchServices download carry quarantine? | **PASS** — `Sokuji.app` does not declare `LSFileQuarantineEnabled`; a curl-fetched file has no `com.apple.quarantine` |
+| 5 | Is the self-signed cert usable for signing? | **PASS to sign, FAIL to discover** — `codesign` works; `find-identity -v` reports 0 valid (see §2.5e(a)) |
+| 6 | Does an unsigned nested driver break strict validation? | **PASS** — it does not (see §2.5e(b)) |
+
+Confirmed in passing: the installed app really is
+`Signature=adhoc, designated => cdhash H"28a2ff42…"`, `/Applications` is
+`drwxrwxr-x root:admin`, and `/Applications/Sokuji.app` is
+`drwxr-xr-x root:wheel`.
+
+**Caveat on test 2.** What passed was a bundle *we own* with mode 555 — the same
+kernel write-permission check, but not literally a root-owned bundle, which
+would have needed a passworded sudo. And renaming is only half of it: Squirrel
+moves the old bundle aside and then deletes it, and deleting a root-owned tree
+as a normal user fails regardless of the rename. So set the ownership in the
+PKG anyway (Option S step 5) — one line makes the outcome deterministic instead
+of resting on this test.
+
+**Test 1 is the only real unknown left**, and it is the one that decides whether
+Option S also fixes the permission re-prompting. Procedure: sign two builds with
+one certificate, install the first, grant microphone access, install the second,
+and see whether macOS asks again.
 
 1. **Does TCC keep microphone permission across a rebuild signed with the same
    self-signed certificate?** Sign two builds with one cert, grant mic access to
@@ -908,9 +986,12 @@ Code signing adds a `_CodeSignature` directory and a signature blob. It changes
 stay put. Every app that has "SokujiVirtualAudio" selected as its microphone —
 Zoom, Meet, Teams — keeps that selection. Signing the driver is safe.
 
-It is also not optional: `kSecCSCheckNestedCode | kSecCSStrictValidate` covers
-the copy inside the app bundle at
-`Contents/Resources/resources/drivers/SokujiVirtualAudio.driver` (§2.5e).
+It is also not *required* — that was an error in an earlier draft of this
+document. Tested on hardware: an unsigned driver bundle under
+`Contents/Resources/` does not break the app's nested/strict validation, because
+content there is sealed as data rather than treated as nested code (§2.5e(b)).
+Sign it anyway if electron-builder's inside-out signing does it for free, but it
+does not gate the updater.
 
 *Cleaner alternative worth considering:* move the driver out of the app bundle
 entirely and ship it as a separate PKG payload. Code under `Resources/` is

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -49,7 +49,8 @@ What the money does and does not buy:
 
 - **Auto-update does not need the USD 99.** A self-signed certificate satisfies
   Squirrel.Mac *and* TCC — both measured — so microphone permission also stops
-  resetting on every update (§2.5c).
+  resetting on every update (§2.5c), and the keychain prompt users see after
+  every update should stop with it (§7.1).
 - **First-install friction does need it.** Gatekeeper requires *notarization*,
   which requires the paid membership. No certificate of your own, and no
   updater, changes the first-run experience: the `sudo xattr -d
@@ -977,14 +978,41 @@ not ship together.
   System Settings shows the app as allowed but access is denied at runtime; the
   fix is `tccutil reset Microphone ai.kizunaai.sokuji` or toggling the checkbox.
   Worth a line in that release's notes.
-- **Sign-in state survives.** `EnableCookieEncryption` is on, so Chromium keeps a
-  "Safe Storage" key in the login keychain whose ACL is bound to the code
-  identity — and TN2206 names the keychain as a DR-based subsystem, so a changed
-  identity can prompt or reset the encrypted cookie store. But better-auth's
-  session does **not** live there: `electron/better-auth-adapter.js:4` puts the
-  cookie jar in `electron-conf`, a plain file under the app's userData. Users
-  stay logged in. And as with TCC, today's ad-hoc builds already churn this key
-  on every single build, so a stable certificate makes it better, not worse.
+- **The keychain prompt after every update has the same cause — and the same
+  fix.** Users report that Sokuji asks for keychain access after installing an
+  update. That is not the app reading user credentials; it is Chromium reading
+  its own cookie-database encryption key. `EnableCookieEncryption` is on
+  (`forge.config.js:127`, `scripts/electron-builder-fuses.js:34`), which
+  Electron documents as encrypting "the cookie store on disk … using OS level
+  cryptography keys"; on macOS that key lives in the login keychain under a name
+  Electron hardcodes at `shell/browser/electron_browser_main_parts.cc:593`:
+
+  ```cpp
+  KeychainPassword::GetServiceName() = app_name + " Safe Storage";
+  ```
+
+  Confirmed present on a real install: `svce="sokuji Safe Storage"`,
+  `acct="sokuji Key"`. The keychain binds that item's ACL to the creating app's
+  code identity, so an ad-hoc rebuild reads as a *different program* asking for
+  the key — hence the dialog. TN2206 names the keychain explicitly as a
+  DR-based subsystem and says "self-signed identities and homemade certificate
+  authorities (CA) work by default for this case", so a stable certificate
+  should end it. Expect **one last prompt** at the transition (the first
+  self-signed build is still a new identity relative to today's ad-hoc one);
+  answer it with "Always Allow".
+
+  *Not measured directly* — unlike the TCC arm (§2.5c). The reasoning is
+  Apple's own documentation plus our measured DR stability, but the keychain
+  arm itself has not been run.
+
+  **Do not "fix" this by turning the fuse off.** Electron's docs are explicit
+  that the transition is one-way: disabling it after it has been enabled "will
+  make your cookie store corrupt and useless".
+
+- **Sign-in state survives regardless.** better-auth's session does not live in
+  the keychain: `electron/better-auth-adapter.js:4` puts the cookie jar in
+  `electron-conf`, a plain file under the app's userData. Even a denied keychain
+  prompt only affects Chromium's own cookie store.
 - **Ownership change** (if the PKG starts chowning the bundle) is invisible to
   the user.
 - **Gatekeeper is unchanged.** The PKG is still not notarized, so the

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -1,0 +1,625 @@
+# macOS Auto-Update for Sokuji: Feasibility Research
+
+Research date: 2026-08-24, against `v0.38.0` (`9d81aeca`). All claims below are
+sourced from primary sources (official docs, first-party source code, or this
+repository) and cited inline. Local source citations refer to
+`electron-updater@6.8.3` as installed in this repo's `node_modules/`.
+
+Related: **issue #106** ("Add macOS code signing and notarization for Gatekeeper
+trust") already covers the signing half — enrollment, certificates, entitlements,
+CI secrets — and is still open. This document is about the *update* half, which
+#106 does not address: what it takes to go from "we show a notification" to "the
+app updates itself". Signing is a prerequisite for that, not the whole of it.
+
+## TL;DR verdict
+
+**Yes, true in-app auto-update (download + silent install + relaunch, like
+Chrome/VS Code) is technically possible for Sokuji on macOS, and most of the
+plumbing already exists in this repo.** Three things stand in the way, and all
+three must go:
+
+1. **No Developer ID code signature** — the hard blocker, and the only one that
+   costs money. Squirrel.Mac (the engine under both Electron's built-in
+   `autoUpdater` and `electron-updater`'s `MacUpdater`) verifies each downloaded
+   update against the *running* app's code-signing designated requirement, and
+   refuses to install anything that does not match. There is no flag, fork, or
+   configuration escape hatch — the check lives in compiled Objective-C inside
+   Electron itself, not in JS. (§1.3, §5.1)
+2. **No `.zip` asset is published.** `MacUpdater` accepts only a zip and
+   explicitly rejects `pkg`/`dmg`; today's releases ship PKGs only, so even a
+   correctly signed build would fail with `ERR_UPDATER_ZIP_FILE_NOT_FOUND`.
+   (§1.4)
+3. **`/Applications/Sokuji.app` is root-owned.** The PKG installs it as root,
+   and Squirrel's installer runs as the invoking user with **no** privilege
+   escalation, so it cannot replace that bundle. Fixing 1 and 2 without fixing
+   this produces an updater that downloads correctly and then fails to install.
+   (failure mode 12)
+
+- With an Apple Developer Program membership (**USD 99/year**) + a Developer ID
+  Application certificate + notarization, the existing
+  `electron/update-manager.js` + `electron-updater` stack can do full
+  auto-update after roughly: add a `zip` target for mac, add ~6 CI secrets, and
+  delete the darwin "notify-only" branch. Estimated effort: 1–2 days of
+  engineering plus Apple enrollment lead time.
+- Without an Apple account, **silent in-place auto-update is impossible** via
+  any Squirrel-based path (ad-hoc signatures mathematically cannot pass the
+  check — see §5.1). The honest fallbacks are (a) a semi-automatic
+  "download the PKG in-app and launch the installer" flow mirroring the
+  existing Windows path, or (b) embedding the native Sparkle framework with
+  EdDSA-signed updates, which avoids Apple signing for *updates* but is a
+  large, unmaintained-territory integration for Electron and does nothing for
+  the first-install Gatekeeper experience.
+- Signing + notarizing would *also* eliminate today's first-install pain (the
+  "unverified developer" dialog / System Settings "Open Anyway" dance, which
+  macOS Sequoia made strictly worse by removing the Control-click override).
+
+---
+
+## 0. What ships today, and why it hurts
+
+| Piece | State |
+|---|---|
+| macOS artifact | `Sokuji-<v>-arm64.pkg` / `-x64.pkg` only (~132–139 MB each) |
+| Signing | ad-hoc only — `scripts/electron-builder-fuses.js` runs `codesign --force --deep --sign -`; `package.json` sets `mac.identity: null`; CI sets `CSC_IDENTITY_AUTO_DISCOVERY: false` |
+| Notarization | none |
+| `latest-mac.yml` | hand-generated in CI (the PKG target does not emit one) and lists the two PKGs |
+| Update path | `electron/update-manager.js:99-113` sets `supportsAutoUpdate: false` on darwin and hands the renderer a `pkgUrl`; `:194-196` refuses `update-download` outright |
+| User steps per release | download in browser → `sudo xattr -d com.apple.quarantine ~/Downloads/Sokuji-*.pkg` → run installer → probably re-grant microphone permission (failure mode 13) |
+
+Linux AppImage already does true in-app auto-update and Windows already downloads
+the installer in-app and launches it. macOS is the only platform left fully manual.
+
+**The volume matters.** The project shipped 15 releases between 2026-07-27 and
+2026-08-23 — roughly one every two days. Every one of them puts a macOS user
+through the sequence above. Whatever this costs to fix, it is amortised over a
+release every 48 hours.
+
+Only the mac `zip` target sets `isWriteUpdateInfo`
+(`app-builder-lib/out/macPackager.js:115-117`), which is why the PKG-only release
+needs that hand-rolled `latest-mac.yml` step in CI — adding a zip makes the file
+machine-generated and emits a blockmap for differential download at the same time.
+
+---
+
+## 1. How the macOS update machinery actually works
+
+### 1.1 Electron's built-in `autoUpdater` = Squirrel.Mac
+
+Electron's docs state the macOS updater is "built upon Squirrel.Mac, meaning
+you don't need any special setup to make it work", and are explicit about the
+blocker:
+
+> "Your application must be signed for automatic updates on macOS. This is a
+> requirement of `Squirrel.Mac`."
+> — https://www.electronjs.org/docs/latest/api/auto-updater
+
+The same page notes update requests are subject to App Transport Security
+(ATS); apps needing to talk to plain-HTTP servers must set
+`NSAllowsArbitraryLoads` (relevant to §1.3's localhost proxy, which works in
+practice because electron-updater serves on `http://127.0.0.1` and Electron's
+helper allows it; keep in mind if updates ever fail with ATS errors).
+
+### 1.2 Squirrel.Mac server contract (JSON + ZIP)
+
+From the Squirrel.Mac README (https://github.com/Squirrel/Squirrel.Mac):
+
+- Server returns HTTP **200 + JSON** when an update exists, **204 No Content**
+  when it doesn't.
+- Update JSON schema:
+
+  ```json
+  {
+    "url": "https://mycompany.example.com/myapp/releases/myrelease",
+    "name": "My Release Name",
+    "notes": "Theses are some release notes innit",
+    "pub_date": "2013-09-18T12:29:53+01:00",
+    "sha256": "…",
+    "size": 104857600,
+    "delta": { "from_version": "412", "url": "…", "sha256": "…", "size": 7340032 }
+  }
+  ```
+
+  "The only required key is \"url\", the others are optional." and
+  "\"pub_date\" if present must be formatted according to ISO 8601."
+- Archive format: **ZIP only** — "Squirrel will request \"url\" with
+  `Accept: application/zip` and only supports installing ZIP updates."
+  (DMG and PKG are *not* update formats; they are first-install formats.)
+- **Delta updates: yes.** Squirrel.Mac supports binary delta patches via the
+  optional `delta` key; the README's Dependencies section says "Binary delta
+  support compiles Sparkle's BinaryDelta sources and the bsdiff it vendors"
+  (submodule pinned to Sparkle 2.9.5). A failed delta falls back to the full
+  ZIP. Note: the electron-updater flow (§1.3) never populates `delta` — it
+  does its own differential download of the ZIP instead.
+- Install/relaunch: downloaded updates are installed automatically when the
+  app terminates, or immediately via the `relaunchToInstallUpdate` signal
+  (surfaced in Electron as `autoUpdater.quitAndInstall()`).
+
+### 1.3 What signature validation Squirrel.Mac actually performs (source)
+
+This is the crux, and it is in Squirrel.Mac's Objective-C, compiled into the
+Electron binary — not overridable from JS:
+
+- At init, `SQRLUpdater` captures the **running app's** signature:
+  `_signature = [SQRLCodeSignature currentApplicationSignature:&error];` and
+  if that fails it logs *"Could not get code signature for running
+  application, application updates are disabled"* and throws
+  `NSInternalInconsistencyException`.
+  — https://github.com/Squirrel/Squirrel.Mac/blob/master/Squirrel/SQRLUpdater.m
+- `SQRLCodeSignature` extracts the running app's **designated requirement**
+  (`SecCodeCopySelf` → `SecCodeCopyDesignatedRequirement`) and verifies every
+  downloaded bundle against it with
+  `SecStaticCodeCheckValidityWithErrors(staticCode, kSecCSCheckNestedCode |
+  kSecCSStrictValidate | kSecCSCheckAllArchitectures, requirement)`; on
+  mismatch the update fails with `SQRLCodeSignatureErrorDidNotPass`.
+  — https://github.com/Squirrel/Squirrel.Mac/blob/master/Squirrel/SQRLCodeSignature.m
+- Consequences by signing state:
+  - **Unsigned app**: `SecCodeCopyDesignatedRequirement` fails → updater
+    disabled/throws at startup.
+  - **Ad-hoc-signed app** (what Sokuji CI produces today): init succeeds, but
+    the update can never verify — see §5.1.
+  - **Developer ID-signed app**: works, because Apple's policy engine
+    deliberately makes new versions of the same signed program satisfy the old
+    DR: "a program's DR should also be satisfied by updates, i.e., new
+    versions of that code, and by nothing else. This is how the macOS code
+    signing policy engine recognizes updates and upgrades."
+    — TN2206, https://developer.apple.com/library/archive/technotes/tn2206/_index.html
+- After installing, Squirrel **removes quarantine** from the new bundle:
+  `clearQuarantineForDirectory:` "Recursively clears the quarantine extended
+  attribute … This ensures users don't see a warning that the application was
+  downloaded from the Internet." (implemented via
+  `removexattr(path, "com.apple.quarantine", XATTR_NOFOLLOW)`).
+  — https://github.com/Squirrel/Squirrel.Mac/blob/master/Squirrel/SQRLInstaller.m
+
+### 1.4 `electron-updater`'s `MacUpdater` (the stack Sokuji already ships)
+
+From the installed source
+(`node_modules/electron-updater/out/MacUpdater.js`, v6.8.3; upstream:
+https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/MacUpdater.ts):
+
+- It selects the **ZIP** asset from the update info:
+  `findFile(files, "zip", ["pkg", "dmg"])`; if none exists it throws
+  `ERR_UPDATER_ZIP_FILE_NOT_FOUND` ("ZIP file not provided"). **Sokuji's
+  current mac releases publish only `.pkg` files (v0.38.0 assets:
+  `latest-mac.yml`, `Sokuji-0.38.0-{arm64,x64}.pkg`), so even a signed build
+  would fail here until a zip target is added.**
+- It downloads the ZIP itself (supports **differential download** against a
+  cached `update.zip` from the previous update), then spins up an
+  `http.createServer()` on `127.0.0.1:<random port>`, guarded by
+  single-use Basic-auth credentials from `crypto.randomBytes`. It calls the
+  native `autoUpdater.setFeedURL({url: "http://127.0.0.1:<port>", headers:
+  {Authorization: "Basic …"}})`; Squirrel then requests `/`, receives
+  `{ "url": "http://127.0.0.1:<port>/<random>.zip" }`, fetches the ZIP from
+  localhost, and performs the §1.3 signature validation + install.
+- Arch handling: it detects arm64/Rosetta (`sysctl.proc_translated`,
+  `uname -a`) and filters release files by whether the file URL contains
+  "arm64" — so per-arch zips must be named accordingly.
+- **Signature verification in electron-updater itself is Windows-only**: the
+  only `verifySignature` implementation is
+  `out/windowsExecutableCodeSignatureVerifier.js` (PowerShell
+  `Get-AuthenticodeSignature`), used by `NsisUpdater`. `MacUpdater` contains
+  no signature code and no unsigned-mode flag — macOS enforcement is entirely
+  delegated to Squirrel.Mac. The docs are categorical: "macOS application must
+  be signed in order for auto updating to work."
+  — https://www.electron.build/docs/features/auto-update
+- Required published files: "`zip` target for macOS is **required** for
+  Squirrel.Mac, otherwise `latest-mac.yml` cannot be created, which causes
+  `autoUpdater` error. Default target for macOS is `dmg`+`zip`, so there is no
+  need to explicitly specify target." (same page). The ZIP is required because
+  Squirrel only installs ZIPs (§1.2); the DMG exists purely for humans doing
+  the first install.
+- Publish providers: GitHub Releases, S3, DigitalOcean Spaces, Cloudflare R2,
+  Keygen, generic HTTPS (same page). The **GitHub provider needs no token for
+  public repos**: `GitHubProvider.getLatestVersion()` reads the public
+  `https://github.com/{owner}/{repo}/releases.atom` feed and downloads
+  `latest-mac.yml` + assets from public release URLs
+  (https://github.com/electron-userland/electron-builder/blob/master/packages/electron-updater/src/providers/GitHubProvider.ts;
+  confirmed in local `out/providers/GitHubProvider.js`). A token (`GH_TOKEN`)
+  is only needed for private repos. Sokuji's update *check* already works this
+  way today on all platforms.
+
+---
+
+## 2. What Apple requires (and what it fixes)
+
+### 2.1 Membership and certificate
+
+- **Apple Developer Program: "Enrollment is 99 USD (or in local currency where
+  available) per membership year."** The free tier explicitly lacks
+  "Notarization & Developer ID for Mac apps".
+  — https://developer.apple.com/support/compare-memberships/
+- **Developer ID Application certificate**: "Sign a Mac app before
+  distributing it outside the Mac App Store." Creation requires the **Account
+  Holder** role (or an admin with the cloud-managed Developer ID certificate
+  access role); a team may hold **up to five** Developer ID Application and
+  five Developer ID Installer certificates.
+  — https://developer.apple.com/help/account/certificates/create-developer-id-certificates/
+- Expiry vs revocation semantics matter for updaters: "If your certificate
+  expires, users can still download, install, and run versions … signed with
+  this certificate. However, you'll need a new certificate to sign updates …
+  If your certificate is revoked, users will no longer be able to install
+  applications that have been signed with this certificate."
+  — https://developer.apple.com/help/account/certificates/certificates-overview/
+
+### 2.2 Notarization
+
+- Required for Developer ID distribution on modern macOS: "Beginning in macOS
+  10.15, all software built after June 1, 2019, and distributed with Developer
+  ID must be notarized."
+  — https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution
+- The notary service requires (same page): a **Developer ID** certificate
+  ("Don't use a Mac Distribution, ad hoc, Apple Developer, or local
+  development certificate."), the **Hardened Runtime** enabled, a secure
+  timestamp, and no `get-task-allow` entitlement.
+- `notarytool` is the current submission CLI; the old `altool` was cut off:
+  "Starting November 1, 2023, the Apple notary service no longer accepts
+  uploads from altool or Xcode 13 or earlier." (same page)
+- **Stapling and ZIPs**: "You should also attach the ticket to your software
+  using the `stapler` tool, so that future distributions include the ticket …
+  This ensures that Gatekeeper can find the ticket even when a network
+  connection isn't available." And critically: "While you can notarize a ZIP
+  archive, you can't staple to it directly. Instead, run `stapler` against
+  each item that you added to the archive. Then create a new ZIP file
+  containing the stapled items for distribution."
+  — https://developer.apple.com/documentation/security/customizing-the-notarization-workflow
+  (electron-builder's `mac.notarize: true` automates sign → notarize → staple;
+  see §4.)
+
+### 2.3 Hardened Runtime and entitlements Sokuji needs
+
+- "To upload a macOS app to be notarized, you must enable the Hardened Runtime
+  capability." — https://developer.apple.com/documentation/security/hardened-runtime
+- Electron requires the JIT runtime exception; microphone capture requires the
+  audio-input resource-access entitlement:
+  - `com.apple.security.cs.allow-jit` (Hardened Runtime "Runtime Exceptions",
+    same page).
+  - `com.apple.security.device.audio-input`: "A Boolean value that indicates
+    whether the app may record audio using the built-in microphone and access
+    audio input using Core Audio."
+    — https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.device.audio-input
+- `@electron/osx-sign` (used by both Forge's `osxSign` and electron-builder)
+  already ships default entitlements covering this:
+  `entitlements/default.darwin.plist` contains `com.apple.security.cs.allow-jit`
+  and `com.apple.security.device.audio-input` (plus camera, bluetooth, etc.).
+  — https://github.com/electron/osx-sign/blob/main/entitlements/default.darwin.plist
+  So no custom entitlements file is strictly needed to start; trimming the
+  defaults to just JIT + audio-input is optional hygiene.
+- TCC prompt text: microphone access also needs `NSMicrophoneUsageDescription`
+  in `Info.plist`. Sokuji's Forge/electron-builder configs do not set one
+  (`grep NSMicrophoneUsageDescription` finds nothing in `forge.config.js` /
+  `package.json`), so it currently rides on Electron's default plist strings —
+  worth setting an app-specific string via `extendInfo` when touching signing.
+
+### 2.4 Gatekeeper, quarantine, translocation — why signed+notarized fixes the UX
+
+- Gatekeeper first-open checks: "all software in macOS is checked for known
+  malicious content the first time it's opened", verifying it is "notarized by
+  Apple to be free of known malicious content" and "from an identified
+  developer", with user approval requested before first open.
+  — https://support.apple.com/guide/security/gatekeeper-and-runtime-protection-sec5599b66df/web
+- `com.apple.quarantine` is the extended attribute browsers and other
+  downloading apps put on files; whether an app's *own* downloads are
+  quarantined is opt-in via the `LSFileQuarantineEnabled` Info.plist key: "A
+  Boolean value indicating whether the files this app creates are quarantined
+  by default."
+  — https://developer.apple.com/documentation/bundleresources/information-property-list/lsfilequarantineenabled
+- The dialogs users see today for Sokuji's unsigned/ad-hoc PKG and app are
+  documented by Apple: the "app developer cannot be verified" alert ("in macOS
+  Catalina and later — the app hasn't been notarized by Apple, macOS can't
+  verify that the app is free of malware"), and the "damaged" alert when
+  "macOS detects that software has been modified or damaged". The only
+  override is System Settings → Privacy & Security → "Open Anyway".
+  — https://support.apple.com/en-us/102445
+- **macOS Sequoia made unsigned distribution strictly worse**: "users will no
+  longer be able to Control-click to override Gatekeeper … They'll need to
+  visit System Settings > Privacy & Security to review security information
+  for software before allowing it to run." (Apple Developer News, 2024-08-06)
+  — https://developer.apple.com/news/?id=saqachfa
+- **App translocation** (a.k.a. Gatekeeper Path Randomization): "Starting with
+  macOS Sierra, running a newly-downloaded app from a disk image, archive, or
+  the Downloads directory will cause Gatekeeper to isolate that app at a
+  unspecified read-only location in the filesystem." (TN2206). The Platform
+  Security guide phrases it as "When necessary, Gatekeeper opens apps from
+  randomized, read-only locations." A translocated app cannot update itself in
+  place (its bundle path is a read-only mount). Mitigation per TN2206: ship an
+  installer or have users drag the app to `/Applications`. Sokuji's PKG
+  installs to `/Applications` with `isRelocatable: false` (package.json →
+  `build.pkg`), which avoids translocation; a future DMG flow must tell users
+  to drag to Applications. There is no entitlement that controls translocation
+  (nothing like `com.apple.security.translocation` exists in Apple's
+  entitlement registry: https://developer.apple.com/documentation/bundleresources/entitlements).
+- **Does a Squirrel in-place update re-trigger Gatekeeper?** No, by design:
+  Gatekeeper's first-open approval applies to quarantined software (above),
+  and Squirrel strips `com.apple.quarantine` from what it installs (§1.3).
+  The update ZIP downloaded by electron-updater over Node HTTP is not
+  quarantined anyway (quarantine is opt-in per `LSFileQuarantineEnabled`,
+  which Electron does not set). Each released version must still be
+  Developer-ID signed and notarized in CI — notarize + staple the `.app`,
+  then zip it (§2.2) — both for first-time downloaders and so the DR check
+  in §1.3 passes.
+
+---
+
+## 3. Cost
+
+| Item | Cost | Source |
+|---|---|---|
+| Apple Developer Program (required; only path to Developer ID + notarization) | **USD 99 / year** | https://developer.apple.com/support/compare-memberships/ |
+| Developer ID Application certificate | included in membership (max 5, Account Holder creates) | https://developer.apple.com/help/account/certificates/create-developer-id-certificates/ |
+| Notarization service (`notarytool` submissions) | no per-submission fee documented; included in Developer ID workflow | https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution |
+| CI macOS runners | already in use and **free**: "Use of the standard GitHub-hosted runners is free and unlimited on public repositories." Sokuji already builds on `macos-26` (arm64) and `macos-15-intel` (x64) — see `.github/workflows/build.yml` | https://docs.github.com/en/actions/reference/runners/github-hosted-runners |
+| Engineering (estimate, not a sourced fact) | ~1–2 days for Option A below: CI secrets + zip target + updater branch change + a release dry-run | — |
+
+Notes on enrollment friction (not a monetary cost): enrolling as an
+*organization* ("Kizuna AI Lab") requires legal-entity verification; enrolling
+as an *individual* is faster but the signature then shows the individual's
+name. Membership lapse consequences are in §2.1 (expiry is survivable;
+revocation is not).
+
+---
+
+## 4. Implementation options, ranked
+
+### Option A (recommended): keep `electron-updater`, add signing + notarization + a mac ZIP
+
+Smallest diff from today's architecture; `UpdateManager` and the renderer
+update store already handle check/download/progress/install states, and the
+Linux AppImage branch already exercises the full
+`downloadUpdate()`/`quitAndInstall()` flow.
+
+1. **Apple side**: enroll (USD 99/yr) → Account Holder creates a Developer ID
+   Application certificate (§2.1) → export as `.p12` → create an App Store
+   Connect API key or app-specific password for notarization (§4.1 below).
+2. **Build side** (electron-builder already builds the mac artifacts in CI):
+   - Change `build.mac.target` from `pkg` to include `zip` (electron-builder's
+     default for mac is `dmg`+`zip`; keeping `pkg` alongside `zip` also works —
+     `MacUpdater` picks the zip, humans can keep using the pkg). The zip is
+     non-negotiable (§1.4: `ERR_UPDATER_ZIP_FILE_NOT_FOUND`).
+   - Remove `"identity": null` from `build.mac` and drop
+     `CSC_IDENTITY_AUTO_DISCOVERY: false` from the mac job; provide
+     `CSC_LINK` (base64 `.p12`) + `CSC_KEY_PASSWORD` secrets instead. With
+     no valid identity electron-builder skips signing; `identity: null`
+     skips it explicitly. — https://www.electron.build/docs/features/code-signing/code-signing-mac
+   - Set `mac.notarize: true` and provide notarization env vars;
+     "electron-builder handles all three steps automatically when configured"
+     (sign → notarize → staple), no `afterSign` hook needed on current
+     versions. — https://www.electron.build/docs/features/code-signing/notarization
+   - Delete the ad-hoc `codesign --force --deep --sign -` fallback in
+     `scripts/electron-builder-fuses.js` for signed builds (fuses are flipped
+     in `afterPack` *before* signing, which is the correct order — the file's
+     own comment says fuses run "before code signing the application").
+   - Keep `--publish never` + the existing release job; just make sure the
+     `.zip` files and the regenerated `latest-mac.yml` (which must list the
+     zips) get uploaded with the other assets, and that the zip names carry
+     `arm64`/`x64` (the arch filter in §1.4 matches on "arm64" in the URL).
+3. **Install-location side** — *this step is easy to miss and fatal to skip.*
+   `pkgbuild` is invoked without an `--ownership` flag
+   (`app-builder-lib/out/targets/pkg.js:215`), so the installed bundle ends up
+   root-owned and Squirrel cannot replace it (failure mode 12). Either add a `chown` to
+   `pkg-scripts/postinstall`:
+
+   ```sh
+   chown -R "$(stat -f%Su /dev/console)" /Applications/Sokuji.app
+   ```
+
+   or stop shipping the app itself in a PKG and go back to a drag-install
+   DMG/ZIP, leaving the PKG (or a separate privileged step) for the HAL driver
+   alone.
+4. **Driver side**: decouple `SokujiVirtualAudio.driver` from app updates.
+   Today every macOS update is a full PKG run whose `preinstall`/`postinstall`
+   delete and re-copy the driver and restart `coreaudiod`, which is pure waste —
+   the driver binary has not changed since 2025-09-17 (2494 commits ago), is
+   pinned at BlackHole 0.6.1 build 596, and nothing in the app ever reads its
+   version. Give it a version stamp and run the privileged install only when it
+   actually changes.
+5. **App side** (`electron/update-manager.js`): remove the darwin
+   `supportsAutoUpdate = false` branch and let darwin share the AppImage code
+   path (`autoUpdater.downloadUpdate()` → `update-downloaded` →
+   `quitAndInstall()`). electron-updater serves the zip to Squirrel via its
+   localhost proxy automatically (§1.4).
+
+CI secrets to add (electron-builder names):
+`CSC_LINK`, `CSC_KEY_PASSWORD`, and either
+`APPLE_API_KEY` + `APPLE_API_KEY_ID` + `APPLE_API_ISSUER` (API key,
+recommended for CI) or `APPLE_ID` + `APPLE_APP_SPECIFIC_PASSWORD` +
+`APPLE_TEAM_ID`. — https://www.electron.build/docs/features/code-signing/notarization
+
+### Option B: Forge-native stack (`MakerZIP` + `publisher-github` + `update-electron-app` / update.electronjs.org)
+
+Forge's own auto-update story
+(https://www.electronforge.io/advanced/auto-update) recommends
+`update-electron-app` + the free update.electronjs.org service, and states
+"having a signed application is a pre-requisite for using auto updates on
+macOS." update.electronjs.org's requirements
+(https://github.com/electron/update.electronjs.org): public GitHub repo,
+builds published to GitHub Releases, and "Your builds are code signed (macOS
+and MSIX only)"; mac assets must be `.zip` named with `-mac`/`-darwin` (+
+optional `-arm64`/`-x64`). Signing/notarization would be configured via
+Forge's `packagerConfig.osxSign` (`@electron/osx-sign`) and `osxNotarize`
+(`@electron/notarize`) —
+https://www.electronforge.io/guides/code-signing/code-signing-macos — and
+Forge's ZIP maker can even emit a Squirrel.Mac `RELEASES.json` manifest for
+static storage via `macUpdateManifestBaseUrl`
+(https://www.electronforge.io/config/makers/zip).
+
+Honest assessment for Sokuji: this replaces a working custom UpdateManager
+(with its per-platform UX, progress events, release notes) with a service that
+still requires exactly the same Apple certificate. It's the right default for
+a fresh app; for this repo it's more churn for no reduction in the actual
+blocker. Rank below Option A.
+
+### Option C (no Apple account needed): semi-automatic PKG update — the zero-cost interim
+
+Mirror the existing Windows flow (`_downloadUpdate()` + `shell.openPath()`)
+on darwin: download `Sokuji-<v>-<arch>.pkg` with Node `https` in-app, then
+launch Installer.app and quit. The user clicks through the installer
+(admin auth). This is *not* silent auto-update, but it removes the
+browser-download step, and — because quarantine on app-created files is
+opt-in via `LSFileQuarantineEnabled` (§2.4), which Electron does not set —
+the downloaded PKG should not carry `com.apple.quarantine`, avoiding the
+Gatekeeper dance for updates (needs one verification pass on real hardware;
+see Open questions). First-time installs keep today's full friction,
+Sequoia-style (§2.4).
+
+### Option D (no Apple account): Sparkle with EdDSA keys — possible, not recommended
+
+Sparkle, the native macOS updater framework, does not hard-require Apple
+signing: its security model is "Sign the published update archive (dmg, zip,
+etc) … with Sparkle's EdDSA (ed25519) signature", with Apple Developer ID
+notarization recommended "if possible"
+(https://sparkle-project.org/documentation/). So it is the one real updater
+that can silently update an app without an Apple account. Costs that make it
+last-ranked here: it is a Cocoa framework with no maintained Electron
+bridge (you'd write and maintain native glue + IPC yourself), Squirrel/
+electron-updater would be abandoned for one platform, and it does nothing
+about first-install Gatekeeper friction or the Sequoia policy (§2.4) — users
+still fight to launch the app the first time.
+
+### What does NOT work (verified against source)
+
+- `electron-updater` with unsigned or ad-hoc builds — see §5.1.
+- update.electronjs.org / `update-electron-app` without signing — requirement
+  is explicit ("Your builds are code signed (macOS and MSIX only)"):
+  https://github.com/electron/update-electron-app,
+  https://github.com/electron/update.electronjs.org.
+- Any "disable verification" flag: none exists in `MacUpdater` (no signature
+  code at all on mac, §1.4) and none can exist without forking Electron's
+  bundled Squirrel.Mac (§1.3).
+- The existing free SignPath arrangement, which is Windows-only in practice —
+  see failure mode 14.
+
+### Recommended sequence
+
+1. **Now, free: ship Option C.** It removes the browser and the Terminal from
+   the update loop for existing users, and it is the smallest change on this
+   page (roughly the `_downloadUpdate`/`_installUpdate` pair already in
+   `update-manager.js`, pointed at `pkgUrl`). One hardware verification gates it
+   (§6.5).
+2. **Decide on the USD 99.** Given the release cadence (§0) and the likely TCC
+   re-prompting (failure mode 13), this looks like the highest-leverage $99 in
+   the project, and it is the only thing that fixes *first* install.
+3. **After signing lands: Option A**, including the ownership and driver steps.
+   At that point macOS reaches parity with Linux AppImage.
+
+Steps 1 and 3 are not wasted work relative to each other: the in-app download
+plumbing from C is what a driver-update prompt in A would reuse.
+
+---
+
+## 5. Failure modes and gotchas
+
+1. **Ad-hoc signature ≠ signature, for update purposes.** Apple's own
+   Security framework synthesizes the designated requirement for ad-hoc code
+   as "a cdhash requirement for all architectures"
+   (`SecStaticCode::defaultDesignatedRequirement()`,
+   https://github.com/apple-oss-distributions/Security/blob/main/OSX/libsecurity_codesigning/lib/StaticCode.cpp).
+   The cdhash changes with every build, so version N+1 can never satisfy the
+   DR captured from running version N — Squirrel's verify (§1.3) always fails.
+   Sokuji CI ad-hoc signs today (`scripts/electron-builder-fuses.js`,
+   `codesign --sign -`), which is why the in-code comment in
+   `electron/update-manager.js` correctly rules auto-update out.
+2. **No mac ZIP published → instant `ERR_UPDATER_ZIP_FILE_NOT_FOUND`.**
+   Current releases ship only PKGs (checked against the v0.38.0 release
+   assets); `latest-mac.yml` must list zips (§1.4).
+3. **Identity/bundle-ID drift breaks the DR chain.** The update must satisfy
+   the *old* version's DR (TN2206, §1.3). Changing team, certificate type, or
+   `CFBundleIdentifier` between releases strands existing installs on manual
+   update for one cycle. Same for the transition release itself: the first
+   signed version cannot be auto-installed by today's ad-hoc installs — users
+   do one final manual install.
+4. **Certificate revocation is fatal, expiry is not** (§2.1 quotes). Protect
+   the `.p12`; a leak → revocation → users cannot install anything signed with
+   it, and notarization's audit trail is the mitigation
+   (https://developer.apple.com/documentation/security/notarizing-macos-software-before-distribution).
+5. **Notarize/staple order with ZIPs.** You cannot staple a ZIP; staple the
+   `.app`, then zip (§2.2). electron-builder's `mac.notarize: true` handles
+   the order; hand-rolled pipelines regularly get this wrong and produce apps
+   that fail Gatekeeper offline.
+6. **Hardened Runtime can break Electron if entitlements are dropped.**
+   Notarization forces Hardened Runtime (§2.3); without
+   `com.apple.security.cs.allow-jit` V8 JIT is disallowed, and without
+   `com.apple.security.device.audio-input` mic capture dies — fatal for a
+   speech-translation app. `@electron/osx-sign` defaults already include both
+   (§2.3), so danger arises only when supplying custom entitlements files.
+7. **App translocation** breaks self-update for apps launched from
+   `Downloads`/DMG without being moved (read-only randomized mount, §2.4).
+   PKG-to-/Applications (current setup) avoids it; if a DMG becomes the
+   primary download, the "drag to Applications" step is load-bearing.
+8. **Fuses vs signing order**: `EnableEmbeddedAsarIntegrityValidation` and
+   `OnlyLoadAppFromAsar` are already flipped in `afterPack`, i.e. before
+   signing — correct; flipping fuses after signing invalidates the signature.
+9. **Per-arch asset naming**: `MacUpdater` distinguishes arm64 by looking for
+   "arm64" in the file URL and applies Rosetta detection (§1.4). Keep
+   electron-builder's default `${productName}-${version}-${arch}-mac.zip`-style
+   names or at minimum keep "arm64" in the arm64 zip name.
+10. **GitHub provider quirks**: version discovery parses the public
+    `releases.atom` feed (§1.4) — a draft release is invisible (good), but a
+    pre-release tag can be picked up by `allowPrerelease` logic; Sokuji's
+    single-channel `vX.Y.Z` tagging is compatible as-is.
+11. **Sequoia first-install policy** (§2.4) is a distribution problem
+    signing+notarization fixes and nothing else does; it also makes Option C's
+    first-install story steadily worse over OS releases.
+12. **Root-owned install location defeats a correctly signed updater.**
+    Squirrel.Mac's `SQRLInstaller` replaces the bundle with `rename()` as the
+    invoking user and contains no `AuthorizationExecuteWithPrivileges` /
+    `SMJobBless` path — when it does run as root it asserts that "the target must
+    be the app bundle that contains this installer"
+    (https://github.com/Squirrel/Squirrel.Mac/blob/master/Squirrel/SQRLInstaller.m).
+    electron-builder invokes `pkgbuild` with no `--ownership` flag
+    (`app-builder-lib/out/targets/pkg.js:215`), so the installed
+    `/Applications/Sokuji.app` is root-owned and the update will fail at install
+    time even with a valid Developer ID. See Option A step 3 for the fix.
+13. **TCC permission thrash — the cost nobody logged.** Apple's guidance is
+    explicit: "If your code is unsigned or signed ad hoc […] the system can't
+    tell that version N+1 of your code is the same as version N, and thus you'll
+    encounter excessive prompts"
+    (https://developer.apple.com/forums/thread/730043). With no stable signing
+    identity TCC keys on the code directory hash, and every Sokuji build
+    produces a new one — so macOS users very likely re-grant microphone and
+    system-audio-recording permission on *every* update today. A Developer ID
+    signature fixes this as a side effect, arguably a bigger day-to-day win than
+    the updater itself. (Unverified on hardware — see §6.)
+14. **The existing SignPath arrangement does not extend to macOS.** SignPath
+    (free for OSS, already used for the Windows Authenticode signature) can hold
+    and use Apple keys through its macOS CryptoTokenKit provider, but it does
+    **not** issue Apple certificates — the Developer ID certificate still has to
+    come from a paid Apple Developer Program membership
+    (https://docs.signpath.io/crypto-providers/macos). There is no OSS discount
+    on the Apple side.
+
+---
+
+## 6. Open questions
+
+1. **Enrollment identity**: individual (fast, personal name on the
+   certificate) vs organization "Kizuna AI Lab" (legal-entity verification,
+   D-U-N-S). Who holds the Account Holder role? (Only that role can create the
+   Developer ID certificate, §2.1.)
+2. **Keep PKG or move to DMG+ZIP?** electron-builder can emit
+   `pkg`+`zip` or `dmg`+`zip`. Keeping PKG preserves the current
+   BlackHole-driver install scripts (`pkg-scripts/`) and avoids translocation
+   by construction; needs a check that a `zip`-installed update keeps whatever
+   the PKG postinstall set up. This decision is coupled to failure mode 12: if
+   the PKG stays, `postinstall` must chown the bundle to the console user, and
+   that chown has to survive the *next* PKG run.
+3. **Does the driver actually need reinstalling after a Squirrel update?**
+   The driver lives outside the app bundle (`/Library/Audio/Plug-Ins/HAL/`), so
+   replacing `Sokuji.app` should leave it untouched — but the app's presence
+   check (`electron/macos-audio-utils.js:159`) and the unity-gain helper path
+   need confirming against a bundle swapped in place rather than reinstalled.
+4. **Do macOS users really lose microphone permission on each update today?**
+   (failure mode 13) Apple's guidance says they should; nobody has confirmed it
+   against a real install. Worth checking before pricing the $99 decision,
+   because it may be the larger of the two benefits.
+5. **Option C verification** (worth doing regardless, since Option C is the
+   zero-cost interim): confirm
+   on real hardware that a PKG downloaded via Node `https` in the packaged app
+   carries no `com.apple.quarantine` and that Installer.app opens it without
+   Gatekeeper interference on Sequoia/Tahoe.
+6. **Windows parity**: mac work would leave Windows as the only platform on
+   the manual `_downloadUpdate()` path (Forge Squirrel.Windows output is not
+   electron-updater-compatible, per the comment in
+   `electron/update-manager.js`) — worth a separate look at NSIS-via-
+   electron-builder to unify, since SignPath signing already exists.
+7. **First signed release migration note**: users on ≤ current ad-hoc builds
+   must manually install the first signed version (failure mode 3); the
+   release notes for that version should say so.

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -19,9 +19,10 @@ app updates itself". Signing is a prerequisite for that, not the whole of it.
 Squirrel.Mac actually demands is a *stable* signature, not an *Apple* one. See
 §2.5, which is the section to read if you read only one.
 
-**This has been verified on real hardware** (macOS 26.6.1, arm64, 2026-08-24) —
-not just derived from Apple's sources. See §6 for what ran and the one test that
-is still outstanding.
+**Verified end to end on real hardware** (macOS 26.6.1, arm64, 2026-08-24) — not
+just derived from Apple's sources. Squirrel's signature check passes across
+rebuilds, and TCC keeps the microphone grant, with an ad-hoc control arm failing
+both to prove the tests discriminate. See §6.
 
 Three things stand in the way today, and all three must go:
 
@@ -47,9 +48,8 @@ Three things stand in the way today, and all three must go:
 What the money does and does not buy:
 
 - **Auto-update does not need the USD 99.** A self-signed certificate satisfies
-  Squirrel.Mac and — very probably — TCC, so microphone permission would also
-  stop resetting on every update (§2.5c; this specific point still needs one
-  hardware test).
+  Squirrel.Mac *and* TCC — both measured — so microphone permission also stops
+  resetting on every update (§2.5c).
 - **First-install friction does need it.** Gatekeeper requires *notarization*,
   which requires the paid membership. No certificate of your own, and no
   updater, changes the first-run experience: the `sudo xattr -d
@@ -421,7 +421,7 @@ specific version of the code."
 **So a rebuild signed with the same certificate and identifier satisfies the
 previous build's DR, and Squirrel.Mac installs it.**
 
-#### 2.5c TCC very likely stops re-prompting too
+#### 2.5c TCC keeps the microphone grant — measured
 
 TN3127 describes the mechanism using *microphone* as its own example:
 
@@ -431,10 +431,25 @@ TN3127 describes the mechanism using *microphone* as its own example:
 > DR."
 
 A self-signed certificate produces a stable DR (§2.5b), so the recorded DR keeps
-matching. **Caveat, stated honestly:** no Apple document says outright that TCC
-accepts a non-Apple certificate — Apple engineers recommend Apple Development /
-Developer ID identities simply because that is what developers have. This is
-inference from a verified mechanism, and it is hardware test #1.
+matching. No Apple document says outright that TCC accepts a *non-Apple*
+certificate, so this was measured directly — two arms, same bundle identifier
+within each arm, different code in v1 vs v2, and the signing identity as the only
+variable between arms:
+
+| Arm | v1 status at launch | v2 status at launch | Prompt on v2? |
+|---|---|---|---|
+| **self-signed** | `0` notDetermined | **`3` AUTHORIZED** | **no dialog at all** |
+| **ad-hoc** (control) | `0` notDetermined | **`0` notDetermined** | **yes, prompted again** |
+
+Each app called `AVCaptureDevice.authorizationStatusForMediaType:` on launch and
+logged it before requesting access. The self-signed v2 came up already
+authorized and returned instantly; the ad-hoc v2 blocked on a fresh permission
+dialog. Same machine, same session, minutes apart.
+
+**So a self-signed certificate is a stable enough identity for TCC.** And the
+control arm settles the other half of the question: today's ad-hoc builds really
+do lose microphone permission on every update, which until now was only an
+inference (failure mode 13).
 
 #### 2.5d What it costs you
 
@@ -743,11 +758,13 @@ browser-downloaded file. The user should always be the one deciding to bypass.
 
 ### Recommended sequence
 
-1. **Run hardware tests #1 and #2** (§6). They are cheap, and between them they
-   decide whether Option S delivers silent updates outright or needs an
-   ownership fix first.
-2. **Ship Option S.** One more manual install for existing macOS users, then
-   parity with Linux AppImage — for $0.
+1. **Ship Option S.** The mechanism is verified (§6); what is left is
+   integration. One more manual install for existing macOS users, then parity
+   with Linux AppImage — for $0, and microphone permission stops resetting as a
+   bonus.
+2. **Set the bundle ownership in the PKG** as part of that same release, rather
+   than depending on the rename result (§6, caveat on test 2). One line, and it
+   makes the outcome deterministic.
 3. **Separately, decide what to do about first install** (§4.4). It is a
    distribution/docs problem, not an updater problem, and the only complete fix
    is the $99.
@@ -868,10 +885,12 @@ the browser and Terminal from the update loop without any certificate at all.
     encounter excessive prompts"
     (https://developer.apple.com/forums/thread/730043). With no stable signing
     identity TCC keys on the code directory hash, and every Sokuji build
-    produces a new one — so macOS users very likely re-grant microphone and
-    system-audio-recording permission on *every* update today. A Developer ID
-    signature fixes this as a side effect, arguably a bigger day-to-day win than
-    the updater itself. (Unverified on hardware — see §6.)
+    produces a new one — so macOS users re-grant microphone and
+    system-audio-recording permission on *every* update today. **Confirmed on
+    hardware** (§2.5c): the ad-hoc control arm was prompted again after a
+    rebuild, while the self-signed arm was not. Any stable certificate fixes
+    this — it does not have to be a Developer ID — and it is arguably a bigger
+    day-to-day win than the updater itself.
 14. **The existing SignPath arrangement does not extend to macOS.** SignPath
     (free for OSS, already used for the Windows Authenticode signature) can hold
     and use Apple keys through its macOS CryptoTokenKit provider, but it does
@@ -885,12 +904,18 @@ the browser and Terminal from the update loop without any certificate at all.
 ## 6. Hardware tests — run 2026-08-24 on macOS 26.6.1 (arm64)
 
 Everything in §2.5 was first verified by reading Apple's own Security sources;
-it has since been run. `scripts/verify-macos-selfsigned.sh` reproduces tests
-2–6 on any Mac or from a `macos-26` CI job — 9 passed, 0 failed.
+it has since been run. Two scripts reproduce it:
+
+- `scripts/verify-macos-selfsigned.sh` — tests 2–6, fully headless, runs on any
+  Mac or from a `macos-26` CI job. 9 passed, 0 failed.
+- `scripts/verify-macos-tcc.sh` — test 1, which needs someone to click Allow.
+  `setup <arm>` builds and installs v1, `swap <arm>` replaces it with v2 and
+  prints the log; run it for both the `selfsigned` and `adhoc` arms and compare.
+  `cleanup` removes the test apps, the TCC entries and the throwaway keychain.
 
 | # | What it decides | Result |
 |---|---|---|
-| 1 | Does TCC keep the microphone grant across a re-sign? | **NOT RUN** — needs a human to click the permission dialog |
+| 1 | Does TCC keep the microphone grant across a re-sign? | **PASS** — self-signed v2 launched already `AUTHORIZED` with no dialog; the ad-hoc control arm was prompted again (§2.5c) |
 | 2 | Can a write-disabled bundle in `/Applications` be renamed? | **PASS** — yes, so `rename(2)`'s CONFORMANCE clause does not bite on APFS here. The root-owned variant still needs a passworded sudo; see the caveat below |
 | 3 | Is the self-signed DR stable, and does build N+1 satisfy build N's DR? | **PASS** — identical DR, `-R` check rc=0, ad-hoc control correctly fails |
 | 4 | Does a non-LaunchServices download carry quarantine? | **PASS** — `Sokuji.app` does not declare `LSFileQuarantineEnabled`; a curl-fetched file has no `com.apple.quarantine` |
@@ -910,10 +935,10 @@ as a normal user fails regardless of the rename. So set the ownership in the
 PKG anyway (Option S step 5) — one line makes the outcome deterministic instead
 of resting on this test.
 
-**Test 1 is the only real unknown left**, and it is the one that decides whether
-Option S also fixes the permission re-prompting. Procedure: sign two builds with
-one certificate, install the first, grant microphone access, install the second,
-and see whether macOS asks again.
+**Nothing material is unverified any more.** Test 1 was run interactively on the
+same machine (a human clicked Allow); see §2.5c for the numbers. What remains is
+ordinary integration work, not open questions about whether the approach can
+work.
 
 1. **Does TCC keep microphone permission across a rebuild signed with the same
    self-signed certificate?** Sign two builds with one cert, grant mic access to

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -833,6 +833,10 @@ Everything in §2.5 was verified by reading Apple's own Security sources, but
 reading source is not running it. These are ordered so the two that could sink
 Option S come first.
 
+**Tests 2–6 are scripted** in `scripts/verify-macos-selfsigned.sh` — run it on
+any Mac, or from a `macos-26` CI job. Test 1 needs a human, because granting
+microphone access requires clicking the dialog.
+
 1. **Does TCC keep microphone permission across a rebuild signed with the same
    self-signed certificate?** Sign two builds with one cert, grant mic access to
    the first, install the second, check for a re-prompt. Decides whether Option S
@@ -851,7 +855,92 @@ Option S come first.
    driver is signed with the same identity?** `kSecCSCheckNestedCode |
    kSecCSStrictValidate` is what Squirrel will apply (§2.5e).
 
-## 7. Open questions
+## 7. What happens to macOS users who already installed
+
+Three changes are on the table — a new app signature, a signed driver, and
+(optionally) a newer BlackHole. They carry very different risk, and they should
+not ship together.
+
+### 7.1 Changing the app signature: ad-hoc → self-signed — low risk
+
+- **The transition build must be installed by hand.** Its DR does not match the
+  installed ad-hoc build, so no updater could apply it. This costs nothing:
+  darwin auto-update is disabled today, so users already install every release
+  by hand. One more time, then never again.
+- **Microphone / system-audio permission: one more prompt.** The code identity
+  changes, so TCC sees a new app. This already happens on *every* update today
+  (failure mode 13), so it is not a regression — and after the transition it
+  should stop, which is the point. Watch for the known stale-row case where
+  System Settings shows the app as allowed but access is denied at runtime; the
+  fix is `tccutil reset Microphone ai.kizunaai.sokuji` or toggling the checkbox.
+  Worth a line in that release's notes.
+- **Sign-in state survives.** `EnableCookieEncryption` is on, so Chromium keeps a
+  "Safe Storage" key in the login keychain whose ACL is bound to the code
+  identity — and TN2206 names the keychain as a DR-based subsystem, so a changed
+  identity can prompt or reset the encrypted cookie store. But better-auth's
+  session does **not** live there: `electron/better-auth-adapter.js:4` puts the
+  cookie jar in `electron-conf`, a plain file under the app's userData. Users
+  stay logged in. And as with TCC, today's ad-hoc builds already churn this key
+  on every single build, so a stable certificate makes it better, not worse.
+- **Ownership change** (if the PKG starts chowning the bundle) is invisible to
+  the user.
+- **Gatekeeper is unchanged.** The PKG is still not notarized, so the
+  `xattr` step stays exactly as it is today.
+
+### 7.2 Signing the driver — safe, and required anyway
+
+The device UID is a compile-time macro. Upstream `BlackHole.c` defines:
+
+```c
+#define kDriver_Name         "BlackHole"     // overridden to "SokujiVirtualAudio"
+#define kDriver_Name_Format  "%ich"
+#define kDevice_UID          kDriver_Name kDriver_Name_Format "_UID"
+#define kNumber_Of_Channels  2               // passed explicitly by our build script
+```
+
+and the shipped binary confirms the resulting literals —
+`SokujiVirtualAudio%ich_UID`, `SokujiVirtualAudio%ich_2_UID`,
+`SokujiVirtualAudio%ich_ModelUID` — which resolve at runtime to
+**`SokujiVirtualAudio2ch_UID`** and friends.
+
+Code signing adds a `_CodeSignature` directory and a signature blob. It changes
+**no string constant**, so the device UID, the device name and the bundle ID all
+stay put. Every app that has "SokujiVirtualAudio" selected as its microphone —
+Zoom, Meet, Teams — keeps that selection. Signing the driver is safe.
+
+It is also not optional: `kSecCSCheckNestedCode | kSecCSStrictValidate` covers
+the copy inside the app bundle at
+`Contents/Resources/resources/drivers/SokujiVirtualAudio.driver` (§2.5e).
+
+*Cleaner alternative worth considering:* move the driver out of the app bundle
+entirely and ship it as a separate PKG payload. Code under `Resources/` is
+precisely what strict validation is unhappy about, and the app only ever uses
+that copy as installer payload — nothing loads it from there.
+
+### 7.3 Bumping the BlackHole version — the actually risky one, and unnecessary
+
+Do not fold this into the signing change. It is a separate decision with its own
+failure modes, and nothing about auto-update requires it — the driver has been
+frozen at BlackHole 0.6.1 / build 596 since 2025-09-17 and works.
+
+- **The device UID could change.** It is derived from `kDriver_Name` plus the
+  channel count. Our build script pins both, so a straight version bump should
+  keep `SokujiVirtualAudio2ch_UID` — but if upstream ever reshapes the
+  `kDevice_UID` macro, or if the channel count changes, the UID changes with it.
+  The symptom is nasty and silent: every app that had the device selected falls
+  back to its default, and users report "translation audio stopped reaching
+  Zoom" with nothing in our logs. Diff the macros before bumping.
+- **`killall coreaudiod` interrupts audio system-wide**, in every running app.
+  The PKG does this on every install today. Doing it mid-meeting is bad; a
+  driver update should be something the user opts into, not a side effect.
+- **Auto-update will not carry the driver.** Squirrel replaces the app bundle;
+  `/Library/Audio/Plug-Ins/HAL/` is outside it and needs root. So once Option S
+  ships, an app update and a driver update are different events — and nothing
+  currently detects the skew, because no code reads the driver's
+  `Contents/Resources/VERSION`. Add that version check *before* you ever need to
+  bump the driver, not after.
+
+## 8. Open questions
 
 1. **Certificate custody.** A self-signed root becomes a permanent project
    secret: losing or rotating it breaks the update chain for every existing

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -496,7 +496,19 @@ nothing and silently skip signing. Two ways round it:
   `sudo security add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain cert.pem`.
   Passwordless on GitHub Actions runners; needs a GUI prompt on a local Mac
   (it fails over SSH with "the authorization was denied since no user
-  interaction was possible"). Trust does not change the DR.
+  interaction was possible"). Trust does not change the DR. **Verified with the
+  real project certificate on 2026-08-28**: an electron-builder-shaped temp
+  keychain showed "0 valid identities found" before the trust step and
+  `92E86A47B9D0179E060C7E7CEA61B8F9D4F3C350 "Sokuji Code Signing"` after it.
+  `scripts/../verify-trust.sh` (kept out of the repo; it takes the private key's
+  password) reproduces this.
+
+  **Pin `mac.identity` by name.** Without a qualifier, `_findIdentity`'s
+  "find non-Apple certificate" fallback takes *any* non-Apple certificate in the
+  keychain — the verification machine already had an unrelated
+  "Sokuji Development Certificate" that it would have picked. That build would
+  carry a different designated requirement and break the update chain with
+  nothing looking wrong.
 - Or sign in the `afterPack` hook, which is what
   `scripts/electron-builder-fuses.js` already does — swap `--sign -` for the
   identity and skip electron-builder's own signing entirely. This sidesteps
@@ -920,7 +932,7 @@ it has since been run. Two scripts reproduce it:
 | 2 | Can a write-disabled bundle in `/Applications` be renamed? | **PASS** — yes, so `rename(2)`'s CONFORMANCE clause does not bite on APFS here. The root-owned variant still needs a passworded sudo; see the caveat below |
 | 3 | Is the self-signed DR stable, and does build N+1 satisfy build N's DR? | **PASS** — identical DR, `-R` check rc=0, ad-hoc control correctly fails |
 | 4 | Does a non-LaunchServices download carry quarantine? | **PASS** — `Sokuji.app` does not declare `LSFileQuarantineEnabled`; a curl-fetched file has no `com.apple.quarantine` |
-| 5 | Is the self-signed cert usable for signing? | **PASS to sign, FAIL to discover** — `codesign` works; `find-identity -v` reports 0 valid (see §2.5e(a)) |
+| 5 | Is the self-signed cert usable for signing? | **PASS** — `codesign` signs with it untrusted; and trusting it makes it discoverable, verified with the real project certificate: `find-identity -v` went 0 → 1 (`92E86A47… "Sokuji Code Signing"`) across `security add-trusted-cert`. See §2.5e(a) |
 | 6 | Does an unsigned nested driver break strict validation? | **PASS** — it does not (see §2.5e(b)) |
 
 Confirmed in passing: the installed app really is

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -13,45 +13,47 @@ app updates itself". Signing is a prerequisite for that, not the whole of it.
 
 ## TL;DR verdict
 
-**Yes, true in-app auto-update (download + silent install + relaunch, like
-Chrome/VS Code) is technically possible for Sokuji on macOS, and most of the
-plumbing already exists in this repo.** Three things stand in the way, and all
-three must go:
+**Yes — and it does not require paying Apple.** True in-app auto-update
+(download + silent install + relaunch, like Chrome/VS Code) is achievable with a
+**locally created self-signed code-signing certificate**, because what
+Squirrel.Mac actually demands is a *stable* signature, not an *Apple* one. See
+§2.5, which is the section to read if you read only one.
 
-1. **No Developer ID code signature** — the hard blocker, and the only one that
-   costs money. Squirrel.Mac (the engine under both Electron's built-in
-   `autoUpdater` and `electron-updater`'s `MacUpdater`) verifies each downloaded
-   update against the *running* app's code-signing designated requirement, and
-   refuses to install anything that does not match. There is no flag, fork, or
-   configuration escape hatch — the check lives in compiled Objective-C inside
-   Electron itself, not in JS. (§1.3, §5.1)
+Three things stand in the way today, and all three must go:
+
+1. **The signature is ad-hoc, so it is not stable.** Squirrel.Mac (the engine
+   under both Electron's built-in `autoUpdater` and `electron-updater`'s
+   `MacUpdater`) verifies each downloaded update against the *running* app's
+   code-signing designated requirement (DR). An ad-hoc signature's DR is a
+   per-build cdhash, so it can never match. A **self-signed certificate**, by
+   contrast, yields a DR of the form
+   `identifier "…" and certificate root = H"…"`, which is identical across
+   rebuilds — and Squirrel does **not** require a trusted anchor. Cost: $0.
+   (§1.3, §2.5, §5.1)
 2. **No `.zip` asset is published.** `MacUpdater` accepts only a zip and
    explicitly rejects `pkg`/`dmg`; today's releases ship PKGs only, so even a
    correctly signed build would fail with `ERR_UPDATER_ZIP_FILE_NOT_FOUND`.
    (§1.4)
 3. **`/Applications/Sokuji.app` is root-owned.** The PKG installs it as root,
    and Squirrel's installer runs as the invoking user with **no** privilege
-   escalation, so it cannot replace that bundle. Fixing 1 and 2 without fixing
-   this produces an updater that downloads correctly and then fails to install.
-   (failure mode 12)
+   escalation, so it likely cannot replace that bundle. Fixing 1 and 2 without
+   fixing this produces an updater that downloads correctly and then fails to
+   install. (failure mode 12)
 
-- With an Apple Developer Program membership (**USD 99/year**) + a Developer ID
-  Application certificate + notarization, the existing
-  `electron/update-manager.js` + `electron-updater` stack can do full
-  auto-update after roughly: add a `zip` target for mac, add ~6 CI secrets, and
-  delete the darwin "notify-only" branch. Estimated effort: 1–2 days of
-  engineering plus Apple enrollment lead time.
-- Without an Apple account, **silent in-place auto-update is impossible** via
-  any Squirrel-based path (ad-hoc signatures mathematically cannot pass the
-  check — see §5.1). The honest fallbacks are (a) a semi-automatic
-  "download the PKG in-app and launch the installer" flow mirroring the
-  existing Windows path, or (b) embedding the native Sparkle framework with
-  EdDSA-signed updates, which avoids Apple signing for *updates* but is a
-  large, unmaintained-territory integration for Electron and does nothing for
-  the first-install Gatekeeper experience.
-- Signing + notarizing would *also* eliminate today's first-install pain (the
-  "unverified developer" dialog / System Settings "Open Anyway" dance, which
-  macOS Sequoia made strictly worse by removing the Control-click override).
+What the money does and does not buy:
+
+- **Auto-update does not need the USD 99.** A self-signed certificate satisfies
+  Squirrel.Mac and — very probably — TCC, so microphone permission would also
+  stop resetting on every update (§2.5c; this specific point still needs one
+  hardware test).
+- **First-install friction does need it.** Gatekeeper requires *notarization*,
+  which requires the paid membership. No certificate of your own, and no
+  updater, changes the first-run experience: the `sudo xattr -d
+  com.apple.quarantine` step stays. The realistic mitigations there are a
+  Homebrew tap or a documented `curl` installer (§4.4), not a code change.
+- Everything else that gets suggested — Sparkle, `update.electronjs.org`, the
+  free Apple tier, the nonprofit fee waiver — either requires the same money or
+  buys nothing over the self-signed route. See "What does NOT work".
 
 ---
 
@@ -339,6 +341,128 @@ https://github.com/electron-userland/electron-builder/blob/master/packages/elect
 
 ---
 
+### 2.5 The self-signed certificate route — auto-update for $0
+
+This is the finding that changes the decision. Squirrel.Mac needs a signature
+that is **stable and self-consistent**, not one that chains to Apple. A
+certificate you generate yourself provides exactly that.
+
+#### 2.5a Verification does not require a trusted anchor
+
+Apple's Code Signing Guide, [Code Signing Tasks](https://developer.apple.com/library/archive/documentation/Security/Conceptual/CodeSigningGuide/Procedures/Procedures.html):
+
+> "The simple act of code signing does not require a certificate authority's
+> signature on your certificate…"
+
+> "Except for the explicit `anchor trusted` requirement, the system does not
+> consult its trust settings database when verifying a code requirement.
+> Therefore, as long as you don't add this designated requirement to your code
+> signature, **the anchor certificate you use for signing your code does not
+> have to be introduced to the user's system for validation to succeed.**"
+
+Confirmed in Apple's open-source Security implementation. `CSCommon.h`
+documents the flag as opt-in, and says what the default is:
+
+```c
+kSecCSCheckTrustedAnchors = 1 << 27, /* build certificate chain to system trust
+                                        anchors, not to any self-signed certificate */
+```
+
+and `StaticCode.cpp`'s `verifySignature` installs an *empty* anchor set unless
+that flag is passed. Squirrel.Mac passes
+`kSecCSCheckNestedCode | kSecCSStrictValidate | kSecCSCheckAllArchitectures`
+(§1.3) — `kSecCSCheckTrustedAnchors` is **absent**. Gatekeeper is the subsystem
+that does demand a trusted anchor, and it only engages on quarantined files.
+
+#### 2.5b The DR is stable across rebuilds
+
+Apple's DR generator (`drmaker.cpp`) branches on whether there is a certificate
+at all:
+
+```cpp
+// we can't make an explicit DR for a (proposed) ad-hoc signing because that
+// requires the CodeDirectory (which we ain't got yet)
+if (ctx.certCount() == 0) return NULL;
+```
+
+With a certificate it emits `identifier <id> and <anchor hash>`; `isAppleCA()`
+is false for a self-signed cert, so it takes the `nonAppleAnchor()` branch and
+pins the SHA-1 of the cert. The result reads:
+
+```
+designated => identifier "ai.kizunaai.sokuji" and certificate root = H"<sha1 of your cert>"
+```
+
+Ad-hoc takes the other path — `StaticCode.cpp` returns "a cdhash requirement for
+all architectures", which is why today's builds can never validate each other.
+TN3127 puts it in prose: "Ad hoc signed code… has a DR but it's tied to that
+specific version of the code."
+
+**So a rebuild signed with the same certificate and identifier satisfies the
+previous build's DR, and Squirrel.Mac installs it.**
+
+#### 2.5c TCC very likely stops re-prompting too
+
+TN3127 describes the mechanism using *microphone* as its own example:
+
+> "macOS solves this problem by recording your app's DR in its database of apps
+> authorized to access the microphone. Each time your app tries to access the
+> microphone, macOS checks that this version of the app satisfies the original
+> DR."
+
+A self-signed certificate produces a stable DR (§2.5b), so the recorded DR keeps
+matching. **Caveat, stated honestly:** no Apple document says outright that TCC
+accepts a non-Apple certificate — Apple engineers recommend Apple Development /
+Developer ID identities simply because that is what developers have. This is
+inference from a verified mechanism, and it is hardware test #1.
+
+#### 2.5d What it costs you
+
+- Apple's guidance says **"Do not ship apps signed by self-signed
+  certificates."** The stated reason is that it proves nothing about authorship
+  to the user — which costs Sokuji nothing here, because without notarization
+  the app already proves nothing to Gatekeeper either. This is a real
+  "against Apple's advice" call, made with eyes open, not a loophole: nothing
+  is hidden from the user and Gatekeeper still behaves exactly as before.
+- **First install is completely unchanged** — Gatekeeper wants notarization.
+- **Certificate rotation resets everything**: a new cert means a new DR, which
+  breaks the update chain *and* re-prompts TCC. Issue it with a very long
+  validity and back it up carefully — this becomes a project secret on par with
+  the signing key itself. Expired certs still *verify* (the engine accepts
+  signatures made with expired certificates) but `codesign` refuses to *sign*
+  with one.
+- **Hardened runtime and entitlements are not needed** — those are notarization
+  requirements. Skip them.
+- **Pin the DR explicitly** with `codesign -r` rather than relying on the
+  `nonAppleAnchor()` organization-field heuristic. Do not hand-write the
+  requirement: dump the generated one with `codesign -d -r-` and reuse it
+  verbatim.
+
+#### 2.5e electron-builder already supports non-Apple identities
+
+`app-builder-lib/out/codeSign/macCodeSign.js:234-250` has an explicit fallback:
+when no "Developer ID Application" identity is found it searches for a
+*non-Apple* certificate, skipping every Apple prefix. That path exists because
+of electron-builder issue #458 — signing with a self-signed certificate is a
+supported configuration, not a hack.
+
+Two CI details to watch:
+
+- `createKeychain` (`:120`) runs `security import` but **never**
+  `security add-trusted-cert`, and identity discovery uses
+  `security find-identity -v -p codesigning` — "-v" meaning valid. Whether a
+  self-signed leaf lists as valid without an explicit trust setting is hardware
+  test #6; if not, add `security add-trusted-cert -d -r trustRoot -k <keychain>`
+  before the build.
+- `kSecCSCheckNestedCode | kSecCSStrictValidate` means **all** nested Mach-O
+  must be signed with the same identity — including
+  `Contents/Resources/resources/drivers/SokujiVirtualAudio.driver`, a universal
+  binary currently built with `CODE_SIGNING_REQUIRED=NO`. Code living under
+  `Resources/` is also exactly what strict validation dislikes. This is a
+  prerequisite for *any* signing route, paid or free.
+
+---
+
 ## 3. Cost
 
 | Item | Cost | Source |
@@ -359,7 +483,45 @@ revocation is not).
 
 ## 4. Implementation options, ranked
 
-### Option A (recommended): keep `electron-updater`, add signing + notarization + a mac ZIP
+**Ranking note:** Option S is the recommendation as of the decision not to pay
+Apple. Option A is the same work with a Developer ID instead of a self-signed
+certificate, and remains the answer if first-install friction is ever judged
+more important than the $99.
+
+### Option S (recommended, $0): self-signed certificate + the existing `electron-updater` stack
+
+Identical in shape to Option A below, with the Developer ID and notarization
+steps replaced by a certificate you issue yourself (§2.5). Concretely:
+
+1. **Certificate**: Keychain Access → Certificate Assistant → Create a
+   Certificate → **Self Signed Root** + **Code Signing**, "Let me override
+   defaults", with a very long validity. Export as `.p12`. Treat it as a
+   permanent project secret — rotating it breaks the update chain and resets
+   TCC (§2.5d).
+2. **CI**: store as `CSC_LINK` (base64 `.p12`) + `CSC_KEY_PASSWORD`. Drop
+   `CSC_IDENTITY_AUTO_DISCOVERY: false` and `mac.identity: null`; set
+   `mac.identity` to the certificate's common name. Do **not** set
+   `mac.notarize`. Add `security add-trusted-cert` before the build if hardware
+   test #6 says it is needed (§2.5e).
+3. **Signing**: replace the ad-hoc `codesign --force --deep --sign -` in
+   `scripts/electron-builder-fuses.js` with electron-builder's normal
+   inside-out signing, and sign the HAL driver with the same identity (§2.5e).
+   Pin the DR with `codesign -r` using a requirement dumped from
+   `codesign -d -r-`.
+4. **Artifacts**: add `zip` alongside `pkg` in `build.mac.target` — required by
+   `MacUpdater`, and it makes `latest-mac.yml` machine-generated (§0).
+5. **Ownership**: resolve per hardware test #2 — either `pkgbuild --ownership
+   preserve` / a `chown` in `pkg-scripts/postinstall`, or drag-install.
+6. **App**: delete the darwin refusal branches at `update-manager.js:99-113`
+   and `:194-196` and let darwin share the AppImage path.
+7. **Driver**: version-gate `SokujiVirtualAudio.driver` so the privileged step
+   only runs when it actually changes (it has not changed since 2025-09-17).
+
+Migration is clean: darwin auto-update is disabled today, so users already
+install manually. They do that **one more time** — the release that carries the
+self-signed bundle and the ownership fix — and are automatic from then on.
+
+### Option A (same work, $99/yr): Developer ID + notarization + a mac ZIP
 
 Smallest diff from today's architecture; `UpdateManager` and the renderer
 update store already handle check/download/progress/install states, and the
@@ -460,7 +622,10 @@ Gatekeeper dance for updates (needs one verification pass on real hardware;
 see Open questions). First-time installs keep today's full friction,
 Sequoia-style (§2.4).
 
-### Option D (no Apple account): Sparkle with EdDSA keys — possible, not recommended
+### Option D (superseded by Option S): Sparkle with EdDSA keys
+
+Sparkle genuinely does not need an Apple account — but neither does Option S,
+which reuses a stack this repo already ships. Recorded here for completeness.
 
 Sparkle, the native macOS updater framework, does not hard-require Apple
 signing: its security model is "Sign the published update archive (dmg, zip,
@@ -476,32 +641,65 @@ still fight to launch the app the first time.
 
 ### What does NOT work (verified against source)
 
-- `electron-updater` with unsigned or ad-hoc builds — see §5.1.
+- `electron-updater` with unsigned or **ad-hoc** builds — see §5.1. Note the
+  distinction that matters: this is a statement about ad-hoc signing, *not*
+  about the absence of an Apple certificate. A self-signed certificate works
+  (§2.5).
 - update.electronjs.org / `update-electron-app` without signing — requirement
   is explicit ("Your builds are code signed (macOS and MSIX only)"):
   https://github.com/electron/update-electron-app,
-  https://github.com/electron/update.electronjs.org.
+  https://github.com/electron/update.electronjs.org. (Unverified whether their
+  check would accept a self-signed cert; moot, since Option S needs no service.)
 - Any "disable verification" flag: none exists in `MacUpdater` (no signature
   code at all on mac, §1.4) and none can exist without forking Electron's
   bundled Squirrel.Mac (§1.3).
 - The existing free SignPath arrangement, which is Windows-only in practice —
   see failure mode 14.
+- **Nothing free fixes first install.** The free Apple tier lists
+  "Notarization & Developer ID" under the paid tier only, and the fee waiver
+  requires being "a legal entity with a status as a nonprofit organization,
+  accredited educational institution, or government entity" —
+  https://developer.apple.com/support/membership-fee-waiver/ — which a
+  for-profit company cannot satisfy. There is no Apple open-source signing
+  programme.
+
+### 4.4 First-install friction — the part no certificate fixes
+
+Gatekeeper wants notarization, so the `sudo xattr -d com.apple.quarantine` step
+survives every option on this page. What can legitimately reduce it:
+
+- **A Homebrew tap.** Homebrew Cask's current
+  `Library/Homebrew/cask/quarantine.rb` hardcodes
+  `check_quarantine_support → [:quarantine_unavailable, nil]`, so `available?`
+  can never be true and **casks are not quarantined at all**; correspondingly
+  `--no-quarantine` no longer appears in the manpage. A third-party tap
+  (`brew tap kizuna-ai-lab/sokuji`) is a supported path and sidesteps
+  homebrew-cask's acceptability rules. The HAL driver still needs root, so the
+  cask would carry a `pkg` stanza and prompt once. *(Which Homebrew release
+  changed this was not pinned down — verify before publishing.)*
+- **A documented `curl` installer.** Quarantine is applied by the downloading
+  application by design, and CLI tools deliberately do not set it, so a script
+  the user reads and runs installs without the xattr dance. This is the same
+  security posture the install docs already ask for, with fewer steps — but say
+  plainly in the docs that it bypasses Gatekeeper, and publish checksums.
+
+What not to do: ship anything that silently strips quarantine from a
+browser-downloaded file. The user should always be the one deciding to bypass.
 
 ### Recommended sequence
 
-1. **Now, free: ship Option C.** It removes the browser and the Terminal from
-   the update loop for existing users, and it is the smallest change on this
-   page (roughly the `_downloadUpdate`/`_installUpdate` pair already in
-   `update-manager.js`, pointed at `pkgUrl`). One hardware verification gates it
-   (§6.5).
-2. **Decide on the USD 99.** Given the release cadence (§0) and the likely TCC
-   re-prompting (failure mode 13), this looks like the highest-leverage $99 in
-   the project, and it is the only thing that fixes *first* install.
-3. **After signing lands: Option A**, including the ownership and driver steps.
-   At that point macOS reaches parity with Linux AppImage.
+1. **Run hardware tests #1 and #2** (§6). They are cheap, and between them they
+   decide whether Option S delivers silent updates outright or needs an
+   ownership fix first.
+2. **Ship Option S.** One more manual install for existing macOS users, then
+   parity with Linux AppImage — for $0.
+3. **Separately, decide what to do about first install** (§4.4). It is a
+   distribution/docs problem, not an updater problem, and the only complete fix
+   is the $99.
 
-Steps 1 and 3 are not wasted work relative to each other: the in-app download
-plumbing from C is what a driver-update prompt in A would reuse.
+Option C (in-app PKG download + launch Installer) is still worth knowing about
+as a fallback if Option S fails a hardware test — it is ~40 lines and removes
+the browser and Terminal from the update loop without any certificate at all.
 
 ---
 
@@ -517,6 +715,14 @@ plumbing from C is what a driver-update prompt in A would reuse.
    Sokuji CI ad-hoc signs today (`scripts/electron-builder-fuses.js`,
    `codesign --sign -`), which is why the in-code comment in
    `electron/update-manager.js` correctly rules auto-update out.
+
+   **But note what this is and is not.** That in-code comment says macOS builds
+   "are unsigned (no Apple Developer ID), so electron-updater cannot apply the
+   update — Squirrel.Mac requires the new bundle to share a valid Developer ID
+   signature with the running one". The first half is right; the "Developer ID"
+   part is not. Squirrel requires a *shared, stable* signature, and any
+   certificate — including a self-signed one — supplies that (§2.5). Worth
+   correcting in the source comment when Option S lands.
 2. **No mac ZIP published → instant `ERR_UPDATER_ZIP_FILE_NOT_FOUND`.**
    Current releases ship only PKGs (checked against the v0.38.0 release
    assets); `latest-mac.yml` must list zips (§1.4).
@@ -558,6 +764,20 @@ plumbing from C is what a driver-update prompt in A would reuse.
 11. **Sequoia first-install policy** (§2.4) is a distribution problem
     signing+notarization fixes and nothing else does; it also makes Option C's
     first-install story steadily worse over OS releases.
+12a. **Never modify a bundle in place.** Apple has a document for exactly this
+    failure — [Updating Mac Software](https://developer.apple.com/documentation/security/updating-mac-software),
+    subtitled "Implement Mac software updates without causing code-signing
+    crashes": "macOS caches information about the code's signature in the
+    kernel. It doesn't flush that cache when you modify the file's contents.
+    Modifying the file in place yields a mismatch… which can cause a
+    hard-to-reproduce code-signing crash", and it applies to "executables,
+    frameworks, dynamic libraries, and **bundles**". The fix is write-to-temp
+    plus `rename(2)`: "the in-kernel cache is associated with the old file,
+    which remains unmodified." Squirrel does this correctly; any hand-rolled
+    updater must too. Related trap: `ditto` *merges* into an existing directory
+    rather than replacing it, leaving stale files that then fail
+    `kSecCSStrictValidate` — always extract to a fresh staging directory and
+    swap.
 12. **Root-owned install location defeats a correctly signed updater.**
     Squirrel.Mac's `SQRLInstaller` replaces the bundle with `rename()` as the
     invoking user and contains no `AuthorizationExecuteWithPrivileges` /
@@ -566,8 +786,27 @@ plumbing from C is what a driver-update prompt in A would reuse.
     (https://github.com/Squirrel/Squirrel.Mac/blob/master/Squirrel/SQRLInstaller.m).
     electron-builder invokes `pkgbuild` with no `--ownership` flag
     (`app-builder-lib/out/targets/pkg.js:215`), so the installed
-    `/Applications/Sokuji.app` is root-owned and the update will fail at install
-    time even with a valid Developer ID. See Option A step 3 for the fix.
+    `/Applications/Sokuji.app` is root-owned.
+
+    The precise mechanics are worth getting right, because they decide how much
+    work this is. `/Applications` is **not** SIP-protected (Apple's System
+    Integrity Protection Guide lists it under "Locations Available to
+    Developers") and is mode 0775 `root:admin` with no sticky bit, so an admin
+    user can write *in* it. But `rename(2)`'s CONFORMANCE section adds a
+    directory-specific restriction — "This restriction has been generalized to
+    disallow renaming of any **write-disabled directory**, even when this would
+    not require a change to the `..` entry" — which suggests a root-owned
+    `drwxr-xr-x Sokuji.app` cannot be renamed by an admin user even though its
+    parent is writable. The man page says nothing about APFS, so this is
+    hardware test #2. If it holds, the fix is `pkgbuild --ownership preserve`
+    (Apple's documented escape hatch for special ownership requirements) or a
+    `chown` to the console user in `pkg-scripts/postinstall`. User-owned apps in
+    `/Applications` are unremarkable — Brave, Cursor and Firefox all install
+    that way.
+
+    Not a problem: Ventura's App Management protection applies to *notarized*
+    apps, which Sokuji is not, and `NSUpdateSecurityPolicy` exists precisely to
+    let same-developer updaters modify a bundle.
 13. **TCC permission thrash — the cost nobody logged.** Apple's guidance is
     explicit: "If your code is unsigned or signed ad hoc […] the system can't
     tell that version N+1 of your code is the same as version N, and thus you'll
@@ -588,38 +827,59 @@ plumbing from C is what a driver-update prompt in A would reuse.
 
 ---
 
-## 6. Open questions
+## 6. Hardware tests (all need a Mac; ranked by what they decide)
 
-1. **Enrollment identity**: individual (fast, personal name on the
-   certificate) vs organization "Kizuna AI Lab" (legal-entity verification,
-   D-U-N-S). Who holds the Account Holder role? (Only that role can create the
-   Developer ID certificate, §2.1.)
-2. **Keep PKG or move to DMG+ZIP?** electron-builder can emit
+Everything in §2.5 was verified by reading Apple's own Security sources, but
+reading source is not running it. These are ordered so the two that could sink
+Option S come first.
+
+1. **Does TCC keep microphone permission across a rebuild signed with the same
+   self-signed certificate?** Sign two builds with one cert, grant mic access to
+   the first, install the second, check for a re-prompt. Decides whether Option S
+   fixes the permission thrash or merely the updater (§2.5c).
+2. **Can an admin user rename a root-owned, write-disabled directory inside
+   `/Applications` on APFS?** `sudo mkdir /Applications/T.app && mv
+   /Applications/T.app /Applications/T2.app` as a normal admin user. Decides
+   whether the ownership fix is needed at all (failure mode 12).
+3. **Does Squirrel.Mac accept the self-signed DR end to end?** Run a real update
+   cycle between two self-signed builds. The source says yes (§2.5b); confirm.
+4. **`xattr -l` a Node-downloaded artifact** → expect no `com.apple.quarantine`
+   (gates Option C, and confirms §2.4's reasoning).
+5. **Does `security find-identity -v -p codesigning` list the self-signed cert as
+   valid** in a fresh CI keychain without `add-trusted-cert`? (§2.5e)
+6. **Does the whole bundle pass `codesign --verify --deep --strict` once the HAL
+   driver is signed with the same identity?** `kSecCSCheckNestedCode |
+   kSecCSStrictValidate` is what Squirrel will apply (§2.5e).
+
+## 7. Open questions
+
+1. **Certificate custody.** A self-signed root becomes a permanent project
+   secret: losing or rotating it breaks the update chain for every existing
+   install and resets TCC (§2.5d). Where does it live, who holds the backup, and
+   what is the recovery plan if it leaks? This is the main *governance* cost of
+   Option S, and it is not zero even though the dollar cost is.
+2. **Enrollment identity** (only if the $99 is ever reconsidered for
+   first-install friction): individual vs organization "Kizuna AI Lab"
+   (legal-entity verification, D-U-N-S). Who holds the Account Holder role?
+   (Only that role can create the Developer ID certificate, §2.1.)
+3. **Keep PKG or move to DMG+ZIP?** electron-builder can emit
    `pkg`+`zip` or `dmg`+`zip`. Keeping PKG preserves the current
    BlackHole-driver install scripts (`pkg-scripts/`) and avoids translocation
    by construction; needs a check that a `zip`-installed update keeps whatever
    the PKG postinstall set up. This decision is coupled to failure mode 12: if
-   the PKG stays, `postinstall` must chown the bundle to the console user, and
-   that chown has to survive the *next* PKG run.
-3. **Does the driver actually need reinstalling after a Squirrel update?**
+   the PKG stays, `postinstall` must set the ownership, and that has to survive
+   the *next* PKG run.
+4. **Does the driver actually need reinstalling after a Squirrel update?**
    The driver lives outside the app bundle (`/Library/Audio/Plug-Ins/HAL/`), so
    replacing `Sokuji.app` should leave it untouched — but the app's presence
    check (`electron/macos-audio-utils.js:159`) and the unity-gain helper path
    need confirming against a bundle swapped in place rather than reinstalled.
-4. **Do macOS users really lose microphone permission on each update today?**
-   (failure mode 13) Apple's guidance says they should; nobody has confirmed it
-   against a real install. Worth checking before pricing the $99 decision,
-   because it may be the larger of the two benefits.
-5. **Option C verification** (worth doing regardless, since Option C is the
-   zero-cost interim): confirm
-   on real hardware that a PKG downloaded via Node `https` in the packaged app
-   carries no `com.apple.quarantine` and that Installer.app opens it without
-   Gatekeeper interference on Sequoia/Tahoe.
-6. **Windows parity**: mac work would leave Windows as the only platform on
+5. **Windows parity**: mac work would leave Windows as the only platform on
    the manual `_downloadUpdate()` path (Forge Squirrel.Windows output is not
    electron-updater-compatible, per the comment in
    `electron/update-manager.js`) — worth a separate look at NSIS-via-
    electron-builder to unify, since SignPath signing already exists.
-7. **First signed release migration note**: users on ≤ current ad-hoc builds
-   must manually install the first signed version (failure mode 3); the
-   release notes for that version should say so.
+6. **First signed release migration note**: users on today's ad-hoc builds
+   cannot auto-install the first self-signed version (DR mismatch, failure
+   mode 3). Since darwin auto-update is disabled today this costs nothing in
+   practice, but the release notes for that version should say so.

--- a/electron/update-manager.js
+++ b/electron/update-manager.js
@@ -1,4 +1,5 @@
 const { autoUpdater } = require('electron-updater');
+const { buildUpdatePayload, usesNativeUpdaterFlow } = require('./update-payload');
 const { app, ipcMain, shell } = require('electron');
 const https = require('https');
 const fs = require('fs');
@@ -63,55 +64,11 @@ class UpdateManager {
     });
 
     autoUpdater.on('update-available', (info) => {
-      // With fullChangelog=true, releaseNotes is an array of {version, note} objects
-      // where note is already HTML (rendered by GitHub). Sorted newest-first.
-      let releaseNotes;
-      if (Array.isArray(info.releaseNotes)) {
-        releaseNotes = info.releaseNotes;
-      } else if (typeof info.releaseNotes === 'string') {
-        releaseNotes = info.releaseNotes;
-      } else {
-        releaseNotes = '';
-      }
-
-      const payload = {
-        status: 'available',
-        version: info.version,
-        releaseNotes,
-      };
-
-      if (process.platform === 'linux') {
-        const version = info.version;
-        // electron-builder names AppImage artifacts with `x86_64` (not `x64`) for
-        // x64 Linux builds, and `arm64` for arm64. Translate Node's process.arch.
-        const appImageArch = process.arch === 'x64' ? 'x86_64' : 'arm64';
-        const debArch = process.arch === 'x64' ? 'amd64' : 'arm64';
-        const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
-
-        payload.supportsAutoUpdate = this.isAppImage;
-        payload.appImageUrl = `${base}/Sokuji-${version}-${appImageArch}.AppImage`;
-        payload.debUrl = `${base}/sokuji_${version}_${debArch}.deb`;
-        payload.releasePageUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${version}`;
-        // Legacy field kept for Windows / backward compat callers of updateStore:
-        if (!this.isAppImage) {
-          payload.downloadUrl = payload.releasePageUrl;
-        }
-      } else if (process.platform === 'darwin') {
-        // macOS builds are unsigned (no Apple Developer ID), so electron-updater
-        // cannot apply the update — Squirrel.Mac requires the new bundle to share
-        // a valid Developer ID signature with the running one. We surface the
-        // notification, then send the user to the GitHub release to download
-        // the PKG manually. See update-download handler below for the matching
-        // refusal path.
-        const version = info.version;
-        const arch = process.arch === 'arm64' ? 'arm64' : 'x64';
-        const base = `https://github.com/kizuna-ai-lab/sokuji/releases/download/v${version}`;
-
-        payload.supportsAutoUpdate = false;
-        payload.pkgUrl = `${base}/Sokuji-${version}-${arch}.pkg`;
-        payload.releasePageUrl = `https://github.com/kizuna-ai-lab/sokuji/releases/tag/v${version}`;
-        payload.downloadUrl = payload.pkgUrl;
-      }
+      const payload = buildUpdatePayload(info, {
+        platform: process.platform,
+        arch: process.arch,
+        isAppImage: this.isAppImage,
+      });
 
       this._updateInfo = info;
       this._sendStatus(payload);
@@ -148,8 +105,9 @@ class UpdateManager {
         return { success: false, error: 'No update available' };
       }
 
-      // Linux AppImage: use electron-updater's native AppImageUpdater flow
-      if (process.platform === 'linux' && this.isAppImage) {
+      // Platforms electron-updater can install in place: Linux AppImage, and
+      // macOS now that builds carry a stable signature (docs/build/macos-auto-update.md).
+      if (usesNativeUpdaterFlow({ platform: process.platform, isAppImage: this.isAppImage })) {
         if (this._downloadPromise) return this._downloadPromise;
 
         // Hook download-progress events from autoUpdater to IPC
@@ -170,7 +128,7 @@ class UpdateManager {
             await autoUpdater.downloadUpdate();
             // `update-downloaded` event is what flips status to 'downloaded';
             // it also populates this.downloadPath implicitly via electron-updater.
-            this.downloadPath = '__appimage__'; // sentinel so install handler proceeds
+            this.downloadPath = '__native__'; // sentinel so install handler proceeds
             return { success: true };
           } catch (err) {
             this._sendStatus({ status: 'error', message: err.message || String(err) });
@@ -186,12 +144,7 @@ class UpdateManager {
       }
 
       // Non-AppImage Linux: no auto-download; renderer opens links manually
-      if (process.platform === 'linux' && !this.isAppImage) {
-        return { success: false, error: 'auto-update-not-supported' };
-      }
-
-      // macOS: same notify-only path as non-AppImage Linux.
-      if (process.platform === 'darwin') {
+      if (process.platform === 'linux') {
         return { success: false, error: 'auto-update-not-supported' };
       }
 
@@ -218,8 +171,10 @@ class UpdateManager {
         return { success: false, error: 'No downloaded update' };
       }
 
-      // Linux AppImage: native quitAndInstall replaces the AppImage in place
-      if (process.platform === 'linux' && this.isAppImage) {
+      // Native flow: quitAndInstall replaces the AppImage / .app bundle in place.
+      // On macOS electron-updater hands the downloaded zip to Squirrel.Mac,
+      // which swaps the bundle after the app quits.
+      if (usesNativeUpdaterFlow({ platform: process.platform, isAppImage: this.isAppImage })) {
         try {
           autoUpdater.quitAndInstall();
           return { success: true };

--- a/electron/update-payload.js
+++ b/electron/update-payload.js
@@ -1,0 +1,75 @@
+// Platform decisions for the update flow, kept free of electron and
+// electron-updater imports so they can be tested directly.
+//
+// Which platforms can apply an update in place comes down to what Squirrel
+// requires of the signature. Squirrel.Mac captures the designated requirement
+// of the *running* bundle and verifies each update against it; an ad-hoc
+// signature's DR is a per-build cdhash, so it can never match, which is why
+// macOS was notify-only. Signing with a stable certificate — it does not have
+// to be an Apple one — makes that check pass. See
+// docs/build/macos-auto-update.md.
+
+const RELEASE_BASE = 'https://github.com/kizuna-ai-lab/sokuji/releases';
+
+/**
+ * Does this platform hand the download and install to electron-updater,
+ * rather than fetching an installer itself or sending the user to a browser?
+ *
+ * @param {{platform: string, isAppImage?: boolean}} env
+ * @returns {boolean}
+ */
+function usesNativeUpdaterFlow({ platform, isAppImage = false }) {
+  if (platform === 'darwin') return true;
+  if (platform === 'linux') return Boolean(isAppImage);
+  // Windows downloads the Squirrel Setup.exe itself: Forge's Squirrel.Windows
+  // output is not electron-updater compatible.
+  return false;
+}
+
+/**
+ * Build the `update-available` payload sent to the renderer.
+ *
+ * @param {{version: string, releaseNotes?: unknown}} info  electron-updater's UpdateInfo
+ * @param {{platform: string, arch: string, isAppImage?: boolean}} env
+ */
+function buildUpdatePayload(info, { platform, arch, isAppImage = false }) {
+  // With fullChangelog=true, releaseNotes is an array of {version, note} objects
+  // where note is already HTML (rendered by GitHub). Sorted newest-first.
+  let releaseNotes;
+  if (Array.isArray(info.releaseNotes)) {
+    releaseNotes = info.releaseNotes;
+  } else if (typeof info.releaseNotes === 'string') {
+    releaseNotes = info.releaseNotes;
+  } else {
+    releaseNotes = '';
+  }
+
+  const version = info.version;
+  const payload = { status: 'available', version, releaseNotes };
+
+  if (platform === 'linux') {
+    // electron-builder names AppImage artifacts with `x86_64` (not `x64`) for
+    // x64 Linux builds, and `arm64` for arm64. Translate Node's process.arch.
+    const appImageArch = arch === 'x64' ? 'x86_64' : 'arm64';
+    const debArch = arch === 'x64' ? 'amd64' : 'arm64';
+    const base = `${RELEASE_BASE}/download/v${version}`;
+
+    payload.supportsAutoUpdate = Boolean(isAppImage);
+    payload.appImageUrl = `${base}/Sokuji-${version}-${appImageArch}.AppImage`;
+    payload.debUrl = `${base}/sokuji_${version}_${debArch}.deb`;
+    payload.releasePageUrl = `${RELEASE_BASE}/tag/v${version}`;
+    // Legacy field kept for Windows / backward compat callers of updateStore:
+    if (!isAppImage) {
+      payload.downloadUrl = payload.releasePageUrl;
+    }
+  } else if (platform === 'darwin') {
+    // Nothing platform-specific beyond the flag. In particular no downloadUrl:
+    // UpdateDialog renders a browser-download button whenever one is present,
+    // which would hide the in-app flow.
+    payload.supportsAutoUpdate = true;
+  }
+
+  return payload;
+}
+
+module.exports = { buildUpdatePayload, usesNativeUpdaterFlow };

--- a/electron/update-payload.test.js
+++ b/electron/update-payload.test.js
@@ -1,0 +1,90 @@
+// electron/update-payload.test.js
+//
+// macOS used to be notify-only: the builds were ad-hoc signed, and Squirrel.Mac
+// verifies each update against the designated requirement captured from the
+// running bundle, which an ad-hoc cdhash can never satisfy. Signing with a
+// stable (self-signed) certificate makes that check pass, so darwin now takes
+// the same native electron-updater path as AppImage.
+//
+// These are pure decisions deliberately kept out of UpdateManager, which cannot
+// be imported under test because it pulls in electron and electron-updater.
+import { describe, it, expect } from 'vitest';
+import { createRequire } from 'node:module';
+
+const nodeRequire = createRequire(import.meta.url);
+const { buildUpdatePayload, usesNativeUpdaterFlow } = nodeRequire('./update-payload.js');
+
+const info = { version: '1.2.3', releaseNotes: '<p>notes</p>' };
+
+describe('usesNativeUpdaterFlow', () => {
+  it('is true on darwin', () => {
+    expect(usesNativeUpdaterFlow({ platform: 'darwin', isAppImage: false })).toBe(true);
+  });
+
+  it('is true for Linux AppImage and false for a distro package', () => {
+    expect(usesNativeUpdaterFlow({ platform: 'linux', isAppImage: true })).toBe(true);
+    expect(usesNativeUpdaterFlow({ platform: 'linux', isAppImage: false })).toBe(false);
+  });
+
+  it('is false on win32, which downloads the Squirrel installer itself', () => {
+    expect(usesNativeUpdaterFlow({ platform: 'win32', isAppImage: false })).toBe(false);
+  });
+});
+
+describe('buildUpdatePayload on darwin', () => {
+  const mac = (arch = 'arm64') =>
+    buildUpdatePayload(info, { platform: 'darwin', arch, isAppImage: false });
+
+  it('advertises auto-update', () => {
+    expect(mac().supportsAutoUpdate).toBe(true);
+  });
+
+  // UpdateDialog renders a browser-download button whenever downloadUrl is set,
+  // which would hide the in-app flow entirely.
+  it('sets no downloadUrl, so the dialog shows the in-app flow', () => {
+    expect(mac().downloadUrl).toBeUndefined();
+  });
+
+  it('offers no AppImage/deb links either', () => {
+    expect(mac().appImageUrl).toBeUndefined();
+    expect(mac().debUrl).toBeUndefined();
+  });
+
+  it('still carries version and release notes', () => {
+    expect(mac()).toMatchObject({
+      status: 'available',
+      version: '1.2.3',
+      releaseNotes: '<p>notes</p>',
+    });
+  });
+});
+
+describe('buildUpdatePayload on linux', () => {
+  it('keeps the AppImage auto-update path', () => {
+    const p = buildUpdatePayload(info, { platform: 'linux', arch: 'x64', isAppImage: true });
+    expect(p.supportsAutoUpdate).toBe(true);
+    expect(p.appImageUrl).toContain('Sokuji-1.2.3-x86_64.AppImage');
+    expect(p.downloadUrl).toBeUndefined();
+  });
+
+  it('sends distro-package users to the release page', () => {
+    const p = buildUpdatePayload(info, { platform: 'linux', arch: 'arm64', isAppImage: false });
+    expect(p.supportsAutoUpdate).toBe(false);
+    expect(p.debUrl).toContain('sokuji_1.2.3_arm64.deb');
+    expect(p.downloadUrl).toBe(p.releasePageUrl);
+  });
+});
+
+describe('buildUpdatePayload release notes normalisation', () => {
+  it('passes an array through (fullChangelog)', () => {
+    const notes = [{ version: '1.2.3', note: '<p>a</p>' }];
+    const p = buildUpdatePayload({ version: '1.2.3', releaseNotes: notes },
+      { platform: 'win32', arch: 'x64' });
+    expect(p.releaseNotes).toBe(notes);
+  });
+
+  it('falls back to an empty string when absent', () => {
+    const p = buildUpdatePayload({ version: '1.2.3' }, { platform: 'win32', arch: 'x64' });
+    expect(p.releaseNotes).toBe('');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
       ],
       "category": "public.app-category.utilities",
       "icon": "assets/icon.icns",
+      "identity": "Sokuji Code Signing",
       "notarize": false
     },
     "pkg": {

--- a/package.json
+++ b/package.json
@@ -72,11 +72,18 @@
             "x64",
             "arm64"
           ]
+        },
+        {
+          "target": "zip",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
         }
       ],
       "category": "public.app-category.utilities",
       "icon": "assets/icon.icns",
-      "identity": null
+      "notarize": false
     },
     "pkg": {
       "scripts": "../pkg-scripts",

--- a/pkg-scripts/postinstall
+++ b/pkg-scripts/postinstall
@@ -5,10 +5,26 @@
 
 echo "Sokuji postinstall: Starting installation..."
 
-# Set correct permissions on the installed app
+# Set correct permissions on the installed app.
+#
+# Ownership matters for auto-update, not just for permissions. The installer
+# runs as root, so without this the bundle lands as root:wheel and Squirrel.Mac
+# -- which runs as the invoking user and never escalates privileges -- cannot
+# replace it. Handing it to the console user is what drag-installed apps look
+# like anyway (Brave, Cursor and Firefox all install user-owned).
+# See docs/build/macos-auto-update.md.
 if [ -d "/Applications/Sokuji.app" ]; then
     echo "Sokuji postinstall: Setting app permissions..."
     chmod -R 755 /Applications/Sokuji.app
+
+    CONSOLE_USER=$(stat -f%Su /dev/console 2>/dev/null)
+    if [ -n "$CONSOLE_USER" ] && [ "$CONSOLE_USER" != "root" ]; then
+        echo "Sokuji postinstall: Handing the app bundle to $CONSOLE_USER so updates can replace it..."
+        chown -R "$CONSOLE_USER" /Applications/Sokuji.app || \
+            echo "Sokuji postinstall: WARNING - chown failed; in-app updates will not be able to replace the bundle"
+    else
+        echo "Sokuji postinstall: WARNING - no console user found; leaving the bundle root-owned"
+    fi
 fi
 
 # Install the virtual audio driver from the app bundle

--- a/scripts/create-macos-signing-cert.sh
+++ b/scripts/create-macos-signing-cert.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# Create the self-signed code-signing certificate that macOS auto-update needs.
+#
+# WHY: Squirrel.Mac verifies each update against the designated requirement
+# captured from the running bundle. Ad-hoc signing produces a per-build cdhash,
+# which can never match; any real certificate produces
+# `identifier "…" and certificate root = H"…"`, which is identical across
+# rebuilds. It does NOT have to be an Apple certificate — verified on macOS
+# 26.6.1. See docs/build/macos-auto-update.md §2.5.
+#
+# This certificate is NOT for Gatekeeper. It gives the app a stable identity so
+# that (a) updates install, (b) the microphone permission survives updates, and
+# (c) the keychain stops prompting after each update. First-install Gatekeeper
+# friction is unaffected — that needs notarization, which needs a paid account.
+#
+#   bash scripts/create-macos-signing-cert.sh [output-dir]
+#
+# ⚠️  CUSTODY: the .p12 this produces becomes a permanent project secret.
+#     Rotating or losing it breaks the update chain for every existing install
+#     and resets every user's microphone permission. Back it up somewhere the
+#     team can reach, and do not commit it.
+
+set -euo pipefail
+
+OUT_DIR="${1:-$HOME/sokuji-signing}"
+CN="Sokuji Code Signing"
+ORG="Kizuna AI Lab"
+DAYS=7300  # ~20 years; codesign refuses to sign with an expired certificate
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "Run this on macOS — it uses the system keychain tooling to verify." >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+chmod 700 "$OUT_DIR"
+KEY="$OUT_DIR/sokuji-signing.key"
+CRT="$OUT_DIR/sokuji-signing.crt"
+P12="$OUT_DIR/sokuji-signing.p12"
+
+if [ -f "$P12" ]; then
+  echo "Refusing to overwrite an existing certificate at $P12" >&2
+  echo "Replacing it would break updates for every existing install." >&2
+  exit 1
+fi
+
+# Prefer Homebrew OpenSSL if present; both work, but the export below needs the
+# right flag depending on which one it is.
+OPENSSL=/usr/bin/openssl
+[ -x /opt/homebrew/bin/openssl ] && OPENSSL=/opt/homebrew/bin/openssl
+echo "Using $($OPENSSL version)"
+
+read -r -s -p "Choose a password for the .p12 (you will store this as a CI secret): " P12_PASS
+echo
+[ -n "$P12_PASS" ] || { echo "A password is required." >&2; exit 1; }
+
+echo "Generating a self-signed code-signing certificate..."
+"$OPENSSL" req -x509 -newkey rsa:2048 -sha256 -days "$DAYS" -nodes \
+  -keyout "$KEY" -out "$CRT" \
+  -subj "/CN=$CN/O=$ORG" \
+  -addext "basicConstraints=critical,CA:false" \
+  -addext "keyUsage=critical,digitalSignature" \
+  -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1
+
+# macOS's Security framework cannot import PKCS#12 written with OpenSSL 3's
+# defaults (AES-256/SHA-256) — `security import` fails with "MAC verification
+# failed during PKCS12 import (wrong password?)", which has nothing to do with
+# the password. -legacy restores algorithms it understands; LibreSSL has no
+# such flag and already writes a compatible file.
+if "$OPENSSL" pkcs12 -help 2>&1 | grep -q -- '-legacy'; then
+  "$OPENSSL" pkcs12 -export -legacy -out "$P12" -inkey "$KEY" -in "$CRT" \
+    -passout "pass:$P12_PASS"
+else
+  "$OPENSSL" pkcs12 -export -out "$P12" -inkey "$KEY" -in "$CRT" \
+    -passout "pass:$P12_PASS"
+fi
+chmod 600 "$KEY" "$P12"
+
+# Prove the result is actually usable before anyone wires it into CI.
+echo "Verifying the certificate can sign..."
+KC="$OUT_DIR/verify.keychain"
+security delete-keychain "$KC" 2>/dev/null || true
+security create-keychain -p "$P12_PASS" "$KC" >/dev/null
+security unlock-keychain -p "$P12_PASS" "$KC" >/dev/null
+security set-keychain-settings "$KC"
+security import "$P12" -k "$KC" -P "$P12_PASS" -A >/dev/null 2>&1
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$P12_PASS" "$KC" >/dev/null 2>&1
+security list-keychains -d user -s "$KC" $(security list-keychains -d user | tr -d '"')
+
+TMPAPP="$OUT_DIR/.verify.app"
+rm -rf "$TMPAPP"; mkdir -p "$TMPAPP/Contents/MacOS" "$TMPAPP/Contents/Resources"
+printf 'int main(void){return 0;}\n' > "$OUT_DIR/.v.c"
+xcrun clang -o "$TMPAPP/Contents/MacOS/v" "$OUT_DIR/.v.c"
+cat > "$TMPAPP/Contents/Info.plist" <<'PLIST'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>CFBundleExecutable</key><string>v</string>
+<key>CFBundleIdentifier</key><string>ai.kizunaai.sokuji</string>
+<key>CFBundleName</key><string>v</string>
+<key>CFBundlePackageType</key><string>APPL</string>
+</dict></plist>
+PLIST
+codesign --force --sign "$CN" --keychain "$KC" "$TMPAPP" 2>&1 | sed 's/^/  /'
+DR=$(codesign -d -r- "$TMPAPP" 2>&1 | grep 'designated =>' | sed 's/^#* *designated => //')
+security delete-keychain "$KC" 2>/dev/null || true
+rm -rf "$TMPAPP" "$OUT_DIR/.v.c"
+
+if [ -z "$DR" ]; then
+  echo "FAILED: the certificate could not sign anything. Do not use it." >&2
+  exit 1
+fi
+
+echo
+echo "Designated requirement Sokuji builds will carry:"
+echo "  $DR"
+echo
+echo "This string must stay identical across releases — it is what Squirrel.Mac,"
+echo "TCC and the keychain all match on."
+echo
+echo "Next: store these as repository secrets on kizuna-ai-lab/sokuji."
+echo "Review them before running — the first one contains the private key."
+echo
+echo "  gh secret set MACOS_CSC_LINK --repo kizuna-ai-lab/sokuji < <(base64 -i '$P12')"
+echo "  gh secret set MACOS_CSC_KEY_PASSWORD --repo kizuna-ai-lab/sokuji"
+echo
+echo "Then back up $P12 and its password somewhere durable, and keep"
+echo "$OUT_DIR out of any repository."

--- a/scripts/electron-builder-fuses.js
+++ b/scripts/electron-builder-fuses.js
@@ -5,10 +5,18 @@ const { flipFuses, FuseVersion, FuseV1Options } = require('@electron/fuses');
 
 // electron-builder afterPack hook.
 // 1. Apply Electron Fuses (mirroring @electron-forge/plugin-fuses settings).
-// 2. On darwin, ad-hoc sign the bundle. electron-builder skips signing entirely
-//    when no identity is configured, but Apple Silicon refuses to launch
-//    unsigned arm64 apps and macOS won't show permission dialogs without at
-//    least an ad-hoc signature.
+// 2. On darwin, ad-hoc sign the bundle ONLY when no real identity is configured.
+//    Apple Silicon refuses to launch unsigned arm64 apps and macOS won't show
+//    permission dialogs without at least an ad-hoc signature, so an unsigned
+//    local build still needs this.
+//
+//    When CSC_NAME/CSC_LINK are set (CI, and local builds that opt in),
+//    electron-builder signs the bundle itself, inside-out, after this hook
+//    runs. Ad-hoc signing here would be overwritten at best and would fight
+//    that at worst, so we skip it. The distinction matters: an ad-hoc
+//    signature's designated requirement is a per-build cdhash, which is
+//    exactly what stops Squirrel.Mac from ever accepting an update. See
+//    docs/build/macos-auto-update.md.
 module.exports = async function afterPack(context) {
   const isDarwin = context.electronPlatformName === 'darwin';
   const productFilename = context.packager.appInfo.productFilename;
@@ -41,7 +49,15 @@ module.exports = async function afterPack(context) {
   console.log(`[electron-builder-fuses] Applied Fuses to ${execPath}`);
 
   if (isDarwin && appBundlePath) {
-    console.log(`[electron-builder-fuses] Ad-hoc signing ${appBundlePath}`);
-    execFileSync('codesign', ['--force', '--deep', '--sign', '-', appBundlePath], { stdio: 'inherit' });
+    const hasRealIdentity = Boolean(process.env.CSC_NAME || process.env.CSC_LINK);
+    if (hasRealIdentity) {
+      console.log('[electron-builder-fuses] Real signing identity configured; ' +
+        'leaving the bundle for electron-builder to sign inside-out');
+    } else {
+      console.log(`[electron-builder-fuses] No identity configured, ad-hoc signing ${appBundlePath}`);
+      // --deep is wrong for distribution signing (Apple: "--deep Considered
+      // Harmful"), but this path only produces a locally runnable build.
+      execFileSync('codesign', ['--force', '--deep', '--sign', '-', appBundlePath], { stdio: 'inherit' });
+    }
   }
 };

--- a/scripts/electron-builder-fuses.js
+++ b/scripts/electron-builder-fuses.js
@@ -49,6 +49,13 @@ module.exports = async function afterPack(context) {
   console.log(`[electron-builder-fuses] Applied Fuses to ${execPath}`);
 
   if (isDarwin && appBundlePath) {
+    // Keyed on the environment, not on build.mac.identity: that is pinned to a
+    // name, and pinning it says nothing about whether the certificate is
+    // actually in this machine's keychain. A developer without it would
+    // otherwise get a bundle that is neither ad-hoc signed here nor signed by
+    // electron-builder afterwards -- and an unsigned arm64 app will not launch.
+    // When the certificate IS present locally, electron-builder simply replaces
+    // this ad-hoc signature on its own pass.
     const hasRealIdentity = Boolean(process.env.CSC_NAME || process.env.CSC_LINK);
     if (hasRealIdentity) {
       console.log('[electron-builder-fuses] Real signing identity configured; ' +

--- a/scripts/verify-macos-selfsigned.sh
+++ b/scripts/verify-macos-selfsigned.sh
@@ -1,0 +1,217 @@
+#!/bin/bash
+# Verify the assumptions behind the self-signed auto-update plan.
+# See docs/build/macos-auto-update.md — this script covers hardware tests 2-6.
+# Test 1 (does TCC keep the microphone grant?) needs a GUI click and is not here.
+#
+# Safe to run on a dev Mac or a CI runner. Creates only temp files plus one
+# throwaway directory in /Applications, which it removes again.
+#
+#   bash scripts/verify-macos-selfsigned.sh
+
+set -uo pipefail
+
+if [ "$(uname)" != "Darwin" ]; then
+  echo "This script only runs on macOS." >&2
+  exit 1
+fi
+
+WORK="$(mktemp -d)"
+KEYCHAIN="$WORK/verify.keychain"
+KC_PASS="verify-$$"
+CERT_CN="Sokuji Self-Signed Test"
+PASS=0
+FAIL=0
+
+cleanup() {
+  security delete-keychain "$KEYCHAIN" 2>/dev/null
+  sudo rm -rf "/Applications/.sokuji-verify-$$" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
+bad()  { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
+note() { echo "        $1"; }
+
+echo "=== macOS $(sw_vers -productVersion) ($(uname -m)) ==="
+echo
+
+# ---------------------------------------------------------------------------
+# Test 5: can a self-signed cert be created and seen as a valid codesigning
+#         identity in a fresh keychain, WITHOUT add-trusted-cert?
+#         electron-builder's createKeychain() only does `security import`.
+# ---------------------------------------------------------------------------
+echo "[5] self-signed identity in a fresh keychain"
+
+openssl req -x509 -newkey rsa:2048 -sha256 -days 7300 -nodes \
+  -keyout "$WORK/key.pem" -out "$WORK/cert.pem" \
+  -subj "/CN=$CERT_CN/O=Sokuji Verify" \
+  -addext "basicConstraints=critical,CA:false" \
+  -addext "keyUsage=critical,digitalSignature" \
+  -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1 \
+  || { bad "openssl could not create the certificate"; exit 1; }
+
+openssl pkcs12 -export -out "$WORK/cert.p12" -inkey "$WORK/key.pem" \
+  -in "$WORK/cert.pem" -passout "pass:$KC_PASS" >/dev/null 2>&1
+
+security create-keychain -p "$KC_PASS" "$KEYCHAIN" >/dev/null
+security unlock-keychain -p "$KC_PASS" "$KEYCHAIN" >/dev/null
+security set-keychain-settings "$KEYCHAIN"
+security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+security import "$WORK/cert.p12" -k "$KEYCHAIN" -P "$KC_PASS" \
+  -T /usr/bin/codesign -T /usr/bin/productbuild >/dev/null 2>&1
+security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null 2>&1
+
+if security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_CN"; then
+  ok "listed as a VALID codesigning identity (no add-trusted-cert needed)"
+else
+  bad "not listed by 'find-identity -v' — CI must run add-trusted-cert"
+  note "retrying with an explicit trust setting..."
+  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cert.pem" 2>/dev/null
+  if security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_CN"; then
+    note "add-trusted-cert fixes it — add that step to CI"
+  else
+    note "still not valid; investigate before relying on Option S"
+  fi
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# Tests 3 + 6: is the designated requirement stable across two DIFFERENT
+#              builds signed with the same cert, and does build B satisfy the
+#              DR captured from build A? That is exactly what Squirrel.Mac does.
+# ---------------------------------------------------------------------------
+echo "[3] designated requirement stability (the core of the plan)"
+
+make_app() { # $1 = path, $2 = distinguishing payload
+  local app="$1"
+  mkdir -p "$app/Contents/MacOS" "$app/Contents/Resources"
+  cat > "$WORK/main.c" <<EOF
+#include <stdio.h>
+int main(void) { printf("$2\n"); return 0; }
+EOF
+  clang -o "$app/Contents/MacOS/verifyapp" "$WORK/main.c" 2>/dev/null
+  cat > "$app/Contents/Info.plist" <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>verifyapp</string>
+  <key>CFBundleIdentifier</key><string>ai.kizunaai.sokuji.verify</string>
+  <key>CFBundleName</key><string>verifyapp</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+</dict></plist>
+EOF
+}
+
+make_app "$WORK/v1.app" "version one"
+make_app "$WORK/v2.app" "version two, different bytes entirely"
+
+codesign --force --sign "$CERT_CN" --keychain "$KEYCHAIN" "$WORK/v1.app" 2>/dev/null
+codesign --force --sign "$CERT_CN" --keychain "$KEYCHAIN" "$WORK/v2.app" 2>/dev/null
+
+DR1="$(codesign -d -r- "$WORK/v1.app" 2>&1 | grep '^designated' | sed 's/^designated => //')"
+DR2="$(codesign -d -r- "$WORK/v2.app" 2>&1 | grep '^designated' | sed 's/^designated => //')"
+
+note "v1 DR: $DR1"
+note "v2 DR: $DR2"
+
+if [ -n "$DR1" ] && [ "$DR1" = "$DR2" ]; then
+  ok "DR is IDENTICAL across two different builds"
+else
+  bad "DR differs across builds — Option S does not work as designed"
+fi
+
+# The decisive check: does v2 satisfy the requirement captured from v1?
+if codesign --verify --deep --strict -R="$DR1" "$WORK/v2.app" 2>/dev/null; then
+  ok "v2 satisfies v1's DR — Squirrel.Mac would accept this update"
+else
+  bad "v2 does NOT satisfy v1's DR"
+fi
+
+# Contrast: ad-hoc must fail the same check, confirming the test is meaningful.
+make_app "$WORK/a1.app" "adhoc one"
+make_app "$WORK/a2.app" "adhoc two, different"
+codesign --force --sign - "$WORK/a1.app" 2>/dev/null
+codesign --force --sign - "$WORK/a2.app" 2>/dev/null
+ADR1="$(codesign -d -r- "$WORK/a1.app" 2>&1 | grep '^designated' | sed 's/^designated => //')"
+if codesign --verify --strict -R="$ADR1" "$WORK/a2.app" 2>/dev/null; then
+  bad "ad-hoc build ALSO passed — the test is not discriminating, investigate"
+else
+  ok "ad-hoc correctly fails the same check (control)"
+fi
+echo
+
+echo "[6] strict nested validation with an unsigned nested Mach-O"
+cp -R "$WORK/v1.app" "$WORK/nested.app"
+mkdir -p "$WORK/nested.app/Contents/Resources/drivers/Fake.driver/Contents/MacOS"
+clang -o "$WORK/nested.app/Contents/Resources/drivers/Fake.driver/Contents/MacOS/Fake" "$WORK/main.c" 2>/dev/null
+codesign --force --sign "$CERT_CN" --keychain "$KEYCHAIN" "$WORK/nested.app" 2>/dev/null
+if codesign --verify --deep --strict "$WORK/nested.app" 2>/dev/null; then
+  note "an unsigned Mach-O under Resources/ did NOT break strict validation here"
+  note "(still sign the HAL driver — do not rely on this)"
+else
+  ok "unsigned nested Mach-O breaks strict validation, as expected"
+  note "=> SokujiVirtualAudio.driver MUST be signed with the same identity"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# Test 2: can a normal admin user rename a root-owned, write-disabled
+#         directory inside /Applications? Decides whether the PKG must chown
+#         the app bundle for Squirrel to be able to swap it.
+# ---------------------------------------------------------------------------
+echo "[2] renaming a root-owned bundle in /Applications (decides the chown)"
+TESTDIR="/Applications/.sokuji-verify-$$"
+if sudo mkdir -p "$TESTDIR/Contents" && sudo chown -R root:wheel "$TESTDIR" && sudo chmod -R 755 "$TESTDIR"; then
+  note "/Applications is $(stat -f '%Sp %Su:%Sg' /Applications)"
+  note "test bundle is $(stat -f '%Sp %Su:%Sg' "$TESTDIR")"
+  if mv "$TESTDIR" "${TESTDIR}-moved" 2>/dev/null; then
+    ok "admin CAN rename a root-owned bundle — no chown needed"
+    sudo rm -rf "${TESTDIR}-moved"
+  else
+    bad "admin CANNOT rename it — the PKG must set ownership (failure mode 12)"
+    sudo rm -rf "$TESTDIR"
+  fi
+else
+  note "SKIPPED — needs sudo"
+fi
+echo
+
+# ---------------------------------------------------------------------------
+# Test 4: does a file downloaded by Node's https (not a browser) carry
+#         com.apple.quarantine? Gates the Option C fallback.
+# ---------------------------------------------------------------------------
+echo "[4] quarantine on a Node-downloaded file"
+if command -v node >/dev/null 2>&1; then
+  cat > "$WORK/dl.js" <<'EOF'
+const https = require('https'); const fs = require('fs');
+const out = fs.createWriteStream(process.argv[3]);
+const get = u => https.get(u, r => {
+  if (r.statusCode === 301 || r.statusCode === 302) { r.resume(); return get(r.headers.location); }
+  r.pipe(out);
+});
+get(process.argv[2]);
+out.on('finish', () => process.exit(0));
+EOF
+  node "$WORK/dl.js" "https://raw.githubusercontent.com/kizuna-ai-lab/sokuji/main/README.md" "$WORK/dl.bin" 2>/dev/null
+  sleep 2
+  if [ -s "$WORK/dl.bin" ]; then
+    XA="$(xattr -l "$WORK/dl.bin" 2>/dev/null)"
+    if echo "$XA" | grep -q "com.apple.quarantine"; then
+      bad "Node-downloaded file IS quarantined — Option C does not help"
+    else
+      ok "no com.apple.quarantine — Option C's premise holds"
+    fi
+  else
+    note "SKIPPED — download produced nothing (network?)"
+  fi
+else
+  note "SKIPPED — node not on PATH"
+fi
+echo
+
+echo "=== $PASS passed, $FAIL failed ==="
+echo "Test 1 (does TCC keep the microphone grant across a re-sign?) still needs"
+echo "a human on a real Mac — it requires clicking the permission dialog."
+[ "$FAIL" -eq 0 ]

--- a/scripts/verify-macos-selfsigned.sh
+++ b/scripts/verify-macos-selfsigned.sh
@@ -21,13 +21,33 @@ KC_PASS="verify-$$"
 CERT_CN="Sokuji Self-Signed Test"
 PASS=0
 FAIL=0
+# Populated before the search list is touched, so cleanup can put it back.
+ORIG_KEYCHAINS=()
 
 cleanup() {
+  # Restore the user's keychain search list. Leaving our temporary keychain in
+  # it would strand a dead path once that keychain is deleted below.
+  if [ ${#ORIG_KEYCHAINS[@]} -gt 0 ]; then
+    security list-keychains -d user -s "${ORIG_KEYCHAINS[@]}" 2>/dev/null
+  fi
   security delete-keychain "$KEYCHAIN" 2>/dev/null
   sudo rm -rf "/Applications/.sokuji-verify-$$" 2>/dev/null
   rm -rf "$WORK"
 }
 trap cleanup EXIT
+
+# Read the current search list into an array so that paths containing spaces
+# survive; the obvious unquoted $(...) splat does not handle them.
+read_keychains() {
+  local line
+  ORIG_KEYCHAINS=()
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"   # strip leading blanks
+    line="${line%\"}"                          # strip trailing quote
+    line="${line#\"}"                          # strip leading quote
+    [ -n "$line" ] && ORIG_KEYCHAINS+=("$line")
+  done < <(security list-keychains -d user)
+}
 
 ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }
 bad()  { echo "  FAIL  $1"; FAIL=$((FAIL+1)); }
@@ -63,7 +83,12 @@ fi
 security create-keychain -p "$KC_PASS" "$KEYCHAIN" >/dev/null
 security unlock-keychain -p "$KC_PASS" "$KEYCHAIN" >/dev/null
 security set-keychain-settings "$KEYCHAIN"
-security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+# Putting the keychain in the search list is load-bearing, not cosmetic:
+# `codesign --keychain <kc>` on its own does NOT resolve an identity by common
+# name -- it reports "no identity found" and leaves the bundle ad-hoc signed
+# (verified on macOS 26.6.1). cleanup() restores the previous list.
+read_keychains
+security list-keychains -d user -s "$KEYCHAIN" "${ORIG_KEYCHAINS[@]}"
 IMPORT_OUT="$(security import "$WORK/cert.p12" -k "$KEYCHAIN" -P "$KC_PASS" -A 2>&1)"
 security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null 2>&1
 

--- a/scripts/verify-macos-selfsigned.sh
+++ b/scripts/verify-macos-selfsigned.sh
@@ -22,13 +22,19 @@ CERT_CN="Sokuji Self-Signed Test"
 PASS=0
 FAIL=0
 # Populated before the search list is touched, so cleanup can put it back.
+# The flag is tracked separately from the array: an empty capture is a real
+# state ("the list was empty") and must still be restored, whereas never having
+# captured means we must not touch the list at all.
 ORIG_KEYCHAINS=()
+KEYCHAINS_CAPTURED=0
 
 cleanup() {
   # Restore the user's keychain search list. Leaving our temporary keychain in
   # it would strand a dead path once that keychain is deleted below.
-  if [ ${#ORIG_KEYCHAINS[@]} -gt 0 ]; then
-    security list-keychains -d user -s "${ORIG_KEYCHAINS[@]}" 2>/dev/null
+  if [ "$KEYCHAINS_CAPTURED" = 1 ]; then
+    # ${a[@]+"${a[@]}"} because bash 3.2 -- what macOS ships -- treats a bare
+    # "${a[@]}" on an empty array as an unbound variable under `set -u`.
+    security list-keychains -d user -s ${ORIG_KEYCHAINS[@]+"${ORIG_KEYCHAINS[@]}"} 2>/dev/null
   fi
   security delete-keychain "$KEYCHAIN" 2>/dev/null
   sudo rm -rf "/Applications/.sokuji-verify-$$" 2>/dev/null
@@ -47,6 +53,7 @@ read_keychains() {
     line="${line#\"}"                          # strip leading quote
     [ -n "$line" ] && ORIG_KEYCHAINS+=("$line")
   done < <(security list-keychains -d user)
+  KEYCHAINS_CAPTURED=1
 }
 
 ok()   { echo "  PASS  $1"; PASS=$((PASS+1)); }

--- a/scripts/verify-macos-selfsigned.sh
+++ b/scripts/verify-macos-selfsigned.sh
@@ -51,28 +51,45 @@ openssl req -x509 -newkey rsa:2048 -sha256 -days 7300 -nodes \
   -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1 \
   || { bad "openssl could not create the certificate"; exit 1; }
 
-openssl pkcs12 -export -out "$WORK/cert.p12" -inkey "$WORK/key.pem" \
-  -in "$WORK/cert.pem" -passout "pass:$KC_PASS" >/dev/null 2>&1
+# OpenSSL 3.x defaults to AES-256/SHA-256 for PKCS#12, which macOS's Security
+# framework cannot import ("MAC verification failed"). -legacy restores the
+# algorithms it understands; LibreSSL (/usr/bin/openssl) does not need it.
+if ! openssl pkcs12 -export -legacy -out "$WORK/cert.p12" -inkey "$WORK/key.pem" \
+     -in "$WORK/cert.pem" -passout "pass:$KC_PASS" >/dev/null 2>&1; then
+  openssl pkcs12 -export -out "$WORK/cert.p12" -inkey "$WORK/key.pem" \
+    -in "$WORK/cert.pem" -passout "pass:$KC_PASS" >/dev/null 2>&1
+fi
 
 security create-keychain -p "$KC_PASS" "$KEYCHAIN" >/dev/null
 security unlock-keychain -p "$KC_PASS" "$KEYCHAIN" >/dev/null
 security set-keychain-settings "$KEYCHAIN"
 security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
-security import "$WORK/cert.p12" -k "$KEYCHAIN" -P "$KC_PASS" \
-  -T /usr/bin/codesign -T /usr/bin/productbuild >/dev/null 2>&1
-security set-key-partition-list -S apple-tool:,apple: -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null 2>&1
+IMPORT_OUT="$(security import "$WORK/cert.p12" -k "$KEYCHAIN" -P "$KC_PASS" -A 2>&1)"
+security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KC_PASS" "$KEYCHAIN" >/dev/null 2>&1
+
+if echo "$IMPORT_OUT" | grep -qi "verification failed"; then
+  bad "PKCS#12 import failed: $IMPORT_OUT"
+else
+  ok "PKCS#12 imported into a throwaway keychain"
+fi
+
+# Two different things: can codesign USE it (what matters), and does
+# electron-builder's discovery SEE it (a CI plumbing detail).
+if security find-identity -p codesigning "$KEYCHAIN" | grep -q "$CERT_CN"; then
+  ok "identity present in the keychain"
+else
+  bad "identity not present at all"
+fi
 
 if security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_CN"; then
-  ok "listed as a VALID codesigning identity (no add-trusted-cert needed)"
+  ok "also listed as VALID — electron-builder's discovery will find it"
 else
-  bad "not listed by 'find-identity -v' — CI must run add-trusted-cert"
-  note "retrying with an explicit trust setting..."
-  sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain "$WORK/cert.pem" 2>/dev/null
-  if security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "$CERT_CN"; then
-    note "add-trusted-cert fixes it — add that step to CI"
-  else
-    note "still not valid; investigate before relying on Option S"
-  fi
+  note "NOT listed by 'find-identity -v' (expect CSSMERR_TP_NOT_TRUSTED)."
+  note "codesign still works — see test 3 — but electron-builder discovers"
+  note "identities with 'find-identity -v', so CI needs:"
+  note "  sudo security add-trusted-cert -d -r trustRoot -p codeSign \\"
+  note "       -k /Library/Keychains/System.keychain cert.pem"
+  note "(passwordless on GitHub Actions runners; needs a GUI prompt locally)"
 fi
 echo
 
@@ -82,6 +99,8 @@ echo
 #              DR captured from build A? That is exactly what Squirrel.Mac does.
 # ---------------------------------------------------------------------------
 echo "[3] designated requirement stability (the core of the plan)"
+
+SIGN_ID="$CERT_CN"
 
 make_app() { # $1 = path, $2 = distinguishing payload
   local app="$1"
@@ -107,8 +126,13 @@ EOF
 make_app "$WORK/v1.app" "version one"
 make_app "$WORK/v2.app" "version two, different bytes entirely"
 
-codesign --force --sign "$CERT_CN" --keychain "$KEYCHAIN" "$WORK/v1.app" 2>/dev/null
-codesign --force --sign "$CERT_CN" --keychain "$KEYCHAIN" "$WORK/v2.app" 2>/dev/null
+S1="$(codesign --force --sign "$SIGN_ID" --keychain "$KEYCHAIN" "$WORK/v1.app" 2>&1)"
+S2="$(codesign --force --sign "$SIGN_ID" --keychain "$KEYCHAIN" "$WORK/v2.app" 2>&1)"
+if echo "$S1$S2" | grep -qi "no identity found"; then
+  bad "codesign could not use the self-signed identity: $S1"
+else
+  ok "codesign signed both bundles with the untrusted self-signed identity"
+fi
 
 DR1="$(codesign -d -r- "$WORK/v1.app" 2>&1 | grep '^designated' | sed 's/^designated => //')"
 DR2="$(codesign -d -r- "$WORK/v2.app" 2>&1 | grep '^designated' | sed 's/^designated => //')"
@@ -161,20 +185,46 @@ echo
 #         directory inside /Applications? Decides whether the PKG must chown
 #         the app bundle for Squirrel to be able to swap it.
 # ---------------------------------------------------------------------------
-echo "[2] renaming a root-owned bundle in /Applications (decides the chown)"
+echo "[2] renaming a write-disabled bundle in /Applications (decides the chown)"
+note "/Applications is $(stat -f '%Sp %Su:%Sg' /Applications)"
+if [ -d /Applications/Sokuji.app ]; then
+  note "installed Sokuji.app is $(stat -f '%Sp %Su:%Sg' /Applications/Sokuji.app)"
+fi
+
+# rename(2)'s CONFORMANCE clause is about whether the CALLER can write into the
+# directory being renamed — not about who owns it. So a directory we own but
+# have chmod'd 555 reproduces a root-owned 755 bundle exactly, with no sudo and
+# nothing destructive. The real root-owned case is checked too when sudo is
+# available without a password.
 TESTDIR="/Applications/.sokuji-verify-$$"
-if sudo mkdir -p "$TESTDIR/Contents" && sudo chown -R root:wheel "$TESTDIR" && sudo chmod -R 755 "$TESTDIR"; then
-  note "/Applications is $(stat -f '%Sp %Su:%Sg' /Applications)"
-  note "test bundle is $(stat -f '%Sp %Su:%Sg' "$TESTDIR")"
+if mkdir -p "$TESTDIR/Contents" 2>/dev/null; then
+  chmod 555 "$TESTDIR"
+  note "test bundle is $(stat -f '%Sp %Su:%Sg' "$TESTDIR") (write-disabled for us)"
   if mv "$TESTDIR" "${TESTDIR}-moved" 2>/dev/null; then
-    ok "admin CAN rename a root-owned bundle — no chown needed"
-    sudo rm -rf "${TESTDIR}-moved"
+    ok "a write-disabled bundle CAN be renamed — Squirrel can swap it"
+    chmod 755 "${TESTDIR}-moved" 2>/dev/null; rm -rf "${TESTDIR}-moved"
   else
-    bad "admin CANNOT rename it — the PKG must set ownership (failure mode 12)"
-    sudo rm -rf "$TESTDIR"
+    bad "cannot rename a write-disabled bundle — the PKG must set ownership"
+    chmod 755 "$TESTDIR" 2>/dev/null; rm -rf "$TESTDIR"
   fi
 else
-  note "SKIPPED — needs sudo"
+  note "SKIPPED — cannot create a directory in /Applications"
+fi
+
+# The genuine root-owned case, only if sudo needs no password.
+if sudo -n true 2>/dev/null; then
+  RTEST="/Applications/.sokuji-verify-root-$$"
+  sudo mkdir -p "$RTEST/Contents" && sudo chown -R root:wheel "$RTEST" && sudo chmod -R 755 "$RTEST"
+  if mv "$RTEST" "${RTEST}-moved" 2>/dev/null; then
+    ok "a root-owned bundle CAN be renamed by an admin — no chown needed"
+    sudo rm -rf "${RTEST}-moved"
+  else
+    bad "a root-owned bundle CANNOT be renamed — PKG must set ownership (fm 12)"
+    sudo rm -rf "$RTEST"
+  fi
+else
+  note "root-owned variant SKIPPED — sudo needs a password (the 555 case above"
+  note "exercises the same kernel check)"
 fi
 echo
 
@@ -182,7 +232,28 @@ echo
 # Test 4: does a file downloaded by Node's https (not a browser) carry
 #         com.apple.quarantine? Gates the Option C fallback.
 # ---------------------------------------------------------------------------
-echo "[4] quarantine on a Node-downloaded file"
+echo "[4] quarantine on a file downloaded by a non-LaunchServices process"
+
+# The mechanism is opt-in via LSFileQuarantineEnabled, so check the shipped app
+# directly — this is the real question, not what some other tool does.
+if [ -f /Applications/Sokuji.app/Contents/Info.plist ]; then
+  if plutil -p /Applications/Sokuji.app/Contents/Info.plist 2>/dev/null | grep -qi "LSFileQuarantineEnabled"; then
+    bad "Sokuji.app DECLARES LSFileQuarantineEnabled — its downloads would be quarantined"
+  else
+    ok "Sokuji.app does not declare LSFileQuarantineEnabled"
+  fi
+fi
+
+# curl is Apple's own documented example of a tool that does not quarantine.
+curl -fsSL -o "$WORK/curl.bin" "https://raw.githubusercontent.com/kizuna-ai-lab/sokuji/main/README.md" 2>/dev/null
+if [ -s "$WORK/curl.bin" ]; then
+  if xattr -l "$WORK/curl.bin" 2>/dev/null | grep -q "com.apple.quarantine"; then
+    bad "even curl quarantined the file — the premise is wrong"
+  else
+    ok "curl-downloaded file carries no com.apple.quarantine"
+  fi
+fi
+
 if command -v node >/dev/null 2>&1; then
   cat > "$WORK/dl.js" <<'EOF'
 const https = require('https'); const fs = require('fs');

--- a/scripts/verify-macos-tcc.sh
+++ b/scripts/verify-macos-tcc.sh
@@ -27,7 +27,11 @@ KC="$WORK/tcc.keychain"
 KCP="tcc-test-pass"
 CN="Sokuji TCC Test Cert"
 # Populated only while the search list is mutated, so the trap can restore it.
+# Capture success is tracked separately from the contents: an empty capture is
+# a real state that still needs restoring, while never having captured means
+# the list must be left alone.
 ORIG_KEYCHAINS=()
+KEYCHAINS_CAPTURED=0
 
 ensure_cert() {
   [ -f "$WORK/cert.p12" ] && return 0
@@ -70,12 +74,19 @@ read_keychains() {
     # could have left it there, and we would otherwise add it twice.
     [ -n "$line" ] && [ "$line" != "$KC" ] && ORIG_KEYCHAINS+=("$line")
   done < <(security list-keychains -d user)
+  KEYCHAINS_CAPTURED=1
 }
 
 restore_keychains() {
-  if [ ${#ORIG_KEYCHAINS[@]} -gt 0 ]; then
-    security list-keychains -d user -s "${ORIG_KEYCHAINS[@]}" 2>/dev/null
+  if [ "$KEYCHAINS_CAPTURED" = 1 ]; then
+    # Restore even when the captured list is empty -- otherwise an interrupted
+    # run that left only $KC behind (read_keychains filters it out, yielding an
+    # empty capture) would keep a path pointing at a keychain we then delete.
+    # ${a[@]+"${a[@]}"} because bash 3.2 -- what macOS ships -- treats a bare
+    # "${a[@]}" on an empty array as an unbound variable under `set -u`.
+    security list-keychains -d user -s ${ORIG_KEYCHAINS[@]+"${ORIG_KEYCHAINS[@]}"} 2>/dev/null
     ORIG_KEYCHAINS=()
+    KEYCHAINS_CAPTURED=0
   fi
 }
 trap restore_keychains EXIT

--- a/scripts/verify-macos-tcc.sh
+++ b/scripts/verify-macos-tcc.sh
@@ -26,28 +26,84 @@ APP="/Applications/$APPNAME.app"
 KC="$WORK/tcc.keychain"
 KCP="tcc-test-pass"
 CN="Sokuji TCC Test Cert"
+# Populated only while the search list is mutated, so the trap can restore it.
+ORIG_KEYCHAINS=()
 
 ensure_cert() {
   [ -f "$WORK/cert.p12" ] && return 0
-  mkdir -p "$WORK"
-  /opt/homebrew/bin/openssl req -x509 -newkey rsa:2048 -sha256 -days 7300 -nodes \
+  mkdir -p "$WORK" || return 1
+
+  # Resolve through PATH: the Homebrew prefix differs on Intel (/usr/local) and
+  # is absent entirely on a machine without Homebrew, where the system LibreSSL
+  # at /usr/bin/openssl does the job.
+  local openssl
+  openssl="$(command -v openssl)" || { echo "openssl not found on PATH" >&2; return 1; }
+
+  "$openssl" req -x509 -newkey rsa:2048 -sha256 -days 7300 -nodes \
     -keyout "$WORK/key.pem" -out "$WORK/cert.pem" \
     -subj "/CN=$CN/O=Sokuji TCC Verify" \
     -addext "basicConstraints=critical,CA:false" \
     -addext "keyUsage=critical,digitalSignature" \
-    -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1
-  /opt/homebrew/bin/openssl pkcs12 -export -legacy -out "$WORK/cert.p12" \
-    -inkey "$WORK/key.pem" -in "$WORK/cert.pem" -passout "pass:$KCP" >/dev/null 2>&1
+    -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1 \
+    || { echo "openssl could not create the certificate" >&2; return 1; }
+
+  # -legacy is an OpenSSL 3 flag and the export fails without it there, because
+  # macOS cannot import the AES-256/SHA-256 default. LibreSSL has no such flag
+  # and already writes something importable, so fall back to a plain export.
+  "$openssl" pkcs12 -export -legacy -out "$WORK/cert.p12" \
+    -inkey "$WORK/key.pem" -in "$WORK/cert.pem" -passout "pass:$KCP" >/dev/null 2>&1 \
+    || "$openssl" pkcs12 -export -out "$WORK/cert.p12" \
+       -inkey "$WORK/key.pem" -in "$WORK/cert.pem" -passout "pass:$KCP" >/dev/null 2>&1 \
+    || { echo "openssl could not export the PKCS#12 bundle" >&2; return 1; }
 }
 
+# Read the current search list into an array so that paths containing spaces
+# survive; the obvious unquoted $(...) splat does not handle them.
+read_keychains() {
+  local line
+  ORIG_KEYCHAINS=()
+  while IFS= read -r line; do
+    line="${line#"${line%%[![:space:]]*}"}"   # strip leading blanks
+    line="${line%\"}"                          # strip trailing quote
+    line="${line#\"}"                          # strip leading quote
+    # Skip our own keychain: a previous run that died before its trap fired
+    # could have left it there, and we would otherwise add it twice.
+    [ -n "$line" ] && [ "$line" != "$KC" ] && ORIG_KEYCHAINS+=("$line")
+  done < <(security list-keychains -d user)
+}
+
+restore_keychains() {
+  if [ ${#ORIG_KEYCHAINS[@]} -gt 0 ]; then
+    security list-keychains -d user -s "${ORIG_KEYCHAINS[@]}" 2>/dev/null
+    ORIG_KEYCHAINS=()
+  fi
+}
+trap restore_keychains EXIT
+
 ensure_keychain() {
-  security find-certificate -c "$CN" "$KC" >/dev/null 2>&1 && return 0
-  security create-keychain -p "$KCP" "$KC" >/dev/null 2>&1
-  security unlock-keychain -p "$KCP" "$KC" >/dev/null 2>&1
-  security set-keychain-settings "$KC"
-  security import "$WORK/cert.p12" -k "$KC" -P "$KCP" -A >/dev/null 2>&1
-  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCP" "$KC" >/dev/null 2>&1
-  security list-keychains -d user -s "$KC" $(security list-keychains -d user | tr -d '"')
+  # Create and populate only once; the certificate has to be the same across
+  # both builds or the experiment measures nothing.
+  if ! security find-certificate -c "$CN" "$KC" >/dev/null 2>&1; then
+    security create-keychain -p "$KCP" "$KC" >/dev/null 2>&1 \
+      || { echo "could not create $KC" >&2; return 1; }
+    security unlock-keychain -p "$KCP" "$KC" >/dev/null 2>&1 \
+      || { echo "could not unlock $KC" >&2; return 1; }
+    security set-keychain-settings "$KC"
+    security import "$WORK/cert.p12" -k "$KC" -P "$KCP" -A >/dev/null 2>&1 \
+      || { echo "could not import the certificate into $KC" >&2; return 1; }
+    security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCP" "$KC" >/dev/null 2>&1
+  else
+    security unlock-keychain -p "$KCP" "$KC" >/dev/null 2>&1
+  fi
+
+  # Outside the branch above on purpose. The EXIT trap restores the search list
+  # when the script ends, so a second `setup` run would otherwise sign against a
+  # keychain that is no longer searchable. `codesign --keychain <kc>` alone does
+  # NOT resolve an identity by common name -- it reports "no identity found" and
+  # leaves the bundle ad-hoc signed, which is exactly the state this script
+  # exists to tell apart from a real signature. Verified on macOS 26.6.1.
+  read_keychains
+  security list-keychains -d user -s "$KC" "${ORIG_KEYCHAINS[@]}"
 }
 
 build_app() { # $1 = dest .app, $2 = build tag (must differ between builds)
@@ -129,7 +185,11 @@ show_dr() { codesign -d -r- "$1" 2>&1 | grep 'designated =>' | sed 's/^#* *desig
 
 case "$MODE" in
 setup)
-  ensure_cert; ensure_keychain
+  # Stop here rather than build and "sign" against a certificate that was never
+  # created -- that would silently produce ad-hoc bundles and quietly invalidate
+  # the whole experiment.
+  ensure_cert || { echo "certificate setup failed" >&2; exit 1; }
+  ensure_keychain || { echo "keychain setup failed" >&2; exit 1; }
   rm -f "$LOG"
   echo "=== arm: $ARM   bundle id: $BID ==="
   build_app "$WORK/v1.app" "V1"

--- a/scripts/verify-macos-tcc.sh
+++ b/scripts/verify-macos-tcc.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+# Hardware test 1: does TCC keep a microphone grant across a rebuild signed
+# with the SAME self-signed certificate?
+#
+# Two arms, separate bundle identifiers so they cannot contaminate each other:
+#   selfsigned  - both builds signed with one self-signed cert  (expect: kept)
+#   adhoc       - both builds ad-hoc signed                     (expect: lost)
+#
+# The measurement is the authorization status the SECOND build sees at launch:
+#   0 notDetermined  -> TCC forgot it; macOS will prompt again
+#   3 authorized     -> TCC kept the grant; no prompt at all
+#
+# Usage: tcc-test.sh <setup|swap|report|cleanup> <selfsigned|adhoc>
+
+set -uo pipefail
+
+MODE="${1:-}"; ARM="${2:-selfsigned}"
+WORK="$HOME/.tcc-test-work"
+LOG="$HOME/tcc-test-$ARM.log"
+case "$ARM" in
+  selfsigned) BID="ai.kizunaai.tcctest.selfsigned"; APPNAME="TCCSelfSigned" ;;
+  adhoc)      BID="ai.kizunaai.tcctest.adhoc";      APPNAME="TCCAdhoc" ;;
+  *) echo "arm must be selfsigned or adhoc" >&2; exit 1 ;;
+esac
+APP="/Applications/$APPNAME.app"
+KC="$WORK/tcc.keychain"
+KCP="tcc-test-pass"
+CN="Sokuji TCC Test Cert"
+
+ensure_cert() {
+  [ -f "$WORK/cert.p12" ] && return 0
+  mkdir -p "$WORK"
+  /opt/homebrew/bin/openssl req -x509 -newkey rsa:2048 -sha256 -days 7300 -nodes \
+    -keyout "$WORK/key.pem" -out "$WORK/cert.pem" \
+    -subj "/CN=$CN/O=Sokuji TCC Verify" \
+    -addext "basicConstraints=critical,CA:false" \
+    -addext "keyUsage=critical,digitalSignature" \
+    -addext "extendedKeyUsage=critical,codeSigning" >/dev/null 2>&1
+  /opt/homebrew/bin/openssl pkcs12 -export -legacy -out "$WORK/cert.p12" \
+    -inkey "$WORK/key.pem" -in "$WORK/cert.pem" -passout "pass:$KCP" >/dev/null 2>&1
+}
+
+ensure_keychain() {
+  security find-certificate -c "$CN" "$KC" >/dev/null 2>&1 && return 0
+  security create-keychain -p "$KCP" "$KC" >/dev/null 2>&1
+  security unlock-keychain -p "$KCP" "$KC" >/dev/null 2>&1
+  security set-keychain-settings "$KC"
+  security import "$WORK/cert.p12" -k "$KC" -P "$KCP" -A >/dev/null 2>&1
+  security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$KCP" "$KC" >/dev/null 2>&1
+  security list-keychains -d user -s "$KC" $(security list-keychains -d user | tr -d '"')
+}
+
+build_app() { # $1 = dest .app, $2 = build tag (must differ between builds)
+  local dest="$1" tag="$2"
+  rm -rf "$dest"
+  mkdir -p "$dest/Contents/MacOS" "$dest/Contents/Resources"
+
+  cat > "$WORK/main.m" <<EOF
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+
+// Padding differs per build so the two bundles have different cdhashes.
+static const char kBuildPadding[] = "$tag-------------------------------------------------";
+
+int main(void) {
+  @autoreleasepool {
+    NSString *log = [NSString stringWithFormat:@"%@/tcc-test-$ARM.log", NSHomeDirectory()];
+    AVAuthorizationStatus before =
+        [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+
+    NSMutableString *line = [NSMutableString string];
+    [line appendFormat:@"build=%s statusBefore=%ld (%s)\n",
+        "$tag", (long)before,
+        before == 0 ? "notDetermined" : before == 1 ? "restricted" :
+        before == 2 ? "denied" : "AUTHORIZED"];
+
+    __block BOOL granted = NO;
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
+                             completionHandler:^(BOOL g) { granted = g; dispatch_semaphore_signal(sem); }];
+    dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 180ull * NSEC_PER_SEC));
+
+    AVAuthorizationStatus after =
+        [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    [line appendFormat:@"build=%s granted=%d statusAfter=%ld padding=%zu\n",
+        "$tag", (int)granted, (long)after, sizeof(kBuildPadding)];
+
+    NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:log];
+    if (!fh) { [[NSFileManager defaultManager] createFileAtPath:log contents:nil attributes:nil];
+               fh = [NSFileHandle fileHandleForWritingAtPath:log]; }
+    [fh seekToEndOfFile];
+    [fh writeData:[line dataUsingEncoding:NSUTF8StringEncoding]];
+    [fh closeFile];
+  }
+  return 0;
+}
+EOF
+
+  xcrun clang -fobjc-arc -o "$dest/Contents/MacOS/$APPNAME" "$WORK/main.m" \
+    -framework Foundation -framework AVFoundation 2>&1 | head -5
+
+  cat > "$dest/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>$APPNAME</string>
+  <key>CFBundleIdentifier</key><string>$BID</string>
+  <key>CFBundleName</key><string>$APPNAME</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>NSMicrophoneUsageDescription</key><string>Sokuji TCC persistence test.</string>
+  <key>LSMinimumSystemVersion</key><string>11.0</string>
+</dict></plist>
+EOF
+}
+
+sign_app() { # $1 = .app
+  if [ "$ARM" = "adhoc" ]; then
+    codesign --force --sign - "$1" 2>&1 | sed 's/^/    /'
+  else
+    codesign --force --sign "$CN" --keychain "$KC" "$1" 2>&1 | sed 's/^/    /'
+  fi
+}
+
+# Ad-hoc designated requirements are printed with a leading "# ", so match both.
+show_dr() { codesign -d -r- "$1" 2>&1 | grep 'designated =>' | sed 's/^#* *designated => //'; }
+
+case "$MODE" in
+setup)
+  ensure_cert; ensure_keychain
+  rm -f "$LOG"
+  echo "=== arm: $ARM   bundle id: $BID ==="
+  build_app "$WORK/v1.app" "V1"
+  build_app "$WORK/v2.app" "V2-different-code-entirely"
+  sign_app "$WORK/v1.app"; sign_app "$WORK/v2.app"
+  echo "  v1 DR: $(show_dr "$WORK/v1.app")"
+  echo "  v2 DR: $(show_dr "$WORK/v2.app")"
+  echo "  v1 cdhash: $(codesign -dv "$WORK/v1.app" 2>&1 | grep CandidateCDHash | head -1)"
+  echo "  v2 cdhash: $(codesign -dv "$WORK/v2.app" 2>&1 | grep CandidateCDHash | head -1)"
+  [ "$(show_dr "$WORK/v1.app")" = "$(show_dr "$WORK/v2.app")" ] \
+    && echo "  => DRs match" || echo "  => DRs DIFFER"
+
+  echo "--- clearing any previous TCC decision for $BID ---"
+  tccutil reset Microphone "$BID" 2>&1 | sed 's/^/    /'
+
+  rm -rf "$APP"; cp -R "$WORK/v1.app" "$APP"
+  echo "--- installed v1 at $APP, launching ---"
+  open -a "$APP" 2>&1 | sed 's/^/    /' || echo "    open failed — launch it by hand"
+  echo
+  echo ">>> A microphone permission dialog should appear. Click ALLOW. <<<"
+  ;;
+
+swap)
+  echo "=== arm: $ARM — replacing with v2 and relaunching ==="
+  rm -rf "$APP"; cp -R "$WORK/v2.app" "$APP"
+  open -a "$APP" 2>&1 | sed 's/^/    /' || echo "    open failed — launch it by hand"
+  sleep 6
+  echo "--- log so far ---"
+  cat "$LOG" 2>/dev/null | sed 's/^/    /'
+  ;;
+
+report)
+  echo "=== $ARM log ==="
+  cat "$LOG" 2>/dev/null | sed 's/^/    /' || echo "    (no log yet)"
+  ;;
+
+cleanup)
+  rm -rf /Applications/TCCSelfSigned.app /Applications/TCCAdhoc.app
+  tccutil reset Microphone ai.kizunaai.tcctest.selfsigned >/dev/null 2>&1
+  tccutil reset Microphone ai.kizunaai.tcctest.adhoc >/dev/null 2>&1
+  security delete-keychain "$KC" 2>/dev/null
+  rm -rf "$WORK" "$HOME/tcc-test-selfsigned.log" "$HOME/tcc-test-adhoc.log"
+  echo "cleaned up"
+  ;;
+*)
+  echo "usage: $0 <setup|swap|report|cleanup> <selfsigned|adhoc>" >&2; exit 1 ;;
+esac

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -156,6 +156,7 @@ export default defineConfig(({ command, mode }) => {
             'subtitle-window': 'electron/subtitle-window.js',
             'popover-windows': 'electron/popover-windows.js',
             'update-manager': 'electron/update-manager.js',
+            'update-payload': 'electron/update-payload.js',
             'window-caption-dblclick': 'electron/window-caption-dblclick.js'
           },
           onstart(args) {


### PR DESCRIPTION
Closes part of #106 (the update half; notarization is still out of scope).

## What this does

macOS is the last platform still fully manual: download in a browser, run
`sudo xattr -d com.apple.quarantine`, install. At the current cadence — 15
releases between 2026-07-27 and 2026-08-23 — that is roughly every other day.

This turns macOS on to the same in-app auto-update flow Linux AppImage already
uses, **without an Apple Developer Program membership**.

## Why it works without paying Apple

The blocker was never the absence of an Apple certificate. It was **ad-hoc
signing**. Squirrel.Mac verifies each update against the designated requirement
captured from the *running* bundle, and an ad-hoc DR is a per-build cdhash that
can never match. Any stable certificate — including a self-signed one — yields
`identifier "…" and certificate root = H"…"`, which is identical across
rebuilds.

Apple's own sources say the anchor does not have to be trusted for this:
`CSCommon.h` documents `kSecCSCheckTrustedAnchors` as opt-in (its default builds
the chain "to any self-signed certificate"), and Squirrel does not pass it.

## Verified on real hardware — macOS 26.6.1, arm64

| # | Check | Result |
|---|---|---|
| 1 | TCC keeps the microphone grant across a re-sign | **PASS** — self-signed v2 launched already `AUTHORIZED`, no dialog; the ad-hoc control arm was prompted again |
| 2 | A write-disabled bundle in `/Applications` can be renamed | PASS |
| 3 | DR is stable, and build N+1 satisfies build N's DR | **PASS** — identical DR, `-R` check rc=0; ad-hoc control correctly fails |
| 4 | A non-LaunchServices download carries no quarantine | PASS |
| 5 | Trusting the cert makes it discoverable to electron-builder | **PASS** — `find-identity -v` went 0 → 1 with the real project certificate |
| 6 | An unsigned nested driver breaks strict validation | PASS — it does not |

`spctl` still rejects the app, which is the expected split: **updates work,
first install does not**. Gatekeeper needs notarization, and notarization needs
the paid account. The `xattr` step for first-time installs is unchanged.

Two scripts reproduce all of this: `scripts/verify-macos-selfsigned.sh`
(headless) and `scripts/verify-macos-tcc.sh` (needs someone to click Allow).

## Changes

- **`electron/update-payload.js`** (new, + tests) — per-platform decisions
  pulled out of `UpdateManager`, which cannot be imported under test because it
  drags in `electron` and `electron-updater`. darwin reports
  `supportsAutoUpdate` and deliberately sets **no** `downloadUrl`:
  `UpdateDialog` renders a browser button whenever one is present, which would
  hide the in-app flow entirely.
- **`update-manager.js`** — darwin shares the native
  `downloadUpdate()`/`quitAndInstall()` path with AppImage.
- **`package.json`** — add the mac `zip` target. `MacUpdater` accepts only a zip
  and rejects pkg/dmg; the zip target is also the only one that sets
  `isWriteUpdateInfo`, so `latest-mac.yml` and the blockmap now come from
  electron-builder instead of a hand-rolled sha512 loop in CI. `identity` is
  pinned by name — without a qualifier, electron-builder's "find non-Apple
  certificate" fallback will take any stray cert in the keychain and silently
  produce a different DR.
- **`pkg-scripts/postinstall`** — hand the installed bundle to the console user.
  The installer runs as root; Squirrel runs as the invoking user and never
  escalates, so a root-owned bundle cannot be replaced.
- **`build.yml`** — trust the certificate before building (an untrusted
  self-signed cert reports `CSSMERR_TP_NOT_TRUSTED` and `find-identity -v` omits
  it), then **assert the built app carries a certificate-pinned DR** and fail on
  a cdhash. electron-builder logs "skipped macOS code signing" and carries on
  when it finds no identity, so without that guard an unsigned release looks
  like a success.
- **`docs/build/macos-auto-update.md`** — the full investigation, every claim
  cited, including what was measured versus inferred.

Everything is gated on the `MACOS_CSC_LINK` secret, so with it unset the build
behaves exactly as it does today.

## Migration — needs a line in the release notes

Existing macOS users must install the first signed build **by hand** (its DR
does not match the installed ad-hoc one). That costs nothing in practice, since
macOS auto-update is off today and every release is already installed manually.
From that build on it is automatic.

That one install will also re-prompt for microphone access and ask for keychain
access once — both because the code identity changes. Answer the keychain one
with **Always Allow**. Both stop recurring afterwards, which is itself a fix:
today's ad-hoc builds re-prompt on *every* update (measured, see the doc).

## Not in this PR

- **First-install Gatekeeper friction.** Needs notarization → needs the $99.
  Mitigations (a Homebrew tap, a documented `curl` installer) are discussed in
  the doc but not implemented.
- **Bumping BlackHole.** Investigated: the UID macros are byte-identical
  upstream, so a bump would *not* drop anyone's device selection — but v0.7.1
  adds an unguarded `CFRetain(NULL)` that crashes inside `coreaudiod`, and the
  fix (upstream PR #901) is unmerged. The one real gain, 24 kHz, is available on
  the pinned revision through the existing preprocessor defines and is worth
  doing separately — the audio pipeline runs at 24000 Hz end to end while the
  device advertises 44100/48000 and up.

## Please do not merge until the macOS job is green

The point of opening this is to see the signing chain run in CI: certificate
import → trust → sign → the new DR assertion. Everything above was verified on
a developer machine, not on a runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS ZIP builds for Intel and Apple Silicon.
  * Enabled native in-app updates for macOS.
  * Improved update details and release-note handling across platforms.
  * Enhanced macOS release packages with ZIP and blockmap assets.

* **Bug Fixes**
  * Ensured installed macOS apps retain permissions needed for future updates.
  * Improved macOS signing validation and microphone-permission persistence.

* **Documentation**
  * Added guidance on macOS auto-update behavior, signing, notarization, and known limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->