### PR TITLE
fix(local-inference): keep ASR VAD ingestion active during decode

### DIFF
--- a/docs/superpowers/notes/2026-09-06-asr-decode-handoff-gb10-validation.md
+++ b/docs/superpowers/notes/2026-09-06-asr-decode-handoff-gb10-validation.md
@@ -1,0 +1,87 @@
+# ASR decode handoff (#470 / #497) — GB10 validation
+
+**Date**: 2026-09-06
+**Branch**: `fix/nonblocking-asr-decode` (PR #497, contributor commit c008509e + review follow-ups)
+**What was tested**: the real `whisper-webgpu`, `cohere-transcribe-webgpu` and
+`granite-speech-webgpu` workers, PR head vs. the pre-PR copies from `main`, driven through the
+same message protocol `AsrEngine` uses (init with `fileUrls` / `hfModelId` / `dtype` / language /
+`ortWasmBaseUrl` / `vadModelUrl` → Int16@24 kHz chunks paced at ~1.7× real time → flush →
+dispose), on the GB10 (NVIDIA, Vulkan, headless Chromium 151 via the Playwright headless shell,
+`--use-vulkan=native`). Same harness shape as the qwen3 run in
+`2026-09-02-qwen3-asr-webgpu-fleet-validation.md`; sources live in the job scratch dir
+(`worker-harness/asr/`, `vite.harness.config.ts`, `run_asr.py`), not committed.
+
+## Stream
+
+Eight Japanese clips (4 Common Voice + 4 FLEURS), each trimmed of its own head/tail silence and
+concatenated into one gapless stream of **70.17 s** of continuous speech, 2.5 s of silence only at
+the very end. The 20 s max-speech cap closes the first segment; the VAD closes the rest. The VAD
+segmentation is deterministic: every run below, old or new, whisper or cohere, produced the same
+six `startSample` / `durationMs` pairs as the qwen3 run on the same clips (20000, 5600, 10656,
+8896, 10016, 10016 ms), so "captured" below is a property of what the worker was fed, not of the
+VAD. The ~5 s between 70.17 and 65.18 is VAD edge trimming, identical across all new-worker runs.
+
+## Audio captured, old vs. new
+
+| worker (q4) | pre-PR (`await` inside feedAudio) | PR head (`void` + serialized chain) |
+|---|---|---|
+| whisper-small | **32.13 s** in 3 segments, 4 speech_starts — the two clips after the cap boundary vanish entirely, the stream resumes mid-clip, the last segment is a 2.2 s tail ("になります") | **65.18 s** in 6 segments, 6 speech_starts, 0 errors |
+| cohere-transcribe | 61.22 s in 6 segments — segment 2 is 2.40 s ("力であるが。"), segments 3/4 are 0.3–0.5 s short | **65.18 s** in 6 segments, segment 2 is the full 5.60 s ("知性は構成されたものによって所与のものを超える力であるが、"), 0 errors |
+
+whisper-small q4 decodes a 20 s segment in ~15 s on this GPU (RTF ≈ 0.75), which makes the
+decode-while-ingesting window enormous and the pre-PR loss dramatic. cohere decodes the same
+segment in ~2 s, so the pre-PR loss is confined to the first seconds after each boundary — exactly
+the "first words of the next utterance" symptom #470 describes, here the head of clip 4 lost
+during the 2.1 s decode of the capped segment.
+
+The 20 s cap happened to land on the clip 3 / clip 4 join (the three trimmed Common Voice clips
+sum to ≈ 20.0 s; segment 2 starts at sample 321024 = 20.06 s), so this stream does not split a
+sentence at the cap the way the qwen3 run did. What it does show is that nothing is lost on
+either side of the cap: with both new workers segment 1 ends on clip 3's last words
+(「…面白みのないものしか見つからなかった」) and segment 2 opens on clip 4's first words
+(「知性は構成されたものによって…」), whereas the pre-PR cohere kept only clip 4's tail
+(「力であるが。」, 2.40 s of 5.60) and the pre-PR whisper lost clips 4 and 5 outright.
+
+## Flush + dispose issued while decodes are in flight (#470 acceptance)
+
+`earlyDispose=1`: the harness posts `flush` and then `dispose` immediately after the last audio
+chunk, while decodes are still queued, and counts what arrives before and after `disposed`.
+
+| worker (PR head) | results before dispose | posted during dispose | after `disposed` | errors after | dispose took |
+|---|---|---|---|---|---|
+| whisper-small | 3 | **3** (the queued decodes drained) | 0 | 0 | 17.2 s |
+| cohere-transcribe | 6 | 0 (already drained) | 0 | 0 | 3.2 s |
+
+Every queued utterance's text lands before `disposed`, nothing after it, no error. Note that in
+the app this path is unreachable today: `WorkerSession.dispose()` posts `dispose` and calls
+`worker.terminate()` on the next line, so the worker-side drain only ever runs in a harness.
+
+## granite: untestable — the model fails on `main` too
+
+Both the pre-PR and the PR-head granite worker fail every decode identically, on every segment
+length, with an ORT error from the audio encoder:
+
+```
+failed to call OrtRun(). ... reshape_helper.h:41 ... The input tensor cannot be reshaped to the
+requested shape. Input shape:{1,1200,1024}, requested shape:{1,5,200,8,-1}
+```
+
+`onnx-community/granite-4.0-1b-speech-ONNX` (q4) has a 5 × 200-frame block reshape baked into the
+exported audio-encoder graph, while Transformers.js 4.2.0's `GraniteSpeechProcessor` blocks on
+`projector_window_size` (15) and pads nothing, so any input that is not exactly 1000 encoder
+frames fails. Not related to #497; the worker's dispose still completed cleanly after the six
+errors (`disposed` posted, 0 errors after). Tracked as #500: either the export or the
+Transformers.js pin.
+
+## Coverage and gaps
+
+- GB10 / Vulkan only. The Mac mini M4 (Metal) and the RTX 4070 SUPER (Windows, Vulkan x64) were
+  not run; the change is worker-side scheduling with no device-specific code, and the
+  two-ORT-instance layout it relies on is the one the fleet already runs for voxtral-3b.
+- q4 variants only (GB10's adapter has no `shader-f16`).
+- One language (ja) per stream. The whisper multilingual 13-clip stream from the qwen3 note was
+  not repeated; the ja stream already exercises the cap boundary and the decode-while-ingesting
+  path.
+- The unit-level guard (`harness-consolidation.test.ts`, "ASR worker VAD decode handoff") was
+  mutation-checked: 5 workers × 3 paths, each `void` → `await` flip turns exactly that worker's
+  case red.

--- a/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+++ b/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
@@ -94,26 +94,75 @@ describe('ASR worker flush handling (PTT finalization)', () => {
   });
 });
 
