### PR TITLE
fix(granite-webgpu): avoid encoder block-pad reshape crash (#500)

### DIFF
--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -244,7 +244,31 @@ async function runGraniteInferenceSegment(audio: Float32Array, startSample: numb
       tokenize: false,
     });
 
-    const inputs = await p(text, audio, { sampling_rate: VAD_SAMPLE_RATE });
+    // Avoid the Granite ONNX export's block-pad reshape crash. The conformer runs
+    // block attention with context_size = 200, and the export dropped the upstream
+    // `if remainder > 0` guard on the block right-pad, so when the encoder frame
+    // count (the input_features time dim) is an exact multiple of 200 the graph pads
+    // a whole extra block and the reshape {1, T+200, 1024} -> {1, T/200, 200, 8, -1}
+    // aborts in OrtRun. The 20 s max-speech cap hits it every time (T = 1000 = 5x200);
+    // other lengths rarely. Append ~1 encoder frame of trailing silence (320 samples =
+    // 20 ms @ 16 kHz = hop 160 x 2-frame stacking) and re-featurise until the count
+    // clears the multiple. The pad falls in the segment's trailing silence, so the
+    // transcript is unaffected; one append usually suffices (T and T+1 can't both be
+    // multiples), and the 4-iteration bound guards against frame-boundary jitter.
+    const BLOCK_SIZE = 200;
+    const BLOCK_PAD_SAMPLES = 320;
+    let paddedAudio = audio;
+    let inputs = await p(text, paddedAudio, { sampling_rate: VAD_SAMPLE_RATE });
+    for (
+      let guard = 0;
+      guard < 4 && inputs.input_features.dims[1] > 0 && inputs.input_features.dims[1] % BLOCK_SIZE === 0;
+      guard++
+    ) {
+      const grown = new Float32Array(paddedAudio.length + BLOCK_PAD_SAMPLES);
+      grown.set(paddedAudio);
+      paddedAudio = grown;
+      inputs = await p(text, paddedAudio, { sampling_rate: VAD_SAMPLE_RATE });
+    }
 
     // Collect output via streamer
     let accumulated = '';


### PR DESCRIPTION
## Summary

Fixes #500. The onnx-community Granite Speech ONNX export (`granite-4.0-1b-speech-ONNX` and `granite-speech-4.1-2b-ONNX`, every quant) drops the upstream `if remainder > 0` guard on the conformer's block right-pad. When the encoder frame count `T` (the `input_features` time dim) is an exact multiple of `context_size = 200`, the graph pads a whole extra block while the block count stays `ceil(T/200)`, so the block-attention reshape `{1, T+200, 1024} -> {1, T/200, 200, 8, -1}` aborts in OrtRun (`input_shape_size % size == 0 was false`).

The crash is fully determined by `T`: the 20 s max-speech cap produces `T = 1000 = 5×200` and fails every time, while ordinary-length utterances land elsewhere and decode fine — which is why the card loads, reports ready, and only some utterances error.

## Fix

After featurising in `runGraniteInferenceSegment`, if `T` is a multiple of 200, append about one encoder frame of trailing silence (320 samples @ 16 kHz) and re-featurise until `T` clears the multiple (4-iteration bound against frame-boundary jitter). The pad lands in the segment's own trailing silence, so the transcript is unaffected. Only the capped segment ever needs it; every other segment re-featurises zero times.

The guard is a few lines inline in the worker. Computing `T` needs the real Transformers.js processor, so it can't run in the vitest suite — it is covered by the GB10 end-to-end run below. warmup uses 1 s of silence (`T≈50`), unaffected.

This is a worker-side workaround. The root cause is the exported graph (`torch.export` flattened a data-dependent branch); a real fix is a re-export. Switching to `granite-speech-4.1-2b-ONNX` does **not** help — same `Sub(200, Mod(T,200))` pad structure, confirmed in q4 and q4f16.

## Testing

End-to-end on GB10 (Vulkan), the exact 8-clip gapless Japanese repro from #500:

| | before | after |
|---|---|---|
| errored segments | 6 / 6 | 0 / 6 |
| captured audio | 0 s | 65.18 s |
| transcripts | empty | all correct |

Instrumentation confirmed only the 20 s cap segment triggered a pad (`T0 1000 → 1001`, one append); the other 5 segments re-featurised 0 times. The existing `_shared` worker test suite stays green (including the granite structural guard).

Not re-checked on Metal / Windows or with the q4f16 variant, but the fix is graph-invariant and hardware-independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed WebGPU speech recognition failures for audio clips whose duration aligns exactly with certain encoder block sizes.
  * Added handling for affected audio near the maximum supported speech length, preventing processing errors without changing transcript results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->