### PR TITLE
fix(supertonic): retire the dead Voice Builder link and serve the weights from our own mirror

### DIFF
--- a/src/components/Settings/sections/ModelManagementSection.test.tsx
+++ b/src/components/Settings/sections/ModelManagementSection.test.tsx
@@ -167,6 +167,28 @@ describe('ModelManagementSection — embedded voice', () => {
     // The voice control renders only in the selected TTS card, nowhere else.
     expect(screen.getAllByText('Voice')).toHaveLength(1);
   });
+
+  it('tells Supertonic users Voice Builder is gone instead of linking to it', async () => {
+    // Supertone (HYBE) resolved to dissolve on 2026-07-15 and shut Voice
+    // Builder on 2026-08-31 — supertonic.supertone.ai is a 404. The card must
+    // say so and must not send anyone to the dead service; already-downloaded
+    // voice_style.json files still import fine, and that is what the notice
+    // should leave the user with.
+    mockSettings.selections = {
+      [directionKey('en', 'en')]: {
+        asr: { modelId: '' }, translation: { modelId: '' }, tts: { modelId: 'supertonic-3' },
+      },
+    };
+    mockStatuses['supertonic-3'] = 'downloaded';
+
+    render(<ModelManagementSection isSessionActive={false} />);
+
+    const card = await waitFor(() => screen.getByTestId('model-card-supertonic-3'));
+    expect(within(card).getByText(/Voice Builder/)).toHaveTextContent(/closed/i);
+    expect(within(card).getByText(/Voice Builder/)).toHaveTextContent(/can still be imported/i);
+    expect(card.querySelector('a[href*="supertone.ai"]')).toBeNull();
+    expect(within(card).queryByText('Need a custom voice?')).toBeNull();
+  });
 });
 
 describe('ModelManagementSection — selected state comes from resolve(), not settings writes (Task 11)', () => {

--- a/src/components/Settings/sections/ModelManagementSection.tsx
+++ b/src/components/Settings/sections/ModelManagementSection.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState, useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Download, Trash2, X, AlertCircle, CheckCircle, ChevronDown, ChevronRight, AlertTriangle, Zap, Star, ExternalLink, FolderInput } from 'lucide-react';
+import { Download, Trash2, X, AlertCircle, CheckCircle, ChevronDown, ChevronRight, AlertTriangle, Zap, Star, FolderInput } from 'lucide-react';
 import {
   useModelStore,
   useModelStatuses,
@@ -38,7 +38,6 @@ import { importedSidFromDbKey, dbKeyFromImportedSid } from '../../../lib/local-i
 import { getEdgeTtsVoices, filterVoicesByLanguage, getVoiceDisplayName } from '../../../lib/edge-tts/voiceList';
 import type { Voice } from '../../../lib/edge-tts/edgeTts';
 import { reportError, describeCause } from '../../../lib/diagnostics/report';
-import { isElectron } from '../../../utils/environment';
 import './ModelManagementSection.scss';
 import { LanguageTags } from './LanguageTags';
 
@@ -890,29 +889,15 @@ export function ModelManagementSection({
       />
       {isSupertonicTts && (
         <>
+          {/* Supertone's Voice Builder — the only source of custom
+              voice_style.json files — closed on 2026-08-31 with the company's
+              liquidation, so there is nothing to link to any more. Files a
+              user already downloaded still import through the section above. */}
           <div className="voice-library-info">
-            {t('voiceLibrary.customVoiceCta', 'Need a custom voice?')}{' '}
-            <a
-              href="https://supertonic.supertone.ai/voice-builder"
-              onClick={(e) => {
-                e.preventDefault();
-                const url = 'https://supertonic.supertone.ai/voice-builder';
-                if (isElectron() && (window as any).electron?.invoke) {
-                  (window as any).electron.invoke('open-external', url);
-                } else {
-                  window.open(url, '_blank', 'noopener,noreferrer');
-                }
-              }}
-            >
-              {t('voiceLibrary.openVoiceBuilder', 'Create one at Voice Builder')}
-              <ExternalLink size={14} />
-            </a>
-            <div className="voice-library-info-sub">
-              {t(
-                'voiceLibrary.voiceBuilderDisclaimer',
-                'Paid Supertone service. Sokuji is not involved in that transaction.',
-              )}
-            </div>
+            {t(
+              'voiceLibrary.voiceBuilderClosed',
+              'Supertone closed its Voice Builder service on August 31, 2026. Voice files you already downloaded can still be imported.',
+            )}
           </div>
           {importError && (
             <div className="setting-item error">

--- a/src/components/Settings/sections/VoiceLibrarySection.scss
+++ b/src/components/Settings/sections/VoiceLibrarySection.scss
@@ -18,22 +18,6 @@
   border-radius: 4px;
   font-size: 13px;
   line-height: 1.4;
-
-  a {
-    color: tk.$color-primary;
-    text-decoration: none;
-    display: inline-flex;
-    align-items: center;
-    gap: 4px;
-    cursor: pointer;
-    &:hover { text-decoration: underline; }
-  }
-}
-
-.voice-library-info-sub {
-  margin-top: 4px;
-  font-size: 11px;
-  opacity: 0.7;
 }
 
 .voice-library-manage {

--- a/src/lib/local-inference/modelManifest.supertonic.test.ts
+++ b/src/lib/local-inference/modelManifest.supertonic.test.ts
@@ -68,10 +68,23 @@ describe('Supertonic 3 manifest entry', () => {
     expect(total).toBeLessThanOrEqual(383 * 1024 * 1024);
   });
 
+  it('pins the mirror to the verified, immutable commit', () => {
+    // The download path validates size and shape only, so a mutable branch
+    // ref would let a later push to the mirror change what users cache. A
+    // commit ref cannot move: this is the commit whose 39 files were
+    // sha256-checked against upstream, and bumping it is a deliberate edit.
+    expect(entry!.hfRevision).toBe('95e49bbdc2a88e24f25f5469d01a6427d14d9d3a');
+  });
+
   it('builds the expected HF download URL', () => {
     const url = getModelDownloadUrl(entry!, 'onnx/duration_predictor.onnx');
     expect(url).toBe(
-      'https://huggingface.co/jiangzhuo9357/supertonic-3/resolve/main/onnx/duration_predictor.onnx',
+      'https://huggingface.co/jiangzhuo9357/supertonic-3/resolve/95e49bbdc2a88e24f25f5469d01a6427d14d9d3a/onnx/duration_predictor.onnx',
     );
+  });
+
+  it('unpinned HF entries still resolve against main', () => {
+    const url = getModelDownloadUrl({ type: 'tts', hfModelId: 'org/model' }, 'x.onnx');
+    expect(url).toBe('https://huggingface.co/org/model/resolve/main/x.onnx');
   });
 });

--- a/src/lib/local-inference/modelManifest.supertonic.test.ts
+++ b/src/lib/local-inference/modelManifest.supertonic.test.ts
@@ -22,8 +22,12 @@ describe('Supertonic 3 manifest entry', () => {
     expect(entry!.numSpeakers).toBe(10);
   });
 
-  it('uses Supertone/supertonic-3 as the HF model id', () => {
-    expect(entry!.hfModelId).toBe('Supertone/supertonic-3');
+  it('downloads from our verbatim mirror, not the dissolving upstream org', () => {
+    // Supertone Inc. resolved to dissolve on 2026-07-15; Supertone/supertonic-3
+    // may disappear with the liquidation. jiangzhuo9357/supertonic-3 is a
+    // sha256-verified byte-for-byte copy of upstream @ 3cadd1ee with the same
+    // file layout, so every path below resolves unchanged.
+    expect(entry!.hfModelId).toBe('jiangzhuo9357/supertonic-3');
   });
 
   it('selects the only variant (default) on any device', () => {
@@ -67,7 +71,7 @@ describe('Supertonic 3 manifest entry', () => {
   it('builds the expected HF download URL', () => {
     const url = getModelDownloadUrl(entry!, 'onnx/duration_predictor.onnx');
     expect(url).toBe(
-      'https://huggingface.co/Supertone/supertonic-3/resolve/main/onnx/duration_predictor.onnx',
+      'https://huggingface.co/jiangzhuo9357/supertonic-3/resolve/main/onnx/duration_predictor.onnx',
     );
   });
 });

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -92,12 +92,20 @@ export interface ModelManifestEntry {
   // Models are hosted in two ways:
   //   1. Self-hosted HF datasets: cdnPath → {type-specific-base}/{cdnPath}/{file}
   //      Used by: sherpa-onnx ASR, streaming ASR, TTS
-  //   2. Third-party HF Hub repos: hfModelId → {hf-hub-base}/{hfModelId}/resolve/main/{file}
+  //   2. Third-party HF Hub repos: hfModelId → {hf-hub-base}/{hfModelId}/resolve/{hfRevision ?? main}/{file}
   //      Used by: Whisper WebGPU ASR, Opus-MT translation, Qwen translation
   /** Self-hosted HF dataset path segment (e.g. 'wasm-sensevoice-int8') */
   cdnPath?: string;
   /** Third-party HuggingFace Hub model ID (e.g. 'onnx-community/whisper-tiny.en', 'Xenova/opus-mt-ja-en') */
   hfModelId?: string;
+  /**
+   * Git revision to download from instead of `main`. The download path
+   * validates size and shape only, so a mutable branch ref lets any later push
+   * to the repo change what users cache; a commit sha cannot move. Set it on
+   * repos we mirror ourselves, where the verified commit is known — bumping it
+   * is then a deliberate manifest edit, not an upstream push.
+   */
+  hfRevision?: string;
 
   // ─── Hardware requirements ─────────────────────────────────────────────
   /** Hardware requirement — model filtered out if device unavailable */
@@ -236,12 +244,13 @@ function getHfHubBase(): string {
  * Exactly one of hfModelId or cdnPath should be set on each manifest entry.
  */
 export function getModelDownloadUrl(
-  entry: { type: ModelType; cdnPath?: string; hfModelId?: string },
+  entry: { type: ModelType; cdnPath?: string; hfModelId?: string; hfRevision?: string },
   filename: string,
 ): string {
-  // Third-party HF Hub models (Whisper WebGPU, Opus-MT, Qwen)
+  // Third-party HF Hub models (Whisper WebGPU, Opus-MT, Qwen); our own mirrors
+  // pin a commit so the cached bytes can only change through a manifest edit.
   if (entry.hfModelId) {
-    return `${getHfHubBase()}/${entry.hfModelId}/resolve/main/${filename}`;
+    return `${getHfHubBase()}/${entry.hfModelId}/resolve/${entry.hfRevision ?? 'main'}/${filename}`;
   }
 
   // Self-hosted HF dataset models (sherpa-onnx ASR, streaming ASR, TTS)
@@ -3020,7 +3029,10 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
     // sha256-checked against the upstream tree). Supertone Inc. resolved to
     // dissolve on 2026-07-15 and its GitHub repo is slated for archival, so the
     // upstream HF org may vanish with the liquidation; the mirror is ours.
+    // hfRevision is the mirror commit those checks were run against — a
+    // re-upload cannot change what users download until this line does.
     hfModelId: 'jiangzhuo9357/supertonic-3',
+    hfRevision: '95e49bbdc2a88e24f25f5469d01a6427d14d9d3a',
     name: 'Supertonic 3',
     languages: [...SUPERTONIC_LANGUAGES],
     numSpeakers: 10,

--- a/src/lib/local-inference/modelManifest.ts
+++ b/src/lib/local-inference/modelManifest.ts
@@ -3016,7 +3016,11 @@ export const MODEL_MANIFEST: ModelManifestEntry[] = [
     type: 'tts',
     engine: 'supertonic',
     recommended: true,
-    hfModelId: 'Supertone/supertonic-3',
+    // Verbatim mirror of Supertone/supertonic-3 @ 3cadd1ee (every file
+    // sha256-checked against the upstream tree). Supertone Inc. resolved to
+    // dissolve on 2026-07-15 and its GitHub repo is slated for archival, so the
+    // upstream HF org may vanish with the liquidation; the mirror is ours.
+    hfModelId: 'jiangzhuo9357/supertonic-3',
     name: 'Supertonic 3',
     languages: [...SUPERTONIC_LANGUAGES],
     numSpeakers: 10,

--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "التسجيل طويل جدًا — أبقِه أقل من {seconds} ثانية.",
     "clipTooShort": "التسجيل قصير جدًا — تحدّث لمدة {seconds} ثانية على الأقل.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "تحتاج صوتًا مخصصًا؟",
     "decodeFailed": "تعذّرت قراءة ذلك الملف الصوتي — جرّب WAV أو MP3 أو تنسيقًا شائعًا آخر.",
     "delete": "حذف",
     "deleteConfirm": "حذف الصوت \"{name}\"؟",
@@ -918,7 +917,6 @@
     "importVoice": "استيراد صوت…",
     "manageImported": "إدارة الأصوات المستوردة",
     "myVoices": "أصواتي",
-    "openVoiceBuilder": "أنشئ واحدًا في Voice Builder",
     "play": "تشغيل",
     "presets": "الإعدادات المسبقة",
     "recordVoice": "تسجيل صوت…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "اكتب بالضبط ما يقوله المقطع…",
     "unstable": "غير مستقر",
     "voice": "الصوت",
-    "voiceBuilderDisclaimer": "خدمة Supertone مدفوعة. Sokuji ليس طرفًا في تلك المعاملة.",
+    "voiceBuilderClosed": "أغلقت Supertone خدمة Voice Builder في 31 أغسطس 2026. لا يزال بالإمكان استيراد ملفات الصوت التي نزّلتها من قبل.",
     "refreshList": "تحديث قائمة الأصوات"
   },
   "echoNotice": {

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "রেকর্ডিং খুব দীর্ঘ — এটি {seconds} সেকেন্ডের মধ্যে রাখুন।",
     "clipTooShort": "রেকর্ডিং খুব ছোট — কমপক্ষে {seconds} সেকেন্ড কথা বলুন।",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "কাস্টম কণ্ঠস্বর দরকার?",
     "decodeFailed": "সেই অডিও ফাইলটি পড়া যায়নি — WAV, MP3 বা অন্য প্রচলিত ফরম্যাট চেষ্টা করুন।",
     "delete": "মুছুন",
     "deleteConfirm": "\"{name}\" কণ্ঠস্বর মুছবেন?",
@@ -918,7 +917,6 @@
     "importVoice": "কণ্ঠস্বর ইমপোর্ট করুন…",
     "manageImported": "ইমপোর্ট করা কণ্ঠস্বর পরিচালনা করুন",
     "myVoices": "আমার কণ্ঠস্বর",
-    "openVoiceBuilder": "Voice Builder-এ একটি তৈরি করুন",
     "play": "চালান",
     "presets": "প্রিসেট",
     "recordVoice": "কণ্ঠস্বর রেকর্ড করুন…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "ক্লিপে ঠিক যা বলা হয়েছে তা টাইপ করুন…",
     "unstable": "অস্থিতিশীল",
     "voice": "কণ্ঠস্বর",
-    "voiceBuilderDisclaimer": "এটি Supertone-এর একটি পেইড পরিষেবা। Sokuji সেই লেনদেনে জড়িত নয়।",
+    "voiceBuilderClosed": "Supertone ৩১ আগস্ট ২০২৬ তারিখে তাদের Voice Builder সেবা বন্ধ করেছে। আগে ডাউনলোড করা ভয়েস ফাইল এখনও ইমপোর্ট করা যাবে।",
     "refreshList": "কণ্ঠস্বর তালিকা রিফ্রেশ করুন"
   },
   "echoNotice": {

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Aufnahme ist zu lang — halten Sie sie unter {seconds} Sekunden.",
     "clipTooShort": "Aufnahme ist zu kurz — sprechen Sie mindestens {seconds} Sekunden.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Brauchen Sie eine eigene Stimme?",
     "decodeFailed": "Audiodatei konnte nicht gelesen werden — versuchen Sie WAV, MP3 oder ein anderes gängiges Format.",
     "delete": "Löschen",
     "deleteConfirm": "Stimme \"{name}\" löschen?",
@@ -918,7 +917,6 @@
     "importVoice": "Stimme importieren…",
     "manageImported": "Importierte Stimmen verwalten",
     "myVoices": "Meine Stimmen",
-    "openVoiceBuilder": "Im Voice Builder erstellen",
     "play": "Abspielen",
     "presets": "Voreinstellungen",
     "recordVoice": "Stimme aufnehmen…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Geben Sie genau ein, was im Clip gesagt wird…",
     "unstable": "instabil",
     "voice": "Stimme",
-    "voiceBuilderDisclaimer": "Kostenpflichtiger Supertone-Dienst. Sokuji ist an dieser Transaktion nicht beteiligt.",
+    "voiceBuilderClosed": "Supertone hat seinen Voice-Builder-Dienst am 31. August 2026 eingestellt. Bereits heruntergeladene Stimmdateien können weiterhin importiert werden.",
     "refreshList": "Stimmenliste aktualisieren"
   },
   "echoNotice": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1103,7 +1103,6 @@
     "clipTooLong": "Recording is too long — keep it under {seconds} seconds.",
     "clipTooShort": "Recording is too short — speak for at least {seconds} seconds.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Need a custom voice?",
     "decodeFailed": "Could not read that audio file — try a WAV, MP3, or other common format.",
     "delete": "Delete",
     "deleteConfirm": "Delete voice \"{name}\"?",
@@ -1113,7 +1112,6 @@
     "importVoice": "Import voice…",
     "manageImported": "Manage imported voices",
     "myVoices": "My Voices",
-    "openVoiceBuilder": "Create one at Voice Builder",
     "play": "Play",
     "presets": "Presets",
     "recordVoice": "Record voice…",
@@ -1129,7 +1127,7 @@
     "transcriptPlaceholder": "Type exactly what the clip says…",
     "unstable": "unstable",
     "voice": "Voice",
-    "voiceBuilderDisclaimer": "Paid Supertone service. Sokuji is not involved in that transaction.",
+    "voiceBuilderClosed": "Supertone closed its Voice Builder service on August 31, 2026. Voice files you already downloaded can still be imported.",
     "refreshList": "Refresh voice list"
   },
   "echoNotice": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "La grabación es demasiado larga — mantenla por debajo de {seconds} segundos.",
     "clipTooShort": "La grabación es demasiado corta — habla durante al menos {seconds} segundos.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "¿Necesitas una voz personalizada?",
     "decodeFailed": "No se pudo leer ese archivo de audio — prueba con WAV, MP3 u otro formato común.",
     "delete": "Eliminar",
     "deleteConfirm": "¿Eliminar la voz \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Importar voz…",
     "manageImported": "Gestionar voces importadas",
     "myVoices": "Mis Voces",
-    "openVoiceBuilder": "Crea una en Voice Builder",
     "play": "Reproducir",
     "presets": "Preajustes",
     "recordVoice": "Grabar voz…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Escribe exactamente lo que dice el clip…",
     "unstable": "inestable",
     "voice": "Voz",
-    "voiceBuilderDisclaimer": "Servicio de pago de Supertone. Sokuji no participa en esa transacción.",
+    "voiceBuilderClosed": "Supertone cerró su servicio Voice Builder el 31 de agosto de 2026. Los archivos de voz que ya hayas descargado se pueden seguir importando.",
     "refreshList": "Actualizar lista de voces"
   },
   "echoNotice": {

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "ضبط خیلی طولانی است — آن را زیر {seconds} ثانیه نگه دارید.",
     "clipTooShort": "ضبط خیلی کوتاه است — حداقل {seconds} ثانیه صحبت کنید.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "به صدای سفارشی نیاز دارید؟",
     "decodeFailed": "خواندن آن فایل صوتی ممکن نشد — یک WAV، MP3 یا قالب رایج دیگر را امتحان کنید.",
     "delete": "حذف",
     "deleteConfirm": "صدای \"{name}\" حذف شود؟",
@@ -918,7 +917,6 @@
     "importVoice": "وارد کردن صدا…",
     "manageImported": "مدیریت صداهای وارد‌شده",
     "myVoices": "صداهای من",
-    "openVoiceBuilder": "یکی را در Voice Builder بسازید",
     "play": "پخش",
     "presets": "پیش‌تنظیم‌ها",
     "recordVoice": "ضبط صدا…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "دقیقاً آنچه در کلیپ گفته می‌شود را تایپ کنید…",
     "unstable": "ناپایدار",
     "voice": "صدا",
-    "voiceBuilderDisclaimer": "سرویس پولی Supertone. Sokuji در آن تراکنش دخالتی ندارد.",
+    "voiceBuilderClosed": "Supertone سرویس Voice Builder را در ۳۱ اوت ۲۰۲۶ تعطیل کرد. فایل‌های صدایی که قبلاً دانلود کرده‌اید همچنان قابل وارد کردن هستند.",
     "refreshList": "به‌روزرسانی فهرست صداها"
   },
   "echoNotice": {

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Tallenne on liian pitkä — pidä se alle {seconds} sekunnissa.",
     "clipTooShort": "Tallenne on liian lyhyt — puhu vähintään {seconds} sekuntia.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Tarvitsetko mukautetun äänen?",
     "decodeFailed": "Äänitiedostoa ei voitu lukea — kokeile WAV-, MP3- tai muuta yleistä muotoa.",
     "delete": "Poista",
     "deleteConfirm": "Poistetaanko ääni \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Tuo ääni…",
     "manageImported": "Hallitse tuotuja ääniä",
     "myVoices": "Omat äänet",
-    "openVoiceBuilder": "Luo sellainen Voice Builderissa",
     "play": "Toista",
     "presets": "Esiasetukset",
     "recordVoice": "Nauhoita ääni…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Kirjoita tarkalleen se, mitä leike sanoo…",
     "unstable": "epävakaa",
     "voice": "Ääni",
-    "voiceBuilderDisclaimer": "Maksullinen Supertone-palvelu. Sokuji ei ole osallisena tässä liiketoimessa.",
+    "voiceBuilderClosed": "Supertone sulki Voice Builder -palvelunsa 31. elokuuta 2026. Jo ladatut äänitiedostot voi edelleen tuoda.",
     "refreshList": "Päivitä äänilista"
   },
   "echoNotice": {

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Masyadong mahaba ang recording — panatilihin itong wala pang {seconds} segundo.",
     "clipTooShort": "Masyadong maikli ang recording — magsalita nang hindi bababa sa {seconds} segundo.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Kailangan ng custom na boses?",
     "decodeFailed": "Hindi mabasa ang audio file na iyon — subukan ang WAV, MP3, o ibang karaniwang format.",
     "delete": "I-delete",
     "deleteConfirm": "I-delete ang boses na \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Mag-import ng boses…",
     "manageImported": "Pamahalaan ang mga na-import na boses",
     "myVoices": "Aking mga Boses",
-    "openVoiceBuilder": "Gumawa ng isa sa Voice Builder",
     "play": "I-play",
     "presets": "Mga Preset",
     "recordVoice": "Mag-record ng boses…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "I-type nang eksakto ang sinasabi ng clip…",
     "unstable": "hindi matatag",
     "voice": "Boses",
-    "voiceBuilderDisclaimer": "Bayad na serbisyo ng Supertone. Hindi kasangkot ang Sokuji sa transaksyong iyon.",
+    "voiceBuilderClosed": "Isinara ng Supertone ang serbisyo nitong Voice Builder noong Agosto 31, 2026. Maaari pa ring i-import ang mga voice file na na-download mo na.",
     "refreshList": "I-refresh ang listahan ng boses"
   },
   "echoNotice": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "L'enregistrement est trop long — restez sous {seconds} secondes.",
     "clipTooShort": "L'enregistrement est trop court — parlez pendant au moins {seconds} secondes.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Besoin d'une voix personnalisée ?",
     "decodeFailed": "Impossible de lire ce fichier audio — essayez un WAV, un MP3 ou un autre format courant.",
     "delete": "Supprimer",
     "deleteConfirm": "Supprimer la voix « {name} » ?",
@@ -918,7 +917,6 @@
     "importVoice": "Importer une voix…",
     "manageImported": "Gérer les voix importées",
     "myVoices": "Mes voix",
-    "openVoiceBuilder": "Créez-en une avec Voice Builder",
     "play": "Lire",
     "presets": "Préréglages",
     "recordVoice": "Enregistrer une voix…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Tapez exactement ce que dit le clip…",
     "unstable": "instable",
     "voice": "Voix",
-    "voiceBuilderDisclaimer": "Service Supertone payant. Sokuji n'intervient pas dans cette transaction.",
+    "voiceBuilderClosed": "Supertone a fermé son service Voice Builder le 31 août 2026. Les fichiers de voix déjà téléchargés peuvent toujours être importés.",
     "refreshList": "Actualiser la liste des voix"
   },
   "echoNotice": {

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "ההקלטה ארוכה מדי — שמור אותה מתחת ל-{seconds} שניות.",
     "clipTooShort": "ההקלטה קצרה מדי — דבר לפחות {seconds} שניות.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "צריך קול מותאם אישית?",
     "decodeFailed": "לא ניתן לקרוא את קובץ השמע הזה — נסה WAV, MP3 או פורמט נפוץ אחר.",
     "delete": "מחק",
     "deleteConfirm": "למחוק את הקול \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "ייבוא קול…",
     "manageImported": "ניהול קולות מיובאים",
     "myVoices": "הקולות שלי",
-    "openVoiceBuilder": "צור קול ב-Voice Builder",
     "play": "נגן",
     "presets": "מוגדרים מראש",
     "recordVoice": "הקלטת קול…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "הקלד בדיוק את מה שנאמר בקליפ…",
     "unstable": "לא יציב",
     "voice": "קול",
-    "voiceBuilderDisclaimer": "שירות בתשלום של Supertone. Sokuji אינה מעורבת בעסקה זו.",
+    "voiceBuilderClosed": "Supertone סגרה את שירות Voice Builder ב-31 באוגוסט 2026. קובצי קול שכבר הורדתם עדיין ניתנים לייבוא.",
     "refreshList": "רענן את רשימת הקולות"
   },
   "echoNotice": {

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "रिकॉर्डिंग बहुत लंबी है — इसे {seconds} सेकंड से कम रखें।",
     "clipTooShort": "रिकॉर्डिंग बहुत छोटी है — कम से कम {seconds} सेकंड बोलें।",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "कस्टम आवाज़ चाहिए?",
     "decodeFailed": "वह ऑडियो फ़ाइल पढ़ी नहीं जा सकी — WAV, MP3 या कोई अन्य सामान्य प्रारूप आज़माएं।",
     "delete": "हटाएं",
     "deleteConfirm": "आवाज़ \"{name}\" हटाएं?",
@@ -918,7 +917,6 @@
     "importVoice": "आवाज़ आयात करें…",
     "manageImported": "आयातित आवाज़ें प्रबंधित करें",
     "myVoices": "मेरी आवाज़ें",
-    "openVoiceBuilder": "Voice Builder में एक बनाएं",
     "play": "चलाएं",
     "presets": "प्रीसेट",
     "recordVoice": "आवाज़ रिकॉर्ड करें…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "क्लिप में जो कहा गया है ठीक वही टाइप करें…",
     "unstable": "अस्थिर",
     "voice": "आवाज़",
-    "voiceBuilderDisclaimer": "सशुल्क Supertone सेवा। Sokuji उस लेन-देन में शामिल नहीं है।",
+    "voiceBuilderClosed": "Supertone ने अपनी Voice Builder सेवा 31 अगस्त 2026 को बंद कर दी। पहले डाउनलोड की गई आवाज़ फ़ाइलें अब भी इंपोर्ट की जा सकती हैं।",
     "refreshList": "आवाज़ सूची रीफ़्रेश करें"
   },
   "echoNotice": {

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Rekaman terlalu panjang — jaga di bawah {seconds} detik.",
     "clipTooShort": "Rekaman terlalu pendek — bicaralah setidaknya {seconds} detik.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Butuh suara kustom?",
     "decodeFailed": "Tidak dapat membaca file audio itu — coba WAV, MP3, atau format umum lainnya.",
     "delete": "Hapus",
     "deleteConfirm": "Hapus suara \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Impor suara…",
     "manageImported": "Kelola suara yang diimpor",
     "myVoices": "Suara Saya",
-    "openVoiceBuilder": "Buat di Voice Builder",
     "play": "Putar",
     "presets": "Preset",
     "recordVoice": "Rekam suara…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Ketik persis apa yang diucapkan dalam klip…",
     "unstable": "tidak stabil",
     "voice": "Suara",
-    "voiceBuilderDisclaimer": "Layanan berbayar Supertone. Sokuji tidak terlibat dalam transaksi tersebut.",
+    "voiceBuilderClosed": "Supertone menutup layanan Voice Builder pada 31 Agustus 2026. File suara yang sudah Anda unduh masih dapat diimpor.",
     "refreshList": "Segarkan daftar suara"
   },
   "echoNotice": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "La registrazione è troppo lunga — mantienila sotto i {seconds} secondi.",
     "clipTooShort": "La registrazione è troppo breve — parla per almeno {seconds} secondi.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Ti serve una voce personalizzata?",
     "decodeFailed": "Impossibile leggere quel file audio — prova con un WAV, MP3 o altro formato comune.",
     "delete": "Elimina",
     "deleteConfirm": "Eliminare la voce \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Importa voce…",
     "manageImported": "Gestisci le voci importate",
     "myVoices": "Le Mie Voci",
-    "openVoiceBuilder": "Creane una su Voice Builder",
     "play": "Riproduci",
     "presets": "Preimpostazioni",
     "recordVoice": "Registra voce…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Scrivi esattamente ciò che dice il clip…",
     "unstable": "instabile",
     "voice": "Voce",
-    "voiceBuilderDisclaimer": "Servizio Supertone a pagamento. Sokuji non è coinvolta in tale transazione.",
+    "voiceBuilderClosed": "Supertone ha chiuso il servizio Voice Builder il 31 agosto 2026. I file voce già scaricati possono ancora essere importati.",
     "refreshList": "Aggiorna elenco voci"
   },
   "echoNotice": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "録音が長すぎます — {seconds}秒以内にしてください。",
     "clipTooShort": "録音が短すぎます — {seconds}秒以上話してください。",
     "cloneVoiceRequired": "この音声はまだ話せません — 下から音声クリップを録音またはインポートしてください。",
-    "customVoiceCta": "カスタム音声が必要ですか？",
     "decodeFailed": "その音声ファイルを読み込めませんでした — WAV、MP3 などの一般的な形式をお試しください。",
     "delete": "削除",
     "deleteConfirm": "音声「{name}」を削除しますか？",
@@ -918,7 +917,6 @@
     "importVoice": "音声をインポート…",
     "manageImported": "インポートした音声を管理",
     "myVoices": "マイ音声",
-    "openVoiceBuilder": "Voice Builder で作成する",
     "play": "再生",
     "presets": "プリセット",
     "recordVoice": "音声を録音…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "クリップの内容をそのまま入力してください…",
     "unstable": "不安定",
     "voice": "音声",
-    "voiceBuilderDisclaimer": "Supertone の有料サービスです。Sokuji はこの取引に関与しません。",
+    "voiceBuilderClosed": "Supertone の Voice Builder サービスは 2026年8月31日に終了しました。すでにダウンロード済みの音声ファイルは引き続きインポートできます。",
     "refreshList": "音声リストを更新"
   },
   "echoNotice": {

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "녹음이 너무 깁니다 — {seconds}초 이내로 유지하세요.",
     "clipTooShort": "녹음이 너무 짧습니다 — 최소 {seconds}초 이상 말하세요.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "맞춤 음성이 필요하신가요?",
     "decodeFailed": "이 오디오 파일을 읽을 수 없습니다 — WAV, MP3 등 일반적인 형식을 사용해 보세요.",
     "delete": "삭제",
     "deleteConfirm": "음성 \"{name}\"을(를) 삭제하시겠습니까?",
@@ -918,7 +917,6 @@
     "importVoice": "음성 가져오기…",
     "manageImported": "가져온 음성 관리",
     "myVoices": "내 음성",
-    "openVoiceBuilder": "Voice Builder에서 만들기",
     "play": "재생",
     "presets": "프리셋",
     "recordVoice": "음성 녹음…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "클립에서 말한 내용을 그대로 입력하세요…",
     "unstable": "불안정",
     "voice": "음성",
-    "voiceBuilderDisclaimer": "Supertone의 유료 서비스입니다. Sokuji는 해당 거래에 관여하지 않습니다.",
+    "voiceBuilderClosed": "Supertone의 Voice Builder 서비스는 2026년 8월 31일에 종료되었습니다. 이미 다운로드한 음성 파일은 계속 가져올 수 있습니다.",
     "refreshList": "음성 목록 새로고침"
   },
   "echoNotice": {

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Rakaman terlalu panjang — pastikan ia kurang daripada {seconds} saat.",
     "clipTooShort": "Rakaman terlalu pendek — bercakap sekurang-kurangnya {seconds} saat.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Perlukan suara tersuai?",
     "decodeFailed": "Tidak dapat membaca fail audio itu — cuba WAV, MP3 atau format biasa yang lain.",
     "delete": "Padam",
     "deleteConfirm": "Padam suara \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Import suara…",
     "manageImported": "Urus suara yang diimport",
     "myVoices": "Suara Saya",
-    "openVoiceBuilder": "Cipta satu di Voice Builder",
     "play": "Main",
     "presets": "Pratetap",
     "recordVoice": "Rakam suara…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Taip dengan tepat apa yang klip itu katakan…",
     "unstable": "tidak stabil",
     "voice": "Suara",
-    "voiceBuilderDisclaimer": "Perkhidmatan berbayar Supertone. Sokuji tidak terlibat dalam transaksi tersebut.",
+    "voiceBuilderClosed": "Supertone telah menutup perkhidmatan Voice Builder pada 31 Ogos 2026. Fail suara yang telah dimuat turun masih boleh diimport.",
     "refreshList": "Segarkan senarai suara"
   },
   "echoNotice": {

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Opname is te lang — houd deze onder {seconds} seconden.",
     "clipTooShort": "Opname is te kort — spreek minstens {seconds} seconden.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Een aangepaste stem nodig?",
     "decodeFailed": "Kon dat audiobestand niet lezen — probeer een WAV, MP3 of ander gangbaar formaat.",
     "delete": "Verwijderen",
     "deleteConfirm": "Stem \"{name}\" verwijderen?",
@@ -918,7 +917,6 @@
     "importVoice": "Stem importeren…",
     "manageImported": "Geïmporteerde stemmen beheren",
     "myVoices": "Mijn stemmen",
-    "openVoiceBuilder": "Maak er een in Voice Builder",
     "play": "Afspelen",
     "presets": "Presets",
     "recordVoice": "Stem opnemen…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Typ precies wat de clip zegt…",
     "unstable": "onstabiel",
     "voice": "Stem",
-    "voiceBuilderDisclaimer": "Betaalde Supertone-dienst. Sokuji is niet betrokken bij die transactie.",
+    "voiceBuilderClosed": "Supertone heeft zijn Voice Builder-dienst op 31 augustus 2026 gesloten. Al gedownloade stembestanden kunnen nog steeds worden geïmporteerd.",
     "refreshList": "Stemlijst vernieuwen"
   },
   "echoNotice": {

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Nagranie jest zbyt długie — nie przekraczaj {seconds} sekund.",
     "clipTooShort": "Nagranie jest zbyt krótkie — mów przez co najmniej {seconds} sekund.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Potrzebujesz własnego głosu?",
     "decodeFailed": "Nie udało się odczytać tego pliku audio — spróbuj WAV, MP3 lub innego popularnego formatu.",
     "delete": "Usuń",
     "deleteConfirm": "Usunąć głos \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Importuj głos…",
     "manageImported": "Zarządzaj zaimportowanymi głosami",
     "myVoices": "Moje Głosy",
-    "openVoiceBuilder": "Utwórz go w Voice Builder",
     "play": "Odtwórz",
     "presets": "Presety",
     "recordVoice": "Nagraj głos…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Wpisz dokładnie to, co słychać w nagraniu…",
     "unstable": "niestabilny",
     "voice": "Głos",
-    "voiceBuilderDisclaimer": "Płatna usługa Supertone. Sokuji nie uczestniczy w tej transakcji.",
+    "voiceBuilderClosed": "Supertone zamknął usługę Voice Builder 31 sierpnia 2026 r. Pobrane wcześniej pliki głosów nadal można importować.",
     "refreshList": "Odśwież listę głosów"
   },
   "echoNotice": {

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "A gravação é muito longa — mantenha-a abaixo de {seconds} segundos.",
     "clipTooShort": "A gravação é muito curta — fale por pelo menos {seconds} segundos.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Precisa de uma voz personalizada?",
     "decodeFailed": "Não foi possível ler esse arquivo de áudio — tente WAV, MP3 ou outro formato comum.",
     "delete": "Excluir",
     "deleteConfirm": "Excluir a voz \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Importar voz…",
     "manageImported": "Gerenciar vozes importadas",
     "myVoices": "Minhas Vozes",
-    "openVoiceBuilder": "Crie uma no Voice Builder",
     "play": "Reproduzir",
     "presets": "Predefinições",
     "recordVoice": "Gravar voz…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Digite exatamente o que o clipe diz…",
     "unstable": "instável",
     "voice": "Voz",
-    "voiceBuilderDisclaimer": "Serviço pago da Supertone. O Sokuji não participa dessa transação.",
+    "voiceBuilderClosed": "A Supertone encerrou o serviço Voice Builder em 31 de agosto de 2026. Os arquivos de voz que você já baixou ainda podem ser importados.",
     "refreshList": "Atualizar lista de vozes"
   },
   "echoNotice": {

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "A gravação é demasiado longa — mantenha-a abaixo dos {seconds} segundos.",
     "clipTooShort": "A gravação é demasiado curta — fale durante pelo menos {seconds} segundos.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Precisa de uma voz personalizada?",
     "decodeFailed": "Não foi possível ler esse ficheiro de áudio — experimente WAV, MP3 ou outro formato comum.",
     "delete": "Eliminar",
     "deleteConfirm": "Eliminar a voz \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Importar voz…",
     "manageImported": "Gerir vozes importadas",
     "myVoices": "As Minhas Vozes",
-    "openVoiceBuilder": "Crie uma no Voice Builder",
     "play": "Reproduzir",
     "presets": "Predefinições",
     "recordVoice": "Gravar voz…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Escreva exatamente o que o clipe diz…",
     "unstable": "instável",
     "voice": "Voz",
-    "voiceBuilderDisclaimer": "Serviço pago da Supertone. O Sokuji não intervém nessa transação.",
+    "voiceBuilderClosed": "A Supertone encerrou o serviço Voice Builder a 31 de agosto de 2026. Os ficheiros de voz já transferidos continuam a poder ser importados.",
     "refreshList": "Atualizar lista de vozes"
   },
   "echoNotice": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Запись слишком длинная — не более {seconds} секунд.",
     "clipTooShort": "Запись слишком короткая — говорите не менее {seconds} секунд.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Нужен свой голос?",
     "decodeFailed": "Не удалось прочитать этот аудиофайл — попробуйте WAV, MP3 или другой распространённый формат.",
     "delete": "Удалить",
     "deleteConfirm": "Удалить голос «{name}»?",
@@ -918,7 +917,6 @@
     "importVoice": "Импортировать голос…",
     "manageImported": "Управление импортированными голосами",
     "myVoices": "Мои голоса",
-    "openVoiceBuilder": "Создайте его в Voice Builder",
     "play": "Воспроизвести",
     "presets": "Пресеты",
     "recordVoice": "Записать голос…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Введите точно то, что сказано в записи…",
     "unstable": "нестабильно",
     "voice": "Голос",
-    "voiceBuilderDisclaimer": "Платный сервис Supertone. Sokuji не участвует в этой сделке.",
+    "voiceBuilderClosed": "Supertone закрыла сервис Voice Builder 31 августа 2026 года. Уже скачанные файлы голосов по-прежнему можно импортировать.",
     "refreshList": "Обновить список голосов"
   },
   "echoNotice": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Inspelningen är för lång — håll den under {seconds} sekunder.",
     "clipTooShort": "Inspelningen är för kort — tala i minst {seconds} sekunder.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Behöver du en anpassad röst?",
     "decodeFailed": "Kunde inte läsa den ljudfilen — prova WAV, MP3 eller ett annat vanligt format.",
     "delete": "Radera",
     "deleteConfirm": "Radera rösten \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Importera röst…",
     "manageImported": "Hantera importerade röster",
     "myVoices": "Mina röster",
-    "openVoiceBuilder": "Skapa en i Voice Builder",
     "play": "Spela upp",
     "presets": "Förinställningar",
     "recordVoice": "Spela in röst…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Skriv exakt vad klippet säger…",
     "unstable": "instabil",
     "voice": "Röst",
-    "voiceBuilderDisclaimer": "Betald Supertone-tjänst. Sokuji är inte inblandat i den transaktionen.",
+    "voiceBuilderClosed": "Supertone stängde sin Voice Builder-tjänst den 31 augusti 2026. Röstfiler som du redan har laddat ned kan fortfarande importeras.",
     "refreshList": "Uppdatera röstlistan"
   },
   "echoNotice": {

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "பதிவு மிக நீளமானது — {seconds} வினாடிகளுக்குள் வைக்கவும்.",
     "clipTooShort": "பதிவு மிகக் குறுகியது — குறைந்தது {seconds} வினாடிகள் பேசவும்.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "தனிப்பயன் குரல் வேண்டுமா?",
     "decodeFailed": "அந்த ஆடியோ கோப்பைப் படிக்க முடியவில்லை — WAV, MP3 அல்லது வேறு பொதுவான வடிவத்தை முயற்சிக்கவும்.",
     "delete": "நீக்கு",
     "deleteConfirm": "\"{name}\" குரலை நீக்கவா?",
@@ -918,7 +917,6 @@
     "importVoice": "குரலை இறக்குமதி செய்…",
     "manageImported": "இறக்குமதி செய்த குரல்களை நிர்வகி",
     "myVoices": "என் குரல்கள்",
-    "openVoiceBuilder": "Voice Builder இல் ஒன்றை உருவாக்கவும்",
     "play": "இயக்கு",
     "presets": "முன்னமைவுகள்",
     "recordVoice": "குரலைப் பதிவு செய்…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "கிளிப் சொல்வதை அப்படியே தட்டச்சு செய்யவும்…",
     "unstable": "நிலையற்றது",
     "voice": "குரல்",
-    "voiceBuilderDisclaimer": "கட்டணச் Supertone சேவை. அந்தப் பரிவர்த்தனையில் Sokuji ஈடுபடவில்லை.",
+    "voiceBuilderClosed": "Supertone தனது Voice Builder சேவையை 31 ஆகஸ்ட் 2026 அன்று நிறுத்தியது. ஏற்கனவே பதிவிறக்கிய குரல் கோப்புகளை இன்னும் இறக்குமதி செய்யலாம்.",
     "refreshList": "குரல் பட்டியலைப் புதுப்பிக்கவும்"
   },
   "echoNotice": {

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "రికార్డింగ్ చాలా పొడవుగా ఉంది — దాన్ని {seconds} సెకన్ల లోపు ఉంచండి.",
     "clipTooShort": "రికార్డింగ్ చాలా చిన్నది — కనీసం {seconds} సెకన్లు మాట్లాడండి.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "అనుకూల వాయిస్ కావాలా?",
     "decodeFailed": "ఆ ఆడియో ఫైల్‌ను చదవలేకపోయాము — WAV, MP3 లేదా ఇతర సాధారణ ఫార్మాట్‌ను ప్రయత్నించండి.",
     "delete": "తొలగించు",
     "deleteConfirm": "\"{name}\" వాయిస్‌ను తొలగించాలా?",
@@ -918,7 +917,6 @@
     "importVoice": "వాయిస్ దిగుమతి చేయి…",
     "manageImported": "దిగుమతి చేసిన వాయిస్‌లను నిర్వహించండి",
     "myVoices": "నా వాయిస్‌లు",
-    "openVoiceBuilder": "Voice Builder లో ఒకటి సృష్టించండి",
     "play": "ప్లే చేయి",
     "presets": "ప్రీసెట్‌లు",
     "recordVoice": "వాయిస్ రికార్డ్ చేయి…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "క్లిప్‌లో ఏం చెప్పారో అచ్చంగా టైప్ చేయండి…",
     "unstable": "అస్థిరం",
     "voice": "వాయిస్",
-    "voiceBuilderDisclaimer": "చెల్లింపు Supertone సేవ. ఆ లావాదేవీలో Sokuji ప్రమేయం లేదు.",
+    "voiceBuilderClosed": "Supertone తన Voice Builder సేవను 31 ఆగస్టు 2026న నిలిపివేసింది. ఇప్పటికే డౌన్‌లోడ్ చేసిన వాయిస్ ఫైళ్లను ఇప్పటికీ దిగుమతి చేసుకోవచ్చు.",
     "refreshList": "వాయిస్ జాబితాను రిఫ్రెష్ చేయండి"
   },
   "echoNotice": {

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "การบันทึกยาวเกินไป — ให้สั้นกว่า {seconds} วินาที",
     "clipTooShort": "การบันทึกสั้นเกินไป — พูดอย่างน้อย {seconds} วินาที",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "ต้องการเสียงที่กำหนดเอง?",
     "decodeFailed": "ไม่สามารถอ่านไฟล์เสียงนั้นได้ — ลองใช้ WAV, MP3 หรือรูปแบบทั่วไปอื่นๆ",
     "delete": "ลบ",
     "deleteConfirm": "ลบเสียง \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "นำเข้าเสียง…",
     "manageImported": "จัดการเสียงที่นำเข้า",
     "myVoices": "เสียงของฉัน",
-    "openVoiceBuilder": "สร้างได้ที่ Voice Builder",
     "play": "เล่น",
     "presets": "พรีเซ็ต",
     "recordVoice": "บันทึกเสียง…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "พิมพ์ให้ตรงกับที่พูดในคลิป…",
     "unstable": "ไม่เสถียร",
     "voice": "เสียง",
-    "voiceBuilderDisclaimer": "บริการแบบเสียเงินของ Supertone Sokuji ไม่มีส่วนเกี่ยวข้องกับธุรกรรมนั้น",
+    "voiceBuilderClosed": "Supertone ปิดบริการ Voice Builder เมื่อวันที่ 31 สิงหาคม 2026 ไฟล์เสียงที่คุณดาวน์โหลดไว้แล้วยังคงนำเข้าได้",
     "refreshList": "รีเฟรชรายการเสียง"
   },
   "echoNotice": {

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Kayıt çok uzun — {seconds} saniyenin altında tutun.",
     "clipTooShort": "Kayıt çok kısa — en az {seconds} saniye konuşun.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Özel bir ses mi lazım?",
     "decodeFailed": "Bu ses dosyası okunamadı — WAV, MP3 veya başka yaygın bir format deneyin.",
     "delete": "Sil",
     "deleteConfirm": "\"{name}\" sesi silinsin mi?",
@@ -918,7 +917,6 @@
     "importVoice": "Ses içe aktar…",
     "manageImported": "İçe aktarılan sesleri yönet",
     "myVoices": "Seslerim",
-    "openVoiceBuilder": "Voice Builder'da oluşturun",
     "play": "Oynat",
     "presets": "Hazır ayarlar",
     "recordVoice": "Ses kaydet…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Klipte söylenenleri tam olarak yazın…",
     "unstable": "kararsız",
     "voice": "Ses",
-    "voiceBuilderDisclaimer": "Ücretli Supertone hizmeti. Sokuji bu işleme dahil değildir.",
+    "voiceBuilderClosed": "Supertone, Voice Builder hizmetini 31 Ağustos 2026'da kapattı. Daha önce indirdiğiniz ses dosyaları yine de içe aktarılabilir.",
     "refreshList": "Ses listesini yenile"
   },
   "echoNotice": {

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Запис задовгий — не довше {seconds} секунд.",
     "clipTooShort": "Запис закороткий — говоріть щонайменше {seconds} секунд.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Потрібен власний голос?",
     "decodeFailed": "Не вдалося прочитати цей аудіофайл — спробуйте WAV, MP3 або інший поширений формат.",
     "delete": "Видалити",
     "deleteConfirm": "Видалити голос «{name}»?",
@@ -918,7 +917,6 @@
     "importVoice": "Імпортувати голос…",
     "manageImported": "Керувати імпортованими голосами",
     "myVoices": "Мої голоси",
-    "openVoiceBuilder": "Створіть його у Voice Builder",
     "play": "Відтворити",
     "presets": "Пресети",
     "recordVoice": "Записати голос…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Введіть точно те, що звучить у записі…",
     "unstable": "нестабільно",
     "voice": "Голос",
-    "voiceBuilderDisclaimer": "Платний сервіс Supertone. Sokuji не бере участі в цій операції.",
+    "voiceBuilderClosed": "Supertone закрила сервіс Voice Builder 31 серпня 2026 року. Уже завантажені файли голосів і надалі можна імпортувати.",
     "refreshList": "Оновити список голосів"
   },
   "echoNotice": {

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "Bản ghi quá dài — hãy giữ dưới {seconds} giây.",
     "clipTooShort": "Bản ghi quá ngắn — hãy nói ít nhất {seconds} giây.",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "Cần một giọng nói tùy chỉnh?",
     "decodeFailed": "Không thể đọc tệp âm thanh đó — hãy thử WAV, MP3 hoặc định dạng phổ biến khác.",
     "delete": "Xóa",
     "deleteConfirm": "Xóa giọng nói \"{name}\"?",
@@ -918,7 +917,6 @@
     "importVoice": "Nhập giọng nói…",
     "manageImported": "Quản lý giọng nói đã nhập",
     "myVoices": "Giọng nói của tôi",
-    "openVoiceBuilder": "Tạo một giọng tại Voice Builder",
     "play": "Phát",
     "presets": "Mẫu có sẵn",
     "recordVoice": "Ghi giọng nói…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "Nhập chính xác nội dung của đoạn ghi…",
     "unstable": "không ổn định",
     "voice": "Giọng nói",
-    "voiceBuilderDisclaimer": "Dịch vụ trả phí của Supertone. Sokuji không tham gia vào giao dịch đó.",
+    "voiceBuilderClosed": "Supertone đã đóng dịch vụ Voice Builder vào ngày 31 tháng 8 năm 2026. Các tệp giọng nói bạn đã tải xuống vẫn có thể nhập được.",
     "refreshList": "Làm mới danh sách giọng nói"
   },
   "echoNotice": {

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "录音过长 — 请控制在 {seconds} 秒以内。",
     "clipTooShort": "录音过短 — 请至少说满 {seconds} 秒。",
     "cloneVoiceRequired": "此声音尚无法发声 — 请先在下方录制或导入一段语音片段。",
-    "customVoiceCta": "需要自定义声音？",
     "decodeFailed": "无法读取该音频文件 — 请尝试 WAV、MP3 等常见格式。",
     "delete": "删除",
     "deleteConfirm": "删除声音「{name}」？",
@@ -918,7 +917,6 @@
     "importVoice": "导入声音…",
     "manageImported": "管理导入的声音",
     "myVoices": "我的声音",
-    "openVoiceBuilder": "前往 Voice Builder 创建",
     "play": "播放",
     "presets": "预设",
     "recordVoice": "录制声音…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "请逐字输入音频中说的内容…",
     "unstable": "不稳定",
     "voice": "语音",
-    "voiceBuilderDisclaimer": "Supertone 的付费服务。Sokuji 不参与该交易。",
+    "voiceBuilderClosed": "Supertone 的 Voice Builder 服务已于 2026 年 8 月 31 日关闭。已下载的音色文件仍可导入。",
     "refreshList": "刷新声音列表"
   },
   "echoNotice": {

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -908,7 +908,6 @@
     "clipTooLong": "錄音太長 — 請控制在 {seconds} 秒以內。",
     "clipTooShort": "錄音太短 — 請至少說滿 {seconds} 秒。",
     "cloneVoiceRequired": "This voice needs a clip before it can speak — record or import one below.",
-    "customVoiceCta": "需要自訂語音嗎？",
     "decodeFailed": "無法讀取該音訊檔案 — 請改用 WAV、MP3 或其他常見格式。",
     "delete": "刪除",
     "deleteConfirm": "刪除語音「{name}」？",
@@ -918,7 +917,6 @@
     "importVoice": "匯入語音…",
     "manageImported": "管理匯入的語音",
     "myVoices": "我的語音",
-    "openVoiceBuilder": "在 Voice Builder 建立",
     "play": "播放",
     "presets": "預設語音",
     "recordVoice": "錄製語音…",
@@ -934,7 +932,7 @@
     "transcriptPlaceholder": "請完整輸入片段中所說的內容…",
     "unstable": "不穩定",
     "voice": "語音",
-    "voiceBuilderDisclaimer": "這是 Supertone 的付費服務。Sokuji 不涉及該交易。",
+    "voiceBuilderClosed": "Supertone 的 Voice Builder 服務已於 2026 年 8 月 31 日結束。已下載的語音檔案仍可匯入。",
     "refreshList": "重新整理語音清單"
   },
   "echoNotice": {


### PR DESCRIPTION
## Summary

Supertone Inc., the vendor behind Supertonic 3, resolved to dissolve on 2026-07-15 (HYBE is liquidating it). Its Voice Builder, Play and API services were discontinued on 2026-08-31: `supertonic.supertone.ai` is a 404, `play.supertone.ai` no longer resolves, and the upstream GitHub repo announced on 2026-07-23 that it will be archived with no further development or support. Two consequences for Sokuji:

- The "Need a custom voice? Create one at Voice Builder" link under the Supertonic 3 card sent users to a dead page.
- The browser/WebGPU path downloaded the ONNX weights straight from the `Supertone` Hugging Face organisation, which may vanish with the liquidation.

## Changes

- **Settings (b4615f77)**: the CTA is replaced by a one-line closure notice; voice files users already downloaded still import through the existing control. The three keys `customVoiceCta`, `openVoiceBuilder`, `voiceBuilderDisclaimer` are replaced by `voiceBuilderClosed` in all 30 locales (translations written, lockstep test green). Link-only SCSS and the now-unused `ExternalLink` / `isElectron` imports are removed.
- **Manifest (2dcaf7ae)**: `hfModelId` now points at `jiangzhuo9357/supertonic-3`, a verbatim mirror of `Supertone/supertonic-3` @ `3cadd1ee`. Same file layout, so every manifest path resolves unchanged; the OpenRAIL-M `LICENSE` and the upstream model card are kept and the mirror README records provenance and the license's use-based restrictions. The native/sidecar GGUF path is unaffected: it was already served by `audio-cpp/audio.cpp-gguf`.
- **Manifest (c6af264f)**: new optional `hfRevision` on manifest entries, used by `getModelDownloadUrl` in place of `main`; the mirror entry pins `95e49bbd`, the commit whose 39 files were sha256-checked. This answers CodeRabbit's point that the download path validates size and shape only: with a commit ref, a later push to the mirror cannot change what users cache until the manifest is edited. Entries without `hfRevision` keep resolving against `main` (covered by a test).

Branch has `origin/main` merged in twice (c6e06424, fb04f151) to pick up #483 (macOS signing keychain) and #480.

## Verification

- Mirror: all 38 upstream files were sha256-checked against the HF tree before upload; a fresh download of the mirror afterwards diffed byte-for-byte clean against that snapshot; the exact commit-pinned URL the app builds returns 200 with the expected 3,700,147 bytes; the repo is public and not gated, license tag `openrail`.
- Tests: `src/lib/local-inference` 51 files / 472 tests pass after the pin; the 5 directly affected files passed 176/176 before it; the full suite passed 329 files / 3776 tests (2 skipped) on 2dcaf7ae. The full run exits 1 only because of 4 pre-existing unhandled rejections in `settingsStore.nativeGate.test.ts`, which reproduce on their own and come from a file this PR does not touch.
- `tsc --noEmit`: 312 errors, the same pre-existing baseline #480 recorded; none are in files this PR touches.

## Not in this PR

- Three specs under `docs/superpowers/specs` still describe Voice Builder as the custom-voice source.
- Whether `supertonic-3` should stay `recommended` now that upstream is unmaintained.
- A replacement for Voice Builder (gradient inversion of the style tensors through the open weights is the community's approach; separate decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Supertonic 3 model downloads by using a verified, fixed model version for more consistent results.
  - Added coverage for model download handling when a fixed version is unavailable.

- **User Experience**
  - Replaced the unavailable Voice Builder link and custom-voice prompt with a notice that the service closed on August 31, 2026.
  - Clarified that previously downloaded voice files can still be imported.
  - Updated the notice across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->