### PR TITLE
chore: #497 follow-ups — document the dispose path, run local-inference in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
   # pre-existing failures unrelated to these files, and a job that is red on
   # arrival gets ignored. Widen it as suites are cleaned up — the value is in
   # the diagnostics guards running on every PR, starting now.
+  #
+  # src/lib/local-inference joined on 2026-09-06 (after #497): its 51 files were
+  # green but had never run in CI, so the source guards for the ASR workers
+  # (harness-consolidation.test.ts) could not fail a PR — #497's first version
+  # of the #470 decode-handoff guard was vacuous for two workers and nothing
+  # noticed until a maintainer ran it locally.
   test:
     name: test (diagnostics)
     runs-on: ubuntu-latest
@@ -42,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run diagnostics and log-surface tests
+      - name: Run diagnostics, log-surface and local-inference tests
         run: >-
           npx vitest run
           src/lib/diagnostics
@@ -50,6 +56,7 @@ jobs:
           src/stores/logStore.test.ts
           src/stores/sanitizeEvent.test.ts
           src/components/LogsPanel
+          src/lib/local-inference
 
   # The sidecar's pytest suite had no CI coverage anywhere (a ledgered slice-3
   # debt, closed here in slice 5) — grep -rl "pytest" .github/ used to return

--- a/src/lib/local-inference/engine/WorkerSession.ts
+++ b/src/lib/local-inference/engine/WorkerSession.ts
@@ -76,6 +76,13 @@ export class WorkerSession {
       this.rejectReady?.(new Error('WorkerSession disposed'));
     }
     this.torn = true;
+    // `dispose` is posted and the worker is terminated on the very next line, deliberately:
+    // Stop is immediate. The ASR workers' handleDispose (flush → drain the decode chain →
+    // release sessions → post `disposed`) therefore never completes in the app — nothing here
+    // waits for `disposed`, no engine consumes it, and a decode still queued at this point is
+    // dropped together with the thread. That drain is exercised only by the worker harness,
+    // which does wait for `disposed` (docs/superpowers/notes/2026-09-06-asr-decode-handoff-
+    // gb10-validation.md). "Finish this utterance" is flush's job (PTT release), not dispose's.
     this.worker.postMessage({ type: 'dispose' });
     this.worker.terminate();
     this._ready = false;

--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -370,6 +370,11 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
+  // Only reachable when the host waits for `disposed`. In the app, WorkerSession.dispose()
+  // posts `dispose` and terminates this worker on the next line, so the drain below runs in the
+  // worker harness only; Stop is meant to be immediate, and PTT release finishes an utterance
+  // through flush, not dispose.
+
   // Flush remaining speech; handleFlush waits for that decode to finish.
   await handleFlush();
 

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -426,6 +426,11 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
+  // Only reachable when the host waits for `disposed`. In the app, WorkerSession.dispose()
+  // posts `dispose` and terminates this worker on the next line, so the drain below runs in the
+  // worker harness only; Stop is meant to be immediate, and PTT release finishes an utterance
+  // through flush, not dispose.
+
   // Flush remaining speech; handleFlush waits for that decode to finish.
   await handleFlush();
 

--- a/src/lib/local-inference/workers/qwen3-asr-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/qwen3-asr-webgpu.worker.ts
@@ -478,6 +478,11 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
+  // Only reachable when the host waits for `disposed`. In the app, WorkerSession.dispose()
+  // posts `dispose` and terminates this worker on the next line, so the drain below runs in the
+  // worker harness only; Stop is meant to be immediate, and PTT release finishes an utterance
+  // through flush, not dispose.
+
   // Flush remaining speech; handleFlush waits for that decode to finish.
   await handleFlush();
 

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -426,6 +426,11 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
+  // Only reachable when the host waits for `disposed`. In the app, WorkerSession.dispose()
+  // posts `dispose` and terminates this worker on the next line, so the drain below runs in the
+  // worker harness only; Stop is meant to be immediate, and PTT release finishes an utterance
+  // through flush, not dispose.
+
   // Flush remaining speech. Fire-and-forget; the `await currentDecodePromise`
   // below picks up the just-kicked decode before we dispose the model.
   if (frameProcessor?.speaking) {

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -521,6 +521,11 @@ async function handleFlush(): Promise<void> {
 }
 
 async function handleDispose(): Promise<void> {
+  // Only reachable when the host waits for `disposed`. In the app, WorkerSession.dispose()
+  // posts `dispose` and terminates this worker on the next line, so the drain below runs in the
+  // worker harness only; Stop is meant to be immediate, and PTT release finishes an utterance
+  // through flush, not dispose.
+
   // Flush remaining speech; handleFlush waits for that decode to finish.
   vadLog('DISPOSE flushing remaining speech');
   await handleFlush();


### PR DESCRIPTION
## What

Two follow-ups from #497, no behaviour change.

- **docs(local-inference)** — `WorkerSession.dispose()` posts `dispose` and terminates the worker on the next line, so the flush → drain → release → `disposed` sequence in the five ASR workers' `handleDispose` never completes in the app; nothing waits for `disposed` and no engine consumes it. That is deliberate (Stop is immediate; PTT release finishes an utterance through flush) but was written down nowhere, and #497's review twice asked for the production path to wait for the drain. Both sides now say the drain is exercised only by the worker harness that does wait for `disposed`.
- **ci** — the vitest job now also runs `src/lib/local-inference`. It is green (51 files, 480 tests) but had never run in CI, so the ASR workers' source guards in `harness-consolidation.test.ts` could not fail a PR: #497's first version of the #470 decode-handoff guard was vacuous for two of three workers and nothing noticed until it was run locally.

## Test plan

- The widened CI command run locally: 58 files, 595 tests pass.
- This PR's own `test (diagnostics)` job is the first run of that command in CI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified how speech worker disposal and utterance completion behave, including the distinction between application shutdown and worker-harness cleanup.
  - Documented that stopping is immediate while completed utterances use the flush process.

- **Tests**
  - Expanded continuous integration diagnostics to include local inference coverage, ensuring its automated tests run in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->