### PR TITLE
release: sidecar 0.2.1 pins the native-v1.0.2 wheels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,8 +118,9 @@ The codebase supports both Electron desktop app and Chrome/Edge browser extensio
 6. **Native runtime (`native/`)**
    - One CMake super-project builds three engines on ONE pristine upstream ggml 0.22 behind
      the `sk_*` C ABI (`native/include/sokuji_native.h`) in `libsokuji_native` / Python package
-     `sokuji_native`: transcribe.cpp (ASR), llama.cpp (translation), audio.cpp (TTS — five
-     families: moss_tts_nano, qwen3_tts, omnivoice, pocket_tts, supertonic). Design:
+     `sokuji_native`: transcribe.cpp (ASR), llama.cpp (translation), audio.cpp (TTS — nine
+     families: moss_tts_nano, qwen3_tts, omnivoice, pocket_tts, supertonic, voxcpm1,
+     voxcpm2, irodori_tts, index_tts2). Design:
      `docs/superpowers/specs/2026-08-30-sidecar-ggml-only-design.md` (Amendment A1: VAD runs in
      the renderer via `native-vad.worker.ts`, not here); build/layout/per-stage detail:
      `native/README.md`. `sokuji_sidecar/native.py` is the sidecar's one door in — nothing else
@@ -167,7 +168,10 @@ The codebase supports both Electron desktop app and Chrome/Edge browser extensio
      by 1.0.1 (R41: the Python binding's `Translator._make_cb` used to decode each streamed
      token piece independently, corrupting a BPE boundary landing inside a multibyte CJK
      character to U+FFFD; fixed with a per-call incremental UTF-8 decoder) before any bundle
-     pinned it. Current native version is 1.0.1.
+     pinned it. `native-v1.0.2` / `sidecar-v0.2.1` (2026-09-03) follow: engine pins to
+     transcribe.cpp 0.2.3 and audio.cpp 0.7.1, and four more TTS families compiled in
+     (voxcpm1, voxcpm2, irodori_tts, index_tts2 — nine in total). Current native version
+     is 1.0.2.
    - **Dev loop**: `native/ci/build.sh <none|vulkan|metal> <plat tag>` (`.ps1` on Windows)
      builds and runs CTest + the Python suite against a fresh stage;
      `SOKUJI_NATIVE_DIR=.../stage` points a wheel-less `import sokuji_native` at it. Models

--- a/native/README.md
+++ b/native/README.md
@@ -421,5 +421,8 @@ in the sidecar's own release, not part of this workflow. `native-v1.0.1` follows
 immediately: a Python-binding-only fix (R41) for streamed translation tokens that split a
 multibyte UTF-8 character across pieces being decoded independently instead of
 incrementally, corrupting CJK output with U+FFFD — see `python/sokuji_native/__init__.py`'s
-`Translator._make_cb`. Current native version is 1.0.1; `sidecar/requirements.txt` pinned
-straight to 1.0.1, so no sidecar bundle ever shipped with 1.0.0 inside.
+`Translator._make_cb`. `sidecar/requirements.txt` pinned straight to 1.0.1, so no sidecar
+bundle ever shipped with 1.0.0 inside. `native-v1.0.2` (2026-09-03) moved the engine pins
+to transcribe.cpp 0.2.3 and audio.cpp 0.7.1 and added four TTS families to the build set
+(voxcpm1, voxcpm2, irodori_tts, index_tts2), taking it to nine. Current native version is
+1.0.2.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokuji",
   "productName": "Sokuji",
   "version": "0.40.0",
-  "sidecarVersion": "0.2.0",
+  "sidecarVersion": "0.2.1",
   "private": true,
   "main": "dist-electron/main.js",
   "homepage": "./",

--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -17,8 +17,8 @@ soxr>=0.5
 # sys_platform/platform_machine so pip installs exactly one per target. setup.sh's
 # local-wheel override (dist/ or $SOKUJI_NATIVE_WHEEL) still exists for developers
 # testing an unreleased native build, but by default this is what ships.
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.1/sokuji_native-1.0.1-py3-none-manylinux_2_35_x86_64.whl ; sys_platform == "linux" and platform_machine == "x86_64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.1/sokuji_native-1.0.1-py3-none-manylinux_2_35_aarch64.whl ; sys_platform == "linux" and platform_machine == "aarch64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.1/sokuji_native-1.0.1-py3-none-win_amd64.whl ; sys_platform == "win32" and platform_machine == "AMD64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.1/sokuji_native-1.0.1-py3-none-macosx_11_0_arm64.whl ; sys_platform == "darwin" and platform_machine == "arm64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.1/sokuji_native-1.0.1-py3-none-macosx_11_0_x86_64.whl ; sys_platform == "darwin" and platform_machine == "x86_64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-manylinux_2_35_x86_64.whl ; sys_platform == "linux" and platform_machine == "x86_64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-manylinux_2_35_aarch64.whl ; sys_platform == "linux" and platform_machine == "aarch64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-win_amd64.whl ; sys_platform == "win32" and platform_machine == "AMD64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-macosx_11_0_arm64.whl ; sys_platform == "darwin" and platform_machine == "arm64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-macosx_11_0_x86_64.whl ; sys_platform == "darwin" and platform_machine == "x86_64"

