### PR TITLE
fix(gemini): exclude transcribe models from the realtime model list

### DIFF
--- a/src/services/clients/GeminiClient.test.ts
+++ b/src/services/clients/GeminiClient.test.ts
@@ -918,3 +918,50 @@ describe('GeminiClient — Live Translate silence segmentation', () => {
     expect(itemsOf('assistant')[0].status).toBe('completed');
   });
 });
+
+// ─────────────────────────────────────────────
+describe('GeminiClient — model filtering', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  function stubModelsEndpoint(models: Array<{ name: string; version: string }>) {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: true,
+      json: async () => ({ models }),
+    })));
+  }
+
+  it('keeps dialogue and live-translate models but excludes transcribe models', async () => {
+    stubModelsEndpoint([
+      { name: 'models/gemini-2.5-flash-native-audio-preview-09-2025', version: '09-2025' },
+      { name: 'models/gemini-3.5-live-translate-preview', version: '3.5' },
+      // STT-only models: transcribe-live matches the "live" substring but has
+      // no translation or audio output, so a session on it silently breaks.
+      { name: 'models/gemini-3.5-transcribe-live', version: '3.5' },
+      { name: 'models/gemini-3.5-transcribe', version: '3.5' },
+      { name: 'models/gemini-2.5-pro', version: '2.5' },
+    ]);
+
+    const { models } = await GeminiClient.validateApiKeyAndFetchModels('test-key');
+    const ids = models.map(m => m.id);
+
+    expect(ids).toContain('gemini-2.5-flash-native-audio-preview-09-2025');
+    expect(ids).toContain('gemini-3.5-live-translate-preview');
+    expect(ids).not.toContain('gemini-3.5-transcribe-live');
+    expect(ids).not.toContain('gemini-3.5-transcribe');
+  });
+
+  it('does not count transcribe-live as the realtime model that validates a key', async () => {
+    stubModelsEndpoint([
+      { name: 'models/gemini-3.5-transcribe-live', version: '3.5' },
+      { name: 'models/gemini-2.5-pro', version: '2.5' },
+    ]);
+
+    const { validation, models } = await GeminiClient.validateApiKeyAndFetchModels('test-key');
+
+    expect(models).toEqual([]);
+    expect(validation.valid).toBe(false);
+  });
+});

--- a/src/services/clients/GeminiClient.ts
+++ b/src/services/clients/GeminiClient.ts
@@ -165,7 +165,15 @@ export class GeminiClient implements IClient {
    */
   private static isRealtimeCapableModel(model: any): boolean {
     const modelName = model.name?.toLowerCase() || '';
-    
+
+    // STT-only transcription models (gemini-3.5-transcribe-live) carry "live"
+    // in the name but require TEXT response modality and produce no
+    // translation or audio output — a dialogue session on them silently
+    // yields no translated audio.
+    if (modelName.includes('transcribe')) {
+      return false;
+    }
+
     // Check for models with "audio" or "live" in the name
     return modelName.includes('audio') || modelName.includes('live');
   }


### PR DESCRIPTION
## Summary

Google shipped **Gemini 3.5 Transcribe** on 2026-08-26. Its streaming variant `gemini-3.5-transcribe-live` carries `live` in the name, so the substring filter in `GeminiClient.isRealtimeCapableModel` (`includes('audio') || includes('live')`) would admit it into the Gemini model dropdown as a realtime dialogue model once Google lists it on the `models.list` endpoint.

It is STT-only: the Live API requires TEXT response modality for it, and it produces no translation and no audio output — a Sokuji session on it connects and then silently yields nothing. Worse, the created-date fallback (`Date.now()` when the version string has no `MM-DD`) could sort it to the top, where `getLatestRealtimeModel` auto-picks it as the default model.

This PR filters out any model whose name contains `transcribe` before the `audio`/`live` check. That covers both paths that share the predicate:

- `filterRelevantModels` — the model dropdown no longer lists transcribe models
- `checkRealtimeModelAvailability` — a key whose only "live" model is `gemini-3.5-transcribe-live` no longer validates as having a realtime model

`gemini-3.5-live-translate-preview` (Live Translate) is unaffected: `translate` ≠ `transcribe`, and the new tests pin that.

## Test plan

- New: `GeminiClient — model filtering` (2 tests), written first and watched fail against the old filter
  - keeps dialogue + live-translate models, excludes `gemini-3.5-transcribe` and `gemini-3.5-transcribe-live`
  - a key whose only live model is `transcribe-live` fails realtime validation
- Full suite: 315 files / 3606 tests pass (the 4 unhandled rejections from `settingsStore.nativeGate.test.ts` are pre-existing on main and untouched by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemini model selection by excluding transcription-only models from realtime dialogue options.
  * Preserved support for eligible audio and live interaction models.
  * API key validation now correctly reports invalid when only transcription-only models are available.

* **Tests**
  * Added coverage for filtering supported and unsupported Gemini models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->