### PR TITLE
feat(mode-picker): name the missing device in the footer

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -87,6 +87,7 @@ import {
 import DisplaySettingsPopover from '../Display/DisplaySettingsPopover';
 import { usePlaybackStore, usePlaybackHighlight } from '../../stores/playbackStore';
 import ModePicker from './ModePicker';
+import MissingDeviceChip from './MissingDeviceChip';
 import SplitDegradedChip from './SplitDegradedChip';
 import { resolveSplitDegraded, type SplitDegradedReason } from './splitDegraded';
 import { buildChannelTelemetryHandlers, type ChannelTelemetryPorts } from './participantTelemetry';
@@ -4271,6 +4272,22 @@ const MainPanel: React.FC<MainPanelProps> = () => {
               }}
             />
 
+            {/* Says WHAT the picker's amber warn ring is pointing at, in
+                words and without a hover. Clicking it opens the same device
+                popover the active segment opens, so the chip is both the
+                explanation and the fix. */}
+            <MissingDeviceChip
+              scope={missingDeviceForMode}
+              onClick={(el) => {
+                if (modePopoverOpen) {
+                  setModePopoverOpen(false);
+                } else {
+                  setModePopoverAnchor(el);
+                  setModePopoverOpen(true);
+                }
+              }}
+            />
+
             {/* Directly beside the "Both" segment it contradicts. Renders
                 nothing unless the split actually failed to take effect. */}
             <SplitDegradedChip reason={splitDegraded} />
@@ -4359,6 +4376,19 @@ const MainPanel: React.FC<MainPanelProps> = () => {
                 } else {
                   handleModeSwitch(target);
                   setModePopoverOpen(false);
+                }
+              }}
+            />
+
+            {/* Same chip, same placement, as in the basic footer. */}
+            <MissingDeviceChip
+              scope={missingDeviceForMode}
+              onClick={(el) => {
+                if (modePopoverOpen) {
+                  setModePopoverOpen(false);
+                } else {
+                  setModePopoverAnchor(el);
+                  setModePopoverOpen(true);
                 }
               }}
             />

--- a/src/components/MainPanel/MissingDeviceChip.scss
+++ b/src/components/MainPanel/MissingDeviceChip.scss
@@ -1,0 +1,51 @@
+// ── Missing-device indicator (rendered in both control footers) ──
+//
+// The resting-state twin of .mode-picker__segment--warn's amber inset ring:
+// the ring says "here", this says what. Deliberately the SAME amber the ring
+// uses (#f59e0b) rather than SplitDegradedChip's #f39c12 — the two chips are
+// mutually exclusive in practice (this one is pre-session, that one only
+// appears once a split session is running), and matching the ring beside it
+// matters more than matching the other chip.
+//
+// Sized against SplitDegradedChip so the two read as the same piece of footer
+// furniture: 11px text, 10px radius, same padding, same narrow-width rule.
+.missing-device-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+  padding: 2px 7px;
+  border-radius: 10px;
+  background: rgba(245, 158, 11, 0.15);
+  border: 1px solid rgba(245, 158, 11, 0.45);
+  color: #f59e0b;
+  font-size: 11px;
+  font-family: inherit;
+  line-height: 1.4;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: background 0.15s ease, border-color 0.15s ease;
+
+  svg { flex-shrink: 0; }
+
+  &:hover {
+    background: rgba(245, 158, 11, 0.25);
+    border-color: rgba(245, 158, 11, 0.7);
+  }
+
+  // Unlike SplitDegradedChip this one is focusable, and the ring it gets is
+  // load-bearing: keyboard reach is half of why the chip is a button.
+  &:focus-visible {
+    outline: 2px solid #f59e0b;
+    outline-offset: 2px;
+  }
+
+  // The footer is tight in basic mode at narrow widths; the icon alone still
+  // carries the warning, the title attribute still explains it, and the
+  // aria-label keeps the accessible name when this text goes. Same breakpoint
+  // as .split-degraded-chip so the two collapse together.
+  @media (max-width: 420px) {
+    .chip-text { display: none; }
+    padding: 2px 4px;
+  }
+}

