### PR TITLE
fix(local-native): the voice-clip notice is a client-held system row, not an onError bubble

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -2715,6 +2715,9 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           id: `error-${Date.now()}`,
           role: 'system',
           type: 'error',
+          // The speaker leg is up and the session is running one-way; the
+          // subtitle window must not read this trailing row as a failed start.
+          severity: 'warning',
           status: 'completed',
           createdAt: Date.now(),
           formatted: { text: participantErrorMessage },
@@ -2732,8 +2735,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           // including SonioxClient's own emitSystemNotice — it is the only
           // system-item type the bubble renderer and subtitleIdleState both
           // understand. A friendlier-sounding type nobody renders would be a
-          // notice the user never sees.
+          // notice the user never sees. `severity: 'warning'` keeps the
+          // subtitle window from reading it as a failed start — the session
+          // is running, on a built-in voice.
           type: 'error',
+          severity: 'warning',
           status: 'completed',
           createdAt: Date.now(),
           formatted: { text: prepareNotice },

--- a/src/components/Subtitle/subtitleIdleState.test.ts
+++ b/src/components/Subtitle/subtitleIdleState.test.ts
@@ -92,6 +92,29 @@ describe('deriveSubtitleIdleState', () => {
     ).toEqual({ kind: 'ended' });
   });
 
