### PR TITLE
fix(settings): voice-list error surfaces — styled retry, one banner per failure, banner clears on success

### DIFF
--- a/src/components/Settings/Settings.scss
+++ b/src/components/Settings/Settings.scss
@@ -73,6 +73,39 @@
     color: vars.$text-secondary;
     line-height: 1.5;
     margin-top: 6px;
+
+    // A recovery action offered inside the sentence that explains why it is
+    // needed ("could not load your voice — [Retry]"), so it flows with the
+    // text and inherits its size rather than sitting on its own row.
+    //
+    // Deliberately NOT `.option-button`: those styles exist only under
+    // `.turn-detection-options`, which draws the shared border its members
+    // lack and stretches each one with `flex: 1`. Reused here the class
+    // matched no rule at all and rendered a browser-default button.
+    .inline-action-button {
+      display: inline-flex;
+      align-items: center;
+      font: inherit;
+      color: vars.$text-primary;
+      background-color: vars.$bg-control;
+      border: 1px solid vars.$border-default;
+      border-radius: vars.$radius-sm;
+      padding: 2px 8px;
+      cursor: pointer;
+      transition: background-color vars.$transition-fast;
+
+      &:hover:not(:disabled) {
+        background-color: vars.$bg-elevated;
+      }
+
+      &:disabled {
+        @include vars.disabled-state;
+      }
+
+      &:focus-visible {
+        @include vars.focus-ring;
+      }
+    }
   }
 
   // Why a channel is greyed (e.g. the speaker monitor outside 'You' mode). Sits

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { compile } from 'sass';
 import type { VoiceLibrarySource } from './voiceLibrarySource';
 import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE } from '../../../lib/soniox/ttsCatalog';
 
