### PR TITLE
feat(soniox): raise the voice-clone reference clip to 2 minutes

### DIFF
--- a/docs/superpowers/specs/2026-07-31-soniox-voice-cloning-byok-design.md
+++ b/docs/superpowers/specs/2026-07-31-soniox-voice-cloning-byok-design.md
@@ -3,6 +3,11 @@
 **Date**: 2026-07-31
 **Status**: Approved (brainstormed with user; API facts live-probed 2026-07-31)
 **Tracking**: follow-up to issue #342 (API-surface audit, item B4)
+**Amendment A1 (2026-09-05)**: Soniox raised the reference-clip bounds. Every
+"≤20 s, ≤10 MB" below is historical — the limits are now **≤2 min, ≤35 MB**,
+and the two are enforced at different points (size at upload, duration only
+during per-model processing, as `voice_audio_too_long`). See A1 at the end of
+Verified facts.
 
 ## Summary
 
@@ -19,7 +24,8 @@ under Future work.
 ## Verified facts (live probes + docs + SDKs, 2026-07-31)
 
 - `/v1/voices` CRUD: create is `multipart/form-data` with exactly `name`
-  (unique per project, 1-128 chars) + `file` (reference clip, ≤20 s, ≤10 MB);
+  (unique per project, 1-128 chars) + `file` (reference clip, ≤20 s, ≤10 MB
+  as of 2026-07-31 — superseded, see Amendment A1);
   no metadata/owner/reference fields exist. List has only `limit`/`cursor` —
   no filters. No rename API. `DELETE` returns 204.
 - End-to-end proven on a real BYOK key: create from a 4 s clip →
@@ -44,6 +50,50 @@ under Future work.
 - Wire: `SonioxTtsStream.openStream` sends `voice` as an opaque string — a
   UUID passes through the whole `settings.voice → buildSessionConfig →
   createTtsStream → wire` chain untouched (code-audited + live-proven).
+
+### Amendment A1 (2026-09-05) — reference clip is now 2 min / 35 MB
+
+Soniox's published limits changed; verified against the docs on 2026-09-05 and
+against the Console playground by the user (a 2-minute recording clones, and
+the result is good):
+
+- **Duration** — "Use a clip of up to 2 minutes. Longer clips are accepted at
+  upload but fail during processing with `voice_audio_too_long`."
+  (`/docs/tts/concepts/voice-cloning`, matching the `voice_audio_too_long`
+  entry in `/docs/api-reference/errors`: "currently a maximum of 2 minutes".)
+- **Size** — "Stay within 35 MB. Larger uploads are rejected."
+- **Voice quota is unchanged**: 20 per organization, across all projects; each
+  reference clip counts as one voice.
+
+The asymmetry is the part that matters for us. Size is a synchronous upload
+rejection, so a too-large file costs nothing. Duration is *not* checked at
+upload: an over-long clip is accepted, consumes one of the 20 org-wide slots
+and a billable create, then lands in the terminal `failed` status this spec
+already treats as "recreate, never retry". So the client-side duration bound
+is not belt-and-braces — it is the only thing preventing a silent slot leak,
+and it must stay at or below Soniox's number rather than being relaxed to
+"let the server decide".
+
+Consequences accepted with this amendment:
+
+- `MAX_UPLOAD_BYTES` reads 35 MB as **decimal** (35 × 10⁶), the smaller of the
+  two plausible readings of "35 MB", so we never wave through what the server
+  would reject.
+- A full 2-minute capture is ~11.5 MB of PCM16 WAV at a 48 kHz AudioContext
+  (`encodeWavPcm16` does not resample or compress), against ~1.9 MB before. It
+  clears 35 MB with room to spare; what it eats into is the **upload timeout
+  budget**, unchanged at 120 s — and, on the managed cold-upload path only, the
+  60 s whole-preparation ceiling in `managedVoicePrep`. Left as-is: the warm
+  slot is the normal session-start path, and a cold 11.5 MB upload still fits
+  60 s on any link above ~1.5 Mbps up. Revisit if session-start voice-prep
+  failures appear in the field.
+- Recording UI: `VoiceLibrarySection`'s countdown now starts at 120 and reads
+  "Stop recording (120s)". Left in seconds rather than mm:ss — one number, and
+  the copy key (`voiceLibrary.clipTooLong`, "keep it under {seconds} seconds")
+  interpolates the same unit across all 35 locales.
+- The 3 s minimum is retained. Soniox publishes no minimum; 3 s is our own
+  floor for a clip that carries enough timbre.
+
 
 ## Decisions
 

