### PR TITLE
test(parity): key the reference audiocpp_cli by the pinned audio.cpp commit

### DIFF
--- a/native/tests/parity/README.md
+++ b/native/tests/parity/README.md
@@ -22,8 +22,11 @@ reference is wrong, not `sk_tts`** — read the investigation report before assu
 
 ## Files
 
-- `build_reference_cli.sh` — builds the reference `audiocpp_cli` once and caches it. Idempotent:
-  a second run is a no-op if the binary already exists.
+- `build_reference_cli.sh` — builds the reference `audiocpp_cli` and caches it with a `PIN_SHA`
+  stamp. Idempotent per pin: a second run is a no-op while the stamp equals the audio.cpp commit
+  `native/cmake/upstreams.cmake` pins, and a pin bump rebuilds the reference on the next run
+  (the source and build directories are reused). `test_tts_parity.py` fails — not skips — when
+  the stamp and the pin differ, so a stale reference can never produce a clean pass.
 - `test_tts_parity.py` — the pytest cases, one per family, each independently env-gated.
 - `compare_pcm.py` — the comparator (`--exact` for CPU, `--min-snr <dB>` for the Vulkan leg);
   pre-existing, not part of this gate's own deliverable.
@@ -41,8 +44,9 @@ hardcoded — a future pin bump is picked up automatically), configures it stand
 targets), builds just the `audiocpp_cli` target, and copies the binary plus its dynamically
 loaded CPU backend module(s) to `~/.cache/sokuji-native-tests/audiocpp-official/`. About 15
 minutes the first time on a 20-core box (mostly ggml's multi-ISA-variant CPU backend and
-audio.cpp's engine core); instant on every later run, since it exits immediately once the
-cached binary exists.
+audio.cpp's engine core); instant on every later run at the same pin (the cached binary's
+`PIN_SHA` stamp equals the commit `upstreams.cmake` pins), and an incremental rebuild in the
+reused build directory after a pin bump.
 
 Two things worth knowing if you ever need to touch this script:
 
