### PR TITLE
fix(ci): leave CSC_LINK unset on fork PRs, instead of empty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -289,7 +289,20 @@ jobs:
         # entirely, so `--mac pkg` alone would silently drop the zip -- and with it
         # latest-mac.yml and the blockmap, leaving auto-update dead while everything
         # still looks green. The zip is what electron-updater actually installs.
-        run: npx electron-builder --mac pkg zip --${{ matrix.arch }} --publish never -c.directories.output=out/make-mac
+        run: |
+          set -euo pipefail
+          # The signing pair is exported here instead of being declared in `env:`
+          # below, because an empty-but-defined CSC_LINK is not "unset" to
+          # electron-builder: getCscLink() keeps "" on purpose ("allow to specify
+          # as empty string"), macPackager guards only `cscLink == null`, and the
+          # pkg target forces the keychain open even when the .app itself skips
+          # signing. loadCscLink("") then resolves the empty path against the
+          # project dir and the build dies with "<projectDir> not a file" -- which
+          # is every fork PR, since GitHub passes it no secrets at all (#453).
+          if [ "$HAS_MAC_CERT" = 'true' ]; then
+            export CSC_LINK="$MACOS_CSC_LINK" CSC_KEY_PASSWORD="$MACOS_CSC_KEY_PASSWORD"
+          fi
+          npx electron-builder --mac pkg zip --${{ matrix.arch }} --publish never -c.directories.output=out/make-mac
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CI: false
@@ -297,12 +310,12 @@ jobs:
           # macOS auto-update stays off; scripts/electron-builder-fuses.js
           # ad-hoc signs in that case.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.MACOS_CSC_LINK != '' && 'true' || 'false' }}
-          CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
+          MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          MACOS_CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
           # electron-builder refuses to sign pull-request builds unless this is
           # set, so that untrusted forks cannot get at signing credentials. That
           # protection is redundant here -- GitHub does not pass secrets to fork
-          # PRs at all, so HAS_MAC_CERT is false and CSC_LINK is empty there --
+          # PRs at all, so HAS_MAC_CERT is false and CSC_LINK stays unset there --
           # while leaving it off means no PR can ever verify the signing chain,
           # which is the whole point of running this on a PR.
           CSC_FOR_PULL_REQUEST: ${{ env.HAS_MAC_CERT }}


### PR DESCRIPTION
## Problem

Both macOS builds fail on every fork PR, with an error that names nothing to do with code signing:

```
⨯ /Users/runner/work/sokuji/sokuji not a file
```

That path is `GITHUB_WORKSPACE` itself.

An empty-but-defined `CSC_LINK` is not "unset" to electron-builder:

- `platformPackager.getCscLink()` routes through `chooseNotNull` and keeps `""` deliberately — the line above it reads `// allow to specify as empty string`.
- `macPackager` guards only `cscLink == null`, so `""` sails through and a code-signing descriptor is assembled anyway.
- `targets/pkg.ts` forces `packager.codeSigningInfo.value` open even when the `.app` itself skips signing (the PR guard), because a `.pkg` needs an installer identity.
- `builder-util`'s `loadCscLink("")` then resolves the empty path against the project dir — `path.resolve(projectDir, "")` is `projectDir` — stats a directory, and throws `` `${filePath} not a file` ``.

GitHub passes no secrets to fork PRs, so `CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}` expanded to exactly that empty string there. #449 introduced the variable; every fork PR has failed since. Same-repo PRs (#451, #452) kept passing because they do get the secret, and #453 was simply the first fork PR to arrive afterwards.

The comment this PR touches had already reasoned its way to "GitHub does not pass secrets to fork PRs at all, so HAS_MAC_CERT is false and CSC_LINK is empty there" — correct premise, wrong conclusion: empty is not unset.

## Change

Export the signing pair from the script under `HAS_MAC_CERT` instead of declaring it in `env:`, so that with no certificate the variables are genuinely absent:

```bash
if [ "$HAS_MAC_CERT" = 'true' ]; then
  export CSC_LINK="$MACOS_CSC_LINK" CSC_KEY_PASSWORD="$MACOS_CSC_KEY_PASSWORD"
fi
```

Untrusted runs go back to the pre-#449 shape — no keychain, ad-hoc signature from the `afterPack` hook, unsigned pkg and zip. Signed runs see exactly what they saw before, and the existing `Verify the macOS update artifacts` step still guards them.

## Verification

- Reproduced the failure locally against the real `builder-util/out/cscLink.js`: with `CSC_LINK=""`, `getCscLink()` yields `""` (`== null` is false) and `loadCscLink` throws `<projectDir> not a file` — the same sentence CI printed. With the variable deleted it yields `undefined`, `== null` is true, and `macPackager` returns null, which is the unsigned path.
- Extracted the patched `run:` script straight out of the YAML and executed it both ways with `npx` stubbed. `HAS_MAC_CERT=false`: both variables report as undefined rather than empty, electron-builder's arguments are unchanged, exit 0. `HAS_MAC_CERT=true`: both are exported with the right values.
- `scripts/electron-builder-fuses.js` keys on `Boolean(process.env.CSC_LINK)`; empty and undefined are both falsy, so fork PRs keep getting the ad-hoc signature exactly as before.
- Swept the repo for other `CSC_LINK` references — nothing else depended on the old spelling.

No source files are touched, so the test suite is unaffected.

## Note on #453

#453 will not pick this up on its own: `on: pull_request` defaults to `opened`/`synchronize`/`reopened`, and a base-branch update triggers none of them. Reopening it (or a rebase push from the author) will run against the corrected workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS build reliability by applying signing credentials only when a valid signing certificate is available.
  * Preserved existing macOS package and ZIP artifact generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->