### PR TITLE
Move the accent off ChatGPT's green, by way of untangling it

### DIFF
--- a/src/components/Auth/AuthGuard.scss
+++ b/src/components/Auth/AuthGuard.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 /**
  * Styles for the AuthGuard component
  */
@@ -14,7 +16,7 @@
     width: 32px;
     height: 32px;
     border: 3px solid #333;
-    border-top-color: #10a37f;
+    border-top-color: tk.$color-primary;
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
     margin-bottom: 16px;
@@ -53,7 +55,7 @@
   
   .upgrade-button {
     padding: 10px 24px;
-    background: #10a37f;
+    background: tk.$color-primary;
     color: #fff;
     border: none;
     border-radius: 4px;
@@ -63,7 +65,7 @@
     transition: background 0.2s;
     
     &:hover {
-      background: #0e8f6f;
+      background: tk.$color-primary-hover;
     }
   }
 }

--- a/src/components/Auth/AuthGuard.scss
+++ b/src/components/Auth/AuthGuard.scss
@@ -65,7 +65,7 @@
     transition: background 0.2s;
     
     &:hover {
-      background: tk.$color-primary-hover;
+      background: tk.$color-primary-fill-hover;
     }
   }
 }

--- a/src/components/Auth/AuthGuard.scss
+++ b/src/components/Auth/AuthGuard.scss
@@ -55,7 +55,7 @@
   
   .upgrade-button {
     padding: 10px 24px;
-    background: tk.$color-primary;
+    background: tk.$color-primary-fill;
     color: tk.$color-on-primary;
     border: none;
     border-radius: 4px;

--- a/src/components/Auth/AuthGuard.scss
+++ b/src/components/Auth/AuthGuard.scss
@@ -56,7 +56,7 @@
   .upgrade-button {
     padding: 10px 24px;
     background: tk.$color-primary;
-    color: #fff;
+    color: tk.$color-on-primary;
     border: none;
     border-radius: 4px;
     font-size: 14px;

--- a/src/components/Auth/AuthLayout.scss
+++ b/src/components/Auth/AuthLayout.scss
@@ -64,7 +64,7 @@
       &:hover {
         // Theme color fill
         border-color: tk.$color-primary;
-        background: tk.$color-primary;
+        background: tk.$color-primary-fill;
         color: tk.$color-on-primary;
 
         // Shadow effect

--- a/src/components/Auth/AuthLayout.scss
+++ b/src/components/Auth/AuthLayout.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // The overlay itself: fixed over the app, never in place of it. The scrim is
 // translucent on purpose — seeing the provider you were configuring behind the
 // form is most of the reason authentication stopped being a route. The form
@@ -61,12 +63,12 @@
 
       &:hover {
         // Theme color fill
-        border-color: #10a37f;
-        background: #10a37f;
+        border-color: tk.$color-primary;
+        background: tk.$color-primary;
         color: #fff;
 
         // Shadow effect
-        box-shadow: 0 2px 8px rgba(16, 163, 127, 0.3);
+        box-shadow: 0 2px 8px rgba(tk.$color-primary, 0.3);
       }
 
       &:active {
@@ -74,7 +76,7 @@
       }
 
       &:focus-visible {
-        outline: 2px solid #10a37f;
+        outline: 2px solid tk.$color-primary;
         outline-offset: 2px;
       }
     }
@@ -95,10 +97,10 @@
   border: none;
   padding: 0;
   font: inherit;
-  color: #10a37f;
+  color: tk.$color-primary;
   cursor: pointer;
   text-decoration: underline;
 
   &:hover { opacity: 0.8; }
-  &:focus-visible { outline: 2px solid #10a37f; outline-offset: 2px; }
+  &:focus-visible { outline: 2px solid tk.$color-primary; outline-offset: 2px; }
 }

--- a/src/components/Auth/AuthLayout.scss
+++ b/src/components/Auth/AuthLayout.scss
@@ -65,7 +65,7 @@
         // Theme color fill
         border-color: tk.$color-primary;
         background: tk.$color-primary;
-        color: #fff;
+        color: tk.$color-on-primary;
 
         // Shadow effect
         box-shadow: 0 2px 8px rgba(tk.$color-primary, 0.3);

--- a/src/components/Auth/ForgotPasswordForm.scss
+++ b/src/components/Auth/ForgotPasswordForm.scss
@@ -123,7 +123,7 @@
     padding: 12px;
     font-size: 14px;
     font-weight: 500;
-    color: #fff;
+    color: tk.$color-on-primary;
     background-color: tk.$color-primary;
     border: none;
     border-radius: 6px;

--- a/src/components/Auth/ForgotPasswordForm.scss
+++ b/src/components/Auth/ForgotPasswordForm.scss
@@ -42,10 +42,10 @@
   .success-message {
     padding: 12px;
     margin-bottom: 16px;
-    background-color: rgba(tk.$color-primary, 0.1);
-    border: 1px solid rgba(tk.$color-primary, 0.3);
+    background-color: rgba(tk.$color-success, 0.1);
+    border: 1px solid rgba(tk.$color-success, 0.3);
     border-radius: 6px;
-    color: tk.$color-primary;
+    color: tk.$color-success;
     font-size: 14px;
   }
 

--- a/src/components/Auth/ForgotPasswordForm.scss
+++ b/src/components/Auth/ForgotPasswordForm.scss
@@ -124,7 +124,7 @@
     font-size: 14px;
     font-weight: 500;
     color: tk.$color-on-primary;
-    background-color: tk.$color-primary;
+    background-color: tk.$color-primary-fill;
     border: none;
     border-radius: 6px;
     cursor: pointer;

--- a/src/components/Auth/ForgotPasswordForm.scss
+++ b/src/components/Auth/ForgotPasswordForm.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .forgot-password-form {
   max-width: 400px;
   margin: 0 auto;
@@ -40,10 +42,10 @@
   .success-message {
     padding: 12px;
     margin-bottom: 16px;
-    background-color: rgba(16, 163, 127, 0.1);
-    border: 1px solid rgba(16, 163, 127, 0.3);
+    background-color: rgba(tk.$color-primary, 0.1);
+    border: 1px solid rgba(tk.$color-primary, 0.3);
     border-radius: 6px;
-    color: #10a37f;
+    color: tk.$color-primary;
     font-size: 14px;
   }
 
@@ -75,7 +77,7 @@
 
       &:focus {
         outline: none;
-        border-color: #10a37f;
+        border-color: tk.$color-primary;
       }
 
       &:disabled {
@@ -101,7 +103,7 @@
       margin-top: 4px;
       padding: 0;
       font-size: 12px;
-      color: #10a37f;
+      color: tk.$color-primary;
       background: none;
       border: none;
       cursor: pointer;
@@ -122,7 +124,7 @@
     font-size: 14px;
     font-weight: 500;
     color: #fff;
-    background-color: #10a37f;
+    background-color: tk.$color-primary;
     border: none;
     border-radius: 6px;
     cursor: pointer;
@@ -176,7 +178,7 @@
     color: #888;
 
     a {
-      color: #10a37f;
+      color: tk.$color-primary;
       text-decoration: none;
 
       &:hover {

--- a/src/components/Auth/SignInForm.scss
+++ b/src/components/Auth/SignInForm.scss
@@ -95,7 +95,7 @@
       min-height: 44px;
 
       &:hover:not(:disabled) {
-        background: tk.$color-primary-hover;
+        background: tk.$color-primary-fill-hover;
       }
 
       &:disabled {

--- a/src/components/Auth/SignInForm.scss
+++ b/src/components/Auth/SignInForm.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .sign-in-form {
   width: 100%;
   max-width: 400px;
@@ -50,7 +52,7 @@
 
         &:focus {
           outline: none;
-          border-color: #10a37f;
+          border-color: tk.$color-primary;
         }
 
         &:disabled {
@@ -66,7 +68,7 @@
       .forgot-password-link {
         align-self: flex-end;
         font-size: 0.75rem;
-        color: #10a37f;
+        color: tk.$color-primary;
         text-decoration: none;
         margin-top: 4px;
 
@@ -79,7 +81,7 @@
     .submit-button {
       padding: 0.75rem;
       margin-top: 0.5rem;
-      background: #10a37f;
+      background: tk.$color-primary;
       border: none;
       border-radius: 4px;
       color: #fff;
@@ -93,7 +95,7 @@
       min-height: 44px;
 
       &:hover:not(:disabled) {
-        background: #0e8f6f;
+        background: tk.$color-primary-hover;
       }
 
       &:disabled {
@@ -122,7 +124,7 @@
       color: #ccc;
 
       a {
-        color: #10a37f;
+        color: tk.$color-primary;
         text-decoration: none;
         font-weight: 500;
 

--- a/src/components/Auth/SignInForm.scss
+++ b/src/components/Auth/SignInForm.scss
@@ -84,7 +84,7 @@
       background: tk.$color-primary;
       border: none;
       border-radius: 4px;
-      color: #fff;
+      color: tk.$color-on-primary;
       font-size: 1rem;
       font-weight: 500;
       cursor: pointer;

--- a/src/components/Auth/SignInForm.scss
+++ b/src/components/Auth/SignInForm.scss
@@ -81,7 +81,7 @@
     .submit-button {
       padding: 0.75rem;
       margin-top: 0.5rem;
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       border: none;
       border-radius: 4px;
       color: tk.$color-on-primary;

--- a/src/components/Auth/SignUpForm.scss
+++ b/src/components/Auth/SignUpForm.scss
@@ -88,7 +88,7 @@
       min-height: 44px;
 
       &:hover:not(:disabled) {
-        background: tk.$color-primary-hover;
+        background: tk.$color-primary-fill-hover;
       }
 
       &:disabled {

--- a/src/components/Auth/SignUpForm.scss
+++ b/src/components/Auth/SignUpForm.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .sign-up-form {
   width: 100%;
   max-width: 400px;
@@ -50,7 +52,7 @@
 
         &:focus {
           outline: none;
-          border-color: #10a37f;
+          border-color: tk.$color-primary;
         }
 
         &:disabled {
@@ -72,7 +74,7 @@
     .submit-button {
       padding: 0.75rem;
       margin-top: 0.5rem;
-      background: #10a37f;
+      background: tk.$color-primary;
       border: none;
       border-radius: 4px;
       color: #fff;
@@ -86,7 +88,7 @@
       min-height: 44px;
 
       &:hover:not(:disabled) {
-        background: #0e8f6f;
+        background: tk.$color-primary-hover;
       }
 
       &:disabled {
@@ -115,7 +117,7 @@
       color: #ccc;
 
       a {
-        color: #10a37f;
+        color: tk.$color-primary;
         text-decoration: none;
         font-weight: 500;
 

--- a/src/components/Auth/SignUpForm.scss
+++ b/src/components/Auth/SignUpForm.scss
@@ -74,7 +74,7 @@
     .submit-button {
       padding: 0.75rem;
       margin-top: 0.5rem;
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       border: none;
       border-radius: 4px;
       color: tk.$color-on-primary;

--- a/src/components/Auth/SignUpForm.scss
+++ b/src/components/Auth/SignUpForm.scss
@@ -77,7 +77,7 @@
       background: tk.$color-primary;
       border: none;
       border-radius: 4px;
-      color: #fff;
+      color: tk.$color-on-primary;
       font-size: 1rem;
       font-weight: 500;
       cursor: pointer;

--- a/src/components/Auth/UserAccountInfo.scss
+++ b/src/components/Auth/UserAccountInfo.scss
@@ -53,7 +53,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       color: tk.$color-on-primary;
       font-weight: 600;
       font-size: 14px;
@@ -142,7 +142,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       color: tk.$color-on-primary;
       font-weight: 600;
       font-size: 18px;
@@ -164,7 +164,7 @@
   transition: all 0.2s;
   
   &.manage-account {
-    background: tk.$color-primary;
+    background: tk.$color-primary-fill;
     color: tk.$color-on-primary;
     
     &:hover {
@@ -237,7 +237,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       color: tk.$color-on-primary;
       font-weight: 600;
       font-size: 14px;
@@ -346,7 +346,7 @@
     transition: background 0.2s;
     
     &.manage-account {
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       color: tk.$color-on-primary;
       
       &:hover {
@@ -413,7 +413,7 @@
     margin-top: 10px;
     border: none;
     border-radius: 5px;
-    background: tk.$color-primary;
+    background: tk.$color-primary-fill;
     color: tk.$color-on-primary;
     // Same size as the popover's signed-out buttons ($font-body). These are
     // the same control at the same level, one shown per session state.

--- a/src/components/Auth/UserAccountInfo.scss
+++ b/src/components/Auth/UserAccountInfo.scss
@@ -54,7 +54,7 @@
       align-items: center;
       justify-content: center;
       background: tk.$color-primary;
-      color: #fff;
+      color: tk.$color-on-primary;
       font-weight: 600;
       font-size: 14px;
     }
@@ -143,7 +143,7 @@
       align-items: center;
       justify-content: center;
       background: tk.$color-primary;
-      color: #fff;
+      color: tk.$color-on-primary;
       font-weight: 600;
       font-size: 18px;
     }
@@ -165,7 +165,7 @@
   
   &.manage-account {
     background: tk.$color-primary;
-    color: #fff;
+    color: tk.$color-on-primary;
     
     &:hover {
       background: tk.$color-primary-hover;
@@ -238,7 +238,7 @@
       align-items: center;
       justify-content: center;
       background: tk.$color-primary;
-      color: #fff;
+      color: tk.$color-on-primary;
       font-weight: 600;
       font-size: 14px;
     }
@@ -347,7 +347,7 @@
     
     &.manage-account {
       background: tk.$color-primary;
-      color: #fff;
+      color: tk.$color-on-primary;
       
       &:hover {
         background: tk.$color-primary-hover;
@@ -414,7 +414,7 @@
     border: none;
     border-radius: 5px;
     background: tk.$color-primary;
-    color: #fff;
+    color: tk.$color-on-primary;
     // Same size as the popover's signed-out buttons ($font-body). These are
     // the same control at the same level, one shown per session state.
     font-size: 13px;

--- a/src/components/Auth/UserAccountInfo.scss
+++ b/src/components/Auth/UserAccountInfo.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 /**
  * Styles for the unified UserAccountInfo component
  */
@@ -11,7 +13,7 @@
     width: 24px;
     height: 24px;
     border: 2px solid #333;
-    border-top-color: #10a37f;
+    border-top-color: tk.$color-primary;
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }
@@ -51,7 +53,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: #10a37f;
+      background: tk.$color-primary;
       color: #fff;
       font-weight: 600;
       font-size: 14px;
@@ -140,7 +142,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: #10a37f;
+      background: tk.$color-primary;
       color: #fff;
       font-weight: 600;
       font-size: 18px;
@@ -162,11 +164,11 @@
   transition: all 0.2s;
   
   &.manage-account {
-    background: #10a37f;
+    background: tk.$color-primary;
     color: #fff;
     
     &:hover {
-      background: #0e8f6f;
+      background: tk.$color-primary-hover;
     }
   }
   
@@ -198,13 +200,13 @@
 
   &.feedback-button {
     background: transparent;
-    color: #10a37f;
-    border: 1px solid #10a37f;
+    color: tk.$color-primary;
+    border: 1px solid tk.$color-primary;
 
     &:hover {
-      background: rgba(16, 163, 127, 0.1);
-      color: #0e8f6f;
-      border-color: #0e8f6f;
+      background: rgba(tk.$color-primary, 0.1);
+      color: tk.$color-primary-hover;
+      border-color: tk.$color-primary-hover;
     }
   }
 }
@@ -235,7 +237,7 @@
       display: flex;
       align-items: center;
       justify-content: center;
-      background: #10a37f;
+      background: tk.$color-primary;
       color: #fff;
       font-weight: 600;
       font-size: 14px;
@@ -265,7 +267,7 @@
       gap: 6px;
 
       .email-verified-icon {
-        color: #10a37f;
+        color: tk.$color-primary;
         flex-shrink: 0;
       }
 
@@ -344,11 +346,11 @@
     transition: background 0.2s;
     
     &.manage-account {
-      background: #10a37f;
+      background: tk.$color-primary;
       color: #fff;
       
       &:hover {
-        background: #0e8f6f;
+        background: tk.$color-primary-hover;
       }
     }
     
@@ -380,9 +382,9 @@
   animation: fadeIn 0.3s ease;
 
   &.success {
-    background: rgba(16, 163, 127, 0.1);
-    color: #10a37f;
-    border: 1px solid rgba(16, 163, 127, 0.3);
+    background: rgba(tk.$color-primary, 0.1);
+    color: tk.$color-primary;
+    border: 1px solid rgba(tk.$color-primary, 0.3);
   }
 
   &.error {
@@ -411,7 +413,7 @@
     margin-top: 10px;
     border: none;
     border-radius: 5px;
-    background: #10a37f;
+    background: tk.$color-primary;
     color: #fff;
     // Same size as the popover's signed-out buttons ($font-body). These are
     // the same control at the same level, one shown per session state.
@@ -420,7 +422,7 @@
     cursor: pointer;
 
     &:hover { background: #0e9070; }
-    &:focus-visible { outline: 2px solid #10a37f; outline-offset: 2px; }
+    &:focus-visible { outline: 2px solid tk.$color-primary; outline-offset: 2px; }
   }
 }
 
@@ -434,7 +436,7 @@
     width: 20px;
     height: 20px;
     border: 2px solid #333;
-    border-top-color: #10a37f;
+    border-top-color: tk.$color-primary;
     border-radius: 50%;
     animation: spin 0.8s linear infinite;
   }
@@ -497,7 +499,7 @@
   }
   
   .wallet-icon {
-    color: #10a37f;
+    color: tk.$color-primary;
     flex-shrink: 0;
   }
   
@@ -521,7 +523,7 @@
   }
   
   .quota-section {
-    color: #10a37f;  // Green for income
+    color: tk.$color-success;  // Green for income
     font-size: 13px;
   }
 }
@@ -570,7 +572,7 @@
     
     .quota-progress {
       height: 100%;
-      background: linear-gradient(90deg, #10a37f, #0e8f6f);
+      background: linear-gradient(90deg, tk.$color-primary, tk.$color-primary-hover);
       transition: width 0.3s ease;
       
       &.high-usage {
@@ -593,7 +595,7 @@
     }
     
     .remaining-label {
-      color: #10a37f;
+      color: tk.$color-primary;
     }
   }
 }

--- a/src/components/Auth/UserAccountInfo.scss
+++ b/src/components/Auth/UserAccountInfo.scss
@@ -168,7 +168,7 @@
     color: tk.$color-on-primary;
     
     &:hover {
-      background: tk.$color-primary-hover;
+      background: tk.$color-primary-fill-hover;
     }
   }
   
@@ -267,7 +267,7 @@
       gap: 6px;
 
       .email-verified-icon {
-        color: tk.$color-primary;
+        color: tk.$color-success;
         flex-shrink: 0;
       }
 
@@ -350,7 +350,7 @@
       color: tk.$color-on-primary;
       
       &:hover {
-        background: tk.$color-primary-hover;
+        background: tk.$color-primary-fill-hover;
       }
     }
     
@@ -382,9 +382,9 @@
   animation: fadeIn 0.3s ease;
 
   &.success {
-    background: rgba(tk.$color-primary, 0.1);
-    color: tk.$color-primary;
-    border: 1px solid rgba(tk.$color-primary, 0.3);
+    background: rgba(tk.$color-success, 0.1);
+    color: tk.$color-success;
+    border: 1px solid rgba(tk.$color-success, 0.3);
   }
 
   &.error {

--- a/src/components/Display/ColorPicker.scss
+++ b/src/components/Display/ColorPicker.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // Styles for the in-app HSV picker. Kept self-contained (no reliance on the
 // popover's selectors) so the component can be dropped anywhere.
 
@@ -23,7 +25,7 @@
       linear-gradient(to right, #ffffff, rgba(255, 255, 255, 0));
 
     &:focus-visible {
-      outline: 2px solid #10a37f;
+      outline: 2px solid tk.$color-primary;
       outline-offset: 2px;
     }
   }
@@ -62,7 +64,7 @@
     );
 
     &:focus-visible {
-      outline: 2px solid #10a37f;
+      outline: 2px solid tk.$color-primary;
       outline-offset: 2px;
     }
 
@@ -120,7 +122,7 @@
 
     &:focus {
       outline: none;
-      border-color: #10a37f;
+      border-color: tk.$color-primary;
     }
   }
 }

--- a/src/components/Display/DisplaySettingsPopover.scss
+++ b/src/components/Display/DisplaySettingsPopover.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .display-settings-popover {
   background: #1a1a1a;
   color: #e8e8e8;
@@ -65,12 +67,12 @@
         // sits outside the chip so it doesn't compete with the selected
         // border. :focus-visible (not :focus) so mouse-clicks don't show it.
         &:focus-visible {
-          outline: 2px solid #10a37f;
+          outline: 2px solid tk.$color-primary;
           outline-offset: 2px;
         }
 
         &.selected {
-          border-color: #10a37f;
+          border-color: tk.$color-primary;
         }
 
         // Custom-color chip: a disclosure button for the inline ColorPicker.

--- a/src/components/LogsPanel/LogsPanel.scss
+++ b/src/components/LogsPanel/LogsPanel.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .logs-panel {
   display: flex;
   flex-direction: column;
@@ -34,11 +36,11 @@
       }
 
       &.active {
-        background-color: rgba(16, 163, 127, 0.1);
-        color: #10a37f;
+        background-color: rgba(tk.$color-primary, 0.1);
+        color: tk.$color-primary;
 
         &:hover {
-          background-color: rgba(16, 163, 127, 0.2);
+          background-color: rgba(tk.$color-primary, 0.2);
         }
       }
     }
@@ -126,7 +128,7 @@
       
       &.success {
         .log-message {
-          color: #10a37f;
+          color: tk.$color-success;
         }
       }
       
@@ -221,7 +223,7 @@
         }
         
         .server-icon {
-          color: #10a37f; // Green for server events
+          color: tk.$color-success; // Green for server events
         }
         
         .event-info {

--- a/src/components/MainLayout/PanelResizer.scss
+++ b/src/components/MainLayout/PanelResizer.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .panel-resizer {
   position: relative;
   z-index: 2;
@@ -19,7 +21,7 @@
     background: #555;       // subtle neutral lift; the col-resize cursor is the main affordance
   }
   &:focus-visible {
-    background: #10a37f;
+    background: tk.$color-primary;
     outline: none;
   }
 
@@ -34,6 +36,6 @@ body.is-resizing-panel {
 
   // Accent the seam only while a drag is actually in progress.
   .panel-resizer {
-    background: #10a37f;
+    background: tk.$color-primary;
   }
 }

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .conversation-row {
   display: flex;
   flex-direction: column;
@@ -31,12 +33,12 @@
   justify-content: center;
 
   &.avatar-speaker {
-    background: #10a37f;
+    background: tk.$color-speaker;
     color: #fff;
   }
 
   &.avatar-participant {
-    background: #f39c12;
+    background: tk.$color-participant;
     color: #1a1a1a;
   }
 }
@@ -72,7 +74,7 @@
   }
 
   &.playing {
-    background: color-mix(in srgb, var(--conversation-translation-color, #10a37f) 15%, transparent);
+    background: color-mix(in srgb, var(--conversation-translation-color, #{tk.$color-speaker}) 15%, transparent);
     border-radius: 4px;
   }
 }
@@ -94,9 +96,9 @@
 
   &.tr {
     &.source-speaker {
-      background: rgba(16, 163, 127, 0.2);
-      color: #10a37f;
-      border: 1px solid rgba(16, 163, 127, 0.4);
+      background: rgba(tk.$color-speaker, 0.2);
+      color: tk.$color-speaker;
+      border: 1px solid rgba(tk.$color-speaker, 0.4);
     }
 
     &.source-participant {
@@ -142,7 +144,7 @@
   }
 
   &.playing {
-    background: rgba(16, 163, 127, 0.45);
+    background: rgba(tk.$color-speaker, 0.45);
     color: #fff;
   }
 
@@ -161,7 +163,7 @@
   border-radius: 50%;
 
   &.source-speaker {
-    background: #10a37f;
+    background: tk.$color-speaker;
   }
 
   &.source-participant {

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -102,9 +102,9 @@
     }
 
     &.source-participant {
-      background: rgba(243, 156, 18, 0.2);
-      color: #f39c12;
-      border: 1px solid rgba(243, 156, 18, 0.4);
+      background: rgba(tk.$color-participant, 0.2);
+      color: tk.$color-participant;
+      border: 1px solid rgba(tk.$color-participant, 0.4);
     }
   }
 }
@@ -167,7 +167,7 @@
   }
 
   &.source-participant {
-    background: #f39c12;
+    background: tk.$color-participant;
   }
 }
 

--- a/src/components/MainPanel/ConversationRow.scss
+++ b/src/components/MainPanel/ConversationRow.scss
@@ -33,7 +33,7 @@
   justify-content: center;
 
   &.avatar-speaker {
-    background: tk.$color-speaker;
+    background: tk.$color-speaker-fill;
     color: #fff;
   }
 

--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -266,7 +266,7 @@
     .send-btn {
       background: tk.$color-primary;
       border: none;
-      color: #fff;
+      color: tk.$color-on-primary;
       width: 36px;
       height: 36px;
       border-radius: 50%;
@@ -462,7 +462,7 @@
   .main-action-btn {
     background: tk.$color-primary;
     border: none;
-    color: #fff;
+    color: tk.$color-on-primary;
     padding: 6px 16px;
     border-radius: 4px;
     font-size: 12px;
@@ -490,7 +490,7 @@
   .session-button {
     background: tk.$color-primary;
     border: none;
-    color: #fff;
+    color: tk.$color-on-primary;
     padding: 6px 12px;
     border-radius: 6px;
     font-size: 13px;

--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // ═══════════════════════════════════════════════════
 // MainPanel — Unified layout for basic & advanced modes
 // ═══════════════════════════════════════════════════
@@ -133,7 +135,7 @@
 
     &.playing {
       background: #555;
-      box-shadow: 0 0 10px rgba(16, 163, 127, 0.3);
+      box-shadow: 0 0 10px rgba(tk.$color-speaker, 0.3);
     }
   }
 
@@ -187,9 +189,9 @@
 // ─── Karaoke Highlighting ──────────────────────────
 
 .karaoke-played {
-  color: #10a37f;
+  color: tk.$color-speaker;
   font-weight: bold;
-  text-shadow: 0 0 8px rgba(16, 163, 127, 0.6);
+  text-shadow: 0 0 8px rgba(tk.$color-speaker, 0.6);
   transition: all 0.2s ease;
 }
 
@@ -257,12 +259,12 @@
       transition: border-color 0.2s ease;
 
       &::placeholder { color: #666; }
-      &:focus { border-color: #10a37f; }
+      &:focus { border-color: tk.$color-primary; }
       &:disabled { opacity: 0.5; cursor: not-allowed; }
     }
 
     .send-btn {
-      background: #10a37f;
+      background: tk.$color-primary;
       border: none;
       color: #fff;
       width: 36px;
@@ -319,7 +321,7 @@
       background: #666;
       transition: background 0.3s ease;
       flex-shrink: 0;
-      &.active { background: #10a37f; }
+      &.active { background: tk.$color-primary; }
       &.reconnecting {
         background: #f39c12;
         animation: pulse 1s ease-in-out infinite;
@@ -380,7 +382,7 @@
       background: #666;
       transition: background 0.3s ease;
       flex-shrink: 0;
-      &.active { background: #10a37f; }
+      &.active { background: tk.$color-primary; }
     }
 
     .footer-spacer { flex: 1; min-width: 12px; }
@@ -458,7 +460,7 @@
   }
 
   .main-action-btn {
-    background: #10a37f;
+    background: tk.$color-primary;
     border: none;
     color: #fff;
     padding: 6px 16px;
@@ -486,7 +488,7 @@
   }
 
   .session-button {
-    background: #10a37f;
+    background: tk.$color-primary;
     border: none;
     color: #fff;
     padding: 6px 12px;

--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -264,7 +264,7 @@
     }
 
     .send-btn {
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       border: none;
       color: tk.$color-on-primary;
       width: 36px;
@@ -460,7 +460,7 @@
   }
 
   .main-action-btn {
-    background: tk.$color-primary;
+    background: tk.$color-primary-fill;
     border: none;
     color: tk.$color-on-primary;
     padding: 6px 16px;
@@ -488,7 +488,7 @@
   }
 
   .session-button {
-    background: tk.$color-primary;
+    background: tk.$color-primary-fill;
     border: none;
     color: tk.$color-on-primary;
     padding: 6px 12px;

--- a/src/components/MainPanel/ModeDevicePopover.scss
+++ b/src/components/MainPanel/ModeDevicePopover.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // Mode device popover — collapsible summary rows that expand to inline
 // DeviceList-style options, matching the settings panel's existing DeviceList
 // pattern. Each row has a dedicated mute toggle button.
@@ -164,9 +166,9 @@
     &:hover { background: #2a2a2a; }
 
     &--selected {
-      background: rgba(16, 163, 127, 0.12);
+      background: rgba(tk.$color-primary, 0.12);
       color: #fff;
-      &:hover { background: rgba(16, 163, 127, 0.18); }
+      &:hover { background: rgba(tk.$color-primary, 0.18); }
     }
   }
 
@@ -174,7 +176,7 @@
     width: 6px;
     height: 6px;
     border-radius: 50%;
-    background: #10a37f;
+    background: tk.$color-primary;
     flex-shrink: 0;
   }
 
@@ -198,10 +200,10 @@
       border: 0;
       padding: 0;
       font: inherit;
-      color: #10a37f;
+      color: tk.$color-primary;
       cursor: pointer;
       &:hover { text-decoration: underline; }
-      &:focus-visible { outline: 2px solid #10a37f; outline-offset: 2px; }
+      &:focus-visible { outline: 2px solid tk.$color-primary; outline-offset: 2px; }
     }
   }
 }

--- a/src/components/MainPanel/ModePicker.scss
+++ b/src/components/MainPanel/ModePicker.scss
@@ -7,7 +7,7 @@
 //   - Each option fills with var --bg-secondary (#1a1a1a)
 //   - Options separated by border-right (not a gap)
 //   - Hover var --bg-hover (#252525)
-//   - Active tokens.$color-primary / #fff
+//   - Active tk.$color-primary-fill / tk.$color-on-primary
 //
 // Deviation from noise-suppression: NO font-weight change on active.
 // Active state is differentiated by bg + text color only — keeps segment

--- a/src/components/MainPanel/ModePicker.scss
+++ b/src/components/MainPanel/ModePicker.scss
@@ -49,7 +49,7 @@
     }
 
     &--active {
-      background: tk.$color-primary;
+      background: tk.$color-primary-fill;
       color: tk.$color-on-primary;
     }
 

--- a/src/components/MainPanel/ModePicker.scss
+++ b/src/components/MainPanel/ModePicker.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // Segmented control. Color palette and structure mirror the
 // .segmented-control.noise-suppression-modes in Settings.scss so the two
 // segmented controls look like the same component across the app:
@@ -5,7 +7,7 @@
 //   - Each option fills with var --bg-secondary (#1a1a1a)
 //   - Options separated by border-right (not a gap)
 //   - Hover var --bg-hover (#252525)
-//   - Active #10a37f / #fff
+//   - Active tokens.$color-primary / #fff
 //
 // Deviation from noise-suppression: NO font-weight change on active.
 // Active state is differentiated by bg + text color only — keeps segment
@@ -47,7 +49,7 @@
     }
 
     &--active {
-      background: #10a37f;
+      background: tk.$color-primary;
       color: #fff;
     }
 

--- a/src/components/MainPanel/ModePicker.scss
+++ b/src/components/MainPanel/ModePicker.scss
@@ -50,7 +50,7 @@
 
     &--active {
       background: tk.$color-primary;
-      color: #fff;
+      color: tk.$color-on-primary;
     }
 
     &--warn {

--- a/src/components/MainPanel/WaveformStrip.scss
+++ b/src/components/MainPanel/WaveformStrip.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // Flat tinted background matching the project's existing visualization
 // panels (.visualization-canvas style from the pre-refactor advanced footer).
 // No gradient, no in-canvas label — color tint alone identifies the channel.
@@ -32,5 +34,5 @@
 
   &--mic    { background: rgba(0, 153, 255, 0.10); }
   &--system { background: rgba(245, 158, 11, 0.10); }
-  &--output { background: rgba(16, 163, 127, 0.10); }
+  &--output { background: rgba(tk.$color-primary, 0.10); }
 }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -167,11 +167,11 @@
     }
 
     .sign-in-button {
-      background: vars.$color-primary;
-      color: vars.$text-primary;
+      background: vars.$color-primary-fill;
+      color: vars.$color-on-primary;
 
       &:hover {
-        background: vars.$color-primary-hover;
+        background: vars.$color-primary-fill-hover;
       }
     }
 
@@ -718,8 +718,8 @@
     width: 100%;
     padding: 10px 20px;
     margin-top: 15px;
-    background-color: vars.$color-primary;
-    color: white;
+    background-color: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
     border: none;
     border-radius: vars.$radius-sm;
     cursor: pointer;
@@ -727,7 +727,7 @@
     transition: background-color vars.$transition-fast;
 
     &:hover {
-      background-color: vars.$color-primary-hover;
+      background-color: vars.$color-primary-fill-hover;
     }
 
     // The acknowledge button becomes secondary when a real action is offered.
@@ -747,8 +747,8 @@
     width: 100%;
     padding: 10px 20px;
     margin-top: 15px;
-    background-color: vars.$color-primary;
-    color: white;
+    background-color: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
     border: none;
     border-radius: vars.$radius-sm;
     cursor: pointer;
@@ -756,7 +756,7 @@
     transition: background-color vars.$transition-fast;
 
     &:hover {
-      background-color: vars.$color-primary-hover;
+      background-color: vars.$color-primary-fill-hover;
     }
   }
 }
@@ -810,11 +810,11 @@
   }
 
   &__accept {
-    background-color: vars.$color-primary;
-    color: white;
+    background-color: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
 
     &:hover {
-      background-color: vars.$color-primary-hover;
+      background-color: vars.$color-primary-fill-hover;
     }
   }
 }
@@ -897,13 +897,13 @@
     padding: 0;
     border: none;
     border-radius: 50%;
-    background-color: vars.$color-primary;
-    color: vars.$text-primary;
+    background-color: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
     cursor: pointer;
     transition: background-color vars.$transition-fast;
 
     &:hover {
-      background-color: vars.$color-primary-hover;
+      background-color: vars.$color-primary-fill-hover;
     }
   }
 
@@ -1056,12 +1056,12 @@
   }
 
   &__accept {
-    background-color: vars.$color-primary;
+    background-color: vars.$color-primary-fill;
     border-color: vars.$color-primary;
-    color: white;
+    color: vars.$color-on-primary;
 
     &:hover:not(:disabled) {
-      background-color: vars.$color-primary-hover;
+      background-color: vars.$color-primary-fill-hover;
       border-color: vars.$color-primary-hover;
     }
   }
@@ -1502,9 +1502,9 @@
   }
 
   .validate-button {
-    background: vars.$color-primary;
+    background: vars.$color-primary-fill;
     border: none;
-    color: vars.$text-primary;
+    color: vars.$color-on-primary;
     padding: 8px 16px;
     border-radius: vars.$radius-sm;
     font-size: vars.$font-title;
@@ -1516,7 +1516,7 @@
     gap: 6px;
 
     &:hover:not(:disabled) {
-      background: vars.$color-primary-hover;
+      background: vars.$color-primary-fill-hover;
     }
 
     &:disabled {

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1,4 +1,5 @@
 @use 'shared/variables' as vars;
+@use '../../styles/tokens' as tk;
 
 .settings-container {
   display: flex;
@@ -38,8 +39,8 @@
       align-items: flex-start;
       gap: 8px;
       padding: 12px;
-      background: rgba(16, 163, 127, 0.1);
-      border: 1px solid rgba(16, 163, 127, 0.3);
+      background: rgba(tk.$color-primary, 0.1);
+      border: 1px solid rgba(tk.$color-primary, 0.3);
       border-radius: 6px;
       font-size: 13px;
       line-height: 1.4;
@@ -47,7 +48,7 @@
       svg {
         flex-shrink: 0;
         margin-top: 2px;
-        color: #10a37f;
+        color: tk.$color-primary;
       }
     }
   }
@@ -2159,7 +2160,7 @@
       }
 
       &.active {
-        background: #10a37f;
+        background: tk.$color-primary;
         color: #fff;
         font-weight: 500;
       }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1621,7 +1621,7 @@
       }
 
       &.active {
-        background: vars.$color-primary;
+        background: vars.$color-primary-fill;
         color: vars.$color-on-primary;
       }
 
@@ -2160,7 +2160,7 @@
       }
 
       &.active {
-        background: tk.$color-primary;
+        background: tk.$color-primary-fill;
         color: tk.$color-on-primary;
         font-weight: 500;
       }

--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -1622,7 +1622,7 @@
 
       &.active {
         background: vars.$color-primary;
-        color: #fff;
+        color: vars.$color-on-primary;
       }
 
       &:disabled {
@@ -2161,7 +2161,7 @@
 
       &.active {
         background: tk.$color-primary;
-        color: #fff;
+        color: tk.$color-on-primary;
         font-weight: 500;
       }
     }

--- a/src/components/Settings/engine/Engine.scss
+++ b/src/components/Settings/engine/Engine.scss
@@ -1,4 +1,5 @@
 @use '../shared/variables' as vars;
+@use '../../../styles/tokens' as tk;
 
 // EngineSurface's own outer shell reuses `.config-section` (Settings.scss)
 // for the section chrome (border, spacing, the `.highlight` hook, and —
@@ -281,7 +282,7 @@
   &__meta { font-size: vars.$font-caption; color: vars.$text-muted; flex-shrink: 0; }
   &__badge {
     font-size: 10px; padding: 1px 6px; border-radius: 10px;
-    background: rgba(16, 163, 127, 0.15); color: vars.$color-primary;
+    background: rgba(tk.$color-primary, 0.15); color: vars.$color-primary;
   }
 
   // Finding 5: matches .model-card__btn--delete's look (ModelManagementSection.scss).

--- a/src/components/Settings/sections/EngineSection.scss
+++ b/src/components/Settings/sections/EngineSection.scss
@@ -25,13 +25,13 @@
 
   &__bar { height: 6px; border-radius: 3px; background: #333; overflow: hidden; }
   &__bar-fill {
-    height: 100%; background: tk.$color-primary; transition: width 0.2s ease;
+    height: 100%; background: tk.$color-primary-fill; transition: width 0.2s ease;
     &--busy { width: 100%; animation: engine-busy 1.2s linear infinite; }
   }
 
   &__action {
     align-self: flex-start; display: inline-flex; align-items: center; gap: 6px;
-    background: tk.$color-primary; color: tk.$color-on-primary; border: none; border-radius: 6px;
+    background: tk.$color-primary-fill; color: tk.$color-on-primary; border: none; border-radius: 6px;
     padding: 6px 12px; font-size: 12px; cursor: pointer;
     &:hover { background: #0e9271; }
     &:disabled { opacity: 0.5; cursor: default; }

--- a/src/components/Settings/sections/EngineSection.scss
+++ b/src/components/Settings/sections/EngineSection.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/tokens' as tk;
+
 // Engine (sidecar bundle) card — dark-theme styling consistent with the
 // model-management cards (see ModelManagementSection.scss).
 .engine-section {
@@ -12,7 +14,7 @@
 
   &__header { display: flex; align-items: center; gap: 8px; color: #e0e0e0; }
   &__title { font-weight: 600; font-size: 13px; flex: 1; }
-  &__version { display: inline-flex; align-items: center; gap: 4px; color: #10a37f; font-size: 12px; }
+  &__version { display: inline-flex; align-items: center; gap: 4px; color: tk.$color-primary; font-size: 12px; }
 
   &__row {
     display: flex; align-items: center; gap: 6px; font-size: 12px; color: #b0b0b0;
@@ -23,13 +25,13 @@
 
   &__bar { height: 6px; border-radius: 3px; background: #333; overflow: hidden; }
   &__bar-fill {
-    height: 100%; background: #10a37f; transition: width 0.2s ease;
+    height: 100%; background: tk.$color-primary; transition: width 0.2s ease;
     &--busy { width: 100%; animation: engine-busy 1.2s linear infinite; }
   }
 
   &__action {
     align-self: flex-start; display: inline-flex; align-items: center; gap: 6px;
-    background: #10a37f; color: #fff; border: none; border-radius: 6px;
+    background: tk.$color-primary; color: #fff; border: none; border-radius: 6px;
     padding: 6px 12px; font-size: 12px; cursor: pointer;
     &:hover { background: #0e9271; }
     &:disabled { opacity: 0.5; cursor: default; }

--- a/src/components/Settings/sections/EngineSection.scss
+++ b/src/components/Settings/sections/EngineSection.scss
@@ -31,7 +31,7 @@
 
   &__action {
     align-self: flex-start; display: inline-flex; align-items: center; gap: 6px;
-    background: tk.$color-primary; color: #fff; border: none; border-radius: 6px;
+    background: tk.$color-primary; color: tk.$color-on-primary; border: none; border-radius: 6px;
     padding: 6px 12px; font-size: 12px; cursor: pointer;
     &:hover { background: #0e9271; }
     &:disabled { opacity: 0.5; cursor: default; }

--- a/src/components/Settings/sections/ModelImportModal.scss
+++ b/src/components/Settings/sections/ModelImportModal.scss
@@ -241,10 +241,12 @@
   &--sm { padding: 5px 9px; font-size: 11.5px; }
 
   &--primary {
-    background: var(--import-accent);
-    border-color: var(--import-accent);
-    color: #fff;
-    &:hover:not(:disabled) { background: vars.$color-primary-fill-hover; border-color: vars.$color-primary-hover; }
+    // --import-accent is the read weight, correct for this modal's icons,
+    // borders and text. A filled button with a label on it is the other job.
+    background: vars.$color-primary-fill;
+    border-color: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
+    &:hover:not(:disabled) { background: vars.$color-primary-fill-hover; border-color: vars.$color-primary-fill-hover; }
     &:disabled { opacity: 0.45; }
   }
 }

--- a/src/components/Settings/sections/ModelImportModal.scss
+++ b/src/components/Settings/sections/ModelImportModal.scss
@@ -244,7 +244,7 @@
     background: var(--import-accent);
     border-color: var(--import-accent);
     color: #fff;
-    &:hover:not(:disabled) { background: vars.$color-primary-hover; border-color: vars.$color-primary-hover; }
+    &:hover:not(:disabled) { background: vars.$color-primary-fill-hover; border-color: vars.$color-primary-hover; }
     &:disabled { opacity: 0.45; }
   }
 }

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -103,7 +103,7 @@
 
         &.active {
           background: vars.$color-primary;
-          color: #fff;
+          color: vars.$color-on-primary;
           font-weight: vars.$weight-medium;
         }
 

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -102,7 +102,7 @@
         }
 
         &.active {
-          background: vars.$color-primary;
+          background: vars.$color-primary-fill;
           color: vars.$color-on-primary;
           font-weight: vars.$weight-medium;
         }

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -1,4 +1,5 @@
 @use '../shared/variables' as vars;
+@use '../../../styles/tokens' as tk;
 
 .model-management-section {
   .model-group {
@@ -290,7 +291,7 @@
   }
 
   &__lang-tag--live { border: 1px solid currentColor; font-weight: 600; }  // highlighted (neutral): chosen-CPU
-  &__lang-tag--accel { border-color: #10a37f; color: #10a37f; }  // GPU live
+  &__lang-tag--accel { border-color: tk.$color-success; color: tk.$color-success; }  // GPU live
   &__lang-tag--warn  { border-color: #e74c3c; color: #e74c3c; }  // degraded CPU
 
   &__recommended-badge {

--- a/src/components/Settings/sections/ModelManagementSection.scss
+++ b/src/components/Settings/sections/ModelManagementSection.scss
@@ -368,11 +368,11 @@
     }
 
     &--download {
-      background: vars.$color-primary;
-      color: vars.$text-primary;
+      background: vars.$color-primary-fill;
+      color: vars.$color-on-primary;
 
       &:hover:not(:disabled) {
-        background: vars.$color-primary-hover;
+        background: vars.$color-primary-fill-hover;
       }
     }
 
@@ -764,15 +764,15 @@
     padding: 6px 14px;
     border: none;
     border-radius: vars.$radius-sm;
-    background: vars.$color-primary;
-    color: vars.$text-primary;
+    background: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
     font-size: vars.$font-caption;
     font-weight: vars.$weight-medium;
     cursor: pointer;
     transition: background vars.$transition-fast;
 
     &:hover {
-      background: vars.$color-primary-hover;
+      background: vars.$color-primary-fill-hover;
     }
   }
 }

--- a/src/components/Settings/sections/UpdateSection.scss
+++ b/src/components/Settings/sections/UpdateSection.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/tokens' as tk;
+
 .check-update-button {
   display: flex;
   align-items: center;
@@ -21,8 +23,8 @@
   }
 
   &.up-to-date {
-    color: #10a37f;
-    border-color: #10a37f;
+    color: tk.$color-primary;
+    border-color: tk.$color-primary;
   }
 
   .spinning {

--- a/src/components/Settings/sections/VoiceLibrarySection.scss
+++ b/src/components/Settings/sections/VoiceLibrarySection.scss
@@ -129,7 +129,7 @@
   gap: 4px;
   padding: 4px 10px;
   font-size: 12px;
-  color: #fff;
+  color: tk.$color-on-primary;
   background: tk.$color-primary;
   border: none;
   border-radius: 4px;

--- a/src/components/Settings/sections/VoiceLibrarySection.scss
+++ b/src/components/Settings/sections/VoiceLibrarySection.scss
@@ -130,7 +130,7 @@
   padding: 4px 10px;
   font-size: 12px;
   color: tk.$color-on-primary;
-  background: tk.$color-primary;
+  background: tk.$color-primary-fill;
   border: none;
   border-radius: 4px;
   cursor: pointer;

--- a/src/components/Settings/sections/VoiceLibrarySection.scss
+++ b/src/components/Settings/sections/VoiceLibrarySection.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/tokens' as tk;
+
 .voice-library-section {
   display: flex;
   flex-direction: column;
@@ -11,14 +13,14 @@
   // body; without this it hugs the manage details directly above it.
   margin-top: 12px;
   padding: 10px;
-  background: rgba(16, 163, 127, 0.08);
-  border: 1px solid rgba(16, 163, 127, 0.25);
+  background: rgba(tk.$color-primary, 0.08);
+  border: 1px solid rgba(tk.$color-primary, 0.25);
   border-radius: 4px;
   font-size: 13px;
   line-height: 1.4;
 
   a {
-    color: #10a37f;
+    color: tk.$color-primary;
     text-decoration: none;
     display: inline-flex;
     align-items: center;
@@ -69,8 +71,8 @@
   transition: background 0.15s ease, border-color 0.15s ease;
 
   &.dragging {
-    background: rgba(16, 163, 127, 0.12);
-    border: 1px dashed #10a37f;
+    background: rgba(tk.$color-primary, 0.12);
+    border: 1px dashed tk.$color-primary;
   }
 }
 
@@ -112,7 +114,7 @@
 
   &:focus {
     outline: none;
-    border-color: #10a37f;
+    border-color: tk.$color-primary;
   }
 }
 
@@ -127,8 +129,8 @@
   gap: 4px;
   padding: 4px 10px;
   font-size: 12px;
-  color: #ffffff;
-  background: #10a37f;
+  color: #fff;
+  background: tk.$color-primary;
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -201,7 +203,7 @@
   font-size: 12px;
   background: transparent;
   border: none;
-  color: #10a37f;
+  color: tk.$color-primary;
   cursor: pointer;
   &:hover { text-decoration: underline; }
 }
@@ -219,7 +221,7 @@
 }
 
 .voice-manage-row.selected {
-  background: rgba(16, 163, 127, 0.16);
+  background: rgba(tk.$color-primary, 0.16);
   color: #ffffff;
 }
 
@@ -301,7 +303,7 @@
   font-size: 13px;
   color: #ffffff;
   background: rgba(255, 255, 255, 0.08);
-  border: 1px solid #10a37f;
+  border: 1px solid tk.$color-primary;
   border-radius: 3px;
 }
 

--- a/src/components/Settings/shared/Button.scss
+++ b/src/components/Settings/shared/Button.scss
@@ -21,11 +21,11 @@
   // --- Variants ---
 
   &--primary {
-    background: vars.$color-primary;
-    color: vars.$text-primary;
+    background: vars.$color-primary-fill;
+    color: vars.$color-on-primary;
 
     &:hover:not(:disabled) {
-      background: vars.$color-primary-hover;
+      background: vars.$color-primary-fill-hover;
     }
   }
 

--- a/src/components/Settings/shared/_variables.scss
+++ b/src/components/Settings/shared/_variables.scss
@@ -12,6 +12,7 @@
 // Brand
 $color-primary:       tk.$color-primary;
 $color-primary-hover: tk.$color-primary-hover;
+$color-primary-fill:  tk.$color-primary-fill;
 $color-on-primary:    tk.$color-on-primary;
 
 // Status
@@ -132,7 +133,7 @@ $toggle-bg-on:    $color-primary;
   // The app's segmented → fill selection form. It is the accent *behind a
   // label*, so it takes the fill value rather than the bright accent: a
   // brighter accent cannot carry legible white text.
-  background: $color-primary;
+  background: $color-primary-fill;
   color: $color-on-primary;
 }
 

--- a/src/components/Settings/shared/_variables.scss
+++ b/src/components/Settings/shared/_variables.scss
@@ -13,6 +13,7 @@
 $color-primary:       tk.$color-primary;
 $color-primary-hover: tk.$color-primary-hover;
 $color-primary-fill:  tk.$color-primary-fill;
+$color-primary-fill-hover: tk.$color-primary-fill-hover;
 $color-on-primary:    tk.$color-on-primary;
 
 // Status

--- a/src/components/Settings/shared/_variables.scss
+++ b/src/components/Settings/shared/_variables.scss
@@ -1,3 +1,5 @@
+@use '../../../styles/tokens' as tk;
+
 // ============================================================
 // Settings Design Tokens
 // ============================================================
@@ -8,11 +10,11 @@
 // --- Color Palette -------------------------------------------
 
 // Brand
-$color-primary:       #10a37f;
-$color-primary-hover: #0e8f6f;
+$color-primary:       tk.$color-primary;
+$color-primary-hover: tk.$color-primary-hover;
 
 // Status
-$color-success: #10a37f;
+$color-success: tk.$color-success;
 $color-warning: #ffc107;
 $color-error:   #ff4444;
 $color-info:    #4285f4;
@@ -126,6 +128,9 @@ $toggle-bg-on:    $color-primary;
 }
 
 @mixin state-selected-fill {
+  // The app's segmented → fill selection form. It is the accent *behind a
+  // label*, so it takes the fill value rather than the bright accent: a
+  // brighter accent cannot carry legible white text.
   background: $color-primary;
   color: $text-primary;
 }

--- a/src/components/Settings/shared/_variables.scss
+++ b/src/components/Settings/shared/_variables.scss
@@ -12,6 +12,7 @@
 // Brand
 $color-primary:       tk.$color-primary;
 $color-primary-hover: tk.$color-primary-hover;
+$color-on-primary:    tk.$color-on-primary;
 
 // Status
 $color-success: tk.$color-success;
@@ -132,7 +133,7 @@ $toggle-bg-on:    $color-primary;
   // label*, so it takes the fill value rather than the bright accent: a
   // brighter accent cannot carry legible white text.
   background: $color-primary;
-  color: $text-primary;
+  color: $color-on-primary;
 }
 
 // --- Selectable option row --------------------------------------

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -85,7 +85,7 @@
     align-items: center;
     gap: 8px;
     background: tk.$color-primary;
-    color: #fff;
+    color: tk.$color-on-primary;
     border: none;
     border-radius: 8px;
     padding: 9px 20px;

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // src/components/Subtitle/SubtitleApp.scss
 .subtitle-app {
   display: flex;
@@ -82,7 +84,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    background: #10a37f;
+    background: tk.$color-primary;
     color: #fff;
     border: none;
     border-radius: 8px;

--- a/src/components/Subtitle/SubtitleApp.scss
+++ b/src/components/Subtitle/SubtitleApp.scss
@@ -84,7 +84,7 @@
     display: inline-flex;
     align-items: center;
     gap: 8px;
-    background: tk.$color-primary;
+    background: tk.$color-primary-fill;
     color: tk.$color-on-primary;
     border: none;
     border-radius: 8px;

--- a/src/components/Subtitle/SubtitleBar.scss
+++ b/src/components/Subtitle/SubtitleBar.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // src/components/Subtitle/SubtitleBar.scss
 .subtitle-bar {
   // Float above the subtitle area instead of pinning to the top of the
@@ -52,7 +54,7 @@
 
   .subtitle-bar__logo {
     font-weight: 600;
-    color: #10a37f;
+    color: tk.$color-primary;
   }
 
   .subtitle-bar__quota {
@@ -87,8 +89,8 @@
     }
 
     &.active {
-      color: #10a37f;
-      background: rgba(16, 163, 127, 0.15);
+      color: tk.$color-primary;
+      background: rgba(tk.$color-primary, 0.15);
     }
 
     &:disabled {
@@ -143,7 +145,7 @@
     -webkit-app-region: no-drag;
     transition: background 120ms ease, opacity 120ms ease;
 
-    &.is-start { background: #10a37f; }
+    &.is-start { background: tk.$color-primary; }
     &.is-stop  { background: #e74c3c; }
 
     &:disabled {

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -56,11 +56,11 @@
     // apart when both are on screen.
     .subtitle-stream__line--participant {
       padding-left: 6px;
-      border-left: 2px solid rgba(243, 156, 18, 0.6);
+      border-left: 2px solid rgba(tk.$color-participant, 0.6);
     }
     .subtitle-stream__line--speaker {
       padding-left: 6px;
-      border-left: 2px solid rgba(tk.$color-primary, 0.6);
+      border-left: 2px solid rgba(tk.$color-speaker, 0.6);
     }
   }
 

--- a/src/components/Subtitle/SubtitleStream.scss
+++ b/src/components/Subtitle/SubtitleStream.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .subtitle-stream {
   flex: 1;
   min-height: 0;
@@ -58,7 +60,7 @@
     }
     .subtitle-stream__line--speaker {
       padding-left: 6px;
-      border-left: 2px solid rgba(16, 163, 127, 0.6);
+      border-left: 2px solid rgba(tk.$color-primary, 0.6);
     }
   }
 

--- a/src/components/TitleBar/AccountButton.scss
+++ b/src/components/TitleBar/AccountButton.scss
@@ -1,7 +1,9 @@
+@use '../../styles/tokens' as tk;
+
 // src/components/TitleBar/AccountButton.scss
 //
 // The outlined circle, not a filled disc: rendered side by side, a filled
-// #10a37f disc outweighs every 14px line icon beside it in the title bar.
+// the accent-filled disc outweighs every 14px line icon beside it in the title bar.
 // The outline keeps the avatar's circular semantics inside the bar's
 // existing wireframe language. When OAuth lands and a real photograph is
 // available, the circle becomes a filled photo — a photograph earns the

--- a/src/components/TitleBar/AccountButton.scss
+++ b/src/components/TitleBar/AccountButton.scss
@@ -3,7 +3,7 @@
 // src/components/TitleBar/AccountButton.scss
 //
 // The outlined circle, not a filled disc: rendered side by side, a filled
-// the accent-filled disc outweighs every 14px line icon beside it in the title bar.
+// accent disc outweighs every 14px line icon beside it in the title bar.
 // The outline keeps the avatar's circular semantics inside the bar's
 // existing wireframe language. When OAuth lands and a real photograph is
 // available, the circle becomes a filled photo — a photograph earns the

--- a/src/components/TitleBar/AccountPopover.scss
+++ b/src/components/TitleBar/AccountPopover.scss
@@ -25,7 +25,7 @@
     flex: 1; height: 32px; border-radius: 5px; font-size: 13px; font-weight: 600;
     cursor: pointer; border: 1px solid transparent; font-family: inherit;
 
-    &--primary { background: tk.$color-primary; color: #fff; &:hover { background: tk.$color-primary-hover; } }
+    &--primary { background: tk.$color-primary; color: tk.$color-on-primary; &:hover { background: tk.$color-primary-hover; } }
     &--ghost {
       background: transparent; color: #ccc; border-color: #555;
       &:hover { background: rgba(255, 255, 255, 0.07); border-color: #6a6a6a; }

--- a/src/components/TitleBar/AccountPopover.scss
+++ b/src/components/TitleBar/AccountPopover.scss
@@ -25,7 +25,7 @@
     flex: 1; height: 32px; border-radius: 5px; font-size: 13px; font-weight: 600;
     cursor: pointer; border: 1px solid transparent; font-family: inherit;
 
-    &--primary { background: tk.$color-primary-fill; color: tk.$color-on-primary; &:hover { background: tk.$color-primary-hover; } }
+    &--primary { background: tk.$color-primary-fill; color: tk.$color-on-primary; &:hover { background: tk.$color-primary-fill-hover; } }
     &--ghost {
       background: transparent; color: #ccc; border-color: #555;
       &:hover { background: rgba(255, 255, 255, 0.07); border-color: #6a6a6a; }

--- a/src/components/TitleBar/AccountPopover.scss
+++ b/src/components/TitleBar/AccountPopover.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // src/components/TitleBar/AccountPopover.scss
 // Values copied from ModeDevicePopover.scss so the two popovers are one
 // control in two places rather than two lookalikes that drift.
@@ -23,7 +25,7 @@
     flex: 1; height: 32px; border-radius: 5px; font-size: 13px; font-weight: 600;
     cursor: pointer; border: 1px solid transparent; font-family: inherit;
 
-    &--primary { background: #10a37f; color: #fff; &:hover { background: #0e9070; } }
+    &--primary { background: tk.$color-primary; color: #fff; &:hover { background: tk.$color-primary-hover; } }
     &--ghost {
       background: transparent; color: #ccc; border-color: #555;
       &:hover { background: rgba(255, 255, 255, 0.07); border-color: #6a6a6a; }

--- a/src/components/TitleBar/AccountPopover.scss
+++ b/src/components/TitleBar/AccountPopover.scss
@@ -25,7 +25,7 @@
     flex: 1; height: 32px; border-radius: 5px; font-size: 13px; font-weight: 600;
     cursor: pointer; border: 1px solid transparent; font-family: inherit;
 
-    &--primary { background: tk.$color-primary; color: tk.$color-on-primary; &:hover { background: tk.$color-primary-hover; } }
+    &--primary { background: tk.$color-primary-fill; color: tk.$color-on-primary; &:hover { background: tk.$color-primary-hover; } }
     &--ghost {
       background: transparent; color: #ccc; border-color: #555;
       &:hover { background: rgba(255, 255, 255, 0.07); border-color: #6a6a6a; }

--- a/src/components/TitleBar/TitleBar.scss
+++ b/src/components/TitleBar/TitleBar.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // src/components/TitleBar/TitleBar.scss
 .title-bar {
   height: 36px;
@@ -73,7 +75,7 @@
   }
 
   &:focus-visible {
-    outline: 2px solid #10a37f;
+    outline: 2px solid tk.$color-primary;
     outline-offset: -1px;
   }
 

--- a/src/components/Toast/Toast.scss
+++ b/src/components/Toast/Toast.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .toast-stack {
   position: fixed;
   bottom: 24px;
@@ -23,7 +25,7 @@
   animation: toast-in 150ms ease-out;
 
   &.toast-success {
-    border-color: #10a37f;
+    border-color: tk.$color-success;
   }
   &.toast-error {
     border-color: #e74c3c;

--- a/src/components/UpdateBanner/UpdateBanner.scss
+++ b/src/components/UpdateBanner/UpdateBanner.scss
@@ -7,7 +7,7 @@
   padding: 6px 12px;
   font-size: 12px;
   color: tk.$color-on-primary;
-  background-color: tk.$color-primary;
+  background-color: tk.$color-primary-fill;
   cursor: default;
   flex-shrink: 0;
 

--- a/src/components/UpdateBanner/UpdateBanner.scss
+++ b/src/components/UpdateBanner/UpdateBanner.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .update-banner {
   display: flex;
   align-items: center;
@@ -5,7 +7,7 @@
   padding: 6px 12px;
   font-size: 12px;
   color: #fff;
-  background-color: #10a37f;
+  background-color: tk.$color-primary;
   cursor: default;
   flex-shrink: 0;
 

--- a/src/components/UpdateBanner/UpdateBanner.scss
+++ b/src/components/UpdateBanner/UpdateBanner.scss
@@ -6,7 +6,7 @@
   justify-content: space-between;
   padding: 6px 12px;
   font-size: 12px;
-  color: #fff;
+  color: tk.$color-on-primary;
   background-color: tk.$color-primary;
   cursor: default;
   flex-shrink: 0;

--- a/src/components/UpdateDialog/UpdateDialog.scss
+++ b/src/components/UpdateDialog/UpdateDialog.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .update-dialog-overlay {
   position: fixed;
   top: 0;
@@ -64,11 +66,11 @@
       color: #999;
 
       .arrow {
-        color: #10a37f;
+        color: tk.$color-primary;
       }
 
       .new-version {
-        color: #10a37f;
+        color: tk.$color-primary;
         font-weight: 600;
       }
     }
@@ -92,7 +94,7 @@
       }
 
       h3 {
-        color: #10a37f;
+        color: tk.$color-primary;
         font-size: 13px;
         font-weight: 600;
         margin: 0 0 8px 0;
@@ -122,7 +124,7 @@
       }
 
       a {
-        color: #10a37f;
+        color: tk.$color-primary;
         text-decoration: none;
 
         &:hover {
@@ -142,7 +144,7 @@
 
         .progress-fill {
           height: 100%;
-          background-color: #10a37f;
+          background-color: tk.$color-primary;
           border-radius: 3px;
           transition: width 0.3s ease;
         }
@@ -168,7 +170,7 @@
       margin: 12px 0;
       padding: 12px;
       border-radius: 6px;
-      background: rgba(16, 163, 127, 0.08);
+      background: rgba(tk.$color-primary, 0.08);
       color: #b8d4c9;
       font-size: 0.9em;
       line-height: 1.5;
@@ -183,7 +185,7 @@
     border-top: 1px solid #333;
 
     .primary-button {
-      background-color: #10a37f;
+      background-color: tk.$color-primary;
       color: #fff;
       border: none;
       border-radius: 4px;

--- a/src/components/UpdateDialog/UpdateDialog.scss
+++ b/src/components/UpdateDialog/UpdateDialog.scss
@@ -185,7 +185,7 @@
     border-top: 1px solid #333;
 
     .primary-button {
-      background-color: tk.$color-primary;
+      background-color: tk.$color-primary-fill;
       color: tk.$color-on-primary;
       border: none;
       border-radius: 4px;

--- a/src/components/UpdateDialog/UpdateDialog.scss
+++ b/src/components/UpdateDialog/UpdateDialog.scss
@@ -186,7 +186,7 @@
 
     .primary-button {
       background-color: tk.$color-primary;
-      color: #fff;
+      color: tk.$color-on-primary;
       border: none;
       border-radius: 4px;
       padding: 8px 16px;

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -10,6 +10,10 @@
 // Buttons, focus rings, active segments, progress, links.
 $color-primary:       #0fbb8f;
 $color-primary-fill:  #008261;  // the accent when it sits behind a label
+// Hover deepens rather than brightens: it lifts the label from 4.8:1 to 6.3:1.
+// The rest state already carries the 3:1 the component needs to be identified,
+// and a hover is a transient state on something the pointer is already on.
+$color-primary-fill-hover: #006e52;
 $color-on-primary:    #fff;             // that label
 $color-primary-hover: #0da77f;
 

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -9,6 +9,7 @@
 // ── Brand and primary action ──
 // Buttons, focus rings, active segments, progress, links.
 $color-primary:       #10a37f;
+$color-on-primary:    #fff;             // that label
 $color-primary-hover: #0e8f6f;
 
 // ── Who is speaking ──

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -8,10 +8,10 @@
 
 // ── Brand and primary action ──
 // Buttons, focus rings, active segments, progress, links.
-$color-primary:       #10a37f;
-$color-primary-fill:  $color-primary;  // the accent when it sits behind a label
+$color-primary:       #0fbb8f;
+$color-primary-fill:  #008261;  // the accent when it sits behind a label
 $color-on-primary:    #fff;             // that label
-$color-primary-hover: #0e8f6f;
+$color-primary-hover: #0da77f;
 
 // ── Who is speaking ──
 // A pair, and it only works as a pair: these two must stay clearly

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -1,0 +1,26 @@
+// App-wide colour tokens.
+//
+// One hex (#10a37f) used to carry three unrelated meanings: the brand accent,
+// who is speaking, and "it worked". That made changing the accent impossible
+// to do safely with a find-and-replace — success states would have followed
+// the brand, and the speaker/participant pair would have collapsed into one
+// colour. The meanings are separated here so each can move on its own.
+
+// ── Brand and primary action ──
+// Buttons, focus rings, active segments, progress, links.
+$color-primary:       #10a37f;
+$color-primary-hover: #0e8f6f;
+
+// ── Who is speaking ──
+// A pair, and it only works as a pair: these two must stay clearly
+// distinguishable from each other. Speaker is pointed at the brand here as a
+// deliberate choice, not an inherited one — change this line alone to give the
+// conversation its own colours. Participant had to move regardless: the old
+// amber sat too close to the new accent to read as a different person.
+$color-speaker:     $color-primary;  // your own voice carries the brand
+$color-participant: #f39c12;        // the other side
+
+// ── "It worked" ──
+// A validated key, a connected session, a finished download, credit in.
+// Green is the right colour for this and is not the brand's to take.
+$color-success: #10a37f;

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -9,6 +9,7 @@
 // ── Brand and primary action ──
 // Buttons, focus rings, active segments, progress, links.
 $color-primary:       #10a37f;
+$color-primary-fill:  $color-primary;  // the accent when it sits behind a label
 $color-on-primary:    #fff;             // that label
 $color-primary-hover: #0e8f6f;
 
@@ -18,7 +19,8 @@ $color-primary-hover: #0e8f6f;
 // deliberate choice, not an inherited one — change this line alone to give the
 // conversation its own colours. Participant had to move regardless: the old
 // amber sat too close to the new accent to read as a different person.
-$color-speaker:     $color-primary;  // your own voice carries the brand
+$color-speaker:      $color-primary;       // read: badges, translated text
+$color-speaker-fill: $color-primary-fill;  // filled: the avatar disc, which carries a glyph
 $color-participant: #f39c12;        // the other side
 
 // ── "It worked" ──

--- a/src/styles/karaoke.scss
+++ b/src/styles/karaoke.scss
@@ -1,4 +1,6 @@
+@use './tokens' as tk;
+
 .karaoke-played {
-  color: var(--karaoke-played-color, #10a37f);
+  color: var(--karaoke-played-color, #{tk.$color-speaker});
   transition: color 80ms ease-out;
 }


### PR DESCRIPTION
`#10a37f` is ChatGPT's green. On a product whose stated position is that you need not depend on any one AI company, it argued against the interface it sat in.

Changing it turned out not to be a find-and-replace, and running one would have broken things quietly. Hence four commits, three of which change no pixels at all.

## What was actually in the way

That hex appeared **95 times** across `src/**/*.scss`, plus **26 more** written as `rgba(16, 163, 127, …)` — the same colour in a spelling a search for `#10a37f` never sees. Left behind, those would have stayed green beside everything that moved.

More importantly the 121 sites were not one colour used 121 times. They carried **three unrelated meanings**:

| meaning | where | what it becomes |
|---|---|---|
| brand / primary action | buttons, focus rings, active segments, progress | `$color-primary` |
| who is speaking | avatar disc, language badge — half of a pair against the participant amber | `$color-speaker` |
| "it worked" | validated key, connected session, credit in | `$color-success` |

A global replace would have turned success states jade and collapsed the speaker/participant pair into one colour.

## The commits

1. **Split the meanings, while everything is still green.** Each site pointed at the variable matching what it *means*, decided by reading the enclosing selector rather than the file name. `$color-primary` already existed in `Settings/shared/_variables.scss`; the literals bypassing it were the problem. Now they live in an app-wide `src/styles/_tokens.scss` that `_variables.scss` sources from.
2. **The label on an accent fill becomes a token.** Twenty hardcoded white labels sat on the accent. Fine at mid-lightness, wrong the moment it is not.
3. **The accent gains a fill weight.** Read as text it wants to be bright; used as a fill under a label it wants to be dark enough for that label to survive. One value cannot do both. `state-selected-fill` — the mixin behind every segmented control — now takes the fill weight once, instead of each call site deciding.
4. **The value changes.** Three lines in one file, because of the three commits above.

## The colour

Picked by measurement after picking by eye kept failing:

- On a dark surface the legible-green band is narrow. Anything at hue 160–170 bright enough to read lands within **2.6** perceptual units of `#10a37f` — below the point where anyone can tell two colours apart. Only brighter or deeper escapes it, and deeper goes dull.
- The green being replaced **already failed twice**: white on the fill is **3.2:1**, passing only because button labels count as large text; as text on a light ground it is **2.9:1**.

So `#0fbb8f` for anything that is read, `#008261` wherever it sits behind a label. The label stays white — a dark one read as awkward — and at **4.8:1** it now passes at any text size. Success stays green and is no longer the same hex as the brand, so the two are finally telling apart.

## How it was checked

Each state was captured through the same headless pipeline and compared pixel by pixel.

- commits 1–3 against `main`: **0.00%** differing
- commit 4: the only one that moves anything

`ConversationRow`, `ModePicker` and `Settings` tests pass (34).

## Worth knowing before review

- `Settings/` uses `vars.$color-primary`, everything else `tk.` — both prefixes needed sweeping.
- `$color-speaker` needed the same two-weight treatment: its avatar is a filled disc carrying a glyph.
- The participant amber was a literal and now reads its token.
- The app has no light theme, so this is SCSS variables. Runtime theming would need CSS custom properties, which is where the web dashboard already is — worth converging on later, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized colors across authentication, subtitle, settings, playback, account, notification, and update screens.
  * Improved visual consistency for primary actions, speaker indicators, success states, focus outlines, and hover states.
  * Refined button and selection states with clearer active, hover, and focus colors.
  * Preserved existing layouts and interactions while enabling more consistent theme updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->