--- a/src/components/MainPanel/MissingDeviceChip.test.tsx
+++ b/src/components/MainPanel/MissingDeviceChip.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MissingDeviceChip from './MissingDeviceChip';
+import { MISSING_DEVICE_CHIP_HINT } from './missingDeviceChip';
+
+// Same shape as SplitDegradedChip.test.tsx, plus {{...}} interpolation so the
+// asserted text is the copy that actually ships rather than a key.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (_k: string, d?: string, v?: Record<string, string>) =>
+      Object.entries(v ?? {}).reduce((s, [name, value]) => s.replace(`{{${name}}}`, value), d ?? _k),
+  }),
+}));
+
+/**
+ * The amber ring on the mode picker's warn segment is a colour-only signal:
+ * nothing on screen says what is wrong, and the three existing explanations
+ * (the segment's native title, the Start button's blocked reason, the device
+ * popover) all require a hover or a click to reach. This chip is the resting
+ * state of that answer, and it is a separate component because MainPanel has
+ * no React harness in this repo — JSX inlined there is pinned by nothing.
+ */
+describe('MissingDeviceChip', () => {
+  it('renders nothing at all when every in-scope channel has a device', () => {
+    // The common case — it must add no footer chrome.
+    const { container } = render(<MissingDeviceChip scope={null} onClick={() => {}} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('names the missing device in visible text, not just in colour', () => {
+    render(<MissingDeviceChip scope="speaker" onClick={() => {}} />);
+    expect(screen.getByText('Microphone not selected')).toBeInTheDocument();
+  });
+
+  it('explains the remedy on hover, via the title attribute', () => {
+    render(<MissingDeviceChip scope="speaker" onClick={() => {}} />);
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'title',
+      `Microphone not selected\n\n${MISSING_DEVICE_CHIP_HINT.defaultValue}`,
+    );
+  });
+
+  it('keeps an accessible name even where the label text is hidden', () => {
+    // The narrow-footer media query hides `.chip-text`, which would take the
+    // accessible name with it — the same trap SplitDegradedChip guards against.
+    render(<MissingDeviceChip scope="participant" onClick={() => {}} />);
+    expect(screen.getByRole('button')).toHaveAccessibleName("Other's audio not selected");
+  });
+
+  it('hands its own element to the click handler so the popover can anchor to it', () => {
+    // MainPanel anchors ModeDevicePopover to whatever was clicked, exactly as
+    // it does for a mode-picker segment.
+    const onClick = vi.fn();
+    render(<MissingDeviceChip scope="speaker" onClick={onClick} />);
+    const chip = screen.getByRole('button');
+    fireEvent.click(chip);
+    expect(onClick).toHaveBeenCalledWith(chip);
+  });
+
+  it('is a real button, so the explanation is reachable by keyboard', () => {
+    // The gap this chip closes: a native `title` never appears on focus and
+    // never appears on touch, so keyboard and touch users had no route to the
+    // warn ring's meaning at all.
+    render(<MissingDeviceChip scope="speaker" onClick={() => {}} />);
+    expect(screen.getByRole('button')).toHaveAttribute('type', 'button');
+  });
+});

--- a/src/components/MainPanel/MissingDeviceChip.tsx
+++ b/src/components/MainPanel/MissingDeviceChip.tsx
@@ -1,0 +1,65 @@
+import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { AlertTriangle } from 'lucide-react';
+import './MissingDeviceChip.scss';
+import { missingDeviceChipText } from './missingDeviceChip';
+import type { DeviceScope } from './sessionStartGate';
+
+interface MissingDeviceChipProps {
+  /**
+   * MainPanel's `missingDeviceForMode` verbatim — the same value that draws
+   * the amber ring on the picker. Passing it straight through is what keeps
+   * the chip and the ring from ever disagreeing about whether there is a
+   * problem. `null` renders nothing.
+   */
+  scope: DeviceScope | null;
+  /** Receives the chip element so the caller can anchor the device popover to it. */
+  onClick: (el: HTMLElement) => void;
+}
+
+/**
+ * "Microphone not selected" — the resting-state twin of the mode picker's
+ * amber warn ring.
+ *
+ * Rendered immediately after the ModePicker in BOTH footers, beside the
+ * segment the ring is on. Placement is the point: the ring says "something is
+ * wrong here" and this says what, without the user having to hover it, hover
+ * the disabled Start button, or click through to the device popover.
+ *
+ * A real `<button>` rather than SplitDegradedChip's inert `role="status"`
+ * span, because unlike a degraded split there IS something to do about this:
+ * clicking opens the same device popover the active segment opens. That also
+ * puts the explanation on the Tab order, which a native `title` never was.
+ *
+ * Its own component rather than JSX inlined twice into MainPanel, for the
+ * reason SplitDegradedChip records: MainPanel has no React harness in this
+ * repo, so inline JSX there is untestable by construction.
+ */
+const MissingDeviceChip: React.FC<MissingDeviceChipProps> = ({ scope, onClick }) => {
+  const { t } = useTranslation();
+  const ref = useRef<HTMLButtonElement | null>(null);
+  if (!scope) return null;
+
+  const { label, title } = missingDeviceChipText(
+    scope,
+    (key, defaultValue, values) => t(key, defaultValue, values),
+  );
+
+  return (
+    // aria-label rather than the inner text alone: the narrow-footer media
+    // query hides `.chip-text`, which would take the accessible name with it.
+    <button
+      ref={ref}
+      type="button"
+      className="missing-device-chip"
+      aria-label={label}
+      title={title}
+      onClick={() => { if (ref.current) onClick(ref.current); }}
+    >
+      <AlertTriangle size={12} aria-hidden="true" />
+      <span className="chip-text">{label}</span>
+    </button>
+  );
+};
+
+export default MissingDeviceChip;

--- a/src/components/MainPanel/missingDeviceChip.test.ts
+++ b/src/components/MainPanel/missingDeviceChip.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import {
+  MISSING_DEVICE_CHIP_HINT,
+  MISSING_DEVICE_CHIP_LABEL,
+  MISSING_DEVICE_NAMES,
+  missingDeviceChipText,
+} from './missingDeviceChip';
+import type { DeviceScope } from './sessionStartGate';
+import en from '../../locales/en/translation.json';
+
+// Resolves to the inline English default and applies {{...}} interpolation,
+// so what is asserted is the copy that actually ships rather than a key.
+const translate = (_k: string, d: string, v?: Record<string, string>) =>
+  Object.entries(v ?? {}).reduce((s, [name, value]) => s.replace(`{{${name}}}`, value), d);
+
+const SCOPES: DeviceScope[] = ['speaker', 'participant', 'both'];
+
+/**
+ * The chip's copy lives in a pure module for the same reason splitDegraded's
+ * does: it can be pinned without a React harness, and the component is left
+ * with nothing but a render.
+ */
+describe('missingDeviceChipText', () => {
+  it('names the microphone when the speaker channel has no device', () => {
+    // The only scope reachable today — see MISSING_DEVICE_NAMES' note.
+    expect(missingDeviceChipText('speaker', translate).label).toBe('Microphone not selected');
+  });
+
+  it('names participant audio when the participant channel has no device', () => {
+    expect(missingDeviceChipText('participant', translate).label).toBe("Other's audio not selected");
+  });
+
+  it('names both devices when neither channel has one', () => {
+    expect(missingDeviceChipText('both', translate).label).toBe("Microphone + Other's audio not selected");
+  });
+
+  it('follows the label with the remedy on hover', () => {
+    // Same cause-then-remedy shape splitDegradedChipText uses, and the blank
+    // line is what makes an unstyled native title read as two thoughts.
+    const { label, title } = missingDeviceChipText('speaker', translate);
+    expect(title).toBe(`${label}\n\n${MISSING_DEVICE_CHIP_HINT.defaultValue}`);
+  });
+
+  it('resolves a real sentence for every scope, never a raw key', () => {
+    // Iterates the scope union rather than a hand-written list so a fourth
+    // scope cannot ship without copy behind it.
+    for (const scope of SCOPES) {
+      const { label } = missingDeviceChipText(scope, translate);
+      expect(label, `no label for ${scope}`).toBeTruthy();
+      expect(label, `unsubstituted placeholder for ${scope}`).not.toMatch(/\{\{/);
+      expect(label, `raw i18n key rendered for ${scope}`).not.toMatch(/^[a-zA-Z]+\.[a-zA-Z0-9]+$/);
+    }
+  });
+});
+
+describe('the strings this module names actually exist in the English catalog', () => {
+  const flat = (o: unknown, prefix = ''): Record<string, string> => {
+    const out: Record<string, string> = {};
+    if (o && typeof o === 'object' && !Array.isArray(o)) {
+      for (const [k, v] of Object.entries(o)) Object.assign(out, flat(v, prefix ? `${prefix}.${k}` : k));
+    } else {
+      out[prefix] = o as string;
+    }
+    return out;
+  };
+  const EN = flat(en);
+
+  it('the chip template and its remedy line match their inline defaults', () => {
+    // Not merely "exists": the inline defaultValue is what renders if i18n
+    // has not loaded, so drift between the two is a real bug.
+    expect(EN[MISSING_DEVICE_CHIP_LABEL.key]).toBe(MISSING_DEVICE_CHIP_LABEL.defaultValue);
+    expect(EN[MISSING_DEVICE_CHIP_HINT.key]).toBe(MISSING_DEVICE_CHIP_HINT.defaultValue);
+  });
+
+  it('every device name it reuses already ships in the catalog', () => {
+    // These are the popover's own row labels. Reusing them is what keeps this
+    // chip to a single new key across all 32 catalogs.
+    for (const names of Object.values(MISSING_DEVICE_NAMES)) {
+      for (const name of names) {
+        expect(EN[name.key], `missing en key: ${name.key}`).toBe(name.defaultValue);
+      }
+    }
+  });
+
+  it('keeps the label short enough to sit in a footer chip', () => {
+    // Same constraint SPLIT_DEGRADED_LABEL is held to: the chip renders beside
+    // the mode picker in a short footer, and a label that wraps would push the
+    // footer taller in basic mode. Measured on the reachable scope.
+    expect(missingDeviceChipText('speaker', translate).label.length).toBeLessThanOrEqual(28);
+  });
+});

--- a/src/components/MainPanel/missingDeviceChip.ts
+++ b/src/components/MainPanel/missingDeviceChip.ts
@@ -1,0 +1,107 @@
+/**
+ * "Which device is missing" — the chip's copy, as a pure function.
+ *
+ * The mode picker marks the offending segment with an amber inset ring
+ * (`.mode-picker__segment--warn`). That ring is a COLOUR-ONLY signal: it names
+ * nothing, and all three existing explanations need an interaction to reach —
+ * the segment's native `title`, the blocked Start button's reason (both
+ * `modePicker.missingDevice`, via sessionStartGate), and the device popover's
+ * amber "Not selected" row. None of them appear on focus or on touch, so a
+ * keyboard or touch user had no route to the ring's meaning at all.
+ *
+ * This module is the resting-state answer: what is missing, in words, beside
+ * the ring that is already pointing at it.
+ *
+ * Kept dependency-free (no React, no i18n) so it can be unit-tested without a
+ * rendering harness — the same rule splitDegraded.ts follows.
+ */
+import type { DeviceScope } from './sessionStartGate';
+
+/** A key plus the English text that renders if i18n has not loaded. */
+export interface LocalizedString {
+  key: string;
+  defaultValue: string;
+}
+
+/**
+ * The one string this feature adds to all 32 catalogs.
+ *
+ * A template rather than three finished sentences: the device NAMES below
+ * already ship everywhere, so interpolating them keeps the locale cost at one
+ * key while still letting each language choose its own word order — "{{device}}
+ * not selected" in English, "未选择{{device}}" in Chinese.
+ */
+export const MISSING_DEVICE_CHIP_LABEL: LocalizedString = {
+  key: 'modePicker.missingDeviceChip',
+  defaultValue: '{{device}} not selected',
+};
+
+/**
+ * The remedy line, reused verbatim from the mode picker's own tooltip.
+ *
+ * "Click to configure devices" rather than `modePicker.missingDevice`
+ * ("Configure devices for this mode to start."): the chip IS the click target
+ * — it opens the same device popover the active segment does — so this is the
+ * sentence that describes what actually happens.
+ */
+export const MISSING_DEVICE_CHIP_HINT: LocalizedString = {
+  key: 'modePicker.configureDevices',
+  defaultValue: 'Click to configure devices.',
+};
+
+const MIC: LocalizedString = { key: 'modePicker.deviceMic', defaultValue: 'Microphone' };
+const PARTICIPANT_AUDIO: LocalizedString = {
+  key: 'modePicker.deviceParticipantAudio',
+  defaultValue: "Other's audio",
+};
+
+/**
+ * The device(s) a scope is short of, named with the popover's own row labels
+ * so the chip and the popover it opens use the same words.
+ *
+ * Only 'speaker' is reachable today: MainPanel's `missingDeviceForMode` sets
+ * `hasParticipant = participantInScope`, which is unconditionally true, so its
+ * 'participant' and 'both' branches cannot fire. They are covered anyway
+ * because the scope type admits them — a chip that renders a blank where a
+ * device name belongs is a worse failure than two unused entries.
+ */
+export const MISSING_DEVICE_NAMES: Record<DeviceScope, LocalizedString[]> = {
+  speaker: [MIC],
+  participant: [PARTICIPANT_AUDIO],
+  both: [MIC, PARTICIPANT_AUDIO],
+};
+
+/** Just enough of i18next's `t` to resolve a key with an English fallback. */
+export type TranslateWithDefault = (
+  key: string,
+  defaultValue: string,
+  values?: Record<string, string>,
+) => string;
+
+export interface MissingDeviceChipText {
+  /** Short text on the chip itself, naming what is missing. */
+  label: string;
+  /** Hover text: the label, a blank line, then the remedy. */
+  title: string;
+}
+
+/**
+ * Compose the chip's visible label and its hover explanation.
+ *
+ * Cause first, remedy second, separated by a blank line — the same shape
+ * splitDegradedChipText uses, and for the same reason: a native `title` is one
+ * unstyled blob, and the blank line is what lets it read as two thoughts.
+ */
+export function missingDeviceChipText(
+  scope: DeviceScope,
+  translate: TranslateWithDefault,
+): MissingDeviceChipText {
+  const device = MISSING_DEVICE_NAMES[scope]
+    .map(name => translate(name.key, name.defaultValue))
+    .join(' + ');
+  const label = translate(MISSING_DEVICE_CHIP_LABEL.key, MISSING_DEVICE_CHIP_LABEL.defaultValue, { device });
+  return {
+    label,
+    title: label + '\n\n' + translate(MISSING_DEVICE_CHIP_HINT.key, MISSING_DEVICE_CHIP_HINT.defaultValue),
+  };
+}

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "الوضع مقفل أثناء الجلسة.",
     "configureDevices": "انقر لتكوين الأجهزة.",
     "missingDevice": "كوّن الأجهزة لهذا الوضع للبدء.",
+    "missingDeviceChip": "لم يتم تحديد {{device}}",
     "popoverHeaderYou": "أنا — الأجهزة",
     "popoverHeaderParticipants": "الآخر — الأجهزة",
     "popoverHeaderBoth": "الكل — الأجهزة",

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "সেশন চলাকালীন মোড লক থাকে।",
     "configureDevices": "ডিভাইস কনফিগার করতে ক্লিক করুন।",
     "missingDevice": "শুরু করতে এই মোডের জন্য ডিভাইস কনফিগার করুন।",
+    "missingDeviceChip": "{{device}} নির্বাচন করা হয়নি",
     "popoverHeaderYou": "আমি — ডিভাইস",
     "popoverHeaderParticipants": "অন্য — ডিভাইস",
     "popoverHeaderBoth": "উভয় — ডিভাইস",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Der Modus ist während einer Sitzung gesperrt.",
     "configureDevices": "Klicken Sie, um Geräte zu konfigurieren.",
     "missingDevice": "Konfigurieren Sie die Geräte für diesen Modus, um zu starten.",
+    "missingDeviceChip": "{{device}} nicht ausgewählt",
     "popoverHeaderYou": "Ich — Geräte",
     "popoverHeaderParticipants": "Gegenüber — Geräte",
     "popoverHeaderBoth": "Beides — Geräte",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Mode is locked during a session.",
     "configureDevices": "Click to configure devices.",
     "missingDevice": "Configure devices for this mode to start.",
+    "missingDeviceChip": "{{device}} not selected",
     "popoverHeaderYou": "Me — devices",
     "popoverHeaderParticipants": "Other — devices",
     "popoverHeaderBoth": "Both — devices",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "El modo está bloqueado durante una sesión.",
     "configureDevices": "Haz clic para configurar los dispositivos.",
     "missingDevice": "Configura los dispositivos para este modo para empezar.",
+    "missingDeviceChip": "{{device}} no seleccionado",
     "popoverHeaderYou": "Yo — dispositivos",
     "popoverHeaderParticipants": "Otro — dispositivos",
     "popoverHeaderBoth": "Ambos — dispositivos",

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "حالت در طول جلسه قفل است.",
     "configureDevices": "برای پیکربندی دستگاه‌ها کلیک کنید.",
     "missingDevice": "برای شروع، دستگاه‌های این حالت را پیکربندی کنید.",
+    "missingDeviceChip": "{{device}} انتخاب نشده است",
     "popoverHeaderYou": "من — دستگاه‌ها",
     "popoverHeaderParticipants": "طرف مقابل — دستگاه‌ها",
     "popoverHeaderBoth": "هر دو — دستگاه‌ها",

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Tila on lukittu istunnon aikana.",
     "configureDevices": "Napsauta määrittääksesi laitteet.",
     "missingDevice": "Määritä tämän tilan laitteet aloittaaksesi.",
+    "missingDeviceChip": "{{device}}: ei valittu",
     "popoverHeaderYou": "Minä — laitteet",
     "popoverHeaderParticipants": "Toinen — laitteet",
     "popoverHeaderBoth": "Molemmat — laitteet",

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Naka-lock ang mode habang may session.",
     "configureDevices": "I-click upang i-configure ang mga device.",
     "missingDevice": "I-configure ang mga device para sa mode na ito upang magsimula.",
+    "missingDeviceChip": "Walang napiling {{device}}",
     "popoverHeaderYou": "Ako — mga device",
     "popoverHeaderParticipants": "Kausap — mga device",
     "popoverHeaderBoth": "Pareho — mga device",

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Le mode est verrouillé pendant une session.",
     "configureDevices": "Cliquez pour configurer les périphériques.",
     "missingDevice": "Configurez les périphériques de ce mode pour démarrer.",
+    "missingDeviceChip": "{{device}} non sélectionné",
     "popoverHeaderYou": "Moi — périphériques",
     "popoverHeaderParticipants": "Autre — périphériques",
     "popoverHeaderBoth": "Les deux — périphériques",

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "המצב נעול במהלך סשן.",
     "configureDevices": "לחץ כדי להגדיר התקנים.",
     "missingDevice": "הגדר התקנים עבור מצב זה כדי להתחיל.",
+    "missingDeviceChip": "{{device}} לא נבחר",
     "popoverHeaderYou": "אני — התקנים",
     "popoverHeaderParticipants": "הצד השני — התקנים",
     "popoverHeaderBoth": "שניהם — התקנים",

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "सत्र के दौरान मोड लॉक रहता है।",
     "configureDevices": "डिवाइस कॉन्फ़िगर करने के लिए क्लिक करें।",
     "missingDevice": "शुरू करने के लिए इस मोड के डिवाइस कॉन्फ़िगर करें।",
+    "missingDeviceChip": "{{device}} चयनित नहीं है",
     "popoverHeaderYou": "मैं — डिवाइस",
     "popoverHeaderParticipants": "दूसरा — डिवाइस",
     "popoverHeaderBoth": "दोनों — डिवाइस",

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Mode terkunci selama sesi.",
     "configureDevices": "Klik untuk mengonfigurasi perangkat.",
     "missingDevice": "Konfigurasikan perangkat untuk mode ini untuk memulai.",
+    "missingDeviceChip": "{{device}} belum dipilih",
     "popoverHeaderYou": "Saya — perangkat",
     "popoverHeaderParticipants": "Lawan bicara — perangkat",
     "popoverHeaderBoth": "Keduanya — perangkat",

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "La modalità è bloccata durante una sessione.",
     "configureDevices": "Clicca per configurare i dispositivi.",
     "missingDevice": "Configura i dispositivi per questa modalità per iniziare.",
+    "missingDeviceChip": "{{device}} non selezionato",
     "popoverHeaderYou": "Io — dispositivi",
     "popoverHeaderParticipants": "Altro — dispositivi",
     "popoverHeaderBoth": "Entrambi — dispositivi",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "セッション中はモードがロックされています。",
     "configureDevices": "クリックしてデバイスを設定。",
     "missingDevice": "このモードを開始するにはデバイスを設定してください。",
+    "missingDeviceChip": "{{device}}が未選択です",
     "popoverHeaderYou": "自分 — デバイス",
     "popoverHeaderParticipants": "相手 — デバイス",
     "popoverHeaderBoth": "両方 — デバイス",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "세션 중에는 모드가 잠겨 있습니다.",
     "configureDevices": "클릭하여 장치를 구성하세요.",
     "missingDevice": "이 모드를 시작하려면 장치를 구성하세요.",
+    "missingDeviceChip": "{{device}} 선택 안 됨",
     "popoverHeaderYou": "나 — 장치",
     "popoverHeaderParticipants": "상대방 — 장치",
     "popoverHeaderBoth": "모두 — 장치",

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Mod dikunci semasa sesi.",
     "configureDevices": "Klik untuk mengkonfigurasi peranti.",
     "missingDevice": "Konfigurasikan peranti untuk mod ini bagi bermula.",
+    "missingDeviceChip": "{{device}} belum dipilih",
     "popoverHeaderYou": "Saya — peranti",
     "popoverHeaderParticipants": "Pihak lain — peranti",
     "popoverHeaderBoth": "Kedua-duanya — peranti",

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "De modus is vergrendeld tijdens een sessie.",
     "configureDevices": "Klik om apparaten te configureren.",
     "missingDevice": "Configureer apparaten voor deze modus om te starten.",
+    "missingDeviceChip": "{{device}} niet geselecteerd",
     "popoverHeaderYou": "Ik — apparaten",
     "popoverHeaderParticipants": "Ander — apparaten",
     "popoverHeaderBoth": "Beide — apparaten",

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Tryb jest zablokowany podczas sesji.",
     "configureDevices": "Kliknij, aby skonfigurować urządzenia.",
     "missingDevice": "Skonfiguruj urządzenia dla tego trybu, aby rozpocząć.",
+    "missingDeviceChip": "Nie wybrano: {{device}}",
     "popoverHeaderYou": "Ja — urządzenia",
     "popoverHeaderParticipants": "Rozmówca — urządzenia",
     "popoverHeaderBoth": "Oba — urządzenia",

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "O modo fica bloqueado durante uma sessão.",
     "configureDevices": "Clique para configurar os dispositivos.",
     "missingDevice": "Configure os dispositivos para este modo para iniciar.",
+    "missingDeviceChip": "{{device}} não selecionado",
     "popoverHeaderYou": "Eu — dispositivos",
     "popoverHeaderParticipants": "Outro — dispositivos",
     "popoverHeaderBoth": "Ambos — dispositivos",

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "O modo está bloqueado durante uma sessão.",
     "configureDevices": "Clique para configurar dispositivos.",
     "missingDevice": "Configure os dispositivos para este modo para começar.",
+    "missingDeviceChip": "{{device}} não selecionado",
     "popoverHeaderYou": "Eu — dispositivos",
     "popoverHeaderParticipants": "Outro — dispositivos",
     "popoverHeaderBoth": "Ambos — dispositivos",

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Режим заблокирован во время сессии.",
     "configureDevices": "Нажмите, чтобы настроить устройства.",
     "missingDevice": "Настройте устройства для этого режима, чтобы начать.",
+    "missingDeviceChip": "Не выбрано: {{device}}",
     "popoverHeaderYou": "Я — устройства",
     "popoverHeaderParticipants": "Собеседник — устройства",
     "popoverHeaderBoth": "Оба — устройства",

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Läget är låst under en session.",
     "configureDevices": "Klicka för att konfigurera enheter.",
     "missingDevice": "Konfigurera enheter för detta läge för att börja.",
+    "missingDeviceChip": "{{device}} har inte valts",
     "popoverHeaderYou": "Jag — enheter",
     "popoverHeaderParticipants": "Den andra — enheter",
     "popoverHeaderBoth": "Båda — enheter",

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "அமர்வின் போது பயன்முறை பூட்டப்பட்டுள்ளது.",
     "configureDevices": "சாதனங்களை உள்ளமைக்க கிளிக் செய்யவும்.",
     "missingDevice": "தொடங்க இந்த பயன்முறைக்கான சாதனங்களை உள்ளமைக்கவும்.",
+    "missingDeviceChip": "{{device}} தேர்ந்தெடுக்கப்படவில்லை",
     "popoverHeaderYou": "நான் — சாதனங்கள்",
     "popoverHeaderParticipants": "மற்றவர் — சாதனங்கள்",
     "popoverHeaderBoth": "இரண்டும் — சாதனங்கள்",

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "సెషన్ సమయంలో మోడ్ లాక్ చేయబడింది.",
     "configureDevices": "పరికరాలను కాన్ఫిగర్ చేయడానికి క్లిక్ చేయండి.",
     "missingDevice": "ప్రారంభించడానికి ఈ మోడ్ కోసం పరికరాలను కాన్ఫిగర్ చేయండి.",
+    "missingDeviceChip": "{{device}} ఎంపిక చేయలేదు",
     "popoverHeaderYou": "నేను — పరికరాలు",
     "popoverHeaderParticipants": "ఇతరులు — పరికరాలు",
     "popoverHeaderBoth": "రెండూ — పరికరాలు",

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "โหมดถูกล็อกระหว่างเซสชัน",
     "configureDevices": "คลิกเพื่อกำหนดค่าอุปกรณ์",
     "missingDevice": "กำหนดค่าอุปกรณ์สำหรับโหมดนี้เพื่อเริ่ม",
+    "missingDeviceChip": "ยังไม่ได้เลือก{{device}}",
     "popoverHeaderYou": "ฉัน — อุปกรณ์",
     "popoverHeaderParticipants": "อีกฝ่าย — อุปกรณ์",
     "popoverHeaderBoth": "ทั้งคู่ — อุปกรณ์",

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Mod, oturum sırasında kilitlidir.",
     "configureDevices": "Cihazları yapılandırmak için tıklayın.",
     "missingDevice": "Başlamak için bu mod için cihazları yapılandırın.",
+    "missingDeviceChip": "{{device}} seçilmedi",
     "popoverHeaderYou": "Ben — cihazlar",
     "popoverHeaderParticipants": "Karşı taraf — cihazlar",
     "popoverHeaderBoth": "Her ikisi — cihazlar",

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Режим заблоковано під час сесії.",
     "configureDevices": "Натисніть для налаштування пристроїв.",
     "missingDevice": "Налаштуйте пристрої для цього режиму, щоб почати.",
+    "missingDeviceChip": "Не вибрано: {{device}}",
     "popoverHeaderYou": "Я — пристрої",
     "popoverHeaderParticipants": "Співрозмовник — пристрої",
     "popoverHeaderBoth": "Обидва — пристрої",

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "Chế độ bị khóa trong phiên.",
     "configureDevices": "Nhấp để cấu hình thiết bị.",
     "missingDevice": "Cấu hình thiết bị cho chế độ này để bắt đầu.",
+    "missingDeviceChip": "Chưa chọn {{device}}",
     "popoverHeaderYou": "Tôi — thiết bị",
     "popoverHeaderParticipants": "Đối phương — thiết bị",
     "popoverHeaderBoth": "Cả hai — thiết bị",

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "会话期间模式已锁定。",
     "configureDevices": "点击配置设备。",
     "missingDevice": "请为此模式配置设备以开始。",
+    "missingDeviceChip": "未选择{{device}}",
     "popoverHeaderYou": "我 — 设备",
     "popoverHeaderParticipants": "对方 — 设备",
     "popoverHeaderBoth": "两者 — 设备",

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -624,6 +624,7 @@
     "switchDisabled": "工作階段期間模式已鎖定。",
     "configureDevices": "點擊配置裝置。",
     "missingDevice": "請為此模式配置裝置以開始。",
+    "missingDeviceChip": "未選擇{{device}}",
     "popoverHeaderYou": "我 — 裝置",
     "popoverHeaderParticipants": "對方 — 裝置",
     "popoverHeaderBoth": "兩者 — 裝置",


### PR DESCRIPTION
## What

The mode picker's amber warn ring is a colour-only signal. Every explanation of it needed an interaction to reach (segment `title`, the blocked Start button's reason, the device popover's amber row), and none of those appear on focus or on touch — so keyboard and touch users had no route to the ring's meaning.

`MissingDeviceChip` is the resting-state answer, rendered beside the picker in both footers: **"Microphone not selected"**. It is a real `<button>` (unlike `SplitDegradedChip`'s inert `role="status"` span) because there is something to do about it: clicking opens the same device popover the active segment opens, which also puts the explanation on the Tab order.

- Copy lives in a dependency-free module (`missingDeviceChip.ts`), pinned by tests without a React harness — the rule `splitDegraded.ts` follows.
- One new catalog key across all 30 locales: `modePicker.missingDeviceChip` = `"{{device}} not selected"`, interpolating the popover's own device names (already translated), so each language keeps its own word order.
- Only the `speaker` scope is reachable today (`missingDeviceForMode` sets `hasParticipant = participantInScope`, unconditionally true). `participant` / `both` are covered anyway so a fourth scope cannot ship a blank chip.

## Rebase notes

This was written on 2026-08-21 and sat unlanded ~204 commits behind `main`. Rebased onto v0.39.3:

- Dropped the branch's first commit (the `--warn` ring corner-radius CSS fix) — `main` already carries the identical fix.
- 30 locale conflicts: `main` renamed the popover headers to Me / Other (#431) in the same lines this branch inserted its key. Resolved by keeping `main`'s headers and inserting the new key before them.
- `PARTICIPANT_AUDIO.defaultValue` aligned to the renamed catalog value `"Other's audio"` (was `"Participant audio"`); the three assertions built on it updated to match. Without this the branch's own "inline default equals catalog" test fails.

## Verification

- `vitest run src/components/MainPanel src/locales/locales.consistency.test.ts` + console ledger: 19 files / 346 tests pass.
- Full `vitest run`: 319 files / 3638 tests pass. The run exits 1 because of 4 unhandled rejections in `settingsStore.nativeGate.test.ts`; reproduced identically on `main`, unrelated to this change.
- `tsc --noEmit`: the error set is byte-identical to `main`'s (312 pre-existing lines, none in touched files).
- Not done: no screenshot / visual check of the chip against current footer styling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