+// #470: an ASR worker must never `await` its model decode from inside feedAudio. Awaiting
+// there holds `processingVad` for the whole decode (0.5–2.5 s on the fleet GPUs), and the guard
+// at the top of feedAudio then drops every audio message arriving meanwhile — on gapless audio
+// that is the first words of the next utterance, and on the 20 s max-speech cap it is words at
+// every boundary. Decodes are fire-and-forget (`void schedule(...)`) on SpeechEnd, on the cap
+// and on flush, serialized behind a worker-local promise that handleFlush drains. voxtral-3b
+// and qwen3-asr established the pattern (#469); whisper, cohere and granite adopted it in #497.
+//
+// Each path gets a positive AND a negative assertion on its own slice, with every anchor
+// required to exist: the first version of this guard anchored the cap slice on a comment that
+// in whisper first appears on the `maxSpeechFrames` declaration and used a section header
+// cohere does not have, so `indexOf` widened the slice until it contained a sibling's `void`
+// and the cap-path assertion passed vacuously for two of the three workers.
 const NON_BLOCKING_DECODE_WORKERS = [
   ['whisper-webgpu.worker.ts', 'scheduleWhisper', 'pendingWhisperDecode'],
   ['cohere-transcribe-webgpu.worker.ts', 'scheduleTranscription', 'currentTranscriptionPromise'],
   ['granite-speech-webgpu.worker.ts', 'scheduleGraniteInference', 'pendingGraniteDecode'],
+  ['qwen3-asr-webgpu.worker.ts', 'transcribe', 'currentDecodePromise'],
+  ['voxtral-3b-webgpu.worker.ts', 'runVoxtral3B', 'currentDecodePromise'],
 ] as const;
 
