### PR TITLE
docs: correct local model counts and align EN/JA/ZH READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ graph LR
 | | |
 |---|---|
 | **Providers** | 9 — OpenAI, Gemini, Palabra.ai, Kizuna AI, Doubao AST 2.0, Soniox, Zoom AI, OpenAI Compatible, Local Inference |
-| **Local Models** | 48 ASR models, 55+ translation pairs, 136 TTS voices |
+| **Local Models** | 44 ASR models, 75 translation models, 137 TTS models |
 | **Languages** | 99+ (speech recognition) · 55+ (translation) · 53 (text-to-speech) |
 | **Platforms** | Linux · Windows · macOS · Chrome · Edge |
 | **Privacy** | Local Inference = 100% on-device, no API key, no internet |
@@ -149,9 +149,9 @@ audio and microphone together, and everyone follows along.
 
 Run everything on your device — no API keys, no internet, no expensive GPU, complete privacy. Powered by WASM and WebGPU, Sokuji runs efficiently on any modern browser using your existing CPU and integrated graphics.
 
-- **50 ASR models** (32 offline + 10 streaming + 8 WebGPU including Whisper, Cohere Transcribe, Voxtral Mini 4B) covering 99+ languages
-- **55+ translation pairs** via Opus-MT + 5 multilingual LLMs (Qwen 2.5 / 3 / 3.5, GemmaTranslate) with WebGPU
-- **136 TTS voices** across 53 languages (Piper, Piper-Plus, Coqui, Mimic3, Matcha engines)
+- **44 ASR models** (23 offline + 10 streaming + 11 WebGPU including Whisper, Cohere Transcribe, Voxtral, Granite Speech) covering 99+ languages
+- **75 translation models** — 69 Opus-MT language pairs + 6 multilingual LLMs (Qwen 2.5 / 3 / 3.5, Hunyuan-MT 1.5, TranslateGemma) with WebGPU
+- **137 TTS models** across 53 languages (Piper, Piper-Plus, Coqui, Mimic3, Matcha, MMS, VITS, Supertonic engines)
 - One-click model download with IndexedDB caching
 
 ### Cloud Providers
