### PR TITLE
fix(linux): replace the system title-bar menu, whose screenshot item freezes the session

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -3,6 +3,7 @@ const path = require('path');
 const { betterAuthAdapter } = require('./better-auth-adapter');
 const { setupSubtitleHandlers } = require('./subtitle-window.js');
 const { setupCaptionDoubleClick } = require('./window-caption-dblclick.js');
+const { setupCaptionContextMenu } = require('./window-caption-menu.js');
 const { setupPopoverWindowHandlers } = require('./popover-windows.js');
 const { applyLinuxGpuFlags } = require('./linux-gpu-flags');
 const { acquireSingleInstanceLock, createFocusRelay } = require('./single-instance');
@@ -387,6 +388,11 @@ function createWindow() {
   // WS_CAPTION style, and with it the native double-click-to-maximize on the
   // custom title bar. Linux and macOS keep it for free — see the module.
   setupCaptionDoubleClick(mainWindow);
+  // Linux only: right-clicking the drag-region title bar would show GNOME's
+  // window menu, whose "Take Screenshot" wedges mutter's input grab on X11
+  // and freezes the whole session — see the module for the measured details.
+  // An Electron-drawn Minimize/Maximize/Close menu takes its place.
+  setupCaptionContextMenu(mainWindow);
   setupPopoverWindowHandlers(mainWindow);
 
   // Set custom User Agent for the window

--- a/electron/window-caption-menu.js
+++ b/electron/window-caption-menu.js
@@ -1,0 +1,100 @@
+/**
+ * Replace the system window menu on the custom title bar (Linux only).
+ *
+ * The main window is `frame: false` (see createWindow in main.js), so its
+ * title bar is a `-webkit-app-region: drag` area. Right-clicking a drag area
+ * on Linux makes Chromium send `_GTK_SHOW_WINDOW_MENU` to the window manager,
+ * which shows the desktop's window menu — under GNOME that menu includes
+ * "Take Screenshot".
+ *
+ * Measured on GNOME Shell 46.0 / mutter 46.2, Ubuntu 24.04, X11 (2026-09-01):
+ * picking "Take Screenshot" from that menu on a client-side-decorated window
+ * wedges mutter — its synchronous passive button-1 grab activates and is
+ * never thawed with XIAllowEvents, so the pointer device stays frozen in the
+ * X server and every click and key in the whole session goes dead until
+ * gnome-shell is restarted. The Xorg grab dump shows gnome-shell as the
+ * owner: `(from passive grab) (device frozen, state 6), passive grab type 4,
+ * detail 0x1`. Server-side-decorated windows (a native title bar) take a
+ * different path inside mutter and are not affected — which is why every
+ * other app on the desktop seems fine and only this app "freezes the system".
+ *
+ * Chromium the browser is immune for a different reason: its caption
+ * right-click never reaches the window manager at all — it draws its own
+ * Minimize/Maximize/Close menu. This module does the same through Electron's
+ * `system-context-menu` event: `preventDefault()` stops the
+ * `_GTK_SHOW_WINDOW_MENU` request (verified on Electron 40.8.5: the event
+ * fires for frameless drag regions on X11 and suppression works), and a
+ * small Electron menu takes the system menu's place.
+ *
+ * Windows keeps its native system menu — it works fine there and losing it
+ * would be a regression (the event exists on win32 too, so the gate matters).
+ * On macOS the event never fires. Popover windows are frameless as well but
+ * declare no drag region, so the event cannot fire for them and they need no
+ * hook.
+ */
+
+/**
+ * The replacement menu: what the system menu's safe core offered. Items check
+ * the window again at click time because the popup can outlive it — the
+ * window can be closed from elsewhere (tray, IPC) while the menu is open.
+ *
+ * @returns {Electron.MenuItemConstructorOptions[]}
+ */
+function captionMenuTemplate(win) {
+  const whileAlive = (action) => () => {
+    if (!win.isDestroyed()) action();
+  };
+  return [
+    {
+      label: 'Minimize',
+      enabled: win.isMinimizable(),
+      click: whileAlive(() => win.minimize()),
+    },
+    win.isMaximized()
+      ? { label: 'Restore', click: whileAlive(() => win.unmaximize()) }
+      : {
+          label: 'Maximize',
+          enabled: win.isMaximizable(),
+          click: whileAlive(() => win.maximize()),
+        },
+    { type: 'separator' },
+    { label: 'Close', click: whileAlive(() => win.close()) },
+  ];
+}
+
+/**
+ * Install the replacement on `win`. No-op off Linux.
+ *
+ * @param {Electron.BrowserWindow} win
+ * @param {{ menuApi?: Pick<typeof Electron.Menu, 'buildFromTemplate'> }} [deps]
+ *   test seam; defaults to Electron's Menu.
+ * @returns {boolean} whether the listener was installed.
+ */
+function setupCaptionContextMenu(win, { menuApi = null } = {}) {
+  if (process.platform !== 'linux') return false;
+  if (!win || typeof win.on !== 'function') return false;
+
+  win.on('system-context-menu', (event) => {
+    // Suppress first, unconditionally: letting the system menu through is the
+    // freeze; a menu-less right-click is merely inert.
+    event.preventDefault();
+    console.log('[Sokuji] [CaptionMenu] Replacing system window menu');
+
+    // Deferred: popping up synchronously from inside this event shows nothing
+    // on Linux (measured on Electron 40.8.5 — the call no-ops without error).
+    setImmediate(() => {
+      if (win.isDestroyed()) return;
+      const Menu = menuApi ?? require('electron').Menu;
+      // No coordinates: popup() defaults to the cursor position, which is
+      // where the right-click happened. The event's `point` is in physical
+      // screen pixels and would need a DIP conversion to be usable here.
+      Menu.buildFromTemplate(captionMenuTemplate(win)).popup({ window: win });
+    });
+  });
+  return true;
+}
+
+module.exports = {
+  setupCaptionContextMenu,
+  captionMenuTemplate,
+};

--- a/electron/window-caption-menu.test.js
+++ b/electron/window-caption-menu.test.js
@@ -1,0 +1,203 @@
+// electron/window-caption-menu.test.js
+//
+// Linux-only: right-clicking the custom title bar (a `-webkit-app-region:
+// drag` area of the frameless main window) makes Chromium forward a
+// _GTK_SHOW_WINDOW_MENU request to the window manager. Under GNOME on X11
+// picking "Take Screenshot" from that menu leaves mutter's synchronous
+// passive button grab frozen (XIAllowEvents is never called), freezing input
+// for the whole session — measured on GNOME Shell 46.0 / mutter 46.2,
+// Ubuntu 24.04, 2026-09-01. Chromium the browser is immune because its own
+// caption right-click never reaches the WM: it shows a browser-drawn menu.
+// This module does the same via Electron's `system-context-menu` event.
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  setupCaptionContextMenu,
+  captionMenuTemplate,
+} from './window-caption-menu.js';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+function setPlatform(value) {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+function makeFakeWindow({ maximized = false, minimizable = true, maximizable = true } = {}) {
+  const win = {
+    listeners: new Map(),
+    maximized,
+    destroyed: false,
+    on: vi.fn((event, callback) => win.listeners.set(event, callback)),
+    isDestroyed: () => win.destroyed,
+    isMaximized: () => win.maximized,
+    isMinimizable: () => minimizable,
+    isMaximizable: () => maximizable,
+    minimize: vi.fn(),
+    maximize: vi.fn(() => { win.maximized = true; }),
+    unmaximize: vi.fn(() => { win.maximized = false; }),
+    close: vi.fn(),
+  };
+  return win;
+}
+
+function makeFakeMenuApi() {
+  const api = {
+    popups: [],
+    templates: [],
+    buildFromTemplate: vi.fn((template) => {
+      api.templates.push(template);
+      const menu = { popup: vi.fn((options) => api.popups.push(options)) };
+      return menu;
+    }),
+  };
+  return api;
+}
+
+function rightClickCaption(win) {
+  const callback = win.listeners.get('system-context-menu');
+  if (!callback) throw new Error('no system-context-menu listener installed');
+  const event = { preventDefault: vi.fn() };
+  callback(event, { x: 0, y: 0 });
+  return event;
+}
+
+// The replacement menu pops up on the next tick: a synchronous popup() from
+// inside the event shows nothing on Linux (measured on Electron 40.8.5).
+const tick = () => new Promise((resolve) => setImmediate(resolve));
+
+beforeEach(() => setPlatform('linux'));
+afterEach(() => Object.defineProperty(process, 'platform', originalPlatform));
+
+describe('setupCaptionContextMenu', () => {
+  it('listens for system-context-menu on Linux', () => {
+    const win = makeFakeWindow();
+
+    expect(setupCaptionContextMenu(win, { menuApi: makeFakeMenuApi() })).toBe(true);
+    expect(win.on).toHaveBeenCalledTimes(1);
+    expect(win.on.mock.calls[0][0]).toBe('system-context-menu');
+  });
+
+  it('installs nothing on Windows, whose native system menu works fine', () => {
+    setPlatform('win32');
+    const win = makeFakeWindow();
+
+    expect(setupCaptionContextMenu(win, { menuApi: makeFakeMenuApi() })).toBe(false);
+    expect(win.on).not.toHaveBeenCalled();
+  });
+
+  it('installs nothing on macOS, where the event never fires anyway', () => {
+    setPlatform('darwin');
+    const win = makeFakeWindow();
+
+    expect(setupCaptionContextMenu(win, { menuApi: makeFakeMenuApi() })).toBe(false);
+    expect(win.on).not.toHaveBeenCalled();
+  });
+
+  it('suppresses the system window menu', () => {
+    const win = makeFakeWindow();
+    setupCaptionContextMenu(win, { menuApi: makeFakeMenuApi() });
+
+    const event = rightClickCaption(win);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('pops up a replacement menu on the window', async () => {
+    const win = makeFakeWindow();
+    const menuApi = makeFakeMenuApi();
+    setupCaptionContextMenu(win, { menuApi });
+
+    rightClickCaption(win);
+    await tick();
+
+    expect(menuApi.buildFromTemplate).toHaveBeenCalledTimes(1);
+    expect(menuApi.popups).toEqual([{ window: win }]);
+  });
+
+  it('suppresses synchronously, before the deferred popup', () => {
+    // preventDefault must not wait for the tick: once the handler returns,
+    // Electron decides whether the system menu goes through.
+    const win = makeFakeWindow();
+    const menuApi = makeFakeMenuApi();
+    setupCaptionContextMenu(win, { menuApi });
+
+    const event = rightClickCaption(win);
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+  });
+
+  it('still suppresses, but shows no menu, once the window is destroyed', async () => {
+    // Covers destruction before the click and in the gap before the tick.
+    const win = makeFakeWindow();
+    const menuApi = makeFakeMenuApi();
+    setupCaptionContextMenu(win, { menuApi });
+    win.destroyed = true;
+
+    const event = rightClickCaption(win);
+    await tick();
+
+    expect(event.preventDefault).toHaveBeenCalledTimes(1);
+    expect(menuApi.buildFromTemplate).not.toHaveBeenCalled();
+  });
+});
+
+describe('captionMenuTemplate', () => {
+  it('offers Minimize, Maximize and Close on an unmaximized window', () => {
+    const win = makeFakeWindow({ maximized: false });
+
+    const labels = captionMenuTemplate(win).map((item) => item.label ?? item.type);
+
+    expect(labels).toEqual(['Minimize', 'Maximize', 'separator', 'Close']);
+  });
+
+  it('offers Restore instead of Maximize on a maximized window', () => {
+    const win = makeFakeWindow({ maximized: true });
+
+    const labels = captionMenuTemplate(win).map((item) => item.label ?? item.type);
+
+    expect(labels).toEqual(['Minimize', 'Restore', 'separator', 'Close']);
+  });
+
+  it('disables Minimize and Maximize when the window forbids them', () => {
+    const win = makeFakeWindow({ minimizable: false, maximizable: false });
+
+    const [minimize, maximize] = captionMenuTemplate(win);
+
+    expect(minimize.enabled).toBe(false);
+    expect(maximize.enabled).toBe(false);
+  });
+
+  it('drives the window from each item', () => {
+    const win = makeFakeWindow({ maximized: false });
+
+    const [minimize, maximize, , close] = captionMenuTemplate(win);
+    minimize.click();
+    maximize.click();
+    close.click();
+
+    expect(win.minimize).toHaveBeenCalledTimes(1);
+    expect(win.maximize).toHaveBeenCalledTimes(1);
+    expect(win.close).toHaveBeenCalledTimes(1);
+  });
+
+  it('restores from the Restore item', () => {
+    const win = makeFakeWindow({ maximized: true });
+
+    const [, restore] = captionMenuTemplate(win);
+    restore.click();
+
+    expect(win.unmaximize).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores clicks that land after the window is destroyed', () => {
+    // Menu items outlive the window: the popup stays open while the window
+    // can be closed from elsewhere (tray, IPC), and the click arrives late.
+    const win = makeFakeWindow({ maximized: false });
+
+    const items = captionMenuTemplate(win);
+    win.destroyed = true;
+    for (const item of items) item.click?.();
+
+    expect(win.minimize).not.toHaveBeenCalled();
+    expect(win.maximize).not.toHaveBeenCalled();
+    expect(win.close).not.toHaveBeenCalled();
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -157,7 +157,8 @@ export default defineConfig(({ command, mode }) => {
             'popover-windows': 'electron/popover-windows.js',
             'update-manager': 'electron/update-manager.js',
             'update-payload': 'electron/update-payload.js',
-            'window-caption-dblclick': 'electron/window-caption-dblclick.js'
+            'window-caption-dblclick': 'electron/window-caption-dblclick.js',
+            'window-caption-menu': 'electron/window-caption-menu.js'
           },
           onstart(args) {
             // Override default [".", "--no-sandbox"] to fix DevTools crash on Linux


### PR DESCRIPTION
## Problem

On Linux/X11 under GNOME, right-clicking Sokuji's custom title bar and picking **Take Screenshot** from the window menu freezes input for the entire desktop session — the cursor still moves, but no click or key registers anywhere, sometimes until gnome-shell is restarted or the user is forced to log out.

## Root cause (measured, GNOME Shell 46.0 / mutter 46.2, Ubuntu 24.04, X11)

The menu is not ours: the title bar is a `-webkit-app-region: drag` area of the frameless window, and Chromium forwards a right-click there to the window manager as `_GTK_SHOW_WINDOW_MENU`. Picking "Take Screenshot" on such a client-side-decorated window leaves mutter's **synchronous passive button grab frozen** — `XIAllowEvents` is never called — so every pointer event in the X session queues forever. The Xorg grab dump (`XF86LogGrabInfo`) names gnome-shell as the owner, pointer `(from passive grab) (device frozen, state 6)`. Server-side-decorated windows (native title bars) take a different mutter path and are unaffected, which is why only Sokuji appeared to "freeze the system".

## Fix

Do what Chromium the browser does — its caption right-click never reaches the WM; it draws its own menu. This PR listens for Electron's `system-context-menu` event (Linux only), calls `preventDefault()` to stop the WM menu request, and pops an Electron-drawn **Minimize / Maximize|Restore / Close** menu in its place. The popup is deferred with `setImmediate`: a synchronous `popup()` from inside the event shows nothing on Linux (measured on Electron 40.8.5). Windows keeps its native system menu (works fine there); on macOS the event never fires.

## Verification

- Live on the affected machine: right-click on the title bar now fires the handler, **no GNOME menu and no gnome-shell grab appear** (verified with an X11 grab probe), the replacement menu pops at the cursor, and its Minimize item drives the window into `_NET_WM_STATE_HIDDEN`.
- Unit tests: 13 new cases for the module (platform gating, synchronous suppression, deferred popup, destroyed-window guards, template contents and actions); electron suite 26 files / 398 tests green, including the vite entry-map consistency test that guards the new module's registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UpEY58pd7EAtkAMQ4hWfJu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Linux window caption controls for frameless windows.
  - Right-clicking the title-bar area now offers Minimize, Maximize/Restore, and Close actions.

- **Bug Fixes**
  - Prevented the system window menu from appearing in supported Linux environments.
  - Window controls safely handle unavailable or closed windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->