### PR TITLE
feat(local-native): temporary tester switch — localStorage debug:local-native shows the provider in packaged Electron builds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -343,6 +343,10 @@ useSettingsStore.subscribe(
 ### Environment Variables
 - `VITE_BACKEND_URL`: Backend API URL (default: `https://sokuji.kizuna.ai`)
 - `VITE_ENABLE_KIZUNA_AI`: Enable Kizuna AI provider in production (`true`/`false`)
+- `VITE_ENABLE_LOCAL_NATIVE`: Register the Local Native (Electron sidecar) provider in
+  production builds; unset in releases. Temporary run-time alternative for testers on a
+  packaged Electron build: DevTools → `localStorage.setItem('debug:local-native', '1')` →
+  restart (`removeItem` to hide again). Remove the switch with the gate when Local Native ships.
 - Environment detection via `src/utils/environment.ts`
 
 ### TypeScript Configuration

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,8 @@ useSettingsStore.subscribe(
 - `VITE_ENABLE_LOCAL_NATIVE`: Register the Local Native (Electron sidecar) provider in
   production builds; unset in releases. Temporary run-time alternative for testers on a
   packaged Electron build: DevTools → `localStorage.setItem('debug:local-native', '1')` →
-  restart (`removeItem` to hide again). Remove the switch with the gate when Local Native ships.
+  restart; `localStorage.removeItem('debug:local-native')` + restart hides it again. Remove the
+  switch with the gate when Local Native ships.
 - Environment detection via `src/utils/environment.ts`
 
 ### TypeScript Configuration

--- a/src/utils/environment.test.ts
+++ b/src/utils/environment.test.ts
@@ -1,7 +1,49 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { getRelayWsUrl } from "./environment";
+import { getRelayWsUrl, isLocalNativeEnabled, LOCAL_NATIVE_DEBUG_KEY } from "./environment";
 
 afterEach(() => { vi.unstubAllEnvs(); });
+
+describe("isLocalNativeEnabled", () => {
+  const asElectron = () => { (window as unknown as { electronAPI?: object }).electronAPI = {}; };
+  const production = () => { vi.stubEnv("DEV", false); vi.stubEnv("VITE_ENABLE_LOCAL_NATIVE", ""); };
+  afterEach(() => {
+    localStorage.removeItem(LOCAL_NATIVE_DEBUG_KEY);
+    delete (window as unknown as { electronAPI?: object }).electronAPI;
+  });
+
+  it("is on in development mode regardless of flags", () => {
+    vi.stubEnv("DEV", true);
+    expect(isLocalNativeEnabled()).toBe(true);
+  });
+
+  it("is off in a packaged build without the build-time flag", () => {
+    production(); asElectron();
+    expect(isLocalNativeEnabled()).toBe(false);
+  });
+
+  it("is on when the build-time flag was baked in", () => {
+    vi.stubEnv("DEV", false); vi.stubEnv("VITE_ENABLE_LOCAL_NATIVE", "true"); asElectron();
+    expect(isLocalNativeEnabled()).toBe(true);
+  });
+
+  it("is on in a packaged Electron build when the tester switch is set in localStorage", () => {
+    production(); asElectron();
+    localStorage.setItem(LOCAL_NATIVE_DEBUG_KEY, "1");
+    expect(isLocalNativeEnabled()).toBe(true);
+  });
+
+  it("ignores the tester switch outside Electron (extension / web)", () => {
+    production();
+    localStorage.setItem(LOCAL_NATIVE_DEBUG_KEY, "1");
+    expect(isLocalNativeEnabled()).toBe(false);
+  });
+
+  it("requires the exact value '1' — anything else leaves the provider hidden", () => {
+    production(); asElectron();
+    localStorage.setItem(LOCAL_NATIVE_DEBUG_KEY, "true");
+    expect(isLocalNativeEnabled()).toBe(false);
+  });
+});
 
 describe("getRelayWsUrl", () => {
   it("derives a wss /v1 URL from the default backend", () => {

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -258,8 +258,9 @@ export function isPalabraAIEnabled(): boolean {
  * The provider is otherwise gated at build time (`VITE_ENABLE_LOCAL_NATIVE`, off in every
  * release), and a packaged app cannot read process env from the renderer. So, for the few
  * people testing the sidecar on release builds: View → Toggle Developer Tools, run
- * `localStorage.setItem('debug:local-native', '1')`, restart the app; `removeItem` hides it
- * again. Electron only. Same convention as `debug:webgpu-features` in `webgpu.ts`.
+ * `localStorage.setItem('debug:local-native', '1')`, restart the app;
+ * `localStorage.removeItem('debug:local-native')` and a restart hide it again. Electron only.
+ * Same convention as `debug:webgpu-features` in `webgpu.ts`.
  * Remove together with the build-time gate once Local Native ships.
  */
 export const LOCAL_NATIVE_DEBUG_KEY = 'debug:local-native';

--- a/src/utils/environment.ts
+++ b/src/utils/environment.ts
@@ -253,14 +253,38 @@ export function isPalabraAIEnabled(): boolean {
 }
 
 /**
+ * Tester switch for the Local Native provider in packaged builds (temporary, 2026-09).
+ *
+ * The provider is otherwise gated at build time (`VITE_ENABLE_LOCAL_NATIVE`, off in every
+ * release), and a packaged app cannot read process env from the renderer. So, for the few
+ * people testing the sidecar on release builds: View → Toggle Developer Tools, run
+ * `localStorage.setItem('debug:local-native', '1')`, restart the app; `removeItem` hides it
+ * again. Electron only. Same convention as `debug:webgpu-features` in `webgpu.ts`.
+ * Remove together with the build-time gate once Local Native ships.
+ */
+export const LOCAL_NATIVE_DEBUG_KEY = 'debug:local-native';
+
+function hasLocalNativeDebugSwitch(): boolean {
+  try {
+    return typeof localStorage !== 'undefined' && localStorage.getItem(LOCAL_NATIVE_DEBUG_KEY) === '1';
+  } catch {
+    return false; // localStorage unavailable in restricted contexts
+  }
+}
+
+/**
  * Check if Local Native (Electron sidecar) provider should be enabled.
- * Development: always true. Production: requires VITE_ENABLE_LOCAL_NATIVE === 'true'.
+ * Development: always true. Production: requires VITE_ENABLE_LOCAL_NATIVE === 'true' at
+ * build time, or the tester switch above at run time (Electron only).
  */
 export function isLocalNativeEnabled(): boolean {
   if (isDevelopmentMode()) {
     return true;
   }
-  return import.meta.env.VITE_ENABLE_LOCAL_NATIVE === 'true';
+  if (import.meta.env.VITE_ENABLE_LOCAL_NATIVE === 'true') {
+    return true;
+  }
+  return isElectron() && hasLocalNativeDebugSwitch();
 }
 
 // ============================================================================


### PR DESCRIPTION
## What

A temporary, private run-time switch that shows the Local Native (Electron sidecar) provider in
packaged builds, for the few people testing the sidecar over the next releases.

`isLocalNativeEnabled()` gains a third branch: in Electron, `localStorage` key
`debug:local-native` set to exactly `'1'` registers the provider. Tester steps on a release
build: View → Toggle Developer Tools → `localStorage.setItem('debug:local-native', '1')` →
restart; `localStorage.removeItem('debug:local-native')` + restart hides it again. Same convention as the existing `debug:webgpu-features`
override in `webgpu.ts`.

## Why this shape

- The gate is a Vite compile-time constant (`VITE_ENABLE_LOCAL_NATIVE`, unset in every
  release), and the renderer cannot read `process.env`, so an env var or CLI flag would both
  need main → `additionalArguments` → preload → `contextBridge` plumbing for the same effect;
  macOS Finder launches would not inherit a shell env anyway.
- It is not a UI hide: without the gate the provider is never registered in
  `ProviderConfigFactory`, so the switch has to be readable synchronously at static init —
  `localStorage` is.
- Build-time behaviour is untouched: the `import.meta.env.VITE_ENABLE_LOCAL_NATIVE` read stays
  (and `featureGateForwarding.consistency.test.ts` still derives the gate set from it); the
  switch is ignored outside Electron and for any value other than `'1'`.

## Temporary

Documented as such in `CLAUDE.md`: delete `LOCAL_NATIVE_DEBUG_KEY` / `hasLocalNativeDebugSwitch`
and the CLAUDE.md line together with the gate when Local Native ships.

## Validation

- `environment.test.ts`: six new cases (dev mode, packaged without flag, packaged with flag,
  Electron + switch, non-Electron + switch ignored, wrong value ignored), written red first.
- utils / providers / SetupWizard / Settings / local-inference suites: 147 files, 1459 tests
  pass; tsc unchanged at the 312-error baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a tester switch for enabling the Local Native provider in packaged Electron builds.
  * The provider can now be enabled through the designated local storage setting, while remaining disabled outside Electron.
* **Documentation**
  * Updated environment variable guidance with the complete command for removing the Local Native debug setting and applying changes after restarting the app.
* **Tests**
  * Added coverage for development, production, Electron, non-Electron, and strict setting-value scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->