--- a/sidecar/tests/test_runtime_gate.py
+++ b/sidecar/tests/test_runtime_gate.py
@@ -1,7 +1,7 @@
 """Verification gate (spec §9.3/§11): no heavyweight legacy-runtime import may
 reappear anywhere under sokuji_sidecar/, and requirements.txt stays pinned to
 its end state: 7 PyPI packages + 5 sokuji-native release-wheel URL lines (one
-per SKU, pinned to the native-v1.0.1 GitHub Release, gated by sys_platform/
+per SKU, pinned to the native-v1.0.2 GitHub Release, gated by sys_platform/
 platform_machine markers). AST-based so comments/docstrings mentioning the
 names stay allowed."""
 import ast
@@ -54,22 +54,22 @@ def test_no_torch_era_imports():
 
 
 NATIVE_RELEASE_BASE = (
-    "https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.1/"
+    "https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/"
 )
 
 # filename -> expected PEP 508 marker (sys_platform/platform_machine values are
 # the literal sys.platform / platform.machine() strings CPython reports —
 # packaging.markers.default_environment() sources both from those same calls).
 NATIVE_WHEELS = {
-    "sokuji_native-1.0.1-py3-none-manylinux_2_35_x86_64.whl":
+    "sokuji_native-1.0.2-py3-none-manylinux_2_35_x86_64.whl":
         'sys_platform == "linux" and platform_machine == "x86_64"',
-    "sokuji_native-1.0.1-py3-none-manylinux_2_35_aarch64.whl":
+    "sokuji_native-1.0.2-py3-none-manylinux_2_35_aarch64.whl":
         'sys_platform == "linux" and platform_machine == "aarch64"',
-    "sokuji_native-1.0.1-py3-none-win_amd64.whl":
+    "sokuji_native-1.0.2-py3-none-win_amd64.whl":
         'sys_platform == "win32" and platform_machine == "AMD64"',
-    "sokuji_native-1.0.1-py3-none-macosx_11_0_arm64.whl":
+    "sokuji_native-1.0.2-py3-none-macosx_11_0_arm64.whl":
         'sys_platform == "darwin" and platform_machine == "arm64"',
-    "sokuji_native-1.0.1-py3-none-macosx_11_0_x86_64.whl":
+    "sokuji_native-1.0.2-py3-none-macosx_11_0_x86_64.whl":
         'sys_platform == "darwin" and platform_machine == "x86_64"',
 }
 
@@ -77,7 +77,7 @@ NATIVE_WHEELS = {
 def test_base_requirements_is_the_seven_pypi_plus_five_native_wheel_end_state():
     # numpy, websockets, huggingface_hub, psutil, zstandard, soundfile, soxr
     # (7 PyPI packages, version-pinned or floor-pinned) + sokuji-native, five
-    # direct-URL lines (one per SKU) pinned to the native-v1.0.1 release and
+    # direct-URL lines (one per SKU) pinned to the native-v1.0.2 release and
     # gated by a sys_platform/platform_machine marker so pip installs exactly
     # one per target — this is what keeps sidecar bundles from shipping
     # hollow (no sokuji_native inside).


### PR DESCRIPTION
## Summary

`native-v1.0.2` published its five wheels (prerelease), so the sidecar moves onto them: the five wheel URLs in `sidecar/requirements.txt` and the gate test that mirrors them go to 1.0.2, and `sidecarVersion` goes to **0.2.1**. This is the order `native/README.md` sets out — tag, then pin, then the sidecar tag — and the `sidecar-v0.2.1` tag is cut from `main` after this merges.

Why it matters: a bundle built before this commit installs 1.0.1, whose build set has only the five older TTS families, so it cannot load the four added in #477 (`voxcpm1`, `voxcpm2`, `irodori_tts`, `index_tts2`). 1.0.2 also carries the engine pins from #476 (transcribe.cpp 0.2.3, audio.cpp 0.7.1).

Docs: the version paragraphs in `CLAUDE.md` and `native/README.md` now say 1.0.2, and the architecture section counts nine audio.cpp families.

## Verification

- sidecar pytest: 734 passed / 12 skipped (the gate test asserts the 1.0.2 URLs).
- The 1.0.2 wheels are the ones measured on GB10 (Vulkan) and the M4 (Metal) for the four new families; those numbers live in the catalog comment beside `_TTS_TIER_OVERRIDES`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for four additional text-to-speech families: VoxCPM1, VoxCPM2, Irodori TTS, and Index TTS2.
  - The native runtime now supports nine TTS families in total.

- **Improvements**
  - Updated the native runtime to version 1.0.2.
  - Updated the sidecar to version 0.2.1.
  - Updated bundled transcription and audio engine components for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->