--- a/docs/superpowers/specs/2026-07-31-soniox-voice-cloning-byok-design.md
+++ b/docs/superpowers/specs/2026-07-31-soniox-voice-cloning-byok-design.md
@@ -87,6 +87,14 @@ Consequences accepted with this amendment:
   slot is the normal session-start path, and a cold 11.5 MB upload still fits
   60 s on any link above ~1.5 Mbps up. Revisit if session-start voice-prep
   failures appear in the field.
+- Import gains a **metadata duration probe** before `decodeAudioData`. Raising
+  the size gate to 35 MB newly admits files that are enormous once decoded — a
+  34 MB 32 kbps MP3 is ~2.4 h and expands past 3 GB of Float32 PCM, enough to
+  take the renderer down purely to reject it for length; the old 10 MiB gate
+  refused such a file on size. The probe reads duration from container metadata
+  via a `preload="metadata"` element and can only reject early, never accept
+  early: no answer (non-Blob, no event, `Infinity`/`NaN`, unparseable, 5 s
+  timeout) falls through to the decode, which is the pre-existing path.
 - Recording UI: `VoiceLibrarySection`'s countdown now starts at 120 and reads
   "Stop recording (120s)". Left in seconds rather than mm:ss — one number, and
   the copy key (`voiceLibrary.clipTooLong`, "keep it under {seconds} seconds")
@@ -102,7 +110,7 @@ Consequences accepted with this amendment:
 | Phase scope | BYOK only. Managed twin: read-only built-ins this phase (creation affordances hidden), same component so Phase 2 only swaps the data source |
 | UI | `hasVoiceSettings` → `false` for Soniox (and twin); new `SonioxVoiceSection` embedded in `renderSonioxSettings`, wrapping `VoiceLibrarySection` in `dropdown` presentation: `builtin` group = the 28 static voices, `custom` group = voices fetched from `/v1/voices` |
 | Source of truth | Soniox. The list is fetched on section mount (+ manual refresh); nothing but the selected id (`settings.voice`) is persisted locally. No local reference-clip storage |
-| Create flow | Record/upload are always available once a client exists (`audio/*`, client-side decode validates 3–20 s / ≤10 MB via the `validateVoiceClip` pattern; recording captures RAW audio — echo cancellation / noise suppression / AGC disabled, since the cloning model mimics processing artifacts) → the validated/recorded clip is staged (not yet uploaded) and opens a post-acquisition confirm modal (`SonioxCloneConfirmModal`) with a design-system player (play/pause, seekable progress, time readout), an empty name field showing only its placeholder (blank → the stripped filename / "My Voice {{n}}" default applies at confirm), and a usage-rights checkbox gating the confirm button → confirm shows an in-flight spinner, `POST /v1/voices`, refreshes the list so the new voice is visible (processing badge) BEFORE the modal closes → background poll until `ready`/`failed` → auto-select on ready. A mapped create failure (e.g. `voice_name_conflict`) keeps the modal open inline so the user can rename and retry without losing the clip |
+| Create flow | Record/upload are always available once a client exists (`audio/*`, client-side validation is 3–120 s / ≤35 MB (Amendment A1; was 3–20 s / ≤10 MB) — size first, then container metadata for an early `too_long`, then the decoded duration via the `validateVoiceClip` pattern; recording captures RAW audio — echo cancellation / noise suppression / AGC disabled, since the cloning model mimics processing artifacts) → the validated/recorded clip is staged (not yet uploaded) and opens a post-acquisition confirm modal (`SonioxCloneConfirmModal`) with a design-system player (play/pause, seekable progress, time readout), an empty name field showing only its placeholder (blank → the stripped filename / "My Voice {{n}}" default applies at confirm), and a usage-rights checkbox gating the confirm button → confirm shows an in-flight spinner, `POST /v1/voices`, refreshes the list so the new voice is visible (processing badge) BEFORE the modal closes → background poll until `ready`/`failed` → auto-select on ready. A mapped create failure (e.g. `voice_name_conflict`) keeps the modal open inline so the user can rename and retry without losing the clip |
 | Failure states | `failed` voices render with an error badge and only a delete affordance (terminal per docs). Quota/4xx on create → explicit "organization voice limit reached — delete one and retry" message, shown inline in the confirm modal. A selected UUID missing from the fetched list renders a "(deleted voice)" placeholder and prompts re-selection; the stored setting is never auto-rewritten |
 | Not doing | Rename (no API; no local aliases — YAGNI), recompute UI (single-model era; noted for when a new TTS model ships), managed-side CRUD |
 | Naming | User-entered display name used as the Soniox `name` verbatim (BYOK org is private to the user); `voice_name_conflict` (409) surfaces as "a voice with this name already exists" |

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -243,12 +243,12 @@ describe('SonioxVoiceSection', () => {
     });
   });
 