@@ -236,7 +236,7 @@ We welcome contributions! Please read our [Contributing Guidelines](.github/CONT
 - **Cloud APIs**: [OpenAI](https://openai.com), [Google Gemini](https://ai.google.dev), [Volcengine](https://www.volcengine.com)
 - **ASR**: [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx), [OpenAI Whisper](https://github.com/openai/whisper), [SenseVoice](https://github.com/FunAudioLLM/SenseVoice), [Moonshine](https://github.com/usefulsensors/moonshine), [Cohere Transcribe](https://cohere.com), [Voxtral Mini 4B](https://github.com/mistralai)
 - **TTS**: [Piper](https://github.com/rhasspy/piper), [Piper-Plus](https://github.com/ayutaz/piper-plus), [Matcha-TTS](https://github.com/shivammehta25/Matcha-TTS), [Coqui TTS](https://github.com/coqui-ai/TTS), [Mimic 3](https://github.com/MycroftAI/mimic3)
-- **Translation**: [Opus-MT](https://github.com/Helsinki-NLP/Opus-MT), [Qwen](https://github.com/QwenLM/Qwen), [GemmaTranslate](https://github.com/google-research/translate-gemma)
+- **Translation**: [Opus-MT](https://github.com/Helsinki-NLP/Opus-MT), [Qwen](https://github.com/QwenLM/Qwen), [TranslateGemma](https://github.com/google-research/translate-gemma)
 - **Infra**: [Transformers.js](https://github.com/huggingface/transformers.js), [ONNX Runtime](https://github.com/microsoft/onnxruntime), [Electron](https://www.electronjs.org), [React](https://react.dev)
 
 For detailed model licenses, see [THIRD_PARTY_NOTICES.md](THIRD_PARTY_NOTICES.md).

--- a/docs/README.ja.md
+++ b/docs/README.ja.md
@@ -58,7 +58,7 @@ graph LR
 | | |
 |---|---|
 | **プロバイダー** | 9 — OpenAI、Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、Soniox、Zoom AI、OpenAI互換、ローカル推論 |
-| **ローカルモデル** | ASR 50モデル、翻訳 55以上の言語ペア、TTS 136ボイス |
+| **ローカルモデル** | ASR 44モデル、翻訳 75モデル、TTS 137モデル |
 | **言語** | 99以上（音声認識）· 55以上（翻訳）· 53（音声合成） |
 | **プラットフォーム** | Linux · Windows · macOS · Chrome · Edge |
 | **プライバシー** | ローカル推論 = 100%オンデバイス、APIキー不要、インターネット不要 |
@@ -149,9 +149,9 @@ npm run electron:build      # 本番ビルド
 
 すべてをデバイス上で実行 — APIキー不要、インターネット不要、高価なGPU不要、完全なプライバシー。WASMとWebGPUにより、既存のCPUと内蔵グラフィックスで効率的に動作。
 
-- **50 ASRモデル**（オフライン32 + ストリーミング10 + WebGPU 8：Whisper、Cohere Transcribe、Voxtral Mini 4Bを含む）99以上の言語をカバー
-- **55以上の翻訳ペア** Opus-MT + 5つの多言語LLM（Qwen 2.5 / 3 / 3.5、GemmaTranslate）WebGPU対応
-- **136 TTSボイス** 53言語（Piper、Piper-Plus、Coqui、Mimic3、Matchaエンジン）
+- **44 ASRモデル**（オフライン23 + ストリーミング10 + WebGPU 11：Whisper、Cohere Transcribe、Voxtral、Granite Speechを含む）99以上の言語をカバー
+- **75 翻訳モデル** — Opus-MT の69言語ペア + 6つの多言語LLM（Qwen 2.5 / 3 / 3.5、Hunyuan-MT 1.5、TranslateGemma）WebGPU対応
+- **137 TTSモデル** 53言語（Piper、Piper-Plus、Coqui、Mimic3、Matcha、MMS、VITS、Supertonicエンジン）
 - ワンクリックモデルダウンロード、IndexedDBキャッシュ
 
 ### クラウドプロバイダー
@@ -236,7 +236,7 @@ npm run electron:build      # 本番ビルド
 - **クラウドAPI**: [OpenAI](https://openai.com), [Google Gemini](https://ai.google.dev), [Volcengine](https://www.volcengine.com)
 - **ASR**: [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx), [OpenAI Whisper](https://github.com/openai/whisper), [SenseVoice](https://github.com/FunAudioLLM/SenseVoice), [Moonshine](https://github.com/usefulsensors/moonshine), [Cohere Transcribe](https://cohere.com), [Voxtral Mini 4B](https://github.com/mistralai)
 - **TTS**: [Piper](https://github.com/rhasspy/piper), [Piper-Plus](https://github.com/ayutaz/piper-plus), [Matcha-TTS](https://github.com/shivammehta25/Matcha-TTS), [Coqui TTS](https://github.com/coqui-ai/TTS), [Mimic 3](https://github.com/MycroftAI/mimic3)
-- **翻訳**: [Opus-MT](https://github.com/Helsinki-NLP/Opus-MT), [Qwen](https://github.com/QwenLM/Qwen), [GemmaTranslate](https://github.com/google-research/translate-gemma)
+- **翻訳**: [Opus-MT](https://github.com/Helsinki-NLP/Opus-MT), [Qwen](https://github.com/QwenLM/Qwen), [TranslateGemma](https://github.com/google-research/translate-gemma)
 - **インフラ**: [Transformers.js](https://github.com/huggingface/transformers.js), [ONNX Runtime](https://github.com/microsoft/onnxruntime), [Electron](https://www.electronjs.org), [React](https://react.dev)
 
 モデルライセンスの詳細は[THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md)をご参照ください。

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -58,7 +58,7 @@ graph LR
 | | |
 |---|---|
 | **服务商** | 9 — OpenAI、Gemini、Palabra.ai、Kizuna AI、豆包 AST 2.0、Soniox、Zoom AI、OpenAI 兼容、本地推理 |
-| **本地模型** | 50 个 ASR 模型、55+ 翻译语言对、136 个 TTS 语音 |
+| **本地模型** | 44 个 ASR 模型、75 个翻译模型、137 个 TTS 模型 |
 | **语言** | 99+（语音识别）· 55+（翻译）· 53（语音合成） |
 | **平台** | Linux · Windows · macOS · Chrome · Edge |
 | **隐私** | 本地推理 = 100% 设备端运行，无需 API 密钥，无需联网 |
@@ -132,9 +132,9 @@ npm run electron:build      # 生产构建
 
 一切在设备上运行 — 无需 API 密钥，无需联网，无需昂贵的 GPU，完全保护隐私。通过 WASM 和 WebGPU，Sokuji 使用您现有的 CPU 和集成显卡即可高效运行。
 
-- **50 个 ASR 模型**（32 个离线 + 10 个流式 + 8 个 WebGPU，包括 Whisper、Cohere Transcribe、Voxtral Mini 4B）覆盖 99+ 种语言
-- **55+ 翻译语言对** 通过 Opus-MT + 5 个多语言 LLM（Qwen 2.5 / 3 / 3.5、GemmaTranslate）支持 WebGPU
-- **136 个 TTS 语音** 覆盖 53 种语言（Piper、Piper-Plus、Coqui、Mimic3、Matcha 引擎）
+- **44 个 ASR 模型**（23 个离线 + 10 个流式 + 11 个 WebGPU，包括 Whisper、Cohere Transcribe、Voxtral、Granite Speech）覆盖 99+ 种语言
+- **75 个翻译模型** — Opus-MT 的 69 个语言对 + 6 个多语言 LLM（Qwen 2.5 / 3 / 3.5、Hunyuan-MT 1.5、TranslateGemma）支持 WebGPU
+- **137 个 TTS 模型** 覆盖 53 种语言（Piper、Piper-Plus、Coqui、Mimic3、Matcha、MMS、VITS、Supertonic 引擎）
 - 一键模型下载，IndexedDB 缓存
 
 ### 云端服务商
@@ -219,7 +219,7 @@ npm run electron:build      # 生产构建
 - **云端 API**: [OpenAI](https://openai.com), [Google Gemini](https://ai.google.dev), [Volcengine](https://www.volcengine.com)
 - **ASR**: [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx), [OpenAI Whisper](https://github.com/openai/whisper), [SenseVoice](https://github.com/FunAudioLLM/SenseVoice), [Moonshine](https://github.com/usefulsensors/moonshine), [Cohere Transcribe](https://cohere.com), [Voxtral Mini 4B](https://github.com/mistralai)
 - **TTS**: [Piper](https://github.com/rhasspy/piper), [Piper-Plus](https://github.com/ayutaz/piper-plus), [Matcha-TTS](https://github.com/shivammehta25/Matcha-TTS), [Coqui TTS](https://github.com/coqui-ai/TTS), [Mimic 3](https://github.com/MycroftAI/mimic3)
-- **翻译**: [Opus-MT](https://github.com/Helsinki-NLP/Opus-MT), [Qwen](https://github.com/QwenLM/Qwen), [GemmaTranslate](https://github.com/google-research/translate-gemma)
+- **翻译**: [Opus-MT](https://github.com/Helsinki-NLP/Opus-MT), [Qwen](https://github.com/QwenLM/Qwen), [TranslateGemma](https://github.com/google-research/translate-gemma)
 - **基础设施**: [Transformers.js](https://github.com/huggingface/transformers.js), [ONNX Runtime](https://github.com/microsoft/onnxruntime), [Electron](https://www.electronjs.org), [React](https://react.dev)
 
 模型许可证详情请参阅 [THIRD_PARTY_NOTICES.md](../THIRD_PARTY_NOTICES.md)。

--- a/docs/blog/qiita-companion-materials.md
+++ b/docs/blog/qiita-companion-materials.md
@@ -378,7 +378,7 @@ While integrating it into Sokuji (an open-source real-time translation app I wor
 
 Full write-up with working code (Japanese, code is universal): [Qiita link]
 
-Sokuji is MIT-licensed: https://github.com/kizuna-ai-lab/sokuji — implementation lives in `OpenAITranslateGAClient.ts` and `OpenAITranslateWebRTCClient.ts` under `src/services/clients/`.
+Sokuji is AGPL-3.0 licensed: https://github.com/kizuna-ai-lab/sokuji — implementation lives in `OpenAITranslateGAClient.ts` and `OpenAITranslateWebRTCClient.ts` under `src/services/clients/`.
 
 Happy to answer questions about the implementation or real-time voice agent patterns generally.
 ```


### PR DESCRIPTION
## Why

The three READMEs disagreed with each other and all three disagreed with `MODEL_MANIFEST`. `README.md`'s summary table said **48 ASR models** while its own Local Inference section said **50**; `docs/README.ja.md` and `docs/README.zh.md` said 50 in both places. None of them matched the manifest.

These numbers are about to be quoted in outbound press material, so they need to be traceable to the source.

## How the counts were derived

By importing `MODEL_MANIFEST` and counting — not by grepping. Grep over `modelManifest.ts` overcounts, because `type: '...'` strings also appear in the type unions and in comments (grep says 81 translation entries; the actual array has 76).

The two entries flagged `isCloudModel` (`edge-tts`, `bing-translator`) are excluded, since the section these numbers appear in describes on-device inference.

| | before | after |
|---|---|---|
| ASR | 48 / 50 | **44** — 23 offline (WASM) + 10 streaming (WASM) + 11 WebGPU |
| Translation | 55+ pairs | **75 models** — 69 Opus-MT pairs + 6 multilingual LLMs |
| TTS | 136 voices | **137 models** across 53 languages |

## Also fixed, same class of error

- **`136 TTS voices` was mislabelled, not just stale.** 137 is the model count; summing `numSpeakers` gives 1,542 voices. The unit was wrong, so changing the digit alone would not have fixed it. Now reads "TTS models".
- **The multilingual LLM list was missing Hunyuan-MT 1.5** and was stated as 5 when there are 6 (`qwen2.5-0.5b`, `qwen3-0.6b`, `qwen3.5-0.8b`, `qwen3.5-2b`, `hy-mt15-1.8b`, `translategemma-4b`).
- **The WebGPU parenthetical omitted Granite Speech** (2 of the 11 WebGPU ASR entries) and named one specific Voxtral variant when two ship (`Voxtral Mini 3B 2507` and `Voxtral Mini 4B Realtime`). Now says "Voxtral".
- **`GemmaTranslate` → `TranslateGemma`** in the credits of all three READMEs. The upstream project and the link target are both `translate-gemma`. The `GemmaTranslateBackend` occurrences under `docs/superpowers/` are class names and were deliberately left alone.
- **`docs/blog/qiita-companion-materials.md` claimed Sokuji is MIT-licensed.** `LICENSE` and all three READMEs are AGPL-3.0. That file is outward-facing draft copy for a Japanese post, so the wrong licence would have shipped with it.

## Not changed

- The licence statements in the READMEs were already consistent (AGPL-3.0 everywhere) and are untouched.
- The **Languages** row (`99+ / 55+ / 53`) is a language count, not a model count, and is consistent across all three. `99+` for speech recognition is backed — the Whisper entries are literally named `(WebGPU, 99+ languages)`.

## Verification

- Counts produced by importing the manifest through vitest; the scratch test was removed before committing.
- Repo-wide grep for the old figures and for `GemmaTranslate` comes back clean apart from the intentional exclusions noted above.
- Markdown-only diff — no code paths touched.

## Follow-up worth considering (not in this PR)

Nothing pins these numbers, which is why they drifted in the first place. A consistency test that counts `MODEL_MANIFEST` and asserts against the three READMEs would match the pattern already used by `descriptorRegistry.test.ts` and `manifest.consistency.test.ts`. The trade-off is that adding a model would then require editing three READMEs in the same diff — a workflow change, so left out of this PR.

Separately: `docs/README.zh.md` is missing the "Two-Way Translation for Bilingual Meetings" section that EN and JA both have, and its tagline is still the pre-two-way version. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local model counts and coverage details across English, Japanese, and Chinese documentation.
  * Added references to newly supported translation and text-to-speech models and engines.
  * Updated translation acknowledgments to reference TranslateGemma.
  * Corrected the project license description in the Hacker News companion materials to AGPL-3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->