### PR TITLE
perf(soniox): back off managed-voice readiness polling to 1.5 s, 1.5 s, then 3 s

### DIFF
--- a/src/components/Settings/sections/voiceLibrarySource.test.ts
+++ b/src/components/Settings/sections/voiceLibrarySource.test.ts
@@ -147,7 +147,7 @@ describe('managedVoiceSource.waitUntilReady', () => {
     const mine = vi.fn()
       .mockResolvedValueOnce({ voiceId: 'v1', status: 'processing', createdAt: 1 })
       .mockResolvedValueOnce({ voiceId: 'v1', status: 'ready', createdAt: 1 });
-    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { intervalMs: 0 });
+    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { pollDelayMs: () => 0 });
     const voice = await source.waitUntilReady('v1');
     expect(voice.models?.[0].status).toBe('ready');
     expect(mine).toHaveBeenCalledTimes(2);
@@ -157,20 +157,37 @@ describe('managedVoiceSource.waitUntilReady', () => {
     // Soniox's `failed` is terminal — retrying the same clip can only fail
     // again. The section maps voice_failed to "try a clearer clip".
     const mine = vi.fn().mockResolvedValue({ voiceId: 'v1', status: 'failed', createdAt: 1 });
-    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { intervalMs: 0 });
+    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { pollDelayMs: () => 0 });
     await expect(source.waitUntilReady('v1')).rejects.toMatchObject({ errorType: 'voice_failed' });
   });
 
   it('rejects when the slot disappears mid-build', async () => {
     // Another device's ensure() can supersede this build, or the LRU can
     // evict the row. Either way there is nothing left to wait for.
-    const source = managedVoiceSource(fakeClient({ mine: vi.fn().mockResolvedValue(null) }), ACCOUNT, { intervalMs: 0 });
+    const source = managedVoiceSource(fakeClient({ mine: vi.fn().mockResolvedValue(null) }), ACCOUNT, { pollDelayMs: () => 0 });
     await expect(source.waitUntilReady('v1')).rejects.toMatchObject({ errorType: 'voice_failed' });
+  });
+
+  it('polls twice at 1.5s, then every 3s', async () => {
+    // Same schedule as session-start preparation: each poll is one Soniox
+    // getVoice against the voices API's own requests-per-minute limit.
+    const processing = { voiceId: 'v1', status: 'processing', createdAt: 1 };
+    const mine = vi.fn()
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce({ voiceId: 'v1', status: 'ready', createdAt: 1 });
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { sleep });
+    await source.waitUntilReady('v1');
+    expect(mine).toHaveBeenCalledTimes(5);
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([1_500, 1_500, 3_000, 3_000]);
   });
 
   it('gives up after the timeout rather than polling forever', async () => {
     const mine = vi.fn().mockResolvedValue({ voiceId: 'v1', status: 'processing', createdAt: 1 });
-    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { intervalMs: 0, timeoutMs: 0 });
+    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { pollDelayMs: () => 0, timeoutMs: 0 });
     await expect(source.waitUntilReady('v1')).rejects.toMatchObject({ errorType: 'timeout' });
   });
 });

--- a/src/components/Settings/sections/voiceLibrarySource.test.ts
+++ b/src/components/Settings/sections/voiceLibrarySource.test.ts
@@ -168,21 +168,43 @@ describe('managedVoiceSource.waitUntilReady', () => {
     await expect(source.waitUntilReady('v1')).rejects.toMatchObject({ errorType: 'voice_failed' });
   });
 
