### PR TITLE
fix(settings): preserve JSON-looking strings in localStorage

### DIFF
--- a/src/services/SettingsService.test.ts
+++ b/src/services/SettingsService.test.ts
@@ -53,6 +53,47 @@ describe('SettingsService.getSetting', () => {
   });
 });
 
+describe('SettingsService localStorage round trips', () => {
+  afterEach(() => {
+    localStorage.clear();
+    delete (globalThis as Record<string, unknown>).chrome;
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    '123456',
+    'true',
+    'false',
+    'null',
+    '[]',
+    '{}',
+    '"quoted"',
+  ])('preserves the JSON-looking string %j exactly', async (value) => {
+    const service = new SettingsService();
+    const key = 'settings.test.opaqueString';
+
+    await expect(service.setSetting(key, value)).resolves.toMatchObject({ success: true });
+    expect(localStorage.getItem(key)).toBe(value);
+
+    const restored = await service.getSetting(key, '');
+    expect(restored).toBe(value);
+    expect(typeof restored).toBe('string');
+  });
+
+  it.each([
+    ['boolean', true],
+    ['number', 123456],
+    ['array', ['one', 'two']],
+    ['object', { enabled: true }],
+  ])('keeps parsing a stored %s value', async (_label, value) => {
+    const service = new SettingsService();
+    const key = 'settings.test.structuredValue';
+
+    await expect(service.setSetting(key, value)).resolves.toMatchObject({ success: true });
+    await expect(service.getSetting(key, null)).resolves.toEqual(value);
+  });
+});
+
 describe('SettingsService.setSetting', () => {
   afterEach(() => {
     delete (globalThis as Record<string, unknown>).chrome;

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -52,6 +52,12 @@ export class SettingsService implements ISettingsService {
         // Electron: Use localStorage
         const value = localStorage.getItem(key);
         if (value !== null) {
+          // setSetting stores strings as raw localStorage values. Return them
+          // before JSON parsing so opaque values such as API keys "123456",
+          // "true", or "null" do not change type across an app restart.
+          if (typeof defaultValue === 'string') {
+            return value as unknown as T;
+          }
           try {
             return JSON.parse(value);
           } catch {


### PR DESCRIPTION
## Summary

- Preserve raw string settings when reading from Electron localStorage.
- Continue JSON parsing for actual booleans, numbers, arrays, and objects.
- Add regression coverage for opaque strings that happen to be valid JSON.

## Problem

In the Electron storage path, `setSetting()` writes strings directly to localStorage, while `getSetting()` attempts to run `JSON.parse()` on every stored value.

As a result, opaque string credentials that are also valid JSON change type after restarting the application:

- `"123456"` becomes the number `123456`
- `"true"` becomes the boolean `true`
- `"null"` becomes `null`
- `"[]"` becomes an array

API key parameters are typed as strings at compile time, but TypeScript types do not perform runtime validation. A numeric API key can therefore reach code such as `apiKey.trim()` and cause:

```text
t.trim is not a function
```

This is especially relevant to OpenAI-compatible endpoints and local proxies, where API keys are opaque, server-defined strings and may legitimately contain values such as 123456 or true.

## Solution

When the caller supplies a string default value, return the raw localStorage value before attempting JSON parsing. This matches the existing setSetting() contract, which stores strings without JSON encoding. Non-string settings continue to use the existing JSON parsing behavior.

## Test plan

- Confirmed the regression tests fail before the fix:
  - "123456" restored as a number
  - "true" and "false" restored as booleans
  - "null" restored as null
  - "[]" and "{}" restored as structured values
- npm test -- --run src/services/SettingsService.test.ts
  - 18 tests passed
- npm test -- --run src/services/SettingsService.test.ts src/stores/settingsStore.test.ts
  - 57 tests passed
- npm run build
- Manual Electron verification with OpenAI Compatible:
  - Initial validation succeeds with 123456 and true
  - Before the fix, validation fails after restarting the app
  - After the fix, both values remain strings and validation succeeds after restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved string-based settings exactly as entered, including values resembling JSON, booleans, or `null`.
  * Ensured settings continue restoring correctly across app restarts while retaining the appropriate types for numbers, arrays, objects, and booleans.

* **Tests**
  * Added coverage for saving and restoring different setting types.
  * Verified successful writes and reliable cleanup between test cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->