### PR TITLE
refactor(tokens): name the amber region, so #f39c12 stops meaning two things

### DIFF
--- a/src/components/AudioSystemBanner/AudioSystemBanner.scss
+++ b/src/components/AudioSystemBanner/AudioSystemBanner.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 .audio-system-banner {
   display: flex;
   align-items: center;
@@ -6,7 +8,10 @@
   padding: 6px 12px;
   font-size: 12px;
   color: #fff;
-  background-color: #e67e22;
+  // NOTE: this is a degraded state wearing the usage amber. Left on the same
+  // value so this commit stays a no-op; which colour it should be is a
+  // separate decision.
+  background-color: tk.$color-usage;
   flex-shrink: 0;
 
   .audio-system-banner-content {

--- a/src/components/AudioSystemBanner/AudioSystemBanner.scss
+++ b/src/components/AudioSystemBanner/AudioSystemBanner.scss
@@ -8,6 +8,7 @@
   padding: 6px 12px;
   font-size: 12px;
   color: #fff;
+
   // NOTE: this is a degraded state wearing the usage amber. Left on the same
   // value so this commit stays a no-op; which colour it should be is a
   // separate decision.

--- a/src/components/Auth/UserAccountInfo.scss
+++ b/src/components/Auth/UserAccountInfo.scss
@@ -185,12 +185,12 @@
   
   &.refresh-account {
     background: transparent;
-    color: #e67e22; // Match usage section color
-    border: 1px solid #e67e22;
+    color: tk.$color-usage; // the usage section it belongs to
+    border: 1px solid tk.$color-usage;
 
     &:hover {
       background: rgba(231, 123, 34, 0.1);
-      border-color: #f39c12;
+      border-color: tk.$color-usage-hover;
     }
 
     &:active svg {
@@ -277,17 +277,17 @@
         gap: 4px;
         padding: 2px 6px;
         font-size: 10px;
-        color: #e67e22;
-        background: rgba(230, 126, 34, 0.1);
-        border: 1px solid rgba(230, 126, 34, 0.3);
+        color: tk.$color-usage;
+        background: rgba(tk.$color-usage, 0.1);
+        border: 1px solid rgba(tk.$color-usage, 0.3);
         border-radius: 3px;
         cursor: pointer;
         transition: all 0.2s;
         flex-shrink: 0;
 
         &:hover:not(:disabled) {
-          background: rgba(230, 126, 34, 0.2);
-          border-color: rgba(230, 126, 34, 0.5);
+          background: rgba(tk.$color-usage, 0.2);
+          border-color: rgba(tk.$color-usage, 0.5);
         }
 
         &:disabled,
@@ -467,9 +467,9 @@
   }
   
   &.warning-critical {
-    background: rgba(230, 126, 34, 0.1);
-    color: #e67e22;
-    border: 1px solid rgba(230, 126, 34, 0.2);
+    background: rgba(tk.$color-usage, 0.1);
+    color: tk.$color-usage;
+    border: 1px solid rgba(tk.$color-usage, 0.2);
   }
   
   &.warning-exceeded {
@@ -504,7 +504,7 @@
   }
   
   .usage-icon {
-    color: #e67e22; // Match the usage section color (amber for spending)
+    color: tk.$color-usage; // the usage section it belongs to (amber for spending)
     flex-shrink: 0;
   }
   
@@ -515,7 +515,7 @@
   }
   
   .usage-section {
-    color: #e67e22;  // Amber for spending
+    color: tk.$color-usage;  // spending
     font-size: 13px;
     display: flex;
     align-items: center;
@@ -576,7 +576,7 @@
       transition: width 0.3s ease;
       
       &.high-usage {
-        background: linear-gradient(90deg, #e67e22, #d35400);
+        background: linear-gradient(90deg, tk.$color-usage, tk.$color-usage-deep);
       }
     }
   }

--- a/src/components/MainPanel/MainPanel.scss
+++ b/src/components/MainPanel/MainPanel.scss
@@ -323,13 +323,13 @@
       flex-shrink: 0;
       &.active { background: tk.$color-primary; }
       &.reconnecting {
-        background: #f39c12;
+        background: tk.$color-degraded;
         animation: pulse 1s ease-in-out infinite;
       }
     }
 
     .reconnecting-label {
-      color: #f39c12;
+      color: tk.$color-degraded;
       font-size: 12px;
       animation: pulse 1s ease-in-out infinite;
       flex-shrink: 0;

--- a/src/components/MainPanel/SplitDegradedChip.scss
+++ b/src/components/MainPanel/SplitDegradedChip.scss
@@ -1,3 +1,5 @@
+@use '../../styles/tokens' as tk;
+
 // ── Split-degraded indicator (rendered in both control footers) ──
 //
 // Persistent footer chrome, not a conversation bubble: a split Both session
@@ -16,9 +18,9 @@
   flex-shrink: 0;
   padding: 2px 7px;
   border-radius: 10px;
-  background: rgba(243, 156, 18, 0.15);
-  border: 1px solid rgba(243, 156, 18, 0.45);
-  color: #f39c12;
+  background: rgba(tk.$color-degraded, 0.15);
+  border: 1px solid rgba(tk.$color-degraded, 0.45);
+  color: tk.$color-degraded;
   font-size: 11px;
   line-height: 1.4;
   white-space: nowrap;

--- a/src/styles/_tokens.scss
+++ b/src/styles/_tokens.scss
@@ -27,6 +27,17 @@ $color-speaker:      $color-primary;       // read: badges, translated text
 $color-speaker-fill: $color-primary-fill;  // filled: the avatar disc, which carries a glyph
 $color-participant: #f39c12;        // the other side
 
+// ── The amber region ──
+// Four hexes were sharing this space with no rule about which meant what, and
+// #f39c12 was doing two unrelated jobs at once — the person on the other end,
+// and a session in trouble. Same problem the accent had. Named apart here so
+// either can move without dragging the other; values are unchanged, so this
+// costs nothing to adopt.
+$color-degraded: #f39c12;  // reconnecting, split degraded — the session is unwell
+$color-usage:       #e67e22;  // spending, quota, an unverified account
+$color-usage-hover: #f39c12;  // the hover those controls already used
+$color-usage-deep:  #d35400;  // the far stop of the high-usage gradient
+
 // ── "It worked" ──
 // A validated key, a connected session, a finished download, credit in.
 // Green is the right colour for this and is not the brand's to take.


### PR DESCRIPTION
Follow-on to #451, same shape, different colour region.

`#f39c12` was doing two unrelated jobs at once: **the person on the other end**
(participant) and **a session in trouble** (reconnecting, split degraded). That
is the collision #451 fixed for the accent, still present one hue over. Three
more ambers — `#e67e22`, `#d35400`, `#f39c12` again — were sharing the usage /
spending space with no rule about which meant what.

This names the region so either meaning can move without dragging the other:

```scss
$color-degraded: #f39c12;  // reconnecting, split degraded — the session is unwell
$color-usage:       #e67e22;  // spending, quota, an unverified account
$color-usage-hover: #f39c12;  // the hover those controls already used
$color-usage-deep:  #d35400;  // the far stop of the high-usage gradient
```

`$color-participant` keeps `#f39c12` and is untouched.

## Values are unchanged — measured, not asserted

Every literal maps to a token holding the identical hex, so nothing moves a
pixel. Verified rather than reasoned about: each of the four changed
stylesheets was compiled with `sass` on `origin/main` and on this branch, and
the emitted CSS is **byte-for-byte identical** across all four. `npm run build`
exits 0 with no new warnings.

Review effort therefore belongs on whether the *names* carve the space
correctly, not on whether the UI changed.

## Deliberately left alone

Two things are flagged in the commit message rather than fixed here, because
each is a design decision and not a rename:

- `AudioSystemBanner` is a **degraded state wearing the usage amber**. It stays
  on `$color-usage` with a `NOTE` at the call site, so this commit remains a
  no-op; which colour it should actually be is a separate call.
- `#ffc107` and `#f59e0b` are two further warning ambers with no rule about
  which to use. Naming them requires deciding what distinguishes them first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Standardized warning, degraded-state, and usage-related colors across the interface.
  * Improved visual consistency while preserving the existing color appearance.
  * Updated account status indicators, quota warnings, reconnecting messages, and degraded-state badges.
  * Clarified visual distinctions between session issues, usage alerts, hover states, and high-usage indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->