### PR TITLE
fix(local-native): lift list_tts_voices preset names into NativeVoiceInfo at the client boundary

### DIFF
--- a/src/lib/local-inference/native/NativeModelClient.test.ts
+++ b/src/lib/local-inference/native/NativeModelClient.test.ts
@@ -72,4 +72,33 @@ describe('NativeModelClient', () => {
     conn.emit({ type: 'model_delete_result', id: conn.sent[0].id, model: 'sense-voice', freed: 1234 });
     await expect(p).resolves.toBe(1234);
   });
+
+  it('listTtsVoices() sends list_tts_voices and lifts the wire\'s preset names into voice descriptors', async () => {
+    // The ggml-only sidecar (spec 2026-08-30 §5.5, sidecar-v0.2.0) answers
+    // list_tts_voices with a flat list of preset NAMES — audio.cpp publishes
+    // nothing else. Every renderer consumer (curatedBuiltinVoices' sort,
+    // defaultTtsVoice, reconcileTtsVoice) reads `.name` off a NativeVoiceInfo,
+    // so the lift has to happen here, once, at the protocol boundary. Passing
+    // the strings through crashed the settings panel the first time a family
+    // with a non-empty load-free listing (supertonic) was selected:
+    // "Cannot read properties of undefined (reading 'localeCompare')".
+    const conn = new FakeSidecarConnection();
+    const c = new NativeModelClient(conn);
+    const p = c.listTtsVoices('supertonic-3');
+    expect(conn.sent[0]).toMatchObject({ type: 'list_tts_voices', model: 'supertonic-3' });
+    conn.emit({ type: 'list_tts_voices_result', id: conn.sent[0].id, voices: ['F1', 'M1'] });
+    await expect(p).resolves.toEqual([
+      { name: 'F1', curated: false, unstable: false, default: false },
+      { name: 'M1', curated: false, unstable: false, default: false },
+    ]);
+  });
+
+  it('listTtsVoices() omits the model field when none is given (whatever is loaded)', async () => {
+    const conn = new FakeSidecarConnection();
+    const c = new NativeModelClient(conn);
+    const p = c.listTtsVoices();
+    expect(conn.sent[0]).not.toHaveProperty('model');
+    conn.emit({ type: 'list_tts_voices_result', id: conn.sent[0].id, voices: [] });
+    await expect(p).resolves.toEqual([]);
+  });
 });

--- a/src/lib/local-inference/native/NativeModelClient.ts
+++ b/src/lib/local-inference/native/NativeModelClient.ts
@@ -74,12 +74,18 @@ export class NativeModelClient {
     return { variants: r.variants, recommended: r.recommended };
   }
 
-  /** Built-in TTS voice descriptors for a voice-capable model (empty if not downloaded). */
+  /** Built-in TTS voice descriptors for a voice-capable model (empty if not
+   *  downloaded). The wire carries preset names only (ListTtsVoicesResultMsg);
+   *  this is the one place they become NativeVoiceInfo, so every consumer
+   *  downstream can read `.name` — handing the raw strings through crashed
+   *  curatedBuiltinVoices' `a.name.localeCompare` the first time a family with
+   *  a non-empty listing (supertonic) was selected. */
   async listTtsVoices(model?: string): Promise<NativeVoiceInfo[]> {
     const payload: { type: 'list_tts_voices'; model?: string } = { type: 'list_tts_voices' };
     if (model) payload.model = model;
     const msg = await this.conn.request(payload);
-    return (msg as Extract<ServerMsg, { type: 'list_tts_voices_result' }>).voices;
+    const names = (msg as Extract<ServerMsg, { type: 'list_tts_voices_result' }>).voices;
+    return names.map((name) => ({ name, curated: false, unstable: false, default: false }));
   }
 
   /** Remove a model from the sidecar's cache; resolves to the bytes freed. */

--- a/src/lib/local-inference/native/nativeProtocol.ts
+++ b/src/lib/local-inference/native/nativeProtocol.ts
@@ -44,6 +44,13 @@ export interface NativeModelInfo {
    *  were computed against — feeds the localized "this machine has X" reason. */
   deviceMemBytes?: number | null;
 }