-  it('onImport rejects a file over 10MB before decoding, creating, or opening the modal', async () => {
+  it('onImport rejects a file over 35MB before decoding, creating, or opening the modal', async () => {
     listMock.mockResolvedValue([]);
     const { container } = mount();
     openManageDetails();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
-    const bigFile = fakeFile('big.wav', 11 * 1024 * 1024);
+    const bigFile = fakeFile('big.wav', 36 * 1000 * 1000);
     fireEvent.change(fileInput, { target: { files: [bigFile] } });
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/too large/i));
     expect(createMock).not.toHaveBeenCalled();
@@ -268,9 +268,9 @@ describe('SonioxVoiceSection', () => {
     expect(screen.queryByPlaceholderText(nameInputPlaceholder)).toBeNull();
   });
 
-  it('onImport rejects a decoded clip longer than 20s with the localized message, without opening the modal', async () => {
+  it('onImport rejects a decoded clip longer than 2 minutes with the localized message, without opening the modal', async () => {
     listMock.mockResolvedValue([]);
-    stubAudioContext(16000, 16000 * 25); // 25s — above the 20s maximum
+    stubAudioContext(16000, 16000 * 130); // 130s — above the 120s maximum
     const { container } = mount();
     openManageDetails();
     const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
@@ -279,6 +279,17 @@ describe('SonioxVoiceSection', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/too long/i));
     expect(createMock).not.toHaveBeenCalled();
     expect(screen.queryByPlaceholderText(nameInputPlaceholder)).toBeNull();
+  });
+
+  it('onImport accepts a 100s clip — past the old 20s bound, inside the 2-minute one', async () => {
+    listMock.mockResolvedValue([]);
+    stubAudioContext(16000, 16000 * 100);
+    const { container } = mount();
+    openManageDetails();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [fakeFile('clip.wav')] } });
+    await waitFor(() => expect(screen.getByPlaceholderText(nameInputPlaceholder)).toBeTruthy());
+    expect(screen.queryByRole('alert')).toBeNull();
   });
 
   it('selecting multiple files stages only the first (single pending slot; no silent last-wins)', async () => {

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -68,6 +68,31 @@ function stubAudioContext(sampleRate: number, numSamples: number) {
   return mockCtx;
 }
 
+// The real constructor, captured before any test replaces it, so beforeEach can
+// put it back — only the metadata-probe tests stub it, and a leaked stub would
+// silently change how later tests reach the probe.
+const REAL_AUDIO = (globalThis as any).Audio;
+
+// Stands in for the <audio> element `probeDurationSeconds` uses to read a
+// container's duration without decoding it. Setting `src` resolves the probe
+// on a later tick, the way a real media element does: 'loadedmetadata' with
+// the given duration, or 'error' for a file the browser can't parse.
+function stubMetadataProbe(duration: number | 'error') {
+  const listeners: Record<string, Array<() => void>> = {};
+  const el: any = {
+    preload: '',
+    duration: duration === 'error' ? NaN : duration,
+    addEventListener: (k: string, fn: () => void) => { (listeners[k] ??= []).push(fn); },
+    removeAttribute: vi.fn(),
+    set src(_v: string) {
+      queueMicrotask(() => (listeners[duration === 'error' ? 'error' : 'loadedmetadata'] ?? []).forEach((fn) => fn()));
+    },
+    get src() { return ''; },
+  };
+  (window as any).Audio = function Audio() { return el; };
+  return el;
+}
+
 // jsdom's File/Blob polyfill doesn't implement `arrayBuffer()` (unlike real
 // browsers), so onImport's `file.arrayBuffer()` call throws under jsdom's
 // real File. Build a minimal File-shaped object instead — only `size`,
@@ -109,6 +134,7 @@ describe('SonioxVoiceSection', () => {
     createMock.mockReset();
     deleteMock.mockReset().mockResolvedValue(undefined);
     waitMock.mockReset();
+    (window as any).Audio = REAL_AUDIO;
     // jsdom has no URL.createObjectURL — the confirm modal's <audio> preview
     // needs it whenever a pending clip opens the modal.
     (URL as any).createObjectURL = vi.fn(() => 'blob:mock');
@@ -279,6 +305,39 @@ describe('SonioxVoiceSection', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/too long/i));
     expect(createMock).not.toHaveBeenCalled();
     expect(screen.queryByPlaceholderText(nameInputPlaceholder)).toBeNull();
+  });
+
+  it('rejects an over-long import from container metadata, without ever decoding it', async () => {
+    listMock.mockResolvedValue([]);
+    // Short enough to sail through validation IF the decode were ever reached,
+    // so the assertion below can only pass via the metadata probe.
+    const ctx = stubAudioContext(44100, 44100 * 5);
+    stubMetadataProbe(8500); // ~2.4 h: what 34 MB of 32 kbps MP3 actually holds
+    const { container } = mount();
+    openManageDetails();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    const longFile = new File([new Uint8Array(64)], 'podcast.mp3', { type: 'audio/mpeg' });
+    fireEvent.change(fileInput, { target: { files: [longFile] } });
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/too long/i));
+    expect(ctx.decodeAudioData).not.toHaveBeenCalled();
+    expect(createMock).not.toHaveBeenCalled();
+    expect(screen.queryByPlaceholderText(nameInputPlaceholder)).toBeNull();
+  });
+
+  it('falls back to the decode when the container reports no usable duration', async () => {
+    listMock.mockResolvedValue([]);
+    const ctx = stubAudioContext(16000, 16000 * 5);
+    stubMetadataProbe('error');
+    const { container } = mount();
+    openManageDetails();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    // A REAL File, because the probe only runs on a Blob — but jsdom's Blob has
+    // no arrayBuffer(), which the decode path needs, so lend it one.
+    const file = new File([new Uint8Array(64)], 'clip.wav', { type: 'audio/wav' });
+    (file as any).arrayBuffer = async () => new ArrayBuffer(64);
+    fireEvent.change(fileInput, { target: { files: [file] } });
+    await waitFor(() => expect(screen.getByPlaceholderText(nameInputPlaceholder)).toBeTruthy());
+    expect(ctx.decodeAudioData).toHaveBeenCalled();
   });
 
   it('onImport accepts a 100s clip — past the old 20s bound, inside the 2-minute one', async () => {

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -106,6 +106,61 @@ const MAX_CLIP_SECONDS = 120;
 // so recordings clear this with room to spare and only imports can hit it.
 const MAX_UPLOAD_BYTES = 35 * 1000 * 1000;
 
+/** How long to wait for a container's metadata before giving up and letting the
+ *  decode decide. Metadata is the first few KB of the file, so this is generous. */
+const DURATION_PROBE_TIMEOUT_MS = 5_000;
+
+/** Duration from container metadata, WITHOUT decoding the audio.
+ *
+ *  `decodeAudioData` materializes the entire file as Float32 PCM: a 34 MB
+ *  32 kbps MP3 holds ~2.4 hours, which expands past 3 GB and can take the
+ *  renderer down before we ever get to reject it for length. Under the old
+ *  10 MiB size gate a file that long was refused on size alone; at 35 MB it is
+ *  not, so duration has to be knowable BEFORE the decode.
+ *
+ *  Returns null whenever the browser won't say — a non-Blob, no metadata event,
+ *  a duration of Infinity/NaN (streamed containers), or an unparseable file. The
+ *  caller then falls through to the decode, which is exactly the old behavior:
+ *  this probe can reject early, never accept early, so a browser that declines
+ *  to answer costs correctness nothing. */
+async function probeDurationSeconds(file: File): Promise<number | null> {
+  // createObjectURL is specified over Blob; test doubles and exotic File-likes
+  // are not, and calling it on one throws rather than returning null.
+  if (typeof URL.createObjectURL !== 'function' || !(file instanceof Blob)) return null;
+  let url: string;
+  try {
+    url = URL.createObjectURL(file);
+  } catch {
+    return null;
+  }
+  try {
+    return await new Promise<number | null>((resolve) => {
+      const el = new Audio();
+      el.preload = 'metadata';
+      let settled = false;
+      const finish = (v: number | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // Stop the element from holding the (about to be revoked) URL.
+        el.removeAttribute('src');
+        resolve(v);
+      };
+      const timer = setTimeout(() => finish(null), DURATION_PROBE_TIMEOUT_MS);
+      el.addEventListener('loadedmetadata', () => {
+        const d = el.duration;
+        finish(Number.isFinite(d) && d > 0 ? d : null);
+      });
+      el.addEventListener('error', () => finish(null));
+      el.src = url;
+    });
+  } catch {
+    return null;
+  } finally {
+    URL.revokeObjectURL(url);
+  }
+}
+
 function isReady(v: SonioxVoice): boolean {
   return v.models?.some((m) => m.model === TTS_MODEL && m.status === 'ready') ?? false;
 }
@@ -418,6 +473,13 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
           )
         );
       }