-describe('ASR worker VAD decode handoff', () => {
-  it.each(NON_BLOCKING_DECODE_WORKERS)('%s releases VAD before %s completes', (name, schedule, pending) => {
-    const src = read(name);
-    const speechEnd = src.match(/case Message\.SpeechEnd:([\s\S]*?)case Message\.VADMisfire:/)?.[1] ?? '';
-    const maxSpeech = src.slice(src.indexOf('// Max speech duration cap'), src.indexOf('// ─── Message Handlers'));
-    const flush = src.slice(src.indexOf('async function handleFlush'), src.indexOf('async function handleDispose'));
-    const call = new RegExp(`\\b${schedule}\\(`);
+/**
+ * `src.slice(from, to)` with both anchors required, in order. A missing anchor must fail the
+ * test loudly — `indexOf` returning -1 silently turns a slice into "the rest of the file".
+ */
+function sliceBetween(src: string, name: string, from: string, to: string): string {
+  const a = src.indexOf(from);
+  expect(a, `${name}: anchor ${JSON.stringify(from)} not found`).toBeGreaterThanOrEqual(0);
+  const b = src.indexOf(to, a + from.length);
+  expect(b, `${name}: anchor ${JSON.stringify(to)} not found after ${JSON.stringify(from)}`)
+    .toBeGreaterThanOrEqual(0);
+  return src.slice(a, b);
+}
 
-    expect(speechEnd).toMatch(new RegExp(`void\\s+${schedule}\\(`));
-    expect(speechEnd).not.toMatch(new RegExp(`await\\s+${schedule}\\(`));
-    expect(maxSpeech).toMatch(new RegExp(`void\\s+${schedule}\\(`));
-    expect(flush).toMatch(new RegExp(`void\\s+${schedule}\\(`));
-    expect(flush).toMatch(new RegExp(`await ${pending}`));
-    expect(src).toMatch(new RegExp(`const \\w+ = ${pending};`));
-    expect(src).toMatch(call);
+describe('ASR worker VAD decode handoff (#470)', () => {
+  it.each(NON_BLOCKING_DECODE_WORKERS)('%s fires %s without awaiting it on every segment-closing path', (name, schedule, pending) => {
+    const src = read(name);
+    const paths: Array<[string, string]> = [
+      ['SpeechEnd', sliceBetween(src, name, 'case Message.SpeechEnd:', 'case Message.VADMisfire:')],
+      ['max-speech cap', sliceBetween(src, name, 'speechFramesSinceStart >= maxSpeechFrames', 'speechFramesSinceStart = 0;')],
+      ['flush', sliceBetween(src, name, 'async function handleFlush', 'async function handleDispose')],
+    ];
+    const voidCall = new RegExp(`\\bvoid\\s+${schedule}\\(`);
+    const awaitCall = new RegExp(`\\bawait\\s+${schedule}\\(`);
+    for (const [label, slice] of paths) {
+      expect(slice, `${name}: the ${label} path must fire-and-forget ${schedule}()`).toMatch(voidCall);
+      expect(slice, `${name}: the ${label} path must not await ${schedule}() (holds processingVad, drops audio)`).not.toMatch(awaitCall);
+    }
+    const [, flush] = paths[2];
+    expect(flush, `${name}: handleFlush must drain ${pending} so PTT release resolves after the utterance's text is posted`)
+      .toMatch(new RegExp(`await\\s+${pending}\\b`));
+  });
+});
+
+// handleDispose nulls the module-level model reference BEFORE its final drain of the decode
+// chain (so a queued decode exits at its guard), which means a decode already past that guard
+// can resume with the global gone. The segment body must therefore read the model through a
+// local captured before its first await — qwen3-asr's `const m = model` — never the module
+// global. granite once did `await processor(...)` and then `model.generate(...)`, which threw
+// inside its try and posted a spurious "Granite inference failed" during dispose (#497 review).
+// whisper and cohere read their global synchronously before the first await, so this guard is
+// granite-specific.
+describe('ASR worker decode body holds its model in a local', () => {
+  it('granite-speech-webgpu.worker.ts never dereferences the module globals after capturing them', () => {
+    const src = read('granite-speech-webgpu.worker.ts');
+    const body = sliceBetween(src, 'granite', 'async function runGraniteInferenceSegment', '// ─── Audio Feed Pipeline');
+    expect(body, 'capture `model` into a local before the first await').toMatch(/= model;/);
+    expect(body, 'capture `processor` into a local before the first await').toMatch(/= processor;/);
+    expect(body, 'must not dereference the module global `model` (nulled by handleDispose mid-decode)').not.toMatch(/\bmodel\./);
+    expect(body, 'must not call or dereference the module global `processor`').not.toMatch(/\bprocessor[.(]/);
   });
 });

--- a/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+++ b/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
@@ -93,3 +93,27 @@ describe('ASR worker flush handling (PTT finalization)', () => {
       .toMatch(/(?:async\s+)?function\s+handleFlush\b/);
   });
 });
+
+const NON_BLOCKING_DECODE_WORKERS = [
+  ['whisper-webgpu.worker.ts', 'scheduleWhisper', 'pendingWhisperDecode'],
+  ['cohere-transcribe-webgpu.worker.ts', 'scheduleTranscription', 'currentTranscriptionPromise'],
+  ['granite-speech-webgpu.worker.ts', 'scheduleGraniteInference', 'pendingGraniteDecode'],
+] as const;
+
+describe('ASR worker VAD decode handoff', () => {
+  it.each(NON_BLOCKING_DECODE_WORKERS)('%s releases VAD before %s completes', (name, schedule, pending) => {
+    const src = read(name);
+    const speechEnd = src.match(/case Message\.SpeechEnd:([\s\S]*?)case Message\.VADMisfire:/)?.[1] ?? '';
+    const maxSpeech = src.slice(src.indexOf('// Max speech duration cap'), src.indexOf('// ─── Message Handlers'));
+    const flush = src.slice(src.indexOf('async function handleFlush'), src.indexOf('async function handleDispose'));
+    const call = new RegExp(`\\b${schedule}\\(`);
+
+    expect(speechEnd).toMatch(new RegExp(`void\\s+${schedule}\\(`));
+    expect(speechEnd).not.toMatch(new RegExp(`await\\s+${schedule}\\(`));
+    expect(maxSpeech).toMatch(new RegExp(`void\\s+${schedule}\\(`));
+    expect(flush).toMatch(new RegExp(`void\\s+${schedule}\\(`));
+    expect(flush).toMatch(new RegExp(`await ${pending}`));
+    expect(src).toMatch(new RegExp(`const \\w+ = ${pending};`));
+    expect(src).toMatch(call);
+  });
+});

--- a/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
+++ b/src/lib/local-inference/workers/_shared/harness-consolidation.test.ts
@@ -162,6 +162,12 @@ describe('ASR worker decode body holds its model in a local', () => {
     const body = sliceBetween(src, 'granite', 'async function runGraniteInferenceSegment', '// ─── Audio Feed Pipeline');
     expect(body, 'capture `model` into a local before the first await').toMatch(/= model;/);
     expect(body, 'capture `processor` into a local before the first await').toMatch(/= processor;/);
+    // Presence is not enough: a capture placed after the first awaited call would reintroduce
+    // the race, so both must precede it. Comments in the body must not spell an `await x(`.
+    const firstAwait = body.search(/\bawait\s+[A-Za-z_$][\w$]*\s*\(/);
+    expect(firstAwait, 'the segment body should contain an awaited call').toBeGreaterThanOrEqual(0);
+    expect(body.indexOf('= model;'), 'capture `model` above the first await').toBeLessThan(firstAwait);
+    expect(body.indexOf('= processor;'), 'capture `processor` above the first await').toBeLessThan(firstAwait);
     expect(body, 'must not dereference the module global `model` (nulled by handleDispose mid-decode)').not.toMatch(/\bmodel\./);
     expect(body, 'must not call or dereference the module global `processor`').not.toMatch(/\bprocessor[.(]/);
   });

--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -151,9 +151,21 @@ let currentTranscriptionPromise: Promise<void> | null = null;
 // ─── Speech Segment Processing ──────────────────────────────────────────────
 
 /**
- * Run Cohere Transcribe on a completed speech segment with token streaming.
+ * Queue one speech segment for decoding, serialized behind whatever decode is already running.
  * TextStreamer emits partial results token-by-token during inference.
- * Awaits any in-flight transcription before starting to prevent races with flush/dispose.
+ *
+ * Callers on the VAD path fire-and-forget this (`void scheduleTranscription(...)`): a decode
+ * takes 0.5–2.5 s, and awaiting it inside `feedAudio` would keep `processingVad` true for that
+ * long, so every audio message arriving meanwhile would hit the guard and be dropped — on
+ * gapless audio that loses the start of the next utterance, and at the 20 s cap it loses words
+ * at every boundary (#470). Same pattern as the voxtral-3b and qwen3-asr workers
+ * (`currentDecodePromise`). Chaining on the previous promise keeps decodes strictly ordered and
+ * never overlapping on the pipeline; the chain is NOT there so that callers can await it. The
+ * returned promise never rejects: the body reports its own errors.
+ *
+ * Overlapping VAD frames with an in-flight decode is safe only because the VAD runs on its own
+ * ORT instance (`_shared/onnxruntime-all`) while the model runs on Transformers.js's — never
+ * put a second session on the model's instance while a decode can be in flight (#469).
  */
 function scheduleTranscription(audio: Float32Array): Promise<void> {
   const previousTranscription = currentTranscriptionPromise;
@@ -238,6 +250,10 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
 
           case Message.SpeechEnd:
             speechFramesSinceStart = 0;
+            // Fire-and-forget: awaiting here would hold `processingVad` for the whole decode
+            // and the guard at the top of this function would drop the audio arriving
+            // meanwhile (#470). `scheduleTranscription` serializes decodes via
+            // `currentTranscriptionPromise`.
             void scheduleTranscription(ev.audio);
             break;
 
@@ -251,6 +267,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
       if (frameProcessor.speaking) {
         speechFramesSinceStart++;
         if (speechFramesSinceStart >= maxSpeechFrames) {
+          // See the SpeechEnd case above: fire-and-forget so no audio is dropped at the cap.
           const endEvents: FrameProcessorEvent[] = [];
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
@@ -343,17 +360,26 @@ async function handleFlush(): Promise<void> {
       }
     }
   }
-  // Wait for any in-flight transcription to complete
+  // Drain the chain: `scheduleTranscription` assigns `currentTranscriptionPromise` before
+  // returning, so this picks up the decode just kicked off (behind anything already queued)
+  // and the flush resolves once the utterance's text has been posted. Runs even when nothing
+  // was speaking, so a flush issued mid-decode still waits for that decode.
   if (currentTranscriptionPromise) {
     try { await currentTranscriptionPromise; } catch { /* already reported */ }
   }
 }
 
 async function handleDispose(): Promise<void> {
+  // Flush remaining speech; handleFlush waits for that decode to finish.
   await handleFlush();
 
+  // Stop accepting new segments before touching the pipeline: with `transcriber` null,
+  // feedAudio returns early and a queued decode exits at its guard.
   const cohereTranscriber = transcriber;
   transcriber = null;
+
+  // A decode may have been queued between the flush's await and the line above; wait for it
+  // so nothing runs against a disposed pipeline. Not redundant with the drain in handleFlush.
   if (currentTranscriptionPromise) {
     try { await currentTranscriptionPromise; } catch { /* already reported */ }
     currentTranscriptionPromise = null;

--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -155,11 +155,11 @@ let currentTranscriptionPromise: Promise<void> | null = null;
  * TextStreamer emits partial results token-by-token during inference.
  * Awaits any in-flight transcription before starting to prevent races with flush/dispose.
  */
-function runTranscribe(audio: Float32Array): Promise<void> {
+function scheduleTranscription(audio: Float32Array): Promise<void> {
+  const previousTranscription = currentTranscriptionPromise;
   const promise = (async () => {
-    // Wait for any in-flight transcription to complete first
-    if (currentTranscriptionPromise) {
-      try { await currentTranscriptionPromise; } catch { /* already reported */ }
+    if (previousTranscription) {
+      try { await previousTranscription; } catch { /* already reported */ }
     }
     if (!transcriber) return;
 
@@ -238,7 +238,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
 
           case Message.SpeechEnd:
             speechFramesSinceStart = 0;
-            await runTranscribe(ev.audio);
+            void scheduleTranscription(ev.audio);
             break;
 
           case Message.VADMisfire:
@@ -255,7 +255,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
             if (ev.msg === Message.SpeechEnd) {
-              await runTranscribe(ev.audio);
+              void scheduleTranscription(ev.audio);
             }
           }
           speechFramesSinceStart = 0;
@@ -339,29 +339,21 @@ async function handleFlush(): Promise<void> {
     frameProcessor.endSegment((ev) => endEvents.push(ev));
     for (const ev of endEvents) {
       if (ev.msg === Message.SpeechEnd) {
-        await runTranscribe(ev.audio);
+        void scheduleTranscription(ev.audio);
       }
     }
   }
   // Wait for any in-flight transcription to complete
   if (currentTranscriptionPromise) {
-    await currentTranscriptionPromise;
+    try { await currentTranscriptionPromise; } catch { /* already reported */ }
   }
 }
 
 async function handleDispose(): Promise<void> {
-  // Flush remaining speech
-  if (frameProcessor?.speaking) {
-    const endEvents: FrameProcessorEvent[] = [];
-    frameProcessor.endSegment((ev) => endEvents.push(ev));
-    for (const ev of endEvents) {
-      if (ev.msg === Message.SpeechEnd) {
-        await runTranscribe(ev.audio);
-      }
-    }
-  }
+  await handleFlush();
 
-  // Wait for any in-flight transcription to complete before disposing
+  const cohereTranscriber = transcriber;
+  transcriber = null;
   if (currentTranscriptionPromise) {
     try { await currentTranscriptionPromise; } catch { /* already reported */ }
     currentTranscriptionPromise = null;
@@ -378,9 +370,8 @@ async function handleDispose(): Promise<void> {
   }
 
   // Dispose transcriber
-  if (transcriber) {
-    await (transcriber as any).dispose?.();
-    transcriber = null;
+  if (cohereTranscriber) {
+    await (cohereTranscriber as any).dispose?.();
     currentLanguage = undefined;
   }
 

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -195,6 +195,22 @@ async function hasWebGPU(): Promise<boolean> {
 
 // ─── Speech Segment Processing ──────────────────────────────────────────────
 
+/**
+ * Queue one speech segment for decoding, serialized behind whatever decode is already running.
+ *
+ * Callers on the VAD path fire-and-forget this (`void scheduleGraniteInference(...)`): a decode
+ * takes 0.5–2.5 s, and awaiting it inside `feedAudio` would keep `processingVad` true for that
+ * long, so every audio message arriving meanwhile would hit the guard and be dropped — on
+ * gapless audio that loses the start of the next utterance, and at the 20 s cap it loses words
+ * at every boundary (#470). Same pattern as the voxtral-3b and qwen3-asr workers
+ * (`currentDecodePromise`). Chaining on the previous promise keeps decodes strictly ordered and
+ * never overlapping on the model. The returned promise never rejects:
+ * `runGraniteInferenceSegment` reports its own errors.
+ *
+ * Overlapping VAD frames with an in-flight decode is safe only because the VAD runs on its own
+ * ORT instance (`_shared/onnxruntime-all`) while the model runs on Transformers.js's — never
+ * put a second session on the model's instance while a decode can be in flight (#469).
+ */
 function scheduleGraniteInference(audio: Float32Array, startSample: number): Promise<void> {
   const previousGraniteDecode = pendingGraniteDecode;
   const promise = (async () => {
@@ -208,7 +224,12 @@ function scheduleGraniteInference(audio: Float32Array, startSample: number): Pro
 }
 
 async function runGraniteInferenceSegment(audio: Float32Array, startSample: number): Promise<void> {
-  if (!processor || !model) return;
+  // Capture both references before the first await: handleDispose nulls the module globals
+  // and only then drains the decode chain, so a decode already past this guard must not read
+  // `model` / `processor` again after `await p(...)` — it would throw and post a spurious error.
+  const p = processor;
+  const m = model;
+  if (!p || !m) return;
 
   const durationMs = Math.round((audio.length / VAD_SAMPLE_RATE) * 1000);
   const startTime = performance.now();
@@ -217,16 +238,16 @@ async function runGraniteInferenceSegment(audio: Float32Array, startSample: numb
     const content = buildPrompt();
     const messages = [{ role: 'user', content }];
 
-    const text = processor.tokenizer.apply_chat_template(messages, {
+    const text = p.tokenizer.apply_chat_template(messages, {
       add_generation_prompt: true,
       tokenize: false,
     });
 
-    const inputs = await processor(text, audio, { sampling_rate: VAD_SAMPLE_RATE });
+    const inputs = await p(text, audio, { sampling_rate: VAD_SAMPLE_RATE });
 
     // Collect output via streamer
     let accumulated = '';
-    const streamer = new TextStreamer(processor.tokenizer, {
+    const streamer = new TextStreamer(p.tokenizer, {
       skip_prompt: true,
       skip_special_tokens: true,
       callback_function: (chunk: string) => {
@@ -234,7 +255,7 @@ async function runGraniteInferenceSegment(audio: Float32Array, startSample: numb
       },
     });
 
-    await model.generate({
+    await m.generate({
       ...inputs,
       max_new_tokens: 256,
       streamer,
@@ -288,6 +309,10 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
             break;
           case Message.SpeechEnd:
             speechFramesSinceStart = 0;
+            // Fire-and-forget: awaiting here would hold `processingVad` for the whole decode
+            // and the guard at the top of this function would drop the audio arriving
+            // meanwhile (#470). `scheduleGraniteInference` serializes decodes via
+            // `pendingGraniteDecode`.
             void scheduleGraniteInference(ev.audio, speechStartSample);
             break;
           case Message.VADMisfire:
@@ -300,6 +325,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
       if (frameProcessor.speaking) {
         speechFramesSinceStart++;
         if (speechFramesSinceStart >= maxSpeechFrames) {
+          // See the SpeechEnd case above: fire-and-forget so no audio is dropped at the cap.
           const endEvents: FrameProcessorEvent[] = [];
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
@@ -389,17 +415,26 @@ async function handleFlush(): Promise<void> {
       }
     }
   }
+  // Drain the chain: `scheduleGraniteInference` assigns `pendingGraniteDecode` before
+  // returning, so this picks up the decode just kicked off (behind anything already queued)
+  // and the flush resolves once the utterance's text has been posted. Runs even when nothing
+  // was speaking, so a flush issued mid-decode still waits for that decode.
   if (pendingGraniteDecode) {
     try { await pendingGraniteDecode; } catch { /* already reported */ }
   }
 }
 
 async function handleDispose(): Promise<void> {
-  // Flush remaining speech
+  // Flush remaining speech; handleFlush waits for that decode to finish.
   await handleFlush();
 
+  // Stop accepting new segments before touching the model: with `model` null, feedAudio
+  // returns early and a queued runGraniteInferenceSegment exits at its guard.
   const activeModel = model;
   model = null;
+
+  // A decode may have been queued between the flush's await and the line above; wait for it
+  // so nothing runs against a disposed model. Not redundant with the drain in handleFlush.
   if (pendingGraniteDecode) {
     try { await pendingGraniteDecode; } catch { /* already reported */ }
     pendingGraniteDecode = null;

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -172,6 +172,7 @@ let model: any = null;
 let currentTask: 'transcribe' | 'translate' = 'transcribe';
 let currentTargetLanguage: string | undefined;
 let processingVad = false;
+let pendingGraniteDecode: Promise<void> | null = null;
 
 function buildPrompt(): string {
   if (currentTask === 'translate' && currentTargetLanguage) {
@@ -194,7 +195,19 @@ async function hasWebGPU(): Promise<boolean> {
 
 // ─── Speech Segment Processing ──────────────────────────────────────────────
 
-async function runGraniteInference(audio: Float32Array, startSample: number): Promise<void> {
+function scheduleGraniteInference(audio: Float32Array, startSample: number): Promise<void> {
+  const previousGraniteDecode = pendingGraniteDecode;
+  const promise = (async () => {
+    if (previousGraniteDecode) {
+      try { await previousGraniteDecode; } catch { /* already reported */ }
+    }
+    await runGraniteInferenceSegment(audio, startSample);
+  })();
+  pendingGraniteDecode = promise;
+  return promise;
+}
+
+async function runGraniteInferenceSegment(audio: Float32Array, startSample: number): Promise<void> {
   if (!processor || !model) return;
 
   const durationMs = Math.round((audio.length / VAD_SAMPLE_RATE) * 1000);
@@ -275,7 +288,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
             break;
           case Message.SpeechEnd:
             speechFramesSinceStart = 0;
-            await runGraniteInference(ev.audio, speechStartSample);
+            void scheduleGraniteInference(ev.audio, speechStartSample);
             break;
           case Message.VADMisfire:
             speechFramesSinceStart = 0;
@@ -291,7 +304,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
             if (ev.msg === Message.SpeechEnd) {
-              await runGraniteInference(ev.audio, speechStartSample);
+              void scheduleGraniteInference(ev.audio, speechStartSample);
             }
           }
           speechFramesSinceStart = 0;
@@ -372,15 +385,25 @@ async function handleFlush(): Promise<void> {
     frameProcessor.endSegment((ev) => endEvents.push(ev));
     for (const ev of endEvents) {
       if (ev.msg === Message.SpeechEnd) {
-        await runGraniteInference(ev.audio, speechStartSample);
+        void scheduleGraniteInference(ev.audio, speechStartSample);
       }
     }
+  }
+  if (pendingGraniteDecode) {
+    try { await pendingGraniteDecode; } catch { /* already reported */ }
   }
 }
 
 async function handleDispose(): Promise<void> {
   // Flush remaining speech
   await handleFlush();
+
+  const activeModel = model;
+  model = null;
+  if (pendingGraniteDecode) {
+    try { await pendingGraniteDecode; } catch { /* already reported */ }
+    pendingGraniteDecode = null;
+  }
 
   frameProcessor = null;
   speechFramesSinceStart = 0;
@@ -390,9 +413,8 @@ async function handleDispose(): Promise<void> {
     vadSession = null;
   }
 
-  if (model) {
-    await model.dispose?.();
-    model = null;
+  if (activeModel) {
+    await activeModel.dispose?.();
   }
   processor = null;
   currentTask = 'transcribe';

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -226,7 +226,8 @@ function scheduleGraniteInference(audio: Float32Array, startSample: number): Pro
 async function runGraniteInferenceSegment(audio: Float32Array, startSample: number): Promise<void> {
   // Capture both references before the first await: handleDispose nulls the module globals
   // and only then drains the decode chain, so a decode already past this guard must not read
-  // `model` / `processor` again after `await p(...)` — it would throw and post a spurious error.
+  // `model` / `processor` again once it has suspended — it would throw and post a spurious
+  // error. The guard in harness-consolidation.test.ts pins the captures above the first await.
   const p = processor;
   const m = model;
   if (!p || !m) return;

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -197,6 +197,7 @@ function resampleInt16ToFloat32_16k(samples: Int16Array, inputRate: number): Flo
 let transcriber: AutomaticSpeechRecognitionPipeline | null = null;
 let currentLanguage: string | undefined;
 let processingVad = false;
+let pendingWhisperDecode: Promise<void> | null = null;
 
 /**
  * Patch config.json and generation_config.json blobs for non-standard Whisper
@@ -263,7 +264,19 @@ async function hasWebGPU(): Promise<boolean> {
 /**
  * Run Whisper on a completed speech audio segment.
  */
-async function runWhisper(audio: Float32Array, startSample: number): Promise<void> {
+function scheduleWhisper(audio: Float32Array, startSample: number): Promise<void> {
+  const previousWhisperDecode = pendingWhisperDecode;
+  const promise = (async () => {
+    if (previousWhisperDecode) {
+      try { await previousWhisperDecode; } catch { /* already reported */ }
+    }
+    await runWhisperSegment(audio, startSample);
+  })();
+  pendingWhisperDecode = promise;
+  return promise;
+}
+
+async function runWhisperSegment(audio: Float32Array, startSample: number): Promise<void> {
   if (!transcriber) return;
 
   const durationMs = Math.round((audio.length / VAD_SAMPLE_RATE) * 1000);
@@ -350,7 +363,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
             speechFramesSinceStart = 0;
             vadLog('SPEECH_END dur=',
               Math.round((ev.audio.length / VAD_SAMPLE_RATE) * 1000), 'ms');
-            await runWhisper(ev.audio, speechStartSample);
+            void scheduleWhisper(ev.audio, speechStartSample);
             break;
 
           case Message.VADMisfire:
@@ -369,7 +382,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
             if (ev.msg === Message.SpeechEnd) {
-              await runWhisper(ev.audio, speechStartSample);
+              void scheduleWhisper(ev.audio, speechStartSample);
             }
           }
           speechFramesSinceStart = 0;
@@ -467,29 +480,30 @@ async function handleInit(msg: WhisperAsrInitMessage): Promise<void> {
  * the redemption window, surfacing the transcription one utterance late.
  */
 async function handleFlush(): Promise<void> {
-  if (!frameProcessor?.speaking) return;
-  vadLog('FLUSH finalizing pending speech');
-  const endEvents: FrameProcessorEvent[] = [];
-  frameProcessor.endSegment((ev) => endEvents.push(ev));
-  for (const ev of endEvents) {
-    if (ev.msg === Message.SpeechEnd) {
-      await runWhisper(ev.audio, speechStartSample);
-    }
-  }
-  speechFramesSinceStart = 0;
-}
-
-async function handleDispose(): Promise<void> {
-  // Flush any remaining speech via FrameProcessor
   if (frameProcessor?.speaking) {
-    vadLog('DISPOSE flushing remaining speech');
+    vadLog('FLUSH finalizing pending speech');
     const endEvents: FrameProcessorEvent[] = [];
     frameProcessor.endSegment((ev) => endEvents.push(ev));
     for (const ev of endEvents) {
       if (ev.msg === Message.SpeechEnd) {
-        await runWhisper(ev.audio, speechStartSample);
+        void scheduleWhisper(ev.audio, speechStartSample);
       }
     }
+    speechFramesSinceStart = 0;
+  }
+  if (pendingWhisperDecode) {
+    try { await pendingWhisperDecode; } catch { /* already reported */ }
+  }
+}
+
+async function handleDispose(): Promise<void> {
+  await handleFlush();
+
+  const activeTranscriber = transcriber;
+  transcriber = null;
+  if (pendingWhisperDecode) {
+    try { await pendingWhisperDecode; } catch { /* already reported */ }
+    pendingWhisperDecode = null;
   }
 
   // Dispose FrameProcessor
@@ -503,9 +517,8 @@ async function handleDispose(): Promise<void> {
   }
 
   // Dispose Whisper
-  if (transcriber) {
-    await (transcriber as any).dispose?.();
-    transcriber = null;
+  if (activeTranscriber) {
+    await (activeTranscriber as any).dispose?.();
     currentLanguage = undefined;
   }
 

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -262,7 +262,20 @@ async function hasWebGPU(): Promise<boolean> {
 // ─── Speech Segment Processing ──────────────────────────────────────────────
 
 /**
- * Run Whisper on a completed speech audio segment.
+ * Queue one speech segment for decoding, serialized behind whatever decode is already running.
+ *
+ * Callers on the VAD path fire-and-forget this (`void scheduleWhisper(...)`): a decode takes
+ * 0.5–2.5 s, and awaiting it inside `feedAudio` would keep `processingVad` true for that long,
+ * so every audio message arriving meanwhile would hit the guard and be dropped — on gapless
+ * audio that loses the start of the next utterance, and at the 20 s cap it loses words at
+ * every boundary (#470). Same pattern as the voxtral-3b and qwen3-asr workers
+ * (`currentDecodePromise`). Chaining on the previous promise keeps decodes strictly ordered
+ * and never overlapping on the pipeline. The returned promise never rejects:
+ * `runWhisperSegment` reports its own errors.
+ *
+ * Overlapping VAD frames with an in-flight decode is safe only because the VAD runs on its own
+ * ORT instance (`_shared/onnxruntime-all`) while the model runs on Transformers.js's — never
+ * put a second session on the model's instance while a decode can be in flight (#469).
  */
 function scheduleWhisper(audio: Float32Array, startSample: number): Promise<void> {
   const previousWhisperDecode = pendingWhisperDecode;
@@ -276,6 +289,7 @@ function scheduleWhisper(audio: Float32Array, startSample: number): Promise<void
   return promise;
 }
 
+/** Run Whisper on one completed speech segment and post its result. Reports its own errors. */
 async function runWhisperSegment(audio: Float32Array, startSample: number): Promise<void> {
   if (!transcriber) return;
 
@@ -363,6 +377,9 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
             speechFramesSinceStart = 0;
             vadLog('SPEECH_END dur=',
               Math.round((ev.audio.length / VAD_SAMPLE_RATE) * 1000), 'ms');
+            // Fire-and-forget: awaiting here would hold `processingVad` for the whole decode
+            // and the guard at the top of this function would drop the audio arriving
+            // meanwhile (#470). `scheduleWhisper` serializes decodes via `pendingWhisperDecode`.
             void scheduleWhisper(ev.audio, speechStartSample);
             break;
 
@@ -378,6 +395,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
         speechFramesSinceStart++;
         if (speechFramesSinceStart >= maxSpeechFrames) {
           vadLog('MAX_DURATION flush frames=', speechFramesSinceStart);
+          // See the SpeechEnd case above: fire-and-forget so no audio is dropped at the cap.
           const endEvents: FrameProcessorEvent[] = [];
           frameProcessor.endSegment((ev) => endEvents.push(ev));
           for (const ev of endEvents) {
@@ -478,6 +496,12 @@ async function handleInit(msg: WhisperAsrInitMessage): Promise<void> {
  * close the segment. Without this the current utterance stays buffered in the
  * FrameProcessor until the next press feeds enough leading silence to complete
  * the redemption window, surfacing the transcription one utterance late.
+ *
+ * The decode is fired without awaiting and the chain is drained afterwards: `scheduleWhisper`
+ * assigns `pendingWhisperDecode` before returning, so the await at the bottom picks up the
+ * decode just kicked off (behind anything already queued) and the flush resolves once the
+ * utterance's text has been posted. Draining happens even when nothing was speaking, so a
+ * flush issued mid-decode still waits for that decode.
  */
 async function handleFlush(): Promise<void> {
   if (frameProcessor?.speaking) {
@@ -497,10 +521,17 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
+  // Flush remaining speech; handleFlush waits for that decode to finish.
+  vadLog('DISPOSE flushing remaining speech');
   await handleFlush();
 
+  // Stop accepting new segments before touching the pipeline: with `transcriber` null,
+  // feedAudio returns early and a queued runWhisperSegment exits at its first line.
   const activeTranscriber = transcriber;
   transcriber = null;
+
+  // A decode may have been queued between the flush's await and the line above; wait for it
+  // so nothing runs against a disposed pipeline. Not redundant with the drain in handleFlush.
   if (pendingWhisperDecode) {
     try { await pendingWhisperDecode; } catch { /* already reported */ }
     pendingWhisperDecode = null;


### PR DESCRIPTION
## Summary

I kept local ASR VAD ingestion running while Granite Speech, Whisper, or Cohere Transcribe decodes a completed segment.

## Problem

Before this change, each worker awaited inference from the guarded VAD loop. Audio arriving during a decode was dropped, including at the max-speech boundary.

## Solution

- Queue each worker's model decode behind a worker-local promise (cohere's existing `currentTranscriptionPromise`; whisper and granite gain `pendingWhisperDecode` / `pendingGraniteDecode`).
- Hand speech-end and max-speech segments to that queue without waiting in `feedAudio`.
- Keep `flush` and `dispose` waiting for queued work before sessions are released.

## Test plan

- `npm test -- --run src/lib/local-inference/workers/_shared/harness-consolidation.test.ts`
- `npm run build`

Fixes #470


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Speech recognition continues processing voice activity without waiting for each segment decode to finish.
  * Sequential decoding preserves segment order while reducing interruptions during transcription.

* **Reliability**
  * Pending transcription work is completed before flushing or shutting down, helping prevent incomplete results.
  * Improved handling of speech endings, duration limits, and manual flushes supports more consistent output.
  * Shutdown now safely completes active recognition work before releasing resources.

* **Tests**
  * Added coverage for non-blocking decoding and safe shutdown across supported speech recognition workers.
  * Documented validation of in-flight decoding and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->