### PR TITLE
feat(local-inference): recommend Qwen3-ASR 0.6B in place of Voxtral Mini 3B 2507

### DIFF
--- a/docs/superpowers/notes/2026-09-02-qwen3-asr-webgpu-fleet-validation.md
+++ b/docs/superpowers/notes/2026-09-02-qwen3-asr-webgpu-fleet-validation.md
@@ -95,8 +95,18 @@ in flight at all) reproduces the identical omission on a 12.96 s segment out of 
 
 ## `recommended` decision
 
-Kept **`recommended: false`** for now. English and Chinese are excellent; Japanese is usable
-but the 0.6B makes proper-noun errors on hard sentences (the 1.7B is the CJK quality tier).
-It is also WebGPU-only, so it does not fill the "no GPU-free recommended model" gap for
-Japanese users. A reasonable candidate to recommend for zh/en later; leaving the call to
-jiangzhuo rather than flipping it unprompted.
+PR #469 shipped with **`recommended: false`**: English and Chinese are excellent, Japanese is
+usable but the 0.6B makes proper-noun errors on hard sentences (the 1.7B is the CJK quality
+tier), and it is WebGPU-only, so it does not fill the "no GPU-free recommended model" gap for
+Japanese users.
+
+**Decision after the merge (jiangzhuo, 2026-09-02):** Qwen3-ASR 0.6B becomes recommended and
+takes the ranking slot Voxtral Mini 3B 2507 held (`sortOrder: 3`); Voxtral Mini 3B 2507 drops
+to non-recommended with Qwen3's former `sortOrder: 5`. Effect on the shared ranking
+(recommended → sortOrder → size): cohere (1) and Voxtral 4B (2) still rank first wherever they
+apply, so the default pick is unchanged for zh/en/ja/ko/de/fr/es/it/pt/nl/hi/ru/ar/vi; for
+th, id and Cantonese the first-ranked recommended WebGPU model changes from Whisper Large V3
+Turbo to Qwen3 (same `sortOrder`, Qwen3 is smaller with shader-f16). Dutch is the one Voxtral
+3B language Qwen3 does not cover; cohere and Voxtral 4B still recommend for it. In the model
+list Qwen3 sits exactly where Voxtral 3B sat (recommended group, after cohere and Voxtral 4B,
+before Whisper Turbo by the language-tier tie-break).

--- a/src/lib/local-inference/modelManifest.qwen3Asr.test.ts
+++ b/src/lib/local-inference/modelManifest.qwen3Asr.test.ts
@@ -14,6 +14,14 @@ describe('Qwen3-ASR 0.6B (WebGPU) manifest entry', () => {
     expect(entry.cdnPath).toBeUndefined();
   });
 
+  it('is recommended and holds the ranking slot Voxtral Mini 3B held; Voxtral 3B moves to the non-recommended slot Qwen3 had (decided 2026-09-02)', () => {
+    const voxtral3b = getManifestEntry('voxtral-mini-3b-webgpu')!;
+    expect(entry.recommended).toBe(true);
+    expect(entry.sortOrder).toBe(3);
+    expect(voxtral3b.recommended).toBe(false);
+    expect(voxtral3b.sortOrder).toBe(5);
+  });
+
   it("lists the 16 languages the model card names, spelled the way the app's language list spells them ('cantonese', not 'yue')", () => {
     expect(entry.languages).toEqual(['zh', 'en', 'ja', 'ko', 'cantonese', 'ar', 'de', 'es', 'fr', 'it', 'pt', 'ru', 'th', 'vi', 'hi', 'id']);
     expect(entry.multilingual).toBeFalsy();

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -977,8 +977,8 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
         ],
       },
     },
-    recommended: true,
-    sortOrder: 3,
+    recommended: false,
+    sortOrder: 5,
   },
 
   // ── Cohere Transcribe WebGPU ASR ───────────────────────────────────────────
@@ -1347,8 +1347,8 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
     requiredDevice: 'webgpu',
     asrEngine: 'qwen3-asr',
     asrWorkerType: 'qwen3-asr-webgpu',
-    recommended: false,
-    sortOrder: 5,
+    recommended: true,
+    sortOrder: 3,
     variants: {
       'q4': {
         dtype: 'q4',


### PR DESCRIPTION
## What

Qwen3-ASR 0.6B (WebGPU) becomes a recommended ASR model and takes the ranking slot Voxtral Mini 3B 2507 (WebGPU) held; Voxtral Mini 3B 2507 drops to non-recommended.

| model | before | after |
|---|---|---|
| `qwen3-asr-0.6b-webgpu` | `recommended: false`, `sortOrder: 5` | `recommended: true`, `sortOrder: 3` |
| `voxtral-mini-3b-webgpu` | `recommended: true`, `sortOrder: 3` | `recommended: false`, `sortOrder: 5` |

Follow-up to #469 (Qwen3-ASR worker), which shipped with `recommended: false` pending this call.

## Effect

Ranking is recommended → sortOrder → size, shared by the model list and the selection layer. cohere (sortOrder 1) and Voxtral 4B (2) still rank first wherever they apply, so the default pick is **unchanged** for zh, en, ja, ko, de, fr, es, it, pt, nl, hi, ru, ar and vi. For **th, id and Cantonese** the first-ranked recommended WebGPU model moves from Whisper Large V3 Turbo to Qwen3 (same `sortOrder`, Qwen3 is smaller with shader-f16). Dutch is the one Voxtral 3B language Qwen3 does not cover; cohere and Voxtral 4B remain recommended for it.

In the model list Qwen3 sits exactly where Voxtral 3B sat: recommended group, after cohere and Voxtral 4B, before Whisper Turbo (language-tier tie-break).

## Validation

- `modelManifest.qwen3Asr.test.ts` gained a case pinning both rows' `recommended` / `sortOrder` (written red, then green).
- `src/lib/local-inference`, `src/components/Settings`, `src/components/SetupWizard`, `src/stores`: 139 files, 1337 tests pass.
- tsc unchanged at the 312-error baseline (none in touched files).
- Decision and effect recorded in `docs/superpowers/notes/2026-09-02-qwen3-asr-webgpu-fleet-validation.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Model Updates**
  - Qwen3-ASR 0.6B is now the recommended WebGPU speech recognition model.
  - Qwen3-ASR moves to ranking position 3, while Voxtral Mini 3B 2507 moves to position 5 and is no longer recommended.
  - Default model selection remains unchanged for most languages.
  - Qwen3-ASR becomes the first-ranked recommended WebGPU model for Thai, Indonesian, and Cantonese.
  - Dutch remains covered by Cohere/Voxtral 4B.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->