### PR TITLE
fix(macos): grant the audio-input entitlement to hardened-runtime builds (#458)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -365,6 +365,32 @@ jobs:
           codesign --verify --deep --strict "$APP"
           echo "OK: bundle passes strict nested validation."
 
+          # The Hardened Runtime (electron-builder's default, so every
+          # certificate-signed build has it) denies the microphone outright --
+          # no TCC prompt, no error, getUserMedia just rejects -- unless the
+          # bundle carries com.apple.security.device.audio-input. electron-builder's
+          # own entitlements template does not, which is how v0.39.1 shipped with
+          # a microphone that could not be turned on from Finder (#458). Check
+          # every nested bundle: the renderer helper is the process that actually
+          # opens the device.
+          # Captured first, then grepped: under `pipefail` a `codesign | grep -q`
+          # pipeline fails whenever grep matches early and codesign takes the
+          # SIGPIPE, so a passing bundle would be reported as FAIL at random.
+          SIGNATURE=$(codesign -dv "$APP" 2>&1)
+          grep -Eq 'flags=0x[0-9a-f]+\([^)]*runtime' <<<"$SIGNATURE" || {
+            echo "FAIL: the app is not signed with the Hardened Runtime; build.mac.hardenedRuntime drifted." >&2
+            echo "$SIGNATURE" >&2
+            exit 1; }
+          for BUNDLE in "$APP" "$APP"/Contents/Frameworks/*.app; do
+            ENTITLEMENTS=$(codesign -d --entitlements - "$BUNDLE" 2>/dev/null)
+            if ! grep -q 'com.apple.security.device.audio-input' <<<"$ENTITLEMENTS"; then
+              echo "FAIL: $(basename "$BUNDLE") lacks com.apple.security.device.audio-input --" >&2
+              echo "the microphone would be denied with no prompt (#458)." >&2
+              exit 1
+            fi
+          done
+          echo "OK: Hardened Runtime with the audio-input entitlement on every bundle."
+
           # MacUpdater installs the zip and nothing else -- it rejects pkg and dmg
           # outright -- and only the zip target emits latest-mac.yml plus the
           # blockmap. Missing either one leaves auto-update dead with a green build.

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -939,9 +939,13 @@ it has since been run. Two scripts reproduce it:
   `setup <arm>` builds and installs v1, `swap <arm>` replaces it with v2 and
   prints the log; run it for both the `selfsigned` and `adhoc` arms and compare.
   `cleanup` removes the test apps, the TCC entries and the throwaway keychain.
+- `scripts/verify-macos-hardened-mic.sh` — test 7, added 2026-08-31 after #458.
+  Headless (ad-hoc signed, no keychain needed); the `ent` arm leaves a real
+  microphone dialog on screen for a minute.
 
 | # | What it decides | Result |
 |---|---|---|
+| 7 | Does the Hardened Runtime deny the microphone with no prompt unless `com.apple.security.device.audio-input` is present? (2026-08-31) | **YES** — without it `requestAccess` returned in 0.00 s with `granted=0`, status `denied`, no dialog, and tccd logged "requires entitlement com.apple.security.device.audio-input but it is missing … Policy disallows prompt"; with it, tccd logged `AUTHREQ_PROMPTING` and the dialog appeared. Reproduced on the installed 0.39.1 (`Microphone permission status: not-determined` → `granted: false` with no dialog) and on a branch build with `electron/entitlements.mac.plist`, launched through `open`, which prompted |
 | 1 | Does TCC keep the microphone grant across a re-sign? | **PASS** — self-signed v2 launched already `AUTHORIZED` with no dialog; the ad-hoc control arm was prompted again (§2.5c) |
 | 2 | Can a write-disabled bundle in `/Applications` be renamed? | **PASS** — yes, so `rename(2)`'s CONFORMANCE clause does not bite on APFS here. The root-owned variant still needs a passworded sudo; see the caveat below |
 | 3 | Is the self-signed DR stable, and does build N+1 satisfy build N's DR? | **PASS** — identical DR, `-R` check rc=0, ad-hoc control correctly fails |

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -283,13 +283,27 @@ https://github.com/electron-userland/electron-builder/blob/master/packages/elect
     whether the app may record audio using the built-in microphone and access
     audio input using Core Audio."
     — https://developer.apple.com/documentation/bundleresources/entitlements/com.apple.security.device.audio-input
-- `@electron/osx-sign` (used by both Forge's `osxSign` and electron-builder)
-  already ships default entitlements covering this:
-  `entitlements/default.darwin.plist` contains `com.apple.security.cs.allow-jit`
-  and `com.apple.security.device.audio-input` (plus camera, bluetooth, etc.).
-  — https://github.com/electron/osx-sign/blob/main/entitlements/default.darwin.plist
-  So no custom entitlements file is strictly needed to start; trimming the
-  defaults to just JIT + audio-input is optional hygiene.
+- `@electron/osx-sign` ships default entitlements that *would* cover this
+  (`entitlements/default.darwin.plist` has `allow-jit` and `device.audio-input`,
+  plus camera, bluetooth, etc.
+  — https://github.com/electron/osx-sign/blob/main/entitlements/default.darwin.plist),
+  **but electron-builder does not use them.** It hands osx-sign its own
+  `app-builder-lib/templates/entitlements.mac.plist` — `allow-jit`,
+  `allow-unsigned-executable-memory`, `disable-library-validation`, nothing
+  else — for the app and every helper, unless `mac.entitlements` /
+  `mac.entitlementsInherit` say otherwise (`MacTargetHelper.getOptionsForFile`).
+  An earlier revision of this section assumed the osx-sign defaults applied,
+  and the hardware tests in §6 signed with bare `codesign` (no
+  `--options runtime`), so neither caught it: v0.39.1, the first
+  certificate-signed release, shipped with the Hardened Runtime and no
+  audio-input entitlement (verified on the release zip: `flags=0x10000(runtime)`,
+  three entitlements), and from Finder the microphone was denied with no prompt
+  at all — #458. From a terminal it worked, because TCC attributes the request
+  to the already-granted Terminal. Sokuji now ships
+  `electron/entitlements.mac.plist` (the three template entitlements plus
+  `device.audio-input`) for app and helpers alike, pinned by
+  `electron/macos-entitlements.consistency.test.js` and verified on the signed
+  artifact in `build.yml`.
 - TCC prompt text: microphone access also needs `NSMicrophoneUsageDescription`
   in `Info.plist`. Sokuji's Forge/electron-builder configs do not set one
   (`grep NSMicrophoneUsageDescription` finds nothing in `forge.config.js` /

--- a/electron/entitlements.mac.plist
+++ b/electron/entitlements.mac.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <!--
+    Entitlements for every certificate-signed macOS bundle, the app and its
+    helpers alike (package.json: build.mac.entitlements / entitlementsInherit).
+    Ad-hoc local builds (scripts/electron-builder-fuses.js) are not signed with
+    the Hardened Runtime and never read this file.
+
+    The first three are what electron-builder's own default template grants;
+    Electron does not start under the Hardened Runtime without them.
+
+    The last one is why this file exists. Under the Hardened Runtime the
+    microphone is denied silently - no TCC prompt, no error - unless the bundle
+    asks for it here, and electron-builder's template does not ask (#458).
+    Pinned by electron/macos-entitlements.consistency.test.js and checked on
+    the signed artifact in .github/workflows/build.yml.
+  -->
+  <dict>
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+    <true/>
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
+  </dict>
+</plist>

--- a/electron/macos-entitlements.consistency.test.js
+++ b/electron/macos-entitlements.consistency.test.js
@@ -1,0 +1,69 @@
+// electron/macos-entitlements.consistency.test.js
+//
+// Every certificate-signed macOS build is signed with the Hardened Runtime
+// (electron-builder's default), and under the Hardened Runtime the microphone
+// is denied outright -- no TCC prompt, no error, getUserMedia simply rejects --
+// unless the bundle carries com.apple.security.device.audio-input.
+// electron-builder's built-in entitlements template does not carry it, so the
+// moment #449 moved the release from an ad-hoc signature to a real signing
+// identity, v0.39.1 shipped with a microphone that could not be turned on from
+// Finder (#458). Nothing in the build noticed: electron-builder logs nothing
+// about entitlements, and the CI signature check only looked at the designated
+// requirement.
+//
+// This pins the packaging half: package.json must point electron-builder at our
+// own plist for the app AND its helpers (the renderer helper is the process
+// that actually opens the device), and that plist must carry the audio-input
+// entitlement on top of the three the default template provides, without which
+// Electron does not launch at all. The signed artifact itself is checked in
+// .github/workflows/build.yml ("Verify the macOS update artifacts").
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const electronDir = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(electronDir, '..');
+const mac = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8')).build.mac;
+
+/** Keys set to <true/> in a plist, read as text -- there is no plist parser in the tree. */
+function trueKeys(plistPath) {
+  const xml = readFileSync(plistPath, 'utf8');
+  const keys = new Set([...xml.matchAll(/<key>([^<]+)<\/key>\s*<true\s*\/>/g)].map(([, key]) => key));
+  if (keys.size === 0) throw new Error(`no <key>...</key><true/> pairs found in ${plistPath}`);
+  return keys;
+}
+
+// What app-builder-lib/templates/entitlements.mac.plist provides. Replacing the
+// template must not drop these: without them the signed app does not start.
+const ELECTRON_BUILDER_DEFAULTS = [
+  'com.apple.security.cs.allow-jit',
+  'com.apple.security.cs.allow-unsigned-executable-memory',
+  'com.apple.security.cs.disable-library-validation',
+];
+const MICROPHONE = 'com.apple.security.device.audio-input';
+
+describe('macOS signing entitlements (#458)', () => {
+  it("names the hardened runtime instead of inheriting electron-builder's default", () => {
+    // The default is already `true`; saying so keeps the entitlement below
+    // visibly tied to the reason it is needed.
+    expect(mac.hardenedRuntime).toBe(true);
+  });
+
+  it('hands electron-builder its own entitlements for the app and every helper', () => {
+    // `entitlements` / `entitlementsInherit` go to @electron/osx-sign as-is and
+    // resolve against the cwd -- the repo root, both in CI and under
+    // `npm run make:pkg` -- unlike `pkg.scripts`, which is buildResources-relative.
+    expect(typeof mac.entitlements).toBe('string');
+    expect(existsSync(path.join(repoRoot, mac.entitlements))).toBe(true);
+    expect(mac.entitlementsInherit).toBe(mac.entitlements);
+  });
+
+  it('grants microphone access on top of what Electron needs to launch', () => {
+    const keys = trueKeys(path.join(repoRoot, mac.entitlements));
+    expect(keys.has(MICROPHONE)).toBe(true);
+    for (const key of ELECTRON_BUILDER_DEFAULTS) {
+      expect(keys.has(key), key).toBe(true);
+    }
+  });
+});

--- a/electron/main.js
+++ b/electron/main.js
@@ -523,7 +523,10 @@ app.whenReady().then(async () => {
   // Create the application menu
   createApplicationMenu();
 
-  // Request microphone permission on macOS before creating window
+  // Request microphone permission on macOS before creating window. Under the
+  // Hardened Runtime this prompt (and the renderer's getUserMedia) is denied
+  // with no dialog at all unless the bundle carries the audio-input
+  // entitlement -- see electron/entitlements.mac.plist (#458).
   if (process.platform === 'darwin') {
     const micStatus = systemPreferences.getMediaAccessStatus('microphone');
     console.log('[Sokuji] [Main] Microphone permission status:', micStatus);

--- a/package.json
+++ b/package.json
@@ -84,6 +84,9 @@
       "category": "public.app-category.utilities",
       "icon": "assets/icon.icns",
       "identity": "Sokuji Code Signing",
+      "hardenedRuntime": true,
+      "entitlements": "electron/entitlements.mac.plist",
+      "entitlementsInherit": "electron/entitlements.mac.plist",
       "notarize": false
     },
     "pkg": {

--- a/scripts/verify-macos-hardened-mic.sh
+++ b/scripts/verify-macos-hardened-mic.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+# Hardware test: does the Hardened Runtime deny the microphone with no prompt
+# unless com.apple.security.device.audio-input is present? (#458)
+#
+# Two arms, same code, same signature type, both signed with --options runtime:
+#   noent : electron-builder's default entitlements (what v0.39.1 shipped with)
+#   ent   : the same three plus com.apple.security.device.audio-input (the fix)
+#
+# Each arm is launched through LaunchServices (`open`), the same path as a
+# Finder launch, and writes the AVFoundation authorization status before and
+# after requestAccess to its own log. Measured on macOS 26.6.1 (arm64),
+# 2026-08-31, ad-hoc identity:
+#   noent : "request returned after 0.00s granted=0 after=2 (denied)", no dialog;
+#           tccd: "Prompting policy for hardened runtime; service:
+#           kTCCServiceMicrophone requires entitlement
+#           com.apple.security.device.audio-input but it is missing ...
+#           Policy disallows prompt ... access to kTCCServiceMicrophone denied"
+#   ent   : the system dialog appears (tccd: AUTHREQ_PROMPTING,
+#           service=kTCCServiceMicrophone) and requestAccess blocks on it.
+#
+# The identity is irrelevant to the entitlement check, so ad-hoc ("-") is the
+# default: it needs no keychain, which an ssh session cannot unlock anyway.
+# Pass IDENTITY="Some Cert" to sign with a real one.
+#
+#   bash scripts/verify-macos-hardened-mic.sh
+#
+# Needs the Xcode command line tools (clang). Leaves nothing behind except the
+# work directory it names at the end.
+set -uo pipefail
+
+IDENTITY="${IDENTITY:--}"
+WORK="$HOME/.hardened-mic-ab"
+WAIT="${WAIT:-8}"
+rm -rf "$WORK"; mkdir -p "$WORK"
+
+write_entitlements() { # $1 = path, $2 = with-audio-input (0/1)
+  {
+    echo '<?xml version="1.0" encoding="UTF-8"?>'
+    echo '<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">'
+    echo '<plist version="1.0"><dict>'
+    echo '  <key>com.apple.security.cs.allow-jit</key><true/>'
+    echo '  <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>'
+    echo '  <key>com.apple.security.cs.disable-library-validation</key><true/>'
+    [ "$2" = 1 ] && echo '  <key>com.apple.security.device.audio-input</key><true/>'
+    echo '</dict></plist>'
+  } > "$1"
+}
+
+build_app() { # $1 = arm
+  local arm="$1" app="$WORK/HRTest-$1.app" bid="ai.kizunaai.hrtest.$1" name="HRTest-$1"
+  mkdir -p "$app/Contents/MacOS"
+  cat > "$WORK/main-$arm.m" <<EOF
+#import <Foundation/Foundation.h>
+#import <AVFoundation/AVFoundation.h>
+static const char *label(long s) {
+  return s == 0 ? "notDetermined" : s == 1 ? "restricted" : s == 2 ? "denied" : "authorized";
+}
+static void append(NSString *log, NSString *line) {
+  NSFileHandle *fh = [NSFileHandle fileHandleForWritingAtPath:log];
+  if (!fh) { [[NSFileManager defaultManager] createFileAtPath:log contents:nil attributes:nil];
+             fh = [NSFileHandle fileHandleForWritingAtPath:log]; }
+  [fh seekToEndOfFile];
+  [fh writeData:[line dataUsingEncoding:NSUTF8StringEncoding]];
+  [fh closeFile];
+}
+int main(void) {
+  @autoreleasepool {
+    NSString *log = @"$WORK/$arm.log";
+    long before = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    append(log, [NSString stringWithFormat:@"before=%ld (%s)\n", before, label(before)]);
+    NSDate *t0 = [NSDate date];
+    __block BOOL granted = NO;
+    dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [AVCaptureDevice requestAccessForMediaType:AVMediaTypeAudio
+                             completionHandler:^(BOOL g) { granted = g; dispatch_semaphore_signal(sem); }];
+    long rc = dispatch_semaphore_wait(sem, dispatch_time(DISPATCH_TIME_NOW, 600ull * NSEC_PER_SEC));
+    long after = [AVCaptureDevice authorizationStatusForMediaType:AVMediaTypeAudio];
+    append(log, [NSString stringWithFormat:@"request %s after %.2fs granted=%d after=%ld (%s)\n",
+                 rc == 0 ? "returned" : "TIMED OUT", -[t0 timeIntervalSinceNow], (int)granted, after, label(after)]);
+  }
+  return 0;
+}
+EOF
+  xcrun clang -fobjc-arc -o "$app/Contents/MacOS/$name" "$WORK/main-$arm.m" \
+    -framework Foundation -framework AVFoundation || return 1
+  cat > "$app/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+  <key>CFBundleExecutable</key><string>$name</string>
+  <key>CFBundleIdentifier</key><string>$bid</string>
+  <key>CFBundleName</key><string>$name</string>
+  <key>CFBundlePackageType</key><string>APPL</string>
+  <key>CFBundleShortVersionString</key><string>1.0</string>
+  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>NSMicrophoneUsageDescription</key><string>Sokuji #458 hardened-runtime A/B ($arm).</string>
+  <key>LSMinimumSystemVersion</key><string>11.0</string>
+</dict></plist>
+EOF
+}
+
+run_arm() { # $1 = arm, $2 = with-audio-input
+  local arm="$1" app="$WORK/HRTest-$1.app" bid="ai.kizunaai.hrtest.$1"
+  echo "=== arm: $arm ==="
+  build_app "$arm" || { echo "build failed"; return 1; }
+  write_entitlements "$WORK/$arm.entitlements.plist" "$2"
+  codesign --force --options runtime --entitlements "$WORK/$arm.entitlements.plist" \
+    --sign "$IDENTITY" "$app" 2>&1 | sed 's/^/  codesign: /'
+  echo "  signature: $(codesign -dv "$app" 2>&1 | grep -E '^CodeDirectory' | head -1)"
+  echo "  entitlements: $(codesign -d --entitlements - "$app" 2>/dev/null | grep '\[Key\]' | sed 's/.*\[Key\] //' | tr '\n' ' ')"
+  # "No such bundle identifier" here just means TCC has never seen this arm.
+  tccutil reset Microphone "$bid" 2>&1 | sed 's/^/  tccutil: /'
+  rm -f "$WORK/$arm.log"
+  open -a "$app" || { echo "  open failed"; return 1; }
+  sleep "$WAIT"
+  echo "  --- $arm.log after ${WAIT}s ---"
+  sed 's/^/    /' "$WORK/$arm.log" 2>/dev/null || echo "    (no log written yet)"
+  echo "  --- process still running? ---"
+  pgrep -fl "HRTest-$arm" | sed 's/^/    /' || echo "    (exited)"
+}
+
+run_arm noent 0
+run_arm ent 1
+
+echo
+echo "=== tccd log (last 2 minutes, hrtest only) ==="
+log show --last 2m --predicate 'process == "tccd"' --style compact 2>/dev/null \
+  | grep -i "hrtest" | grep -i "PROMPTING\|disallows\|requires entitlement\|denied" | cut -c1-220 | tail -6 | sed 's/^/  /'
+
+echo
+echo "=== leaving the 'ent' dialog on screen for 60s so it can be answered, then cleaning up ==="
+sleep 60
+sed 's/^/  ent.log final: /' "$WORK/ent.log" 2>/dev/null
+pkill -f "HRTest-ent" 2>/dev/null
+pkill -f "HRTest-noent" 2>/dev/null
+tccutil reset Microphone ai.kizunaai.hrtest.noent >/dev/null 2>&1
+tccutil reset Microphone ai.kizunaai.hrtest.ent >/dev/null 2>&1
+echo "done (work dir kept at $WORK)"

--- a/src/lib/diagnostics/consoleLedger.consistency.test.ts
+++ b/src/lib/diagnostics/consoleLedger.consistency.test.ts
@@ -164,7 +164,7 @@ const LEDGER: Record<string, number> = {
   'src/lib/modern-audio/ModernBrowserAudioService.ts': 29,
   'src/lib/modern-audio/WebRTCAudioBridge.ts': 10,
   'src/lib/modern-audio/AppAudioRecorder.ts': 9,
-  'src/lib/modern-audio/ModernAudioRecorder.ts': 9,
+  'src/lib/modern-audio/ModernAudioRecorder.ts': 8,
   'src/lib/analytics.ts': 6,
   'src/lib/modern-audio/LoopbackRecorder.ts': 6,
   'src/lib/modern-audio/BaseAudioRecorder.ts': 2,

--- a/src/lib/modern-audio/ModernAudioRecorder.test.ts
+++ b/src/lib/modern-audio/ModernAudioRecorder.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { ModernAudioRecorder } from './ModernAudioRecorder';
+
+const getUserMedia = vi.fn();
+
+beforeEach(() => {
+  getUserMedia.mockReset();
+  Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+    configurable: true,
+    value: { getUserMedia },
+  });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+/** What getUserMedia rejects with: a DOMException, which carries its kind in `name`. */
+const captureFailure = (name: string, message = 'capture failed') =>
+  Object.assign(new Error(message), { name });
+
+describe('ModernAudioRecorder.begin — a capture that fails is an error, not `false` (#458)', () => {
+  // The old contract returned `false` and left the caller to find out from
+  // record()'s "please call .begin() first" -- which is exactly what a user
+  // whose microphone macOS had silently denied got to read.
+  it('rejects with a permission message when the microphone is blocked', async () => {
+    getUserMedia.mockRejectedValue(captureFailure('NotAllowedError', 'Permission denied'));
+    const rec = new ModernAudioRecorder();
+
+    await expect(rec.begin('mic-1')).rejects.toThrow(/microphone access is blocked/i);
+    expect(rec.getStatus()).toBe('ended');
+  });
+
+  it('keeps the original failure as the cause and names its kind in the message', async () => {
+    const cause = captureFailure('NotAllowedError', 'Permission denied');
+    getUserMedia.mockRejectedValue(cause);
+    const rec = new ModernAudioRecorder();
+
+    const error = await rec.begin('mic-1').catch((e: unknown) => e);
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error & { cause?: unknown }).cause).toBe(cause);
+    expect((error as Error).message).toContain('NotAllowedError');
+  });
+
+  it('points at the OS privacy settings in Electron, at site permissions elsewhere', async () => {
+    getUserMedia.mockRejectedValue(captureFailure('NotAllowedError'));
+
+    const browser = await new ModernAudioRecorder().begin('mic-1').catch((e: Error) => e.message);
+    expect(browser).toMatch(/site permissions/i);
+
+    vi.stubGlobal('electronAPI', {});
+    const electron = await new ModernAudioRecorder().begin('mic-1').catch((e: Error) => e.message);
+    expect(electron).toMatch(/Privacy & Security/);
+  });
+
+  it('tells a vanished device apart from a busy one', async () => {
+    getUserMedia.mockRejectedValue(captureFailure('NotFoundError'));
+    await expect(new ModernAudioRecorder().begin('gone')).rejects.toThrow(/no longer available/i);
+
+    getUserMedia.mockRejectedValue(captureFailure('NotReadableError'));
+    await expect(new ModernAudioRecorder().begin('busy')).rejects.toThrow(/in use/i);
+  });
+
+  it('releases a stream it did acquire when a later step fails', async () => {
+    const stop = vi.fn();
+    const track = { stop, getSettings: () => ({ echoCancellation: true }) };
+    getUserMedia.mockResolvedValue({ getAudioTracks: () => [track], getTracks: () => [track] });
+    vi.stubGlobal('AudioContext', class {
+      constructor() { throw new Error('no audio output hardware'); }
+    });
+    const rec = new ModernAudioRecorder();
+
+    await expect(rec.begin('mic-1')).rejects.toThrow(/no audio output hardware/);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(rec.getStatus()).toBe('ended');
+    // A retry must start from a clean slate, not trip "Already connected".
+    getUserMedia.mockRejectedValue(captureFailure('NotAllowedError'));
+    await expect(rec.begin('mic-1')).rejects.toThrow(/microphone access is blocked/i);
+  });
+});

--- a/src/lib/modern-audio/ModernAudioRecorder.ts
+++ b/src/lib/modern-audio/ModernAudioRecorder.ts
@@ -1,4 +1,5 @@
 import { BaseAudioRecorder } from './BaseAudioRecorder';
+import { MicrophoneCaptureError } from './microphoneCaptureError';
 import { DEBUG_CONFIG, AUDIO_CONSTRAINT_PROFILES } from '../config/performance.js';
 
 // Vite ?url imports for AudioWorklet and WASM assets
@@ -249,8 +250,40 @@ export class ModernAudioRecorder extends BaseAudioRecorder {
 
       return true;
     } catch (err) {
-      console.error(`${this.getLogPrefix()} Could not start audio recording`, err);
-      return false;
+      // Whatever was acquired before the failure -- a live capture stream, an
+      // AudioContext, half a processing graph -- is released so the next
+      // attempt starts clean, and the failure is THROWN. Returning `false` here
+      // left the caller to trip over record()'s "please call .begin() first",
+      // which is what a user whose microphone macOS had silently denied got to
+      // read (#458). No console line of its own: the session-start path reports
+      // the error once, with this `cause` attached.
+      await this.abortBegin();
+      throw new MicrophoneCaptureError(err);
+    }
+  }
+
+  /**
+   * Undo a `begin()` that failed part-way. Mirrors the teardown in `end()`,
+   * minus the save: nothing was recorded. Best effort -- the failure that got
+   * us here is the one worth surfacing, not a hiccup while cleaning up.
+   */
+  private async abortBegin(): Promise<void> {
+    try {
+      this.mediaRecorder = null;
+      if (this.rnnoiseNode) {
+        this.rnnoiseNode.disconnect();
+        this.rnnoiseNode.destroy();
+        this.rnnoiseNode = null;
+      }
+      this.rnnoiseModuleLoaded = false;
+      this._disconnectGtcrnWorker();
+      if (this.analyser) {
+        this.analyser.disconnect();
+        this.analyser = null;
+      }
+      await this.cleanup();
+    } catch {
+      // See above.
     }
   }
 

--- a/src/lib/modern-audio/microphoneCaptureError.ts
+++ b/src/lib/modern-audio/microphoneCaptureError.ts
@@ -1,0 +1,55 @@
+import { isElectron } from '../../utils/environment';
+import { describeCause } from '../diagnostics/describeCause';
+
+/** The DOMException kind, when the caught value carries one. */
+function kindOf(cause: unknown): string {
+  if (typeof cause === 'object' && cause !== null) {
+    const name = (cause as { name?: unknown }).name;
+    if (typeof name === 'string') return name;
+  }
+  return '';
+}
+
+/**
+ * One sentence a user can act on for a failed microphone capture, keyed on the
+ * DOMException kind getUserMedia rejects with. The kind stays in the text so a
+ * pasted LogsPanel line still says which one it was.
+ *
+ * The permission case matters most: in Electron there is no per-site prompt,
+ * so a NotAllowedError means the OS itself said no -- and on macOS it can say
+ * no without ever having asked (#458), so the only fix is the privacy pane.
+ */
+export function describeMicrophoneFailure(cause: unknown): string {
+  const kind = kindOf(cause);
+  switch (kind) {
+    case 'NotAllowedError':
+    case 'PermissionDeniedError':
+    case 'SecurityError':
+      return isElectron()
+        ? `Microphone access is blocked (${kind}). Allow Sokuji to use the microphone in your system's privacy settings (macOS: System Settings › Privacy & Security › Microphone), then start again.`
+        : `Microphone access is blocked (${kind}). Allow the microphone for Sokuji in your browser's site permissions, then start again.`;
+    case 'NotFoundError':
+    case 'OverconstrainedError':
+      return `The selected microphone is no longer available (${kind}). Choose another input device and start again.`;
+    case 'NotReadableError':
+    case 'AbortError':
+      return `The microphone could not be opened (${kind}); it may be in use by another application.`;
+    default:
+      return `Could not start the microphone: ${describeCause(cause)}`;
+  }
+}
+
+/**
+ * Thrown by `ModernAudioRecorder.begin()` when capture cannot start. The
+ * original rejection rides along as `cause` for the console; the message is
+ * what reaches the user through the session-start failure path.
+ */
+export class MicrophoneCaptureError extends Error {
+  readonly cause: unknown;
+
+  constructor(cause: unknown) {
+    super(describeMicrophoneFailure(cause));
+    this.name = 'MicrophoneCaptureError';
+    this.cause = cause;
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,25 @@
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { searchForWorkspaceRoot } from 'vite'
 import { defineConfig, configDefaults } from 'vitest/config'
 import react from '@vitejs/plugin-react'
 
+// The node_modules Node actually resolves against. From the main checkout that
+// is ./node_modules; from a worktree under .claude/worktrees/ it is the main
+// checkout's, three directories up, which vite's default `server.fs.allow`
+// (the workspace root) does not cover -- so every `?url` asset import there
+// failed with "Denied ID .../node_modules/..." and a dozen test files were
+// unrunnable from a worktree.
+const require = createRequire(import.meta.url)
+const nodeModulesInUse = path.resolve(path.dirname(require.resolve('vite/package.json')), '..')
+
 export default defineConfig({
   plugins: [react()],
+  server: {
+    fs: {
+      allow: [searchForWorkspaceRoot(process.cwd()), nodeModulesInUse],
+    },
+  },
   test: {
     globals: true,
     environment: 'jsdom',


### PR DESCRIPTION
Fixes #458.

## What was wrong

Since #449 the macOS release is signed with a real identity, and with it electron-builder's default **Hardened Runtime**. Under the Hardened Runtime the microphone is denied outright — no TCC prompt, no error, `getUserMedia` simply rejects — unless the bundle carries `com.apple.security.device.audio-input`. electron-builder does not hand `@electron/osx-sign` its defaults (which do carry it); it passes its own `templates/entitlements.mac.plist` — `allow-jit`, `allow-unsigned-executable-memory`, `disable-library-validation`, nothing else — to the app and every helper.

So v0.39.1, the first certificate-signed release, shipped with `flags=0x10000(runtime)` and those three entitlements on both the app and the renderer helper (read off the release zip), and from Finder the microphone never worked: the app never appeared under Privacy & Security › Microphone because macOS never asked. From a terminal it worked, because TCC attributes the request to the already-granted Terminal — which is what made the report look like a permission mix-up instead of a packaging one.

tccd says it verbatim (measured on macOS 26.6.1 with the installed 0.39.1, launched through `open`):

```
Prompting policy for hardened runtime; service: kTCCServiceMicrophone requires entitlement
com.apple.security.device.audio-input but it is missing for requesting={… ai.kizunaai.sokuji …}
Policy disallows prompt for Sub:{ai.kizunaai.sokuji} …; access to kTCCServiceMicrophone denied
```

and main.js's own log: `Microphone permission status: not-determined` → `Microphone permission granted: false`, immediately.

The text the user saw, "Session ended: please call .begin() first", was a second defect: `ModernAudioRecorder.begin()` caught the `NotAllowedError`, logged it to the console and returned `false`; `startRecording()` never checked and went straight on to `record()`.

## What changes

- **`electron/entitlements.mac.plist`** — the three template entitlements plus `audio-input`, wired as `build.mac.entitlements` **and** `entitlementsInherit` (the renderer helper is the process that opens the device), with `hardenedRuntime: true` named explicitly.
- **`electron/macos-entitlements.consistency.test.js`** pins the config and the plist; the CI "Verify the macOS update artifacts" step now reads the entitlements back off every signed bundle and asserts the runtime flag (captured-then-grepped — under `pipefail` a `codesign | grep -q` pipeline fails at random when grep matches early).
- **`ModernAudioRecorder.begin()`** releases whatever it acquired and throws `MicrophoneCaptureError` — "Microphone access is blocked (NotAllowedError). Allow Sokuji to use the microphone in your system's privacy settings…" — with the original rejection as `cause`. The session-start path already reports it once through `onConnectFailed`; the console line goes and the ledger row drops 9 → 8.
- **`vitest.config.ts`** adds the node_modules Node actually resolves against to `server.fs.allow`, so a suite run from a worktree under `.claude/worktrees/` no longer fails ~12 files with "Denied ID …/node_modules/…" (315 files / 3604 tests now pass clean from a worktree).
- **docs/build/macos-auto-update.md** §2.3 corrected (it had assumed the osx-sign defaults applied; the §6 hardware tests signed with bare `codesign`, so neither caught this) and §6 gets row 7 with `scripts/verify-macos-hardened-mic.sh`.

## Verified on hardware (macOS 26.6.1, arm64)

| | without `audio-input` | with `audio-input` |
|---|---|---|
| Minimal AVFoundation app, ad-hoc + `--options runtime` | `requestAccess` returned in 0.00 s, `granted=0`, status `denied`, no dialog | tccd `AUTHREQ_PROMPTING`, dialog shown, request pending |
| Real app through `open` (LaunchServices, same path as Finder) | installed 0.39.1: `not-determined` → `granted: false`, tccd "requires entitlement … missing" | this branch, built with electron-builder (ad-hoc identity): `not-determined`, then the microphone dialog |

The branch build carries `audio-input` on `Sokuji.app` and all four helpers with `flags=0x10002(adhoc,runtime)`; the exact CI assertion text was run against it under `set -euo pipefail` (passes) and against the installed 0.39.1 (fails, as it should). This PR's own macOS CI job signs with the real certificate and runs the same assertion.

## Not in this PR

- An app-specific `NSMicrophoneUsageDescription` via `extendInfo` (the prompt currently shows Electron's default string).
- tccd also logs `kTCCServiceAppleEvents requires entitlement com.apple.security.automation.apple-events` at every launch (an `osascript` call in startup, denied on both 0.39.1 and this branch); no user-visible effect found, left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved microphone capture failures with clearer, actionable error messages.
  * Ensured partially initialized recording resources are cleaned up after capture failures.
  * Fixed macOS microphone access for hardened, signed app builds.

* **Tests**
  * Added coverage for microphone permissions, device errors, retries, cleanup, and macOS signing entitlements.
  * Strengthened macOS artifact verification and microphone authorization checks.

* **Documentation**
  * Updated macOS build documentation with entitlement requirements and hardware verification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->