### PR TITLE
chore(ci): stop the last three checkouts persisting the token

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,6 +91,10 @@ jobs:
           # Full history for releases (changelog generation). Use string '0'
           # because numeric 0 is falsy in GitHub Actions expressions.
           fetch-depth: ${{ startsWith(github.ref, 'refs/tags/v') && '0' || 1 }}
+          # This job runs `npm ci` and `npm run build` on the checked-out tree,
+          # so lifecycle scripts from a dependency could read a token left in
+          # .git/config. It does no git work itself. Same reason as the test job.
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v5
@@ -482,6 +486,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v5
+        with:
+          # This job only signs artifacts downloaded from the build job;
+          # it does no git work, so the token has nothing to do here.
+          persist-credentials: false
 
       - name: Download unsigned artifacts
         uses: actions/download-artifact@v7

--- a/.github/workflows/sidecar-metal-smoke.yml
+++ b/.github/workflows/sidecar-metal-smoke.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: macos-14   # M-series, Metal-capable
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v6
         with: { python-version: '3.11' }
       - name: Install sidecar deps (CPU onnxruntime)

--- a/.github/workflows/sidecar-metal-smoke.yml
+++ b/.github/workflows/sidecar-metal-smoke.yml
@@ -9,6 +9,12 @@
 name: sidecar-metal-smoke
 on: workflow_dispatch
 
+# Stated rather than inherited, as sidecar-bundles.yml states it: the
+# repository default is already read, but that is a setting somewhere else
+# and this job only ever needs to read the tree.
+permissions:
+  contents: read
+
 jobs:
   metal-smoke:
     runs-on: macos-14   # M-series, Metal-capable


### PR DESCRIPTION
Six of the nine `actions/checkout` steps in this repo already pass `persist-credentials: false` — all five in `sidecar-bundles.yml`, and `build.yml`'s `test` job, whose comment states the reason. Three were missed. This finishes the convention.

| workflow | job | why it needs no token |
|---|---|---|
| `build.yml` | `build` | runs `npm ci` and `npm run build` on the checked-out tree; does no git work |
| `build.yml` | `sign-windows` | only signs artifacts downloaded from `build` |
| `sidecar-metal-smoke.yml` | `metal-smoke` | only builds and smoke-tests a sidecar |

## On the severity

`build` is the one that matters: it runs on `pull_request` under the workflow's `contents: write, packages: write, issues: write`, and it executes dependency lifecycle scripts.

That is narrower than it first appears — for `pull_request`, GitHub hands **fork** PRs a read-only token no matter what `permissions:` says, so the write token exists only for same-repo branches and pushes, which already require push access. The realistic threat is a malicious package in the lockfile reading a write token out of `.git/config` during `npm ci` on a maintainer-triggered run. Worth closing, not urgent.

## Safety

Nothing in these workflows depends on the persisted credentials — every token use goes through an explicit `GITHUB_TOKEN` / `GH_TOKEN` env var, never git config. Checked all three files; all nine checkouts now opt out.

Found by CodeRabbit on #455, which flagged two of the three. The `metal-smoke` one only turns up by auditing all nine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved CI workflow security by preventing checkout credentials from being persisted in repository configuration.
  * Restricted the sidecar smoke-test workflow to read-only repository access.
  * Applied these protections across build, Windows signing, and sidecar smoke-test workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->