+      // Cheap length gate before the expensive one. Only `too_long` is worth
+      // catching here: an over-long file is precisely the one whose decode can
+      // exhaust the renderer, while a too-short or silent file is small by
+      // construction and is caught below on the decoded samples, where the
+      // measurement is exact.
+      const probed = await probeDurationSeconds(file);
+      if (probed !== null && probed > MAX_CLIP_SECONDS) throw new Error(mapClipError('too_long'));
       const arrayBuffer = await file.arrayBuffer();
       const ctx = new AudioContext();
       let buffer: AudioBuffer;

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -9,7 +9,7 @@
  *
  * Create flow: record/upload are always available once a source exists (the
  * shared voice-library look, no gating checkbox) → client-side validation
- * (upload only: ≤10 MB, decoded duration 3-20s, mirroring NativeVoiceSection's
+ * (upload only: ≤35 MB, decoded duration 3-120s, mirroring NativeVoiceSection's
  * `validateVoiceClip` pattern) → the validated/recorded clip is staged as
  * `pending` rather than uploaded immediately, which opens
  * `SonioxCloneConfirmModal` for playback + naming + the consent statement
@@ -88,11 +88,23 @@ export interface SonioxVoiceSectionProps {
 const BUILTIN_VOICES = new SonioxProviderConfig().getConfig().voices;
 const TTS_MODEL = SONIOX_TTS_MODEL;
 const DEFAULT_VOICE = SONIOX_DEFAULT_VOICE;
-// Reference-clip bounds Soniox enforces server-side; validated client-side on
-// upload too (mirrors NativeVoiceSection / validateVoiceClip's defaults).
+// Reference-clip bounds Soniox documents for `/v1/voices`, validated
+// client-side because the two are enforced at DIFFERENT points server-side:
+// size is rejected at upload, but duration is accepted at upload and only
+// fails later, per model, as `voice_audio_too_long` — a terminal `failed`
+// status that has already spent one of the organization's 20 voice slots and
+// a billable create. So the duration bound below is the only thing standing
+// between a too-long clip and a slot the user has to notice and clean up.
+// (These are Soniox's own numbers — deliberately NOT validateVoiceClip's
+// local-model defaults, which NativeVoiceSection keeps at 3-20s.)
 const MIN_CLIP_SECONDS = 3;
-const MAX_CLIP_SECONDS = 20;
-const MAX_UPLOAD_BYTES = 10 * 1024 * 1024;
+const MAX_CLIP_SECONDS = 120;
+// Soniox says "stay within 35 MB"; read as decimal, the smaller of the two
+// plausible readings, so we never wave through what the server would reject.
+// The bound that actually matters day to day is MAX_CLIP_SECONDS: a full
+// 2-minute capture at a 48 kHz AudioContext encodes to ~11.5 MB of PCM16 WAV,
+// so recordings clear this with room to spare and only imports can hit it.
+const MAX_UPLOAD_BYTES = 35 * 1000 * 1000;
 
 function isReady(v: SonioxVoice): boolean {
   return v.models?.some((m) => m.model === TTS_MODEL && m.status === 'ready') ?? false;
@@ -382,7 +394,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
   };
 
   // Client-side upload validation (spec: "client-side decode validates
-  // 3-20s / ≤10MB via the validateVoiceClip pattern"): reject an oversize
+  // 3-120s / ≤35MB via the validateVoiceClip pattern"): reject an oversize
   // file outright (cheap, no decode needed), then decode the file to measure
   // its REAL duration — a file's extension/MIME claims nothing about actual
   // length — and run it through the same validateVoiceClip bounds
@@ -398,7 +410,11 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
         throw new Error(
           t('voiceLibrary.importError', 'Import failed: {error}').replace(
             '{error}',
-            `File is too large (${(file.size / (1024 * 1024)).toFixed(1)} MB, max ${MAX_UPLOAD_BYTES / (1024 * 1024)} MB)`
+            // Both figures in the SAME unit as the published limit (decimal
+            // MB), so "36.0 MB, max 35 MB" reads as one comparison. Dividing
+            // the cap by 1024^2 while quoting it as "MB" would print 33.4 —
+            // a number that appears nowhere in Soniox's docs.
+            `File is too large (${(file.size / 1_000_000).toFixed(1)} MB, max ${MAX_UPLOAD_BYTES / 1_000_000} MB)`
           )
         );
       }

--- a/src/services/clients/ManagedVoicesClient.test.ts
+++ b/src/services/clients/ManagedVoicesClient.test.ts
@@ -51,7 +51,8 @@ describe('ManagedVoicesClient.mine', () => {
 
 describe('ManagedVoicesClient.ensure', () => {
   it('posts multipart with pin=1 and no clip on the warm path', async () => {
-    // The clip is up to 10 MB. Uploading it when the slot is already warm
+    // The clip runs to ~11.5 MB for a full 2-minute recording (35 MB for an
+    // import). Uploading it when the slot is already warm
     // would waste the user's uplink on every single session start.
     fetchMock.mockResolvedValue(json(200, { voiceId: 'v1', status: 'ready' }));
     const res = await make().ensure({ pin: true });

--- a/src/services/clients/SonioxVoicesClient.ts
+++ b/src/services/clients/SonioxVoicesClient.ts
@@ -8,7 +8,12 @@
  *
  * Facts honored here (docs + live probes):
  * - create is multipart with exactly `name` (unique per project) + `file`
- *   (reference clip <= 20 s / 10 MB); there are no metadata/owner fields.
+ *   (reference clip <= 2 min / 35 MB); there are no metadata/owner fields.
+ *   The two bounds are enforced at DIFFERENT points: size is rejected at
+ *   upload, duration is ACCEPTED at upload and fails later, per model, as
+ *   `voice_audio_too_long` — which lands in the terminal `failed` status
+ *   below, having already spent a voice slot. Hence the client-side duration
+ *   check in SonioxVoiceSection.
  * - readiness is per model: models[].status in
  *   not_computed | processing | ready | failed; `failed` is TERMINAL despite
  *   the API using a 503 for it — recreate, never retry.
@@ -66,7 +71,9 @@ export async function throwApiError(res: Response): Promise<never> {
 // Per-request bounds: without them a hung fetch never settles, and the
 // section's refresh() then sits in 'loading' forever with its own Refresh
 // button disabled — an unrecoverable stall until remount. Uploads get a much
-// longer leash (a 10 MB reference clip on a slow uplink is legitimate).
+// longer leash (a 2-minute reference clip is ~11.5 MB of PCM16 WAV at a
+// 48 kHz AudioContext, and an imported file may be up to 35 MB — both are
+// legitimate on a slow uplink).
 const REQUEST_TIMEOUT_MS = 15_000;
 const UPLOAD_TIMEOUT_MS = 120_000;
 

--- a/src/types/VoiceLibrary.ts
+++ b/src/types/VoiceLibrary.ts
@@ -25,8 +25,9 @@ export interface VoiceLibraryCapability {
    *  it's non-empty. Omitted/false → no new UI, unchanged behavior. */
   transcriptRequired?: boolean;
   /** Longest usable reference clip in seconds for THIS model. Cloning models
-   *  differ (e.g. OmniVoice's decode degrades past ~8 s while others accept
-   *  20 s), so the limit is provider-declared: recording shows a countdown and
+   *  differ by orders of magnitude (OmniVoice's decode degrades past ~8 s,
+   *  local models take 20 s, Soniox takes 2 min), so the limit is
+   *  provider-declared: recording shows a countdown and
    *  auto-stops at it; imports longer than it are rejected. Unset → the
    *  store/UI default. */
   maxClipSeconds?: number;


### PR DESCRIPTION
Soniox's published limits moved: the voice-clone reference clip is now up to **2 minutes / 35 MB**, against the **20 s / 10 MB** this section has enforced since the BYOK design (2026-07-31).

Verified two ways: against the docs on 2026-09-05 — [`/docs/tts/concepts/voice-cloning`](https://soniox.com/docs/tts/concepts/voice-cloning) ("Use a clip of up to 2 minutes", "Stay within 35 MB") and the `voice_audio_too_long` entry in [`/docs/api-reference/errors`](https://soniox.com/docs/api-reference/errors) ("currently a maximum of 2 minutes") — and against the Console playground, where a 2-minute recording clones and sounds good. The 20-voices-per-organization quota is unchanged.

## Why the client-side duration check has to be exact

The two bounds are enforced at different points, and that asymmetry is the whole reason this PR is not just a constant bump.

**Size** is a synchronous upload rejection, so a too-large file costs nothing. **Duration is not checked at upload**: an over-long clip is accepted, spends one of the 20 org-wide voice slots and a billable create, and only then lands in the per-model terminal `failed` status that this flow deliberately never retries. Our bound is the only thing standing between a too-long clip and a slot the user has to notice and clean up by hand — so it has to stay at or below Soniox's number rather than being relaxed to "let the server decide".

## Changes

- `MAX_CLIP_SECONDS` 20 → **120**, `MAX_UPLOAD_BYTES` `10 * 1024 * 1024` → **`35 * 1000 * 1000`**. "35 MB" is read as decimal, the smaller of the two plausible readings, so we never wave through what the server would reject.
- Fixed the too-large message, which divided the cap by 1024² while calling the result "MB". Invisible at 10 MiB (it printed 10); with the new constant it would have printed **"max 33.4 MB"**, a number appearing nowhere in Soniox's docs. Both figures now use the published unit.
- Synced the stale `≤20 s / 10 MB` comments in `SonioxVoicesClient.ts`, `ManagedVoicesClient.test.ts` and `types/VoiceLibrary.ts`, and recorded Amendment A1 on the BYOK spec.

`NativeVoiceSection`'s 3–20 s defaults are untouched: those are local-model bounds that happened to match Soniox's old number, not the same limit. The 3 s minimum here is ours too — Soniox publishes no minimum — and stays.

## Deliberately not changed (recorded in Amendment A1)

- **Upload timeouts stay at 120 s**, and the managed cold-upload path's 60 s whole-preparation ceiling stays too. A full 2-minute capture is ~11.5 MB of PCM16 WAV at a 48 kHz AudioContext (`encodeWavPcm16` neither resamples nor compresses), against ~1.9 MB before — so what the longer clip eats into is the timeout budget, not the size limit. It still fits 60 s above ~1.5 Mbps up, and the warm slot is the normal session-start path. Worth revisiting if session-start voice-prep failures show up in the field, or if large imports become a real workflow (a 35 MB file will not finish inside 120 s).
- **The recording countdown stays in seconds** ("Stop recording (120s)"), so `voiceLibrary.clipTooLong` keeps interpolating one unit across all 35 locales.

## Testing

TDD: the bounds tests were moved to the new limits first — the added "a 100 s clip is accepted" case went red — then the constants were changed to green it.

- Full suite: **330 files / 3791 tests pass**. (The 4 unhandled rejections from `settingsStore.nativeGate.test.ts` are pre-existing on `main`, verified.)
- `tsc --noEmit`: **zero new errors** vs `main`, compared line by line (both sides carry the same pre-existing 534).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Soniox voice reference clips now support recordings up to 2 minutes and imports up to 35 MB.
  - Longer valid clips can proceed to confirmation without errors.
  - Over-limit clips are detected during import with updated validation limits.

- **Documentation**
  - Updated guidance to clarify Soniox’s clip limits, decimal megabyte sizing, duration checks, and upload behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->