+  // A session that started fine but degraded (Local Native without a voice
+  // clip, a Soniox custom voice that could not be prepared) leaves a client-
+  // or MainPanel-held notice in items. It is typed `error` because that is
+  // the only system row the bubble renderer draws, but it is not a failed
+  // start: the session ran. Stopping it before the first transcript leaves
+  // that notice trailing, and Retry would be the wrong offer.
+  it('does not read a trailing warning-severity notice as a failed start', () => {
+    const degraded = item({
+      id: 'n-600', role: 'system', type: 'error', severity: 'warning', createdAt: 600,
+      formatted: { text: '"qwen3-tts" needs a voice clip' },
+    });
+    expect(
+      deriveSubtitleIdleState({ ...base, hasRunSession: true, startRequestedAt: 500, items: [degraded] }),
+    ).toEqual({ kind: 'ended' });
+  });
+
+  it('still reads a trailing error-severity item after the start request as failed', () => {
+    const hard = { ...errorItem(600, 'sidecar exited'), severity: 'error' as const };
+    expect(
+      deriveSubtitleIdleState({ ...base, hasRunSession: true, startRequestedAt: 500, items: [hard] }),
+    ).toEqual({ kind: 'failed', message: 'sidecar exited' });
+  });
+
   it('only considers the trailing item, not an error buried in history', () => {
     expect(
       deriveSubtitleIdleState({

--- a/src/components/Subtitle/subtitleIdleState.ts
+++ b/src/components/Subtitle/subtitleIdleState.ts
@@ -57,10 +57,16 @@ export function deriveSubtitleIdleState(input: IdleStateInput): SubtitleIdleStat
     };
   }
 
+  // `severity: 'warning'` is a notice about a session that started and ran
+  // degraded (see ConversationItem.severity). It is typed `error` only so
+  // the bubble renderer draws it; stopping such a session before its first
+  // transcript leaves that notice trailing, and offering Retry for a start
+  // that succeeded would be wrong.
   const last = items[items.length - 1];
   const isFreshStartFailure =
     startRequestedAt !== null &&
     last?.type === 'error' &&
+    last.severity !== 'warning' &&
     (last.createdAt ?? 0) >= startRequestedAt;
   if (isFreshStartFailure) {
     return { kind: 'failed', message: last.formatted?.text ?? '' };

--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -1013,7 +1013,9 @@ describe('LocalNativeClient clone-only voice gate', () => {
     // contract.
     expect(errors).toHaveLength(0);
     expect(emitted).toHaveLength(1);
-    expect(emitted[0]).toMatchObject({ role: 'system', type: 'error', status: 'completed' });
+    // severity 'warning': the session runs, so subtitleIdleState must not read
+    // this trailing row as a failed start (Codex review on #482).
+    expect(emitted[0]).toMatchObject({ role: 'system', type: 'error', status: 'completed', severity: 'warning' });
     expect(emitted[0].formatted.text).toMatch(/needs a voice clip/i);
     expect(c.getConversationItems()).toEqual([emitted[0]]);
     expect(diagnostics.some((d) => d.startsWith('tts_degraded:'))).toBe(true);

--- a/src/services/clients/LocalNativeClient.test.ts
+++ b/src/services/clients/LocalNativeClient.test.ts
@@ -996,16 +996,26 @@ describe('LocalNativeClient clone-only voice gate', () => {
     vi.spyOn(await import('../../lib/local-inference/nativeVoiceStorage'), 'listNativeVoices').mockResolvedValue([]);
     const errors: string[] = [];
     const diagnostics: string[] = [];
+    const emitted: any[] = [];
     const c = new LocalNativeClient(m);
     c.setEventHandlers({
       onError: (e: any) => errors.push(String(e?.message ?? e)),
       onDiagnostic: (d: any) => diagnostics.push(`${d.code}: ${d.message}`),
+      onConversationUpdated: ({ item }: any) => emitted.push(item),
     } as any);
     await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'en', targetLanguage: 'en',
       asrModelId: 'sense-voice', ttsModelId: CLONE_ONLY_MODEL } as any);
     expect(m.tts.init).not.toHaveBeenCalled();
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatch(/needs a voice clip/i);
+    // The session continues, degraded: not an onError (which would raise a
+    // React-state-only bubble MainPanel wipes the moment connect() resolves,
+    // plus an api_error), but a system notice the CLIENT holds, so every
+    // setItems(getConversationItems()) keeps it — SonioxClient.emitSystemNotice's
+    // contract.
+    expect(errors).toHaveLength(0);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0]).toMatchObject({ role: 'system', type: 'error', status: 'completed' });
+    expect(emitted[0].formatted.text).toMatch(/needs a voice clip/i);
+    expect(c.getConversationItems()).toEqual([emitted[0]]);
     expect(diagnostics.some((d) => d.startsWith('tts_degraded:'))).toBe(true);
   });
 
@@ -1065,7 +1075,10 @@ describe('LocalNativeClient clone-only voice gate', () => {
     await c.connect({ provider: 'local_native', model: 'native', sourceLanguage: 'en', targetLanguage: 'en',
       asrModelId: 'sense-voice', ttsModelId: REQUIRED_MODEL } as any);
     expect(m.tts.init).not.toHaveBeenCalled();
-    expect(errors[0]).toMatch(/needs a voice clip/i);
+    expect(errors).toHaveLength(0);
+    const notices = c.getConversationItems().filter((i) => i.role === 'system' && i.type === 'error');
+    expect(notices).toHaveLength(1);
+    expect(notices[0].formatted?.text).toMatch(/needs a voice clip/i);
   });
 
   it('a preset/named-voice family (no voice field, no clones) is unaffected by the gate', async () => {
@@ -1192,8 +1205,10 @@ describe('LocalNativeClient reconcileTtsVoice — stale custom selection (transc
 
     // The pre-init gate catches it before TTS ever loads — unchanged from Task 7.
     expect(m.tts.init).not.toHaveBeenCalled();
-    expect(errors).toHaveLength(1);
-    expect(errors[0]).toMatch(/needs a voice clip/i);
+    expect(errors).toHaveLength(0);
+    const notices = c.getConversationItems().filter((i) => i.role === 'system' && i.type === 'error');
+    expect(notices).toHaveLength(1);
+    expect(notices[0].formatted?.text).toMatch(/needs a voice clip/i);
     expect(diagnostics).toHaveLength(1);
     expect(diagnostics[0].code).toBe('tts_degraded');
   });

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -159,7 +159,13 @@ export class LocalNativeClient implements IClient {
         if (eligibleClips === 0) {
           this.ttsEnabled = false;
           this.diagnose('tts_degraded', `TTS unavailable, continuing without it: "${config.ttsModelId}" needs a voice clip — record or import one in Settings first`);
-          this.handlers.onError?.(new Error(`"${config.ttsModelId}" needs a voice clip — record or import one in Settings before it can speak`));
+          // A notice, not onError: the session goes on (text-only), so the
+          // user is owed a sentence they can still find, not a session-broken
+          // signal. onError's bubble lives only in MainPanel's React state and
+          // connectConversation's setItems(getConversationItems()) wipes it
+          // the moment connect() resolves — which is exactly how this notice
+          // used to vanish before anyone read it (#481 has the full inventory).
+          this.emitSystemNotice(`"${config.ttsModelId}" needs a voice clip — record or import one in Settings before it can speak`);
         }
       }
     }
@@ -299,6 +305,29 @@ export class LocalNativeClient implements IClient {
 
   private emit(item: ConversationItem, delta?: any): void {
     this.handlers.onConversationUpdated?.({ item, delta });
+  }
+
+  /**
+   * A system notice the CLIENT holds. Pushed into `items` before it is
+   * emitted, so it is part of every `getConversationItems()` read and survives
+   * MainPanel's wholesale `setItems(getConversationItems())` — both the one in
+   * connectConversation right after connect() and the one on every later
+   * conversation update. Same contract as SonioxClient.emitSystemNotice; `error`
+   * is the one system-item type the bubble renderer and subtitleIdleState both
+   * understand. Cleared with the rest of the conversation.
+   */
+  private emitSystemNotice(text: string): void {
+    const item: ConversationItem = {
+      id: this.nextId('notice'),
+      role: 'system',
+      type: 'error',
+      status: 'completed',
+      createdAt: Date.now(),
+      formatted: { text },
+      content: [{ type: 'text', text }],
+    };
+    this.items.push(item);
+    this.emit(item);
   }
 
   /** Mirror the LocalInferenceClient logging contract so events reach the Logs panel. */

--- a/src/services/clients/LocalNativeClient.ts
+++ b/src/services/clients/LocalNativeClient.ts
@@ -313,14 +313,17 @@ export class LocalNativeClient implements IClient {
    * MainPanel's wholesale `setItems(getConversationItems())` — both the one in
    * connectConversation right after connect() and the one on every later
    * conversation update. Same contract as SonioxClient.emitSystemNotice; `error`
-   * is the one system-item type the bubble renderer and subtitleIdleState both
-   * understand. Cleared with the rest of the conversation.
+   * is the one system-item type the bubble renderer draws. `severity: 'warning'`
+   * because the session goes on: without it, subtitleIdleState would read this
+   * row, when it trails a session stopped before its first transcript, as a
+   * failed start and offer Retry. Cleared with the rest of the conversation.
    */
   private emitSystemNotice(text: string): void {
     const item: ConversationItem = {
       id: this.nextId('notice'),
       role: 'system',
       type: 'error',
+      severity: 'warning',
       status: 'completed',
       createdAt: Date.now(),
       formatted: { text },

--- a/src/services/interfaces/IClient.ts
+++ b/src/services/interfaces/IClient.ts
@@ -11,6 +11,16 @@ export interface ConversationItem {
   id: string;
   role: 'user' | 'assistant' | 'system';
   type: 'message' | 'function_call' | 'function_call_output' | 'error';
+  /**
+   * For `type: 'error'` system rows only. `'warning'` marks a notice about a
+   * session that is RUNNING, degraded (Local Native without a voice clip, a
+   * Soniox custom voice that could not be prepared, a participant leg that
+   * never came up) — the row still renders as the red error bubble, the one
+   * system row the renderer draws, but subtitleIdleState must not read it as
+   * a failed start. Absent means `'error'`: the session is broken, or never
+   * started. A real `notice` item type replaces this flag under #481.
+   */
+  severity?: 'error' | 'warning';
   status: 'in_progress' | 'completed' | 'incomplete' | 'cancelled';
   source?: 'speaker' | 'participant'; // Source of the conversation item (speaker's mic or participant's system audio)
   createdAt?: number; // Timestamp for accurate sorting


### PR DESCRIPTION
## What

When a Local Native TTS model reports `voice.required` and no eligible clip is stored, the session now continues text-only with a **client-held** system notice in the conversation (`LocalNativeClient.emitSystemNotice`, the `SonioxClient.emitSystemNotice` contract) instead of an `onError`.

Second commit, from the Codex review: `ConversationItem.severity` (`'warning'` = the session runs, degraded) on that notice and on MainPanel's two same-shaped rows (`prepareNotice`, `participantErrorMessage`), and `deriveSubtitleIdleState` skips warnings — a session stopped before its first transcript no longer reads as a failed start with Retry in the subtitle window. Rendering is unchanged.

## Why

The gate used to raise both a `tts_degraded` diagnostic and an `onError`. The `onError` bubble is appended to MainPanel's React state only (`MainPanel.tsx:1430`), and `connectConversation` replaces that state wholesale with `setItems(speakerClientRef.current?.getConversationItems() || [])` (`MainPanel.tsx:2706`) as soon as `connect()` resolves — the gate runs inside `connect()`, so the bubble lived for well under a second and the user started a text-only session with no idea why. Every later `onConversationUpdated` does the same replace (1518 / 1549 / 1554), so it could never have survived the first transcript either.

An item the client pushes into its own `items` before emitting is part of every `getConversationItems()` read, so it stays in the conversation like any other row, reaches the subtitle overlay, and goes away with a clear or the next session — exactly what `SplitDegradedChip.tsx` and the `prepareNotice` ordering comment already warn about.

`onError` also raised an `api_error` analytics event and a `session.error` log row for what is a degraded-but-running session; the `tts_degraded` diagnostic (LogsPanel, advanced mode) is the record now, per the diagnostics policy.

## Not changed here

- The gate itself and its copy. The sentence is still raw English; #481 covers i18n along with the rest.
- Packaged 0.40.0 wrongly gates `moss-tts-nano`: bundle `sidecar-v0.2.0` does not send `voice.required`, so `requiresVoiceClip` falls back to the voice shape. `chore/sidecar-v0.2.1` fixes that; this PR only makes the notice visible when the gate fires for a model that really needs a clip (qwen3_tts, omnivoice, index_tts2).
- The general fragility of React-state-only error bubbles, and the red ERROR styling of every degraded notice — #481.

## Verified

- `LocalNativeClient.test.ts`: the three gate tests now assert no `onError`, one `role: 'system'` / `type: 'error'` / `severity: 'warning'` item both emitted through `onConversationUpdated` and present in `getConversationItems()`, and the `tts_degraded` diagnostic unchanged. Written red first.
- `subtitleIdleState.test.ts`: a trailing warning-severity notice after a start request is `ended`, not `failed`; a trailing error-severity item still is `failed`. Written red first.
- Full `vitest run`: 329 files, 3777 tests passed.
- `tsc --noEmit` reports the same 312 pre-existing errors as `main`; none in the touched lines.

Refs #481.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved messaging when text-to-speech is unavailable because a required voice clip is missing.
  * Displays a persistent system notice in the conversation instead of triggering a transient error callback.
  * Prevents duplicate error reporting while preserving missing-voice-clip details.
  * Prevents degraded but active sessions from being incorrectly shown as failed starts.
  * Distinguishes warnings from errors in session status messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->