@@ -278,10 +278,13 @@ describe('SonioxVoiceSection', () => {
   // all, and shipped a browser-default button — invisible to TypeScript, to
   // every render test, and to review, because the class does exist somewhere.
   //
-  // So this asserts the pairing that actually broke: whatever class the retry
-  // button renders must be styled INSIDE the `.setting-description` block that
-  // contains it. A plain `toContain('.' + cls)` on the whole file would have
-  // passed on the bug.
+  // So this asserts the pairing that actually broke, against what the browser
+  // would really receive: Settings.scss is COMPILED, and the emitted CSS must
+  // contain a selector reaching the button through the ancestors the rendered
+  // DOM actually places it under. Compiling (rather than parsing the source
+  // text) makes the check immune to how the stylesheet is formatted or nested,
+  // and it is the only evidence that answers "does the rule reach this element"
+  // — a `toContain('.' + cls)` over the source would have passed on the bug.
   it('styles the list-error retry button where it actually lives', async () => {
     listMock.mockRejectedValue(new Error('offline'));
     mount();
@@ -290,27 +293,15 @@ describe('SonioxVoiceSection', () => {
     expect(cls).toBeTruthy();
     expect(cls).not.toBe('option-button');
 
-    const scss = readFileSync(resolve(__dirname, '../Settings.scss'), 'utf-8');
-    const start = scss.indexOf('.setting-description {');
-    expect(start).toBeGreaterThan(-1);
-    // Walk braces from the block's opening `{` to find where it closes.
-    let depth = 0, end = start;
-    for (let i = scss.indexOf('{', start); i < scss.length; i++) {
-      if (scss[i] === '{') depth++;
-      else if (scss[i] === '}' && --depth === 0) { end = i; break; }
-    }
-    expect(scss.slice(start, end)).toContain(`.${cls}`);
+    // The chain is read off the real DOM, not assumed: the button must sit in
+    // a `.setting-description` inside a `.settings-section`.
+    expect(btn.closest('.setting-description')).not.toBeNull();
+    expect(btn.closest('.settings-section')).not.toBeNull();
+
+    const { css } = compile(resolve(__dirname, '../Settings.scss'));
+    expect(css).toMatch(new RegExp(String.raw`\.settings-section \.setting-description \.${cls}(?![\w-])`));
   });
 
-  // Seen in production 2026-09-05, during the managed-voice incident: with a
-  // voice stuck at "processing", the post-create readiness poll ran for its
-  // whole budget, and when the backend's /mine started answering 500 the poll
-  // rejected with a network error. finishCreate's `finally` then re-fetched the
-  // list — which failed the SAME way and painted the list-error banner with its
-  // Retry — and the rejection went on to paint a SECOND banner: the raw,
-  // untranslated "Failed to fetch" in the capture-error alert. One failure, two
-  // surfaces, one of them unreadable. Connectivity has exactly one home here,
-  // the list banner; a transport failure on the poll must not add a second.
   it('a transport failure on the readiness poll leaves only the list-error banner, with no raw fetch message', async () => {
     // Mount and the post-create refresh both succeed; only the refresh that
     // finishCreate runs AFTER the poll dies fails. That pins the list banner

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -312,7 +312,17 @@ describe('SonioxVoiceSection', () => {
   // surfaces, one of them unreadable. Connectivity has exactly one home here,
   // the list banner; a transport failure on the poll must not add a second.
   it('a transport failure on the readiness poll leaves only the list-error banner, with no raw fetch message', async () => {
-    listMock.mockResolvedValueOnce([]).mockRejectedValue(new SonioxVoicesError('network', 'Failed to fetch', 0));
+    // Mount and the post-create refresh both succeed; only the refresh that
+    // finishCreate runs AFTER the poll dies fails. That pins the list banner
+    // to the poll-triggered refresh specifically — with an earlier refresh
+    // failing too, the banner would already be up before the poll ran and
+    // the test would prove less than it claims. (refresh() swallows its own
+    // rejection, so an earlier failure would not have stopped the flow — it
+    // would only have muddied what the assertion is about.)
+    listMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockRejectedValue(new SonioxVoicesError('network', 'Failed to fetch', 0));
     createMock.mockResolvedValue({ id: 'new-id', name: 'Me', models: [] });
     waitMock.mockRejectedValue(new SonioxVoicesError('network', 'Failed to fetch', 0));
     stubAudioContext(16000, 16000 * 5);

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -302,6 +302,65 @@ describe('SonioxVoiceSection', () => {
     expect(scss.slice(start, end)).toContain(`.${cls}`);
   });
 
+  // Seen in production 2026-09-05, during the managed-voice incident: with a
+  // voice stuck at "processing", the post-create readiness poll ran for its
+  // whole budget, and when the backend's /mine started answering 500 the poll
+  // rejected with a network error. finishCreate's `finally` then re-fetched the
+  // list — which failed the SAME way and painted the list-error banner with its
+  // Retry — and the rejection went on to paint a SECOND banner: the raw,
+  // untranslated "Failed to fetch" in the capture-error alert. One failure, two
+  // surfaces, one of them unreadable. Connectivity has exactly one home here,
+  // the list banner; a transport failure on the poll must not add a second.
+  it('a transport failure on the readiness poll leaves only the list-error banner, with no raw fetch message', async () => {
+    listMock.mockResolvedValueOnce([]).mockRejectedValue(new SonioxVoicesError('network', 'Failed to fetch', 0));
+    createMock.mockResolvedValue({ id: 'new-id', name: 'Me', models: [] });
+    waitMock.mockRejectedValue(new SonioxVoicesError('network', 'Failed to fetch', 0));
+    stubAudioContext(16000, 16000 * 5);
+    const { container } = mount({ managed: true });
+    // Managed: the manage panel renders only once the first list has settled.
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    openManageDetails();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [fakeFile('clip.wav')] } });
+    // Managed hides the name field (the backend names voices), so the modal's
+    // arrival is marked by its confirm button, not the name input.
+    const confirm = await screen.findByRole('button', { name: confirmButtonName });
+    checkConsent();
+    fireEvent.click(confirm);
+
+    // The one surface: the list banner, translated, with its retry.
+    await screen.findByText(/could not load your voice/i);
+    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
+    // And not the other: no capture-error alert at all, and the raw fetch text
+    // never reaches the DOM.
+    await waitFor(() => expect(waitMock).toHaveBeenCalled());
+    expect(screen.queryByRole('alert')).toBeNull();
+    expect(screen.queryByText(/failed to fetch/i)).toBeNull();
+  });
+
+  // The guard on the guard: a NON-transport poll outcome is not a duplicate of
+  // anything — `voice_failed` carries its own advice ("delete this voice and
+  // try a clearer clip") that the list banner does not — so it must keep its
+  // alert. Suppressing every poll failure would hide this one.
+  it('a voice_failed outcome on the readiness poll still surfaces in the capture-error alert', async () => {
+    listMock.mockResolvedValue([]);
+    createMock.mockResolvedValue({ id: 'new-id', name: 'Me', models: [] });
+    waitMock.mockRejectedValue(new SonioxVoicesError('voice_failed', 'terminal', 503));
+    stubAudioContext(16000, 16000 * 5);
+    const { container } = mount({ managed: true });
+    // Managed: the manage panel renders only once the first list has settled.
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    openManageDetails();
+    const fileInput = container.querySelector('input[type="file"]') as HTMLInputElement;
+    fireEvent.change(fileInput, { target: { files: [fakeFile('clip.wav')] } });
+    // Managed hides the name field (the backend names voices), so the modal's
+    // arrival is marked by its confirm button, not the name input.
+    const confirm = await screen.findByRole('button', { name: confirmButtonName });
+    checkConsent();
+    fireEvent.click(confirm);
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/processing failed/i));
+  });
+
   it('onImport rejects a file over 35MB before decoding, creating, or opening the modal', async () => {
     listMock.mockResolvedValue([]);
     const { container } = mount();

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -361,6 +361,26 @@ describe('SonioxVoiceSection', () => {
     await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/processing failed/i));
   });
 
+  // Reported from production 2026-09-05: a "Failed to fetch" in the
+  // capture-error alert stayed on screen after the list had reloaded fine.
+  // Nothing ever cleared it — the only `setCaptureError(null)` calls sat at
+  // the START of the next record/import/preview, so an outage message
+  // outlived the outage until the user happened to start a new capture. A
+  // successful list load is positive evidence that whatever last went wrong
+  // has been superseded, so it clears the banner.
+  it('a successful list refresh clears a stale capture-error alert', async () => {
+    listMock.mockResolvedValue([cloned()]);
+    deleteMock.mockRejectedValue(new Error('boom'));
+    mount();
+    await waitFor(() => expect(listMock).toHaveBeenCalled());
+    openManageDetails();
+    fireEvent.click(await screen.findByRole('button', { name: /^delete$/i }));
+    await waitFor(() => expect(screen.getByRole('alert')).toHaveTextContent(/boom/));
+
+    fireEvent.click(screen.getByTitle(/refresh voice list/i));
+    await waitFor(() => expect(screen.queryByRole('alert')).toBeNull());
+  });
+
   it('onImport rejects a file over 35MB before decoding, creating, or opening the modal', async () => {
     listMock.mockResolvedValue([]);
     const { container } = mount();

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import type { VoiceLibrarySource } from './voiceLibrarySource';
 import { SONIOX_TTS_MODEL, SONIOX_DEFAULT_VOICE } from '../../../lib/soniox/ttsCatalog';
 
@@ -267,6 +269,37 @@ describe('SonioxVoiceSection', () => {
       const select = container.querySelector('select')!;
       expect([...select.querySelectorAll('option')].some((o) => o.value === 'uuid-1')).toBe(true);
     });
+  });
+
+  // A class name is not a style. `.option-button` exists in Settings.scss, but
+  // only nested under `.turn-detection-options`, whose members it stretches with
+  // `flex: 1` and whose shared border the CONTAINER draws. Borrowing that class
+  // for the standalone retry button in `.setting-description` matched no rule at
+  // all, and shipped a browser-default button — invisible to TypeScript, to
+  // every render test, and to review, because the class does exist somewhere.
+  //
+  // So this asserts the pairing that actually broke: whatever class the retry
+  // button renders must be styled INSIDE the `.setting-description` block that
+  // contains it. A plain `toContain('.' + cls)` on the whole file would have
+  // passed on the bug.
+  it('styles the list-error retry button where it actually lives', async () => {
+    listMock.mockRejectedValue(new Error('offline'));
+    mount();
+    const btn = await screen.findByRole('button', { name: /retry/i });
+    const cls = btn.className.trim();
+    expect(cls).toBeTruthy();
+    expect(cls).not.toBe('option-button');
+
+    const scss = readFileSync(resolve(__dirname, '../Settings.scss'), 'utf-8');
+    const start = scss.indexOf('.setting-description {');
+    expect(start).toBeGreaterThan(-1);
+    // Walk braces from the block's opening `{` to find where it closes.
+    let depth = 0, end = start;
+    for (let i = scss.indexOf('{', start); i < scss.length; i++) {
+      if (scss[i] === '{') depth++;
+      else if (scss[i] === '}' && --depth === 0) { end = i; break; }
+    }
+    expect(scss.slice(start, end)).toContain(`.${cls}`);
   });
 
   it('onImport rejects a file over 35MB before decoding, creating, or opening the modal', async () => {

--- a/src/components/Settings/sections/SonioxVoiceSection.test.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.test.tsx
@@ -293,10 +293,15 @@ describe('SonioxVoiceSection', () => {
     expect(cls).toBeTruthy();
     expect(cls).not.toBe('option-button');
 
-    // The chain is read off the real DOM, not assumed: the button must sit in
-    // a `.setting-description` inside a `.settings-section`.
-    expect(btn.closest('.setting-description')).not.toBeNull();
-    expect(btn.closest('.settings-section')).not.toBeNull();
+    // The chain is read off the real DOM, not assumed, and in ORDER: the
+    // button must sit in a `.setting-description` which itself sits in a
+    // `.settings-section`. Two independent `closest()` calls from the button
+    // would only prove both ancestors exist somewhere above it — a reversed
+    // nesting would pass them while the descendant selector below could
+    // never match. Chaining the second lookup from the first pins the order.
+    const description = btn.closest('.setting-description');
+    expect(description).not.toBeNull();
+    expect(description!.closest('.settings-section')).not.toBeNull();
 
     const { css } = compile(resolve(__dirname, '../Settings.scss'));
     expect(css).toMatch(new RegExp(String.raw`\.settings-section \.setting-description \.${cls}(?![\w-])`));

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -666,7 +666,7 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
             {managed
               ? t('settings.sonioxManagedVoiceListError', 'Could not load your voice — check your connection and try again.')
               : t('settings.sonioxVoiceListError', 'Could not load cloned voices — check the API key.')}{' '}
-            <button className="option-button" onClick={() => void refresh()}>
+            <button className="inline-action-button" onClick={() => void refresh()}>
               {t('common.retry', 'Retry')}
             </button>
           </div>

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -218,6 +218,13 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       if (generation !== loadGeneration.current || sourceRef.current !== requestSource) return;
       setClones(voices);
       setListState('idle');
+      // A fresh, successful load supersedes whatever the capture banner was
+      // still reporting. Without this the banner had no way OFF the screen
+      // short of the user starting another record/import/preview — the only
+      // places that reset it — so an outage's "Failed to fetch" outlived the
+      // outage (seen in production, 2026-09-05). Sits after the guard above
+      // on purpose: a superseded refresh must not clear anything either.
+      setCaptureError(null);
     } catch {
       if (generation !== loadGeneration.current || sourceRef.current !== requestSource) return;
       setListState('error');

--- a/src/components/Settings/sections/SonioxVoiceSection.tsx
+++ b/src/components/Settings/sections/SonioxVoiceSection.tsx
@@ -259,6 +259,11 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       if (e.errorType === 'authentication_required') {
         return new Error(t('settings.sonioxVoiceSignInRequired', 'Sign in to build a custom voice.'));
       }
+      // Transport, not a voices-API verdict: the raw `fetch` text ("Failed to
+      // fetch") is what would otherwise reach the banner, untranslated.
+      if (e.errorType === 'network' || e.errorType === 'timeout') {
+        return new Error(t('auth.networkError', 'Network error. Please check your connection'));
+      }
       if (e.errorType === 'clip_clear_failed') {
         // Half a delete: the voice is gone, the recording it was built from
         // is not. Saying "delete failed" would be the wrong half, and saying
@@ -278,6 +283,23 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
     }
     return e instanceof Error ? e : new Error(String(e));
   };
+
+  // A failure of the CONNECTION rather than a verdict about the voice: the
+  // wire, a timeout, the backend unable to reach Soniox (`upstream_unavailable`),
+  // or a 5xx that came with no slug at all (`http_error` is what throwApiError
+  // assigns when the body names nothing — the bare-500 shape). These are the
+  // failures the list banner already reports, with its Retry, because the same
+  // fetch fails the same way.
+  //
+  // Judged by errorType, never by status alone: Soniox returns `voice_failed`
+  // — a TERMINAL verdict with its own advice — as a 503, so `status >= 500`
+  // would swallow exactly the message the user most needs to see.
+  const isTransportFailure = (e: unknown): boolean =>
+    e instanceof SonioxVoicesError &&
+    (e.errorType === 'network' ||
+      e.errorType === 'timeout' ||
+      e.errorType === 'upstream_unavailable' ||
+      (e.errorType === 'http_error' && e.status >= 500));
 
   // Separate from mapCreateError: those branches are all voices-CRUD specific
   // (name conflicts, voice quota, terminal processing failure), none of which
@@ -417,7 +439,14 @@ const SonioxVoiceSection: React.FC<SonioxVoiceSectionProps> = ({
       try {
         await finishCreate(created, createSource, selectionAtCreate);
       } catch (e) {
-        setCaptureError(mapCreateError(e).message);
+        // finishCreate's `finally` has already re-fetched the list. If the
+        // poll died of a transport failure, that refresh failed the same way
+        // and the list banner (with its Retry) is already up — painting this
+        // banner too showed the same outage twice, once as raw "Failed to
+        // fetch" (seen in production, 2026-09-05). A non-transport outcome —
+        // voice_failed, above all — is not a duplicate of anything and keeps
+        // its own advice here.
+        if (!isTransportFailure(e)) setCaptureError(mapCreateError(e).message);
       }
     } catch (e) {
       setModalError(mapCreateError(e).message);


### PR DESCRIPTION
Three fixes to the managed voice section's error surfaces, all reported from production on 2026-09-05 alongside the backend incident (kizuna-ai-lab/sokuji-backend#58).

## 1. The retry button rendered with no styling

When the managed voice list fails to load, the **Retry** offered in the error line rendered as a bare browser-default button — grey and boxy against the dark panel:

```html
<div class="setting-description">音声を読み込めませんでした — 接続を確認して再度お試しください。 <button class="option-button">再試行</button></div>
```

`.option-button` really is in `Settings.scss` — but only nested under `.turn-detection-options`, so **the selector matched nothing** for a button in `.setting-description`. Hoisting that rule would have been worse than leaving it: those styles describe a *segment of a segmented control* (the container draws the shared border; each member gets `flex: 1` and `border: none`), and applied to a lone button inside a sentence they stretch it and strip its border.

The button gets a style for what it actually is — an inline recovery action that flows with the sentence and inherits its size, in the panel's control language — and is renamed `inline-action-button`, since reusing the segmented-control name is precisely the trap that produced this.

The regression test asserts the *pairing* against what the browser actually receives: it **compiles `Settings.scss` with `sass`** and requires the emitted CSS to contain a selector reaching the button through the ancestors the rendered DOM really places it under (`.settings-section .setting-description .<class>`, both ancestors read off the DOM via `closest()`). Compiling rather than parsing source text makes it indifferent to how the stylesheet is formatted or nested. Mutation-checked: renaming the class in the SCSS makes the test fail.

## 2. One connection failure painted two banners

With a voice stuck at "processing…", the post-create readiness poll ran for its whole budget; when the backend's `/mine` began answering 500, the poll rejected with a network error and the section showed the same outage twice — the list banner (translated, with its Retry) **and** the capture-error alert reading, verbatim, `Failed to fetch`.

The duplicate is structural: `finishCreate` re-fetches the list in a `finally`, so a transport failure on the poll is followed by the same failure on the list (which raises the list banner), and the rejection then reaches a catch whose `mapCreateError` had no `network`/`timeout` branch and fell through to the raw `Error` message.

Connectivity now has one home, the list banner. The poll's catch no longer paints the capture-error alert for a **transport** failure — and that is the *only* thing suppressed: `voice_failed` ("delete this voice and try a clearer clip") is not a duplicate of anything and keeps its alert, with a test guarding exactly that. The transport predicate judges by `errorType`, never by status: Soniox returns `voice_failed` as a **503**, so `status >= 500` would have swallowed precisely the verdict the user most needs. `mapCreateError` also maps `network`/`timeout` to the existing translated "Network error. Please check your connection", so raw fetch text cannot reach a banner from the other paths either.

## 3. The capture-error alert never went away

Reported next: that `Failed to fetch` stayed on screen **after the list had reloaded fine**. Nothing ever cleared it — the only `setCaptureError(null)` calls sat at the *start* of the next record/import/preview, so an outage's message outlived the outage until the user happened to begin another capture. Refresh, Retry, a successful delete: none of them touched it.

A fresh, successful list load is positive evidence that whatever the banner last reported has been superseded, so `refresh()` now clears it on success. One rule in one place covers every path that reloads the list (mount, toolbar button, list-error Retry, post-create refresh), placed after the generation/source guard so a superseded refresh clears nothing. Ordering with the post-create flow is preserved: the `finally` refresh clears *before* the catch sets `voice_failed`, so that verdict still lands.

Accepted trade-off for #2: if the poll dies of a blip and the list re-fetch succeeds, no error shows and auto-select is lost — the voice is in the list with its real badge and can be picked by hand.

## Testing

TDD throughout: each fix's test failed on the prior code first. The transport test reproduced the duplicate exactly (an `alert` present alongside the list banner); the `voice_failed` guard caught my first predicate over-suppressing on its 503; the stale-alert test reproduced the banner surviving a successful refresh; the compiled-CSS test was mutation-checked.

- Full suite: **3797 passed / 2 skipped**, +4 versus `main` — the new tests. (The 4 unhandled rejections from `settingsStore.nativeGate.test.ts` are pre-existing on `main`, verified separately.)
- `tsc --noEmit`: **zero new errors** versus `main`, compared line by line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved voice creation error handling by showing a localized connectivity message for network and timeout failures.
  - Prevented duplicate error alerts when readiness checks fail due to connectivity issues.
  - Continued displaying processing errors when voice creation reaches a terminal failure.
  - Cleared outdated capture-error alerts after a successful voice list refresh.
  - Updated the list retry action for clearer presentation, including improved hover, disabled, and focus states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->