-  it('polls twice at 1.5s, then every 3s', async () => {
+  it('waits 1.5s before each of the first two polls, then 3s — and never polls before waiting', async () => {
     // Same schedule as session-start preparation: each poll is one Soniox
-    // getVoice against the voices API's own requests-per-minute limit.
+    // getVoice against the voices API's own requests-per-minute limit. The
+    // ORDER matters as much as the delays: `create` has just reported
+    // `processing`, so a poll at t=0 would only repeat that answer.
+    const events: string[] = [];
     const processing = { voiceId: 'v1', status: 'processing', createdAt: 1 };
-    const mine = vi.fn()
-      .mockResolvedValueOnce(processing)
-      .mockResolvedValueOnce(processing)
-      .mockResolvedValueOnce(processing)
-      .mockResolvedValueOnce(processing)
-      .mockResolvedValueOnce({ voiceId: 'v1', status: 'ready', createdAt: 1 });
-    const sleep = vi.fn().mockResolvedValue(undefined);
-    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { sleep });
+    const mine = vi.fn().mockImplementation(async () => {
+      events.push('mine');
+      return mine.mock.calls.length < 5 ? processing : { voiceId: 'v1', status: 'ready', createdAt: 1 };
+    });
+    let t = 0;
+    const sleep = vi.fn().mockImplementation(async (ms: number) => { events.push(`sleep:${ms}`); t += ms; });
+    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { sleep, now: () => t });
     await source.waitUntilReady('v1');
-    expect(mine).toHaveBeenCalledTimes(5);
-    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([1_500, 1_500, 3_000, 3_000]);
+    expect(events).toEqual([
+      'sleep:1500', 'mine',
+      'sleep:1500', 'mine',
+      'sleep:3000', 'mine',
+      'sleep:3000', 'mine',
+      'sleep:3000', 'mine',
+    ]);
+  });
+
+  it('clamps the last wait to the remaining budget and starts no poll past the deadline', async () => {
+    // Checking the deadline only before the wait let a 3s wait step over it
+    // and then start one more `mine` — a request with its own timeout, holding
+    // the panel past the budget it had just been told was spent.
+    let t = 0;
+    const mine = vi.fn().mockResolvedValue({ voiceId: 'v1', status: 'processing', createdAt: 1 });
+    const sleep = vi.fn().mockImplementation(async (ms: number) => { t += ms; });
+    const source = managedVoiceSource(fakeClient({ mine }), ACCOUNT, { sleep, now: () => t, timeoutMs: 4_000 });
+    await expect(source.waitUntilReady('v1')).rejects.toMatchObject({ errorType: 'timeout' });
+    // 1.5s + 1.5s consumed 3s of 4s; the third wait is clamped to the 1s left...
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([1_500, 1_500, 1_000]);
+    // ...and no poll started once that was spent.
+    expect(mine).toHaveBeenCalledTimes(2);
   });
 
   it('gives up after the timeout rather than polling forever', async () => {

--- a/src/components/Settings/sections/voiceLibrarySource.ts
+++ b/src/components/Settings/sections/voiceLibrarySource.ts
@@ -89,12 +89,14 @@ export function managedVoiceSource(
     pollDelayMs?: (attempt: number) => number;
     timeoutMs?: number;
     sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
   } = {}
 ): VoiceLibrarySource {
   const {
     pollDelayMs = managedVoicePollDelayMs,
     timeoutMs = 60_000,
     sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+    now = () => Date.now(),
   } = opts;
   return {
     async list() {
@@ -136,9 +138,24 @@ export function managedVoiceSource(
     // `_id` unused: this account has at most one voice, so `client.mine()`
     // already names it unambiguously — there is nothing to disambiguate by id.
     async waitUntilReady(_id) {
-      const deadline = Date.now() + timeoutMs;
+      const deadline = now() + timeoutMs;
       let attempt = 0;
       for (;;) {
+        // Wait FIRST: `create` has just reported `processing`, so a poll
+        // right now would only repeat that answer — at the price of one
+        // Soniox getVoice. The wait is clamped to what is left of the budget
+        // and the deadline is re-checked after it, so no poll begins past the
+        // ceiling (the same rule session-start preparation follows: that
+        // poll carries its own request timeout and would otherwise hold the
+        // panel well past the budget it was just told was spent).
+        const remaining = deadline - now();
+        if (remaining <= 0) {
+          throw new SonioxVoicesError('timeout', 'Voice processing timed out', 408);
+        }
+        await sleep(Math.min(pollDelayMs(attempt++), remaining));
+        if (now() >= deadline) {
+          throw new SonioxVoicesError('timeout', 'Voice processing timed out', 408);
+        }
         const voice = await client.mine();
         if (!voice) {
           // Another device superseded this build, or the LRU evicted the row.
@@ -150,10 +167,6 @@ export function managedVoiceSource(
         if (voice.status === 'failed') {
           throw new SonioxVoicesError('voice_failed', 'Voice processing failed', 503);
         }
-        if (Date.now() >= deadline) {
-          throw new SonioxVoicesError('timeout', 'Voice processing timed out', 408);
-        }
-        await sleep(pollDelayMs(attempt++));
       }
     },
 

--- a/src/components/Settings/sections/voiceLibrarySource.ts
+++ b/src/components/Settings/sections/voiceLibrarySource.ts
@@ -17,6 +17,7 @@ import type { ManagedVoicesClient, ManagedVoice } from '../../../services/client
 import { SonioxVoicesError } from '../../../services/clients/SonioxVoicesClient';
 import { saveVoiceClip, clearVoiceClip } from '../../../lib/soniox/voiceClipStorage';
 import { SONIOX_TTS_MODEL } from '../../../lib/soniox/ttsCatalog';
+import { managedVoicePollDelayMs } from '../../../services/clients/managedVoicePolling';
 
 export interface VoiceLibrarySource {
   /** Every voice this source can offer. The managed source returns zero or
@@ -82,9 +83,19 @@ function toSonioxVoice(voice: ManagedVoice): SonioxVoice {
 export function managedVoiceSource(
   client: ManagedVoicesClient,
   accountId: string,
-  opts: { intervalMs?: number; timeoutMs?: number } = {}
+  opts: {
+    /** Wait before readiness poll number `attempt` (0-based). Defaults to the
+     *  schedule shared with session-start preparation. */
+    pollDelayMs?: (attempt: number) => number;
+    timeoutMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+  } = {}
 ): VoiceLibrarySource {
-  const { intervalMs = 1500, timeoutMs = 60_000 } = opts;
+  const {
+    pollDelayMs = managedVoicePollDelayMs,
+    timeoutMs = 60_000,
+    sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+  } = opts;
   return {
     async list() {
       const voice = await client.mine();
@@ -126,6 +137,7 @@ export function managedVoiceSource(
     // already names it unambiguously — there is nothing to disambiguate by id.
     async waitUntilReady(_id) {
       const deadline = Date.now() + timeoutMs;
+      let attempt = 0;
       for (;;) {
         const voice = await client.mine();
         if (!voice) {
@@ -141,7 +153,7 @@ export function managedVoiceSource(
         if (Date.now() >= deadline) {
           throw new SonioxVoicesError('timeout', 'Voice processing timed out', 408);
         }
-        await new Promise((r) => setTimeout(r, intervalMs));
+        await sleep(pollDelayMs(attempt++));
       }
     },
 

--- a/src/services/clients/managedVoicePolling.test.ts
+++ b/src/services/clients/managedVoicePolling.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from 'vitest';
+import { managedVoicePollDelayMs } from './managedVoicePolling';
+
+describe('managedVoicePollDelayMs', () => {
+  it('waits 1.5s before each of the first two polls, then 3s before every later one', () => {
+    expect([0, 1, 2, 3, 4, 40].map(managedVoicePollDelayMs)).toEqual([1_500, 1_500, 3_000, 3_000, 3_000, 3_000]);
+  });
+});

--- a/src/services/clients/managedVoicePolling.ts
+++ b/src/services/clients/managedVoicePolling.ts
@@ -1,0 +1,24 @@
+/**
+ * How long a client waits before readiness poll number `attempt` (0-based) of
+ * a managed voice build — the gap between `ensure` answering `processing` and
+ * each `mine` that follows, and between one `mine` and the next.
+ *
+ * Every poll is one Soniox `getVoice` made by the backend on this client's
+ * behalf, and the voices API carries its own requests-per-minute limit that
+ * every user's build shares with the reaper's census. Two quick polls catch
+ * the builds that finish within a few seconds without making the user wait
+ * for them; from the third poll on, 3 s halves what a slow build spends per
+ * minute. Both poll loops — session-start preparation and the settings
+ * panel — take their schedule from here, so the two cannot drift apart.
+ *
+ * Neither loop counts polls: each is bounded by its own time budget instead
+ * (60 s by default), which this schedule turns into at most ~21 polls.
+ */
+export const MANAGED_VOICE_POLL_FAST_MS = 1_500;
+export const MANAGED_VOICE_POLL_STEADY_MS = 3_000;
+/** How many polls use the fast delay before the steady one takes over. */
+export const MANAGED_VOICE_POLL_FAST_ATTEMPTS = 2;
+
+export function managedVoicePollDelayMs(attempt: number): number {
+  return attempt < MANAGED_VOICE_POLL_FAST_ATTEMPTS ? MANAGED_VOICE_POLL_FAST_MS : MANAGED_VOICE_POLL_STEADY_MS;
+}

--- a/src/services/providers/managedVoicePrep.test.ts
+++ b/src/services/providers/managedVoicePrep.test.ts
@@ -17,7 +17,7 @@ const deps = (over: {
   } as unknown as ManagedVoicesClient,
   loadClip: over.loadClip ?? (async () => clip()),
   sleep: async () => {},
-  pollIntervalMs: 0,
+  pollDelayMs: () => 0,
 });
 
 describe('prepareManagedVoice', () => {
@@ -145,7 +145,7 @@ describe('prepareManagedVoice', () => {
       sleep,
       now: () => t,
       timeoutMs: 1_000,
-      pollIntervalMs: 1_500,
+      pollDelayMs: () => 1_500,
     });
     expect(res).toEqual({ ok: false, reason: 'unavailable' });
     // Clamped to what was left rather than sleeping the full interval...
@@ -167,10 +167,36 @@ describe('prepareManagedVoice', () => {
       sleep,
       now: () => t,
       timeoutMs: 5_000,
-      pollIntervalMs: 1_500,
+      pollDelayMs: () => 1_500,
     });
     expect(res).toEqual({ ok: true, voiceId: 'vA' });
     expect(mine).toHaveBeenCalledWith(3_500);
+  });
+
+  it('polls twice at 1.5s, then every 3s', async () => {
+    // Every poll is one Soniox getVoice through the backend, and the voices
+    // API has its own requests-per-minute limit. Two quick polls catch the
+    // builds that finish in a few seconds; the steady 3s keeps a slow build
+    // from spending forty calls a minute on one user.
+    let t = 0;
+    const ensure = vi.fn().mockResolvedValue({ voiceId: 'vB', status: 'processing' });
+    const processing = { voiceId: 'vB', status: 'processing', createdAt: 1 };
+    const mine = vi.fn()
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce(processing)
+      .mockResolvedValueOnce({ voiceId: 'vB', status: 'ready', createdAt: 1 });
+    const sleep = vi.fn().mockImplementation(async (ms: number) => { t += ms; });
+    const res = await prepareManagedVoice({
+      client: { ensure, mine, remove: vi.fn() } as unknown as ManagedVoicesClient,
+      loadClip: async () => clip(),
+      sleep,
+      now: () => t,
+      timeoutMs: 60_000,
+    });
+    expect(res).toEqual({ ok: true, voiceId: 'vB' });
+    expect(sleep.mock.calls.map(([ms]) => ms)).toEqual([1_500, 1_500, 3_000, 3_000, 3_000]);
   });
 
   it('abandons the clip upload when reading the clip itself ran out the clock', async () => {

--- a/src/services/providers/managedVoicePrep.ts
+++ b/src/services/providers/managedVoicePrep.ts
@@ -22,6 +22,7 @@
 // Moved beside its caller (KizunaAISonioxProviderConfig.prepareToStart, S5); deliberately React-, store- and i18n-free — a descriptor calls it without cycles.
 import type { ManagedVoicesClient } from '../../services/clients/ManagedVoicesClient';
 import { SonioxVoicesError } from '../../services/clients/SonioxVoicesClient';
+import { managedVoicePollDelayMs } from '../../services/clients/managedVoicePolling';
 import { reportError, describeCause } from '../../lib/diagnostics/report';
 
 export type VoicePrepFailure = 'clip_required' | 'pool_exhausted' | 'voice_failed' | 'unavailable';
@@ -67,7 +68,10 @@ export interface PrepareManagedVoiceDeps {
    *  (`ports.signal`), so 135 s is a bound this codebase's only caller no
    *  longer hits in practice. */
   timeoutMs?: number;
-  pollIntervalMs?: number;
+  /** Wait before readiness poll number `attempt` (0-based). Defaults to the
+   *  schedule shared with the settings panel (`managedVoicePolling.ts`);
+   *  tests inject a constant. */
+  pollDelayMs?: (attempt: number) => number;
 }
 
 const DEFAULT_RETRY_MS = 3000;
@@ -80,7 +84,7 @@ export async function prepareManagedVoice(deps: PrepareManagedVoiceDeps): Promis
     sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
     now = () => Date.now(),
     timeoutMs = 60_000,
-    pollIntervalMs = 1500,
+    pollDelayMs = managedVoicePollDelayMs,
   } = deps;
 
   const deadline = now() + timeoutMs;
@@ -93,6 +97,7 @@ export async function prepareManagedVoice(deps: PrepareManagedVoiceDeps): Promis
 
     if (ensured.value.status === 'ready') return { ok: true, voiceId: ensured.value.voiceId };
 
+    let attempt = 0;
     for (;;) {
       const remaining = deadline - now();
       // A cancelled caller resolves through the exact same degrade result a
@@ -105,7 +110,7 @@ export async function prepareManagedVoice(deps: PrepareManagedVoiceDeps): Promis
       // Start stayed disabled well past the budget it had just been told it
       // was out of. The rule everywhere in this routine is the same: no new
       // attempt may BEGIN after the deadline (or after a cancel).
-      await sleep(Math.min(pollIntervalMs, remaining));
+      await sleep(Math.min(pollDelayMs(attempt++), remaining));
       // The poll gets the budget too, not just permission to start: `mine`
       // otherwise runs its own fixed 15s timeout, so a poll beginning just
       // inside the deadline still finishes outside it.


### PR DESCRIPTION
Every managed-voice readiness poll is one Soniox `getVoice` that the backend makes on the client's behalf, and the voices API has a requests-per-minute limit (20 on our account) shared by every user's build and the reaper's per-minute census. Both client poll loops asked every 1.5 s for up to 60 s, so one user with a slow build alone spent forty calls a minute against that limit.

## Change

- The poll schedule lives in one place, `src/services/clients/managedVoicePolling.ts`: **1.5 s before each of the first two polls, then 3 s** before every later one. Builds that finish in a few seconds are caught as quickly as before; a slow one costs about half as many requests.
- Both loops read it — session-start preparation (`managedVoicePrep.ts`) and the settings panel (`voiceLibrarySource.ts`) — so the two cannot drift apart. The settings-panel source gains an injectable `sleep` so the schedule is asserted by its tests rather than timed.
- Polling starts only after the upload `POST` has returned the voice id; upload time adds no polls (unchanged, stated here because it was asked).
- No poll-count cap is added: each loop keeps its own 60 s time budget as the ceiling, which the new schedule turns into at most about 21 polls per build instead of 40.

## Testing

Three new tests pin the sequence `[1500, 1500, 3000, 3000, …]` (the schedule function, and each loop through an injected `sleep`); they failed before the change. Existing tests that injected a constant interval now inject a constant function. The three touched files pass (40 tests); the full suite passes (330 files, 3800 tests). `tsc` reports nothing in the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Voice readiness checks now poll quickly during the first two attempts, then switch to a steadier interval.
  * Polling respects remaining timeout limits to avoid unnecessary waits and prevents checks after the timeout expires.
  * Voice preparation and managed voice setup now use the same polling schedule for more consistent behavior.

* **Tests**
  * Added coverage validating polling timing, scheduled delays, and timeout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->