+/** A built-in TTS voice as the renderer consumes it. NOT a wire shape: the
+ *  ggml-only sidecar publishes preset NAMES only (spec 2026-08-30 §5.5 —
+ *  audio.cpp's sk_tts_presets carries no language/curation metadata), and
+ *  NativeModelClient.listTtsVoices lifts each name into one of these with every
+ *  flag false. The flags survive so a renderer-side curation table can fill
+ *  them in later without touching the consumers (curatedBuiltinVoices,
+ *  defaultTtsVoice, reconcileTtsVoice), which all read `.name`. */
 export interface NativeVoiceInfo {
   name: string; language?: string; curated: boolean; unstable: boolean; default: boolean;
 }
@@ -89,5 +96,7 @@ export type ModelDownloadStatus = 'ready' | 'cancelled';
 export interface ModelDownloadDoneMsg { type: 'model_download_done'; model: string; status: ModelDownloadStatus; }
 export interface TtsChunkMsg { type: 'tts_chunk'; id: number; seq: number; }
 export interface TtsDoneMsg { type: 'tts_done'; id: number; totalSamples: number; generationTimeMs: number; }
-export interface ListTtsVoicesResultMsg { type: 'list_tts_voices_result'; id: number; voices: NativeVoiceInfo[]; }
+/** `voices` is the flat preset-name list the sidecar's tts_voices.list_builtin_voices
+ *  returns (sidecar-v0.2.0+); see NativeVoiceInfo for why it is not the descriptor. */
+export interface ListTtsVoicesResultMsg { type: 'list_tts_voices_result'; id: number; voices: string[]; }
 export type ServerMsg = ReadyMsg | OkMsg | TtsGenerateResultMsg | TranslateResultMsg | TranslatePartialMsg | AsrPartialMsg | AsrResultMsg | ModelStatusResultMsg | ModelDeleteResultMsg | ModelProgressMsg | ModelDownloadDoneMsg | ErrorMsg | HardwareInfoResultMsg | ModelsCatalogResultMsg | ListVariantsResultMsg | TtsChunkMsg | TtsDoneMsg | ListTtsVoicesResultMsg;


### PR DESCRIPTION
## Problem

Selecting **supertonic** in the Local Native settings panel (right after downloading it) crashes the panel with React Router's error boundary:

```
TypeError: Cannot read properties of undefined (reading 'localeCompare')
    at nativeModelStore-*.js … Array.sort … curatedBuiltinVoices
```

## Root cause

The ggml-only sidecar (spec 2026-08-30 §5.5, shipped as `sidecar-v0.2.0` and unchanged on `main`) answers `list_tts_voices` with a **flat list of preset names** — audio.cpp's `sk_tts_presets` carries no language or curation metadata. The renderer kept the pre-#459 `NativeVoiceInfo` contract and reads `.name` off every entry in `curatedBuiltinVoices`, `defaultTtsVoice` and `reconcileTtsVoice`.

Every family other than supertonic and pocket_tts lists `[]`, so the sort comparator never ran and the mismatch stayed hidden since #459. supertonic is the first family with a non-empty listing to be selected.

## Fix

Lift the names into `NativeVoiceInfo` once, at the protocol boundary:

- `nativeProtocol.ts`: `ListTtsVoicesResultMsg.voices` is `string[]` (what the wire carries); `NativeVoiceInfo` is documented as the renderer-side shape.
- `NativeModelClient.listTtsVoices`: map each name to `{ name, curated: false, unstable: false, default: false }` — no curation invented (the renderer has no curation table today; the flags stay so one can be added later without touching consumers).

Works against `sidecar-v0.2.0` and `main` alike; no sidecar change or re-tag needed.

## Verification

- New tests in `NativeModelClient.test.ts`: the lift (fails before the fix — raw strings pass through) and the no-model request form.
- Every test file touching the voices protocol (`nativeCatalog`, `NativeModelClient`, `nativeTtsVoiceReconciliation`, `LocalNativeClient`): 127 passed.
- Native directory + voice settings sections (13 files): 180 passed.
- `tsc --noEmit` error count unchanged before/after (312, pre-existing baseline noise).

## Not in scope

MOSS's "needs a voice clip" refusal seen in the same log is a separate, version-coupled issue: `voice.required` was added to the sidecar catalog on 2026-09-03 (357b7d7d), after the `sidecar-v0.2.0` tag, so it clears with the next sidecar tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech voice listing so built-in voice names are correctly converted into usable voice details.
  - Prevented downstream errors caused by incomplete voice information.
  - Voice listing now behaves correctly when no model is specified or when no voices are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->