### PR TITLE
fix(electron): make the bundled sidecar interpreter hermetic

### DIFF
--- a/electron/native-host-manager.js
+++ b/electron/native-host-manager.js
@@ -46,6 +46,27 @@ function resolveSidecarLaunch({ platform, envOverride, bundleRoot, requiredVersi
   return { python: devVenvPython, cwd: devCwd, source: 'venv' };
 }
 
+// Environment for the sidecar interpreter. The installed bundle ships its own
+// CPython, but CPython still honours the USER's environment: user site-packages
+// (~/.local/lib/pythonX.Y/site-packages, %APPDATA%\Python) precede the
+// interpreter's own site-packages on sys.path, and PYTHONPATH / PYTHONHOME
+// redirect imports and the stdlib. Field case (sidecar-v0.3.0 smoke, 2026-09-05):
+// a stale `pip install --user` of a CPU-lane sokuji_native shadowed the bundled
+// Vulkan wheel — the device profile came back unknown and the lane read "cpu".
+// The bundle interpreter is therefore made hermetic; the developer launch paths
+// (SOKUJI_SIDECAR_PYTHON, dev venv) keep the developer's environment on purpose
+// (PYTHONPATH=native/python is how a stage is pointed at without a wheel).
+// Pure: never mutates the env object it is given.
+function sidecarEnv(baseEnv, { hfHome, source }) {
+  const env = { ...baseEnv, HF_HOME: hfHome };
+  if (source === 'bundle') {
+    env.PYTHONNOUSERSITE = '1';
+    delete env.PYTHONPATH;
+    delete env.PYTHONHOME;
+  }
+  return env;
+}
+
 function parseHandshake(line) {
   try {
     const obj = JSON.parse(line);
@@ -110,7 +131,7 @@ class NativeHostManager {
       // CUDA consumer, via preload_dlls() at startup, spec D8) is gone —
       // every stage (ASR/translate/TTS) runs through sokuji-native, which
       // accelerates NVIDIA/AMD/Intel through Vulkan and needs no CUDA runtime.
-      const env = { ...process.env, HF_HOME: hfHome };
+      const env = sidecarEnv(process.env, { hfHome, source: launch.source });
       const spawnedAt = Date.now();
       const child = spawn(launch.python, ['-m', 'sokuji_sidecar'], {
         cwd: launch.cwd, env,
@@ -167,4 +188,4 @@ class NativeHostManager {
   }
 }
 
-module.exports = { resolvePython, resolveSidecarLaunch, parseHandshake, NativeHostManager, HANDSHAKE_TIMEOUT_MS };
+module.exports = { resolvePython, resolveSidecarLaunch, sidecarEnv, parseHandshake, NativeHostManager, HANDSHAKE_TIMEOUT_MS };

--- a/electron/native-host-manager.js
+++ b/electron/native-host-manager.js
@@ -57,12 +57,20 @@ function resolveSidecarLaunch({ platform, envOverride, bundleRoot, requiredVersi
 // (SOKUJI_SIDECAR_PYTHON, dev venv) keep the developer's environment on purpose
 // (PYTHONPATH=native/python is how a stage is pointed at without a wheel).
 // Pure: never mutates the env object it is given.
+//
+// The strip is case-INsensitive: Windows environment names are, but a spread of
+// process.env is a plain object, so `delete env.PYTHONPATH` would leave a
+// `PythonPath` behind — and Node hands the child the lexicographically first
+// case-insensitive match, so that survivor is exactly what CPython would read.
+// Harmless on POSIX, where the variants are distinct variables anyway.
+const PYTHON_REDIRECT_KEYS = /^python(path|home|nousersite)$/i;
 function sidecarEnv(baseEnv, { hfHome, source }) {
   const env = { ...baseEnv, HF_HOME: hfHome };
   if (source === 'bundle') {
+    for (const key of Object.keys(env)) {
+      if (PYTHON_REDIRECT_KEYS.test(key)) delete env[key];
+    }
     env.PYTHONNOUSERSITE = '1';
-    delete env.PYTHONPATH;
-    delete env.PYTHONHOME;
   }
   return env;
 }

--- a/electron/native-host-manager.test.js
+++ b/electron/native-host-manager.test.js
@@ -254,6 +254,17 @@ describe('sidecarEnv', () => {
     expect(env.LANG).toBe('C');
   });
 
+  it('strips the redirects case-insensitively (Windows env names are), leaving one uppercase key', () => {
+    // Node passes a Windows child the lexicographically first case-insensitive
+    // match, so a surviving `PythonPath` would be what CPython reads.
+    const win = { Path: 'C:\\W', PythonPath: 'C:\\hacks', pythonhome: 'C:\\py', PYTHONNOUSERSITE: '0', PythonNoUserSite: '0' };
+    const env = sidecarEnv(win, { hfHome: 'C:\\hf', source: 'bundle' });
+    const keys = Object.keys(env).filter((k) => /^python/i.test(k));
+    expect(keys).toEqual(['PYTHONNOUSERSITE']);
+    expect(env.PYTHONNOUSERSITE).toBe('1');
+    expect(env.Path).toBe('C:\\W');
+  });
+
   it('leaves the developer paths alone apart from HF_HOME', () => {
     for (const source of ['env', 'venv']) {
       const env = sidecarEnv(base, { hfHome: '/u/hf', source });

--- a/electron/native-host-manager.test.js
+++ b/electron/native-host-manager.test.js
@@ -231,3 +231,42 @@ describe('resolveSidecarLaunch strict version matching (spec S2)', () => {
     expect(l.source).toBe('env');
   });
 });
+
+import { sidecarEnv } from './native-host-manager.js';
+
+// The installed bundle ships its own interpreter, but CPython still honours the
+// user's environment: user site-packages precede the bundle's own site-packages
+// on sys.path, and PYTHONPATH / PYTHONHOME redirect imports and the stdlib. A
+// stale `pip install --user sokuji_native` shadowed the bundled Vulkan wheel on a
+// real box (sidecar-v0.3.0 smoke, 2026-09-05): the profile came back unknown and
+// the lane read cpu. The bundle interpreter must be hermetic; the developer
+// paths (env override, dev venv) keep the developer's environment on purpose.
+describe('sidecarEnv', () => {
+  const base = { PATH: '/usr/bin', PYTHONPATH: '/home/u/hacks', PYTHONHOME: '/opt/py', LANG: 'C' };
+
+  it('isolates the bundle interpreter from the user site and PYTHON* redirects', () => {
+    const env = sidecarEnv(base, { hfHome: '/u/hf', source: 'bundle' });
+    expect(env.PYTHONNOUSERSITE).toBe('1');
+    expect(env).not.toHaveProperty('PYTHONPATH');
+    expect(env).not.toHaveProperty('PYTHONHOME');
+    expect(env.HF_HOME).toBe('/u/hf');
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.LANG).toBe('C');
+  });
+
+  it('leaves the developer paths alone apart from HF_HOME', () => {
+    for (const source of ['env', 'venv']) {
+      const env = sidecarEnv(base, { hfHome: '/u/hf', source });
+      expect(env).not.toHaveProperty('PYTHONNOUSERSITE');
+      expect(env.PYTHONPATH).toBe('/home/u/hacks');
+      expect(env.PYTHONHOME).toBe('/opt/py');
+      expect(env.HF_HOME).toBe('/u/hf');
+    }
+  });
+
+  it('does not mutate the process environment it was given', () => {
+    const before = { ...base };
+    sidecarEnv(base, { hfHome: '/u/hf', source: 'bundle' });
+    expect(base).toEqual(before);
+  });
+});


### PR DESCRIPTION
## What

The installed sidecar bundle ships its own CPython, but CPython still honours the user's environment: user site-packages (`~/.local/lib/pythonX.Y/site-packages`, `%APPDATA%\Python`) precede the interpreter's own site-packages on `sys.path`, and `PYTHONPATH` / `PYTHONHOME` redirect imports and the stdlib.

During the `sidecar-v0.3.0` fleet smoke a stale `pip install --user` of a CPU-lane `sokuji_native` (left behind by a local `ci/build.sh` run) shadowed the bundled Vulkan wheel: the device profile came back `known: false` and the lane read `cpu`. Any end user with a user-site copy of a bundled package (`sokuji_native`, `numpy`, `websockets`…) would hit the same thing, with no diagnostic.

## Change

`electron/native-host-manager.js` builds the child environment through a new pure `sidecarEnv(baseEnv, { hfHome, source })`: for the **bundle** launch it sets `PYTHONNOUSERSITE=1` and drops `PYTHONPATH` and `PYTHONHOME`. The developer launch paths (`SOKUJI_SIDECAR_PYTHON` override, dev venv) are deliberately untouched — `PYTHONPATH=native/python` is how a stage is pointed at without a wheel.

Three vitest cases pin the split (bundle isolated / dev paths untouched / no mutation of `process.env`). `npx vitest run electron/native-host-manager.test.js`: 18 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA3dgPZSc6pHsamAmYKk9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved bundled sidecar launches by using an isolated Python environment, preventing unintended user or system Python settings from affecting startup.
  - Preserved developer environment settings when launching through configured environments or virtual environments.
  - Ensured sidecar configuration does not alter the original application environment.
  - Improved reliability across different operating systems and environment variable capitalization styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->