@@ -66,7 +70,10 @@ Two things worth knowing if you ever need to touch this script:
   comparison exercises, since the tier actually selected at runtime here is `armv8.6_2` either
   way (`ggml_options.cmake`'s own comment says as much for our build).
 
-Force a rebuild by deleting the cached binary (or the whole `~/.cache/sokuji-native-tests/audiocpp-official*` tree for a clean re-clone), or point `SOKUJI_NATIVE_TEST_CACHE` at a
+A pin bump needs no manual step: the stamp no longer matches, so the next run rebuilds (and
+refetches the source if its checkout is at another commit). To force a rebuild at the SAME
+pin, delete `~/.cache/sokuji-native-tests/audiocpp-official/` (or the whole
+`audiocpp-official*` tree for a clean re-clone), or point `SOKUJI_NATIVE_TEST_CACHE` at a
 different root.
 
 ## 2. Run the suite

--- a/native/tests/parity/build_reference_cli.sh
+++ b/native/tests/parity/build_reference_cli.sh
@@ -51,8 +51,13 @@ if [[ -x "$OUT_BIN" ]]; then
 fi
 
 if [[ -d "$SRC_DIR/.git" && "$(git -C "$SRC_DIR" rev-parse HEAD)" != "$GIT_SHA" ]]; then
-    echo "build_reference_cli.sh: $SRC_DIR is at $(git -C "$SRC_DIR" rev-parse HEAD), pin is $GIT_SHA — refetching"
-    rm -rf "$SRC_DIR" "$BUILD_DIR"
+    # Move the existing checkout to the pin IN PLACE and keep BUILD_DIR: the source path
+    # is unchanged, so CMake's cache stays valid and the rebuild below is incremental
+    # (only the files that differ between the two commits recompile). `-f` discards the
+    # SME drop applied to external/ggml on the previous run; it is re-applied below.
+    echo "build_reference_cli.sh: $SRC_DIR is at $(git -C "$SRC_DIR" rev-parse HEAD), pin is $GIT_SHA — refetching in place"
+    git -C "$SRC_DIR" fetch --depth 1 origin "$GIT_SHA"
+    git -C "$SRC_DIR" checkout -q -f FETCH_HEAD
 fi
 if [[ ! -d "$SRC_DIR/.git" ]]; then
     rm -rf "$SRC_DIR"

--- a/native/tests/parity/build_reference_cli.sh
+++ b/native/tests/parity/build_reference_cli.sh
@@ -7,10 +7,15 @@
 # pulls in and builds audio.cpp's OWN fork of ggml (external/ggml inside its own tree) — the
 # only intentional difference between the two binaries under test.
 #
-# Idempotent: exits immediately if the cached binary already exists (delete it, or point
-# SOKUJI_NATIVE_TEST_CACHE elsewhere, to force a rebuild). First run: a git clone plus a CPU-only
-# build of ggml + engine_runtime + audiocpp_cli (no server/webui/model-manager targets, so no
-# OpenSSL/libyaml/cpp-httplib dependency) — about 15 minutes on a 20-core box.
+# Idempotent PER PIN: the cached binary carries a PIN_SHA stamp, and a second run is a no-op
+# only while that stamp equals the audio.cpp commit pinned in upstreams.cmake. A pin bump
+# therefore rebuilds the reference on the next run instead of leaving a stale one in place
+# (before 2026-09-05 the early exit fired on the binary's mere existence, BEFORE the pin was
+# read — a silently stale reference that the parity suite then "passed" against). Delete
+# $OUT_DIR, or point SOKUJI_NATIVE_TEST_CACHE elsewhere, to force a rebuild at the same pin.
+# First run: a git clone plus a CPU-only build of ggml + engine_runtime + audiocpp_cli (no
+# server/webui/model-manager targets, so no OpenSSL/libyaml/cpp-httplib dependency) — about
+# 15 minutes on a 20-core box; a rebuild for a new pin reuses the build directory.
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
@@ -21,11 +26,7 @@ SRC_DIR="$CACHE_DIR/audiocpp-official-src"
 BUILD_DIR="$CACHE_DIR/audiocpp-official-build"
 OUT_DIR="$CACHE_DIR/audiocpp-official"
 OUT_BIN="$OUT_DIR/audiocpp_cli"
-
-if [[ -x "$OUT_BIN" ]]; then
-    echo "build_reference_cli.sh: $OUT_BIN already exists — skipping (delete it, or set SOKUJI_NATIVE_TEST_CACHE, to force a rebuild)"
-    exit 0
-fi
+STAMP="$OUT_DIR/PIN_SHA"
 
 # The repo URL and pinned commit are read out of upstreams.cmake, not hardcoded here, so a
 # future pin bump (native/README.md's "Bumping a pin" step 3: "run the parity suite — a bump
@@ -39,6 +40,20 @@ if [[ -z "$REPO_URL" || -z "$GIT_SHA" ]]; then
 fi
 echo "build_reference_cli.sh: pristine audio.cpp @ $GIT_SHA from $REPO_URL"
 
+if [[ -x "$OUT_BIN" ]]; then
+    BUILT_FOR="$(cat "$STAMP" 2>/dev/null || echo "unknown (no PIN_SHA stamp — built before 2026-09-05)")"
+    if [[ "$BUILT_FOR" == "$GIT_SHA" ]]; then
+        echo "build_reference_cli.sh: $OUT_BIN already built for $GIT_SHA — skipping (delete $OUT_DIR, or set SOKUJI_NATIVE_TEST_CACHE, to force a rebuild)"
+        exit 0
+    fi
+    echo "build_reference_cli.sh: $OUT_BIN was built for $BUILT_FOR, pin is $GIT_SHA — rebuilding"
+    rm -rf "$OUT_DIR"
+fi
+
+if [[ -d "$SRC_DIR/.git" && "$(git -C "$SRC_DIR" rev-parse HEAD)" != "$GIT_SHA" ]]; then
+    echo "build_reference_cli.sh: $SRC_DIR is at $(git -C "$SRC_DIR" rev-parse HEAD), pin is $GIT_SHA — refetching"
+    rm -rf "$SRC_DIR" "$BUILD_DIR"
+fi
 if [[ ! -d "$SRC_DIR/.git" ]]; then
     rm -rf "$SRC_DIR"
     mkdir -p "$SRC_DIR"
@@ -51,7 +66,7 @@ if [[ ! -d "$SRC_DIR/.git" ]]; then
 fi
 ACTUAL_SHA="$(git -C "$SRC_DIR" rev-parse HEAD)"
 if [[ "$ACTUAL_SHA" != "$GIT_SHA" ]]; then
-    echo "build_reference_cli.sh: $SRC_DIR is at $ACTUAL_SHA, expected the pin $GIT_SHA — delete it and re-run" >&2
+    echo "build_reference_cli.sh: $SRC_DIR is at $ACTUAL_SHA after refetch, expected the pin $GIT_SHA" >&2
     exit 1
 fi
 
@@ -90,7 +105,9 @@ fi
 
 # Flags mirror native/cmake/upstreams.cmake's audio.cpp block as closely as a standalone
 # configure allows, so the only deliberate difference from our own build is the ggml source:
-#   - AUDIOCPP_MODEL_SET/MODELS: the same five families sokuji_native links.
+#   - AUDIOCPP_MODEL_SET/MODELS: the five families the parity suite compares — a subset of
+#     the nine sokuji_native links (native/cmake/upstreams.cmake AUDIOCPP_MODELS); the four
+#     2026-09-03 families have no parity case yet.
 #   - CPU only, deployment build, no native model manager: matches upstreams.cmake verbatim.
 #   - ENGINE_ENABLE_CPU_ALL_VARIANTS=ON (audio.cpp's own default is OFF): our build gets this
 #     behavior for free because native/cmake/ggml_options.cmake configures ggml itself, before
@@ -137,4 +154,7 @@ if ! "$OUT_BIN" --list-devices >/dev/null 2>&1; then
     echo "build_reference_cli.sh: built binary at $OUT_BIN failed to run --list-devices" >&2
     exit 1
 fi
-echo "build_reference_cli.sh: built $OUT_BIN"
+# Written last, so a build that died half-way leaves no stamp and the next run rebuilds.
+# test_tts_parity.py reads this and FAILS (not skips) when it differs from the pin.
+printf '%s\n' "$GIT_SHA" > "$STAMP"
+echo "build_reference_cli.sh: built $OUT_BIN for audio.cpp $GIT_SHA"

--- a/native/tests/parity/test_tts_parity.py
+++ b/native/tests/parity/test_tts_parity.py
@@ -102,6 +102,7 @@ import hashlib
 import json
 import os
 import pathlib
+import re
 import shutil
 import subprocess
 import sys
@@ -254,7 +255,30 @@ def _sve_free_copy(src_dir: pathlib.Path, key_file: str) -> pathlib.Path:
     return dst_dir
 
 
+_UPSTREAMS_CMAKE = pathlib.Path(__file__).resolve().parents[2] / "cmake" / "upstreams.cmake"
+
+
+def _pinned_audiocpp_sha() -> str:
+    """The audio.cpp commit native/cmake/upstreams.cmake pins — the same parse
+    build_reference_cli.sh does, so the two can never disagree about what "current" means."""
+    text = _UPSTREAMS_CMAKE.read_text()
+    block = text[text.index("FetchContent_Declare(audiocpp"):]
+    m = re.search(r"^\s*GIT_TAG\s+([0-9a-f]{40})", block, re.M)
+    assert m, f"no 40-hex GIT_TAG in the audiocpp block of {_UPSTREAMS_CMAKE}"
+    return m.group(1)
+
+
 def _official_cli_nosve() -> pathlib.Path:
+    # A reference built for another audio.cpp pin is worse than none: the suite would
+    # compare against the wrong engine and report a clean pass. build_reference_cli.sh
+    # stamps the pin it built for; a missing stamp is a pre-2026-09-05 build. Fail, do not
+    # skip — a skip after a pin bump is exactly the silent path this guards against.
+    stamp = OFFICIAL_CLI.parent / "PIN_SHA"
+    built_for = stamp.read_text().strip() if stamp.exists() else "unknown (no PIN_SHA stamp)"
+    pinned = _pinned_audiocpp_sha()
+    if built_for != pinned:
+        pytest.fail(f"reference audiocpp_cli at {OFFICIAL_CLI} was built for audio.cpp {built_for}, "
+                    f"but upstreams.cmake pins {pinned} — re-run native/tests/parity/build_reference_cli.sh")
     dst_dir = _sve_free_copy(OFFICIAL_CLI.parent, "audiocpp_cli")
     return dst_dir / "audiocpp_cli"
 


### PR DESCRIPTION
## What

`native/tests/parity/build_reference_cli.sh` exited early whenever the cached `audiocpp_cli` existed — before it had even read the audio.cpp pin out of `upstreams.cmake` — so after a pin bump the parity suite kept comparing against the OLD engine and reported a clean pass. The candidate side was already signature-keyed (the nosve copies); the reference side was not.

## Change

- The script reads the pin first, stamps the commit it built for in `audiocpp-official/PIN_SHA` (written last, so a half-finished build leaves no stamp), skips only while the stamp equals the pin, and otherwise rebuilds — refetching the source at the new commit and reusing the build directory.
- `test_tts_parity.py` reads the same stamp against the same parse of `upstreams.cmake` and **fails, not skips**, on a mismatch or a pre-stamp build: a skip after a pin bump would be exactly the silent path this closes.
- READMEs updated.

## Verified on GB10

- First run against the pre-existing (unstamped) reference: rebuilt incrementally, stamp written for `c4dde1c2…` (the v0.7.1 pin). Second run: no-op.
- `pytest native/tests/parity -k supertonic`: passes with the correct stamp; with a bogus stamp it fails with `reference audiocpp_cli … was built for audio.cpp deadbeef…, but upstreams.cmake pins c4dde1c2… — re-run native/tests/parity/build_reference_cli.sh`.

Not in this PR: the reference CLI is still configured with the original five families (`-DAUDIOCPP_MODELS=…`), which is the parity suite's scope, not sokuji_native's nine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RA3dgPZSc6pHsamAmYKk9d


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reference speech-synthesis parity tests now detect when the cached reference build does not match the configured source revision, preventing comparisons against outdated binaries.
  * Cached reference builds are automatically refreshed when the pinned source revision changes, while stale or incomplete cache metadata triggers a rebuild.

* **Documentation**
  * Updated rebuild guidance explains automatic revision-based rebuilds and how to force a rebuild at the same revision.
  * Clarified the set of model families covered by parity testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->