### PR TITLE
chore(sidecar): pin the five native wheels to native-v1.1.0

### DIFF
--- a/sidecar/requirements.txt
+++ b/sidecar/requirements.txt
@@ -17,8 +17,8 @@ soxr>=0.5
 # sys_platform/platform_machine so pip installs exactly one per target. setup.sh's
 # local-wheel override (dist/ or $SOKUJI_NATIVE_WHEEL) still exists for developers
 # testing an unreleased native build, but by default this is what ships.
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-manylinux_2_35_x86_64.whl ; sys_platform == "linux" and platform_machine == "x86_64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-manylinux_2_35_aarch64.whl ; sys_platform == "linux" and platform_machine == "aarch64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-win_amd64.whl ; sys_platform == "win32" and platform_machine == "AMD64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-macosx_11_0_arm64.whl ; sys_platform == "darwin" and platform_machine == "arm64"
-sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/sokuji_native-1.0.2-py3-none-macosx_11_0_x86_64.whl ; sys_platform == "darwin" and platform_machine == "x86_64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.1.0/sokuji_native-1.1.0-py3-none-manylinux_2_35_x86_64.whl ; sys_platform == "linux" and platform_machine == "x86_64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.1.0/sokuji_native-1.1.0-py3-none-manylinux_2_35_aarch64.whl ; sys_platform == "linux" and platform_machine == "aarch64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.1.0/sokuji_native-1.1.0-py3-none-win_amd64.whl ; sys_platform == "win32" and platform_machine == "AMD64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.1.0/sokuji_native-1.1.0-py3-none-macosx_11_0_arm64.whl ; sys_platform == "darwin" and platform_machine == "arm64"
+sokuji-native @ https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.1.0/sokuji_native-1.1.0-py3-none-macosx_11_0_x86_64.whl ; sys_platform == "darwin" and platform_machine == "x86_64"

--- a/sidecar/tests/test_runtime_gate.py
+++ b/sidecar/tests/test_runtime_gate.py
@@ -1,7 +1,7 @@
 """Verification gate (spec §9.3/§11): no heavyweight legacy-runtime import may
 reappear anywhere under sokuji_sidecar/, and requirements.txt stays pinned to
 its end state: 7 PyPI packages + 5 sokuji-native release-wheel URL lines (one
-per SKU, pinned to the native-v1.0.2 GitHub Release, gated by sys_platform/
+per SKU, pinned to the native-v1.1.0 GitHub Release, gated by sys_platform/
 platform_machine markers). AST-based so comments/docstrings mentioning the
 names stay allowed."""
 import ast
@@ -54,22 +54,22 @@ def test_no_torch_era_imports():
 
 
 NATIVE_RELEASE_BASE = (
-    "https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.0.2/"
+    "https://github.com/kizuna-ai-lab/sokuji/releases/download/native-v1.1.0/"
 )
 
 # filename -> expected PEP 508 marker (sys_platform/platform_machine values are
 # the literal sys.platform / platform.machine() strings CPython reports —
 # packaging.markers.default_environment() sources both from those same calls).
 NATIVE_WHEELS = {
-    "sokuji_native-1.0.2-py3-none-manylinux_2_35_x86_64.whl":
+    "sokuji_native-1.1.0-py3-none-manylinux_2_35_x86_64.whl":
         'sys_platform == "linux" and platform_machine == "x86_64"',
-    "sokuji_native-1.0.2-py3-none-manylinux_2_35_aarch64.whl":
+    "sokuji_native-1.1.0-py3-none-manylinux_2_35_aarch64.whl":
         'sys_platform == "linux" and platform_machine == "aarch64"',
-    "sokuji_native-1.0.2-py3-none-win_amd64.whl":
+    "sokuji_native-1.1.0-py3-none-win_amd64.whl":
         'sys_platform == "win32" and platform_machine == "AMD64"',
-    "sokuji_native-1.0.2-py3-none-macosx_11_0_arm64.whl":
+    "sokuji_native-1.1.0-py3-none-macosx_11_0_arm64.whl":
         'sys_platform == "darwin" and platform_machine == "arm64"',
-    "sokuji_native-1.0.2-py3-none-macosx_11_0_x86_64.whl":
+    "sokuji_native-1.1.0-py3-none-macosx_11_0_x86_64.whl":
         'sys_platform == "darwin" and platform_machine == "x86_64"',
 }
 
@@ -77,7 +77,7 @@ NATIVE_WHEELS = {
 def test_base_requirements_is_the_seven_pypi_plus_five_native_wheel_end_state():
     # numpy, websockets, huggingface_hub, psutil, zstandard, soundfile, soxr
     # (7 PyPI packages, version-pinned or floor-pinned) + sokuji-native, five
-    # direct-URL lines (one per SKU) pinned to the native-v1.0.2 release and
+    # direct-URL lines (one per SKU) pinned to the native-v1.1.0 release and
     # gated by a sys_platform/platform_machine marker so pip installs exactly
     # one per target — this is what keeps sidecar bundles from shipping
     # hollow (no sokuji_native inside).


### PR DESCRIPTION
Pins the sidecar's five native wheel URLs to the `native-v1.1.0` prerelease (published from `main` at 3284626e, five wheels, all lanes green), so the bundles built from this commit carry sokuji_native 1.1.0 (ABI 2).

Without this, a `sidecar-v0.3.0` bundle would install the 1.0.2 wheels, whose library has neither `sk_device_profile_get` nor `sk_device_supports_ops`. The sidecar would still run — every op-coverage query degrades to "unknown" and the planner passes everything through — so the failure would be silent, which is exactly the shape the pin exists to prevent.

`sidecarVersion` in the root `package.json` deliberately stays at 0.2.1 in this PR. It selects which bundle the app downloads, and the 0.3.0 bundles do not exist until the `sidecar-v0.3.0` tag builds them; moving it here would leave a window where any app build fetches a release that is not there. It moves in its own PR once the bundles are published.

Verified: `sidecar/requirements.txt` carries five `native-v1.1.0/sokuji_native-1.1.0-…` lines and no 1.0.2 mention; `test_runtime_gate.py`'s release base, five wheel filenames and two prose references all read 1.1.0; the sidecar suite is 780 passed / 12 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA3dgPZSc6pHsamAmYKk9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated platform-specific native components to release v1.1.0 across Linux, Windows, and macOS.
  * Updated runtime verification to validate the v1.1.0 release packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->