### PR TITLE
chore(ci): move the workflows onto the Node 24 runtime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
     name: test (diagnostics)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # `npm ci` runs lifecycle scripts from this checkout, and this job does
           # no git work, so the token has nothing to do here.
           persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'npm'
@@ -86,14 +86,14 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           # Full history for releases (changelog generation). Use string '0'
           # because numeric 0 is falsy in GitHub Actions expressions.
           fetch-depth: ${{ startsWith(github.ref, 'refs/tags/v') && '0' || 1 }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: 'npm'
@@ -425,7 +425,7 @@ jobs:
 
       - name: Upload Linux x64 artifacts
         if: startsWith(github.ref, 'refs/tags/v') && matrix.name == 'linux-x64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-x64-artifacts
           path: |
@@ -437,7 +437,7 @@ jobs:
 
       - name: Upload Linux ARM64 artifacts
         if: startsWith(github.ref, 'refs/tags/v') && matrix.name == 'linux-arm64'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: linux-arm64-artifacts
           path: |
@@ -447,21 +447,21 @@ jobs:
 
       - name: Upload unsigned Windows installer for signing
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-unsigned
           path: out/make/squirrel.windows/x64/*Setup*.exe
 
       - name: Upload Windows nupkg for release
         if: startsWith(github.ref, 'refs/tags/v') && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-nupkg
           path: out/make/squirrel.windows/x64/*.nupkg
 
       - name: Upload macOS artifacts
         if: startsWith(github.ref, 'refs/tags/v') && runner.os == 'macOS'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact_name }}-artifacts
           path: |
@@ -481,10 +481,10 @@ jobs:
       actions: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Download unsigned artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-unsigned
           path: unsigned/
@@ -494,7 +494,7 @@ jobs:
       # and artifact IDs cannot be passed across jobs without explicit output wiring.
       - name: Upload for SignPath
         id: upload-for-signing
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-to-sign
           path: unsigned/
@@ -515,7 +515,7 @@ jobs:
           wait-for-completion-timeout-in-seconds: 3600
 
       - name: Upload signed artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: windows-signed
           path: signed/
@@ -528,37 +528,37 @@ jobs:
 
     steps:
       - name: Download Linux x64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: linux-x64-artifacts
           path: linux-x64-artifacts
 
       - name: Download Linux ARM64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: linux-arm64-artifacts
           path: linux-arm64-artifacts
 
       - name: Download signed Windows installer
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-signed
           path: windows-signed
 
       - name: Download Windows nupkg
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: windows-nupkg
           path: windows-nupkg
 
       - name: Download macOS ARM64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: macos-arm64-artifacts
           path: macos-arm64-artifacts
 
       - name: Download macOS x64 artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: macos-x64-artifacts
           path: macos-x64-artifacts
@@ -677,7 +677,7 @@ jobs:
           cat release-assets/latest-mac.yml
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: release-assets/*
           body_path: linux-x64-artifacts/CHANGELOG.md

--- a/.github/workflows/sidecar-bundles.yml
+++ b/.github/workflows/sidecar-bundles.yml
@@ -26,7 +26,7 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Verify tag matches package.json sidecarVersion
@@ -35,7 +35,7 @@ jobs:
           WANT="${GITHUB_REF_NAME#sidecar-v}"
           HAVE="$(node -p "require('./package.json').sidecarVersion")"
           [ "$WANT" = "$HAVE" ] || { echo "tag $WANT != package.json sidecarVersion $HAVE"; exit 1; }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
       - run: python -m pip install zstandard
       - name: Build linux-nvidia bundle
@@ -45,7 +45,7 @@ jobs:
           # runners share egress IPs whose anonymous API quota is exhausted.
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/build-sidecar-bundle.py --sku linux-nvidia --version "$VERSION" --archive --out out/bundles
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sidecar-linux-nvidia
           path: out/bundles/sidecar-linux-nvidia-v*
@@ -53,7 +53,7 @@ jobs:
   build-linux-arm:
     runs-on: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Verify tag matches package.json sidecarVersion
@@ -62,7 +62,7 @@ jobs:
           WANT="${GITHUB_REF_NAME#sidecar-v}"
           HAVE="$(node -p "require('./package.json').sidecarVersion")"
           [ "$WANT" = "$HAVE" ] || { echo "tag $WANT != package.json sidecarVersion $HAVE"; exit 1; }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
       - run: python -m pip install zstandard
       - name: Build linux-arm64 bundle
@@ -99,7 +99,7 @@ jobs:
           p.terminate()
           p.wait(timeout=10)
           EOF
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sidecar-linux-arm64
           path: out/bundles/sidecar-linux-arm64-v*
@@ -110,7 +110,7 @@ jobs:
       matrix:
         sku: [win-nvidia, win-directml]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Verify tag matches package.json sidecarVersion
@@ -120,7 +120,7 @@ jobs:
           WANT="${GITHUB_REF_NAME#sidecar-v}"
           HAVE="$(node -p "require('./package.json').sidecarVersion")"
           [ "$WANT" = "$HAVE" ] || { echo "tag $WANT != package.json sidecarVersion $HAVE"; exit 1; }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
       - run: python -m pip install zstandard
       - name: Build ${{ matrix.sku }} bundle
@@ -128,7 +128,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/build-sidecar-bundle.py --sku ${{ matrix.sku }} --version "$env:VERSION" --archive --out out/bundles
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sidecar-${{ matrix.sku }}
           path: out/bundles/sidecar-${{ matrix.sku }}-v*
@@ -136,7 +136,7 @@ jobs:
   build-mac:
     runs-on: macos-14
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Verify tag matches package.json sidecarVersion
@@ -145,7 +145,7 @@ jobs:
           WANT="${GITHUB_REF_NAME#sidecar-v}"
           HAVE="$(node -p "require('./package.json').sidecarVersion")"
           [ "$WANT" = "$HAVE" ] || { echo "tag $WANT != package.json sidecarVersion $HAVE"; exit 1; }
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.12' }
       - run: python -m pip install zstandard
       - name: Build mac bundle
@@ -153,7 +153,7 @@ jobs:
           VERSION: ${{ inputs.version }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: python scripts/build-sidecar-bundle.py --sku mac --version "$VERSION" --archive --out out/bundles
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v6
         with:
           name: sidecar-mac
           path: out/bundles/sidecar-mac-v*
@@ -165,17 +165,17 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: out/bundles
           merge-multiple: true
       - name: Merge per-SKU manifest fragments
         run: python scripts/build-sidecar-bundle.py --merge-fragments out/bundles/sidecar-*.json --merged-out out/bundles/manifest.json
       - name: Publish prerelease
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           prerelease: true
           files: |

--- a/.github/workflows/sidecar-metal-smoke.yml
+++ b/.github/workflows/sidecar-metal-smoke.yml
@@ -13,8 +13,8 @@ jobs:
   metal-smoke:
     runs-on: macos-14   # M-series, Metal-capable
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with: { python-version: '3.11' }
       - name: Install sidecar deps (CPU onnxruntime)
         run: |
@@ -39,7 +39,7 @@ jobs:
             tests/test_translate_engine.py \
             -v
       - name: Cache GGUF + llama binary
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/huggingface


### PR DESCRIPTION
GitHub is already forcing these onto Node 24 and annotating every run. This moves the tags to versions that ask for it.

## Not the obvious jump, in two cases

`upload-artifact@v5` and `download-artifact@v5`/`v6` still **defaulted to Node 20** despite advertising preliminary v24 support — their own release notes say so. The first majors that actually run on 24 are **v6** and **v7**, which is what this uses rather than the latest tags.

They share the artifact backend introduced in v4, so `upload@v6` and `download@v7` interoperate exactly as the v4 pair did. No artifact in this repo changes shape.

## The bumps

| action | | notes |
|---|---|---|
| `actions/checkout` | v4 → v5 | ×9 |
| `actions/setup-node` | v4 → v5 | ×2 — v5 auto-enables caching when `package.json` declares a `packageManager`. It does not, so this stays off |
| `actions/upload-artifact` | v4 → v6 | ×11 — see above |
| `actions/download-artifact` | v4 → v7 | ×8 — see above |
| `actions/setup-python` | v5 → v6 | ×5 |
| `actions/cache` | v4 → v5 | ×1 |
| `softprops/action-gh-release` | v2 → v3 | ×2 |

Every one of the seven release notes says nothing beyond "now runs on Node.js 24, needs runner ≥ 2.327.1". Hosted runners are on 2.337.0, and every `runs-on` here is hosted (`ubuntu-latest`, `ubuntu-24.04-arm`, `macos-14`, `windows-latest`).

## Left alone

- `signpath/github-action-submit-signing-request@v2` — already node24.
- `ilammy/msvc-dev-cmd@v1` — no major exists past v1, so it will keep warning until upstream ships one.

## Verification

Read `runs.using` out of each candidate tag's `action.yml` rather than trusting version numbers — that is how the upload/download v5 trap surfaced. All three workflow files still parse, with their job structure intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated diagnostic and log-surface tests to the pull request validation workflow.
  * Tests now run before the build validation.

* **Chores**
  * Updated build, release, packaging, and smoke-test automation to newer action versions.
  * Preserved existing build, artifact, release, and smoke-test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->