### PR TITLE
chore: point the app at sidecar 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sokuji",
   "productName": "Sokuji",
   "version": "0.40.0",
-  "sidecarVersion": "0.2.1",
+  "sidecarVersion": "0.3.0",
   "private": true,
   "main": "dist-electron/main.js",
   "homepage": "./",


### PR DESCRIPTION
Sets `sidecarVersion` to 0.3.0 so the app downloads the sidecar bundles that carry sokuji_native 1.1.0 (ABI 2) and the device-profile planner work. `sidecar/requirements.txt` was pinned to the 1.1.0 wheels in #488.

It is also what unblocks the tag. `sidecar-bundles.yml` runs `Verify tag matches package.json sidecarVersion` as the first step of all five lanes, so `sidecar-v0.3.0` cannot build while this reads 0.2.1 — the first attempt failed on exactly that, in every lane, before anything was published (no release, no assets). The tag will be deleted and re-cut on this PR's merge commit.

The split that caused it was a deliberate but wrong call on my side: keeping the bump out of the pin PR avoids a window where `main` names bundles that do not exist yet, but that window is precisely what the workflow's guard is there to close, and the guard is the invariant this repo has chosen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA3dgPZSc6pHsamAmYKk9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Sidecar version from 0.2.1 to 0.3.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->