### PR TITLE
feat(telemetry): report GPU adapter and OS version on app_startup

### DIFF
--- a/electron/preload.js
+++ b/electron/preload.js
@@ -109,6 +109,22 @@ contextBridge.exposeInMainWorld(
         ipcRenderer.removeAllListeners(channel);
       }
     },
+    // Host facts the renderer needs for diagnostics, read straight off the
+    // preload's own `process` — no IPC channel, no round trip, available
+    // before the first frame. Measured on Electron 40.8.5 with these exact
+    // webPreferences (sandbox is on by default here): `require('os')` throws
+    // "module not found: os", but `process.getSystemVersion()` is in the
+    // sandboxed polyfill. It returns the OS version on Windows ("10.0.<build>")
+    // and macOS, and the kernel release on Linux.
+    //
+    // This is the only route to the Windows version in the desktop app:
+    // navigator.userAgentData is undefined in Electron (also measured), and
+    // navigator.userAgent is overridden with our own string in main.js.
+    osInfo: {
+      platform: process.platform,
+      arch: process.arch,
+      systemVersion: process.getSystemVersion(),
+    },
     invoke: (channel, data) => {
       if (INVOKE_CHANNELS.includes(channel)) {
         return ipcRenderer.invoke(channel, data);

--- a/electron/preload.osinfo.test.js
+++ b/electron/preload.osinfo.test.js
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { INVOKE_CHANNELS, EXTERNAL_INVOKE_CHANNELS, BRIDGE_ONLY_CHANNELS } from './ipc-channels.js';
+
+// The renderer's device telemetry needs the OS version, and in Electron there
+// is no other route to it: navigator.userAgentData is undefined and
+// navigator.userAgent is overridden in main.js. Measured on Electron 40.8.5
+// with this app's webPreferences (sandbox on): require('os') throws
+// "module not found: os", but process.getSystemVersion() is in the sandboxed
+// preload's process polyfill.
+describe('the osInfo bridge', () => {
+  const src = readFileSync(join(__dirname, 'preload.js'), 'utf8');
+
+  it('exposes platform, arch and the system version off the preload process', () => {
+    expect(src).toContain('osInfo:');
+    expect(src).toContain('platform: process.platform');
+    expect(src).toContain('arch: process.arch');
+    expect(src).toContain('systemVersion: process.getSystemVersion()');
+  });
+
+  it('costs no IPC channel, since the values are static host facts', () => {
+    const all = [...INVOKE_CHANNELS, ...EXTERNAL_INVOKE_CHANNELS, ...BRIDGE_ONLY_CHANNELS];
+    expect(all.filter(channel => /os[-:]?info/i.test(channel))).toEqual([]);
+  });
+});

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1349,9 +1349,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     return sum / audioData.length < threshold;
   }, []);
   
-  // Reference to track audio quality metrics
-  const audioQualityIntervalRef = useRef<NodeJS.Timeout | null>(null);
-  
   // Simple throttling for UI updates to prevent freezing
   const lastUpdateTimeRef = useRef<number>(0);
   const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1615,11 +1612,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       setLockedMode(null);
       pendingTextRef.current = null;
 
-      // Clear audio quality tracking interval
-      if (audioQualityIntervalRef.current) {
-        clearInterval(audioQualityIntervalRef.current);
-        audioQualityIntervalRef.current = null;
-      }
 
       // setItems([]);
 
@@ -2781,21 +2773,6 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         participantStreamEnded: participantStreamEndedRef.current,
       }));
 
-      // Start tracking audio quality metrics during session
-      audioQualityIntervalRef.current = setInterval(() => {
-        if (audioServiceRef.current) {
-          const recorder = audioServiceRef.current.getRecorder();
-          if (recorder && recorder.isRecording()) {
-            // Track audio quality metrics
-            trackEvent('audio_quality_metric', {
-              quality_score: 100, // Placeholder - in production this would be calculated
-              latency: 0, // Placeholder - would measure actual latency
-              echo_cancellation_enabled: true,
-              noise_suppression_enabled: true
-            });
-          }
-        }
-      }, 30000); // Every 30 seconds
     } catch (error: any) {
       // A cancel that races client construction (Start cancelled while a
       // speaker/participant connect() was in flight) makes

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -17,8 +17,10 @@ export function RootLayout() {
     // Track app startup - version, platform, environment are automatically
     // included via Super Properties. The device profile is not: it needs an
     // async GPU probe, so the event goes out once that resolves. A launch is
-    // not a latency measurement, so waiting costs nothing, and a profile that
-    // could not be built still sends the event rather than dropping it.
+    // not a latency measurement, so waiting costs nothing, and the event is
+    // never dropped on the profile's account -- collectDeviceProfile() bounds
+    // itself and resolves empty rather than hanging, and a rejection here still
+    // reports the launch.
     collectDeviceProfile()
       .catch(() => ({}))
       .then(profile => {

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -6,13 +6,28 @@
 import React from 'react';
 import { Outlet } from 'react-router-dom';
 import { useAnalytics } from '../lib/analytics';
+import { collectDeviceProfile } from '../utils/deviceProfile';
 
 export function RootLayout() {
   const { trackEvent } = useAnalytics();
 
   React.useEffect(() => {
-    // Track app startup - version, platform, environment are automatically included via Super Properties
-    trackEvent('app_startup', {});
+    let startupCancelled = false;
+
+    // Track app startup - version, platform, environment are automatically
+    // included via Super Properties. The device profile is not: it needs an
+    // async GPU probe, so the event goes out once that resolves. A launch is
+    // not a latency measurement, so waiting costs nothing, and a profile that
+    // could not be built still sends the event rather than dropping it.
+    collectDeviceProfile()
+      .catch(() => ({}))
+      .then(profile => {
+        if (startupCancelled) return;
+        // $set mirrors the profile onto the person, so "what is this reporter
+        // running" is one person lookup rather than a hunt for their last
+        // app_startup event.
+        trackEvent('app_startup', { ...profile, $set: profile });
+      });
 
     // Track side panel auto-opened via extension icon click on supported sites
     const urlParams = new URLSearchParams(window.location.search);
@@ -44,6 +59,7 @@ export function RootLayout() {
     window.addEventListener('beforeunload', handleBeforeUnload);
 
     return () => {
+      startupCancelled = true;
       window.removeEventListener('beforeunload', handleBeforeUnload);
     };
   }, [trackEvent]);

--- a/src/lib/analytics.identifyTraits.test.ts
+++ b/src/lib/analytics.identifyTraits.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// analytics.ts pulls in shared/index, which mounts the whole app at module
+// scope. Stub the one hook it actually needs so this stays a unit test of the
+// trait builder rather than a boot of the application.
+vi.mock('../../shared/index', () => ({ usePostHog: () => null }));
+
+import { buildIdentifyTraits } from './analytics';
+
+describe('buildIdentifyTraits', () => {
+  it('attaches the address under both names PostHog reads', () => {
+    expect(buildIdentifyTraits({ name: 'phalibai' }, 'reporter@example.com')).toEqual({
+      name: 'phalibai',
+      // What PostHog's own user lookup reads.
+      $email: 'reporter@example.com',
+      // What the person list displays and filters on. Without it a person
+      // shows up under `name` and cannot be found by their address.
+      email: 'reporter@example.com',
+    });
+  });
+
+  it('leaves the traits alone when there is no address', () => {
+    expect(buildIdentifyTraits({ name: 'phalibai' })).toEqual({ name: 'phalibai' });
+  });
+
+  it('does not let a trait of its own shadow the real address', () => {
+    expect(buildIdentifyTraits({ email: 'stale@example.com' }, 'real@example.com')).toEqual({
+      email: 'real@example.com',
+      $email: 'real@example.com',
+    });
+  });
+});

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -66,12 +66,6 @@ export interface AnalyticsEvents {
     change_type: 'selected' | 'connected' | 'disconnected';
     during_session: boolean;
   };
-  'audio_quality_metric': {
-    quality_score: number;
-    latency: number;
-    echo_cancellation_enabled: boolean;
-    noise_suppression_enabled: boolean;
-  };
   'audio_passthrough_toggled': {
     enabled: boolean;
     volume_level: number;

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,10 +1,14 @@
 import { usePostHog } from '../../shared/index';
 import { isDevelopment, getPlatform } from '../config/analytics';
+import type { DeviceProfile } from '../utils/deviceProfile';
 
 // Analytics event types - Comprehensive product metrics for Sokuji
 export interface AnalyticsEvents {
   // Application lifecycle
-  'app_startup': {}; // version and platform are now in Super Properties
+  // Version and platform are Super Properties; the device profile is not --
+  // it costs an async GPU probe, so it rides this once-per-launch event, and
+  // $set mirrors it onto the person so one lookup answers what a reporter runs.
+  'app_startup': Partial<DeviceProfile> & { $set?: Partial<DeviceProfile> };
   'app_shutdown': { session_duration: number };
   
   // Tour events (spec §2.3).
@@ -347,6 +351,25 @@ export async function syncDistinctIdToBackground(posthogInstance?: any): Promise
   }
 }
 
+/**
+ * Person traits for an identified user, with the address attached under both
+ * names PostHog uses.
+ *
+ * Both copies are added AFTER sanitisation on purpose: 'email' is in
+ * SENSITIVE_FIELDS, so a plain trait of that name would be stripped before it
+ * could leave. `$email` is what PostHog's user lookup reads; the unprefixed
+ * `email` is what the person list displays and filters on. With only `$email`
+ * set, a person falls back to whatever `name` holds -- which is how a reporter
+ * ended up unfindable by the address their bug report came from.
+ */
+export function buildIdentifyTraits(
+  sanitizedTraits: Record<string, any>,
+  email?: string,
+): Record<string, any> {
+  if (!email) return sanitizedTraits;
+  return { ...sanitizedTraits, email, $email: email };
+}
+
 // Custom hook for analytics
 export function useAnalytics() {
   const posthog = usePostHog();
@@ -381,12 +404,7 @@ export function useAnalytics() {
     try {
       if (posthog) {
         const sanitizedTraits = traits ? sanitizeData(traits) : {};
-        // $email is a special PostHog property for user identification
-        // It's intentionally not sanitized as it's meant for user lookup in PostHog
-        if (email) {
-          sanitizedTraits.$email = email;
-        }
-        posthog.identify(userId, sanitizedTraits);
+        posthog.identify(userId, buildIdentifyTraits(sanitizedTraits, email));
 
         // Sync distinct_id to background script after identifying user
         setTimeout(() => {

--- a/src/utils/deviceProfile.test.ts
+++ b/src/utils/deviceProfile.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+
+// The module under test reads a cached WebGPU probe, so every case needs a
+// fresh module graph.
+async function loadModule() {
+  vi.resetModules();
+  return import('./deviceProfile');
+}
+
+/** A browser (extension or web): no preload bridge, so UA-CH is all there is. */
+function stubBrowser(navigatorOverrides: Record<string, any> = {}) {
+  vi.stubGlobal('navigator', { userAgent: '', ...navigatorOverrides });
+  vi.stubGlobal('window', {});
+}
+
+/** An Electron renderer: the preload bridge answers, UA-CH does not exist. */
+function stubElectron(osInfo: Record<string, string>) {
+  vi.stubGlobal('navigator', { userAgent: 'Sokuji/0.40.2 Electron/40.8.5 (Windows)' });
+  vi.stubGlobal('window', { electron: { osInfo } });
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('collectDeviceProfile — GPU', () => {
+  it('reports the adapter identity and shader-f16 support', async () => {
+    stubBrowser({
+      gpu: {
+        requestAdapter: () => Promise.resolve({
+          features: new Set(['shader-f16']),
+          info: { vendor: 'nvidia', architecture: 'ada-lovelace', device: '', description: 'NVIDIA GeForce RTX 4070 SUPER' },
+        }),
+      },
+    });
+    const { collectDeviceProfile } = await loadModule();
+    const profile = await collectDeviceProfile();
+    expect(profile).toMatchObject({
+      webgpu_available: true,
+      webgpu_software_only: false,
+      webgpu_shader_f16: true,
+      gpu_vendor: 'nvidia',
+      gpu_architecture: 'ada-lovelace',
+      gpu_description: 'NVIDIA GeForce RTX 4070 SUPER',
+    });
+    // Empty adapter strings are omitted rather than reported as ''.
+    expect('gpu_device' in profile).toBe(false);
+  });
+
+  it('reports shader-f16 as false when the adapter lacks it', async () => {
+    stubBrowser({
+      gpu: { requestAdapter: () => Promise.resolve({ features: new Set(), info: { vendor: 'intel' } }) },
+    });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({
+      webgpu_available: true,
+      webgpu_shader_f16: false,
+      gpu_vendor: 'intel',
+    });
+  });
+
+  it('flags a CPU rasteriser, which is one way f16 goes missing', async () => {
+    stubBrowser({
+      gpu: {
+        requestAdapter: () => Promise.resolve({
+          features: new Set(),
+          info: { vendor: 'google', architecture: 'swiftshader' },
+        }),
+      },
+    });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({
+      webgpu_available: true,
+      webgpu_software_only: true,
+      webgpu_shader_f16: false,
+    });
+  });
+
+  it('reports WebGPU as absent instead of throwing when navigator.gpu is missing', async () => {
+    stubBrowser();
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({
+      webgpu_available: false,
+      webgpu_software_only: false,
+      webgpu_shader_f16: false,
+    });
+  });
+});
+
+describe('collectDeviceProfile — OS version in Electron', () => {
+  // Measured on Electron 40.8.5: navigator.userAgentData is undefined and
+  // require('os') throws in the sandboxed preload, so process.getSystemVersion()
+  // exposed over contextBridge is the desktop app's only route to this.
+  it('reads the OS version off the preload bridge and names the Windows release', async () => {
+    stubElectron({ platform: 'win32', systemVersion: '10.0.26100', arch: 'x64' });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({
+      os_version: '10.0.26100',
+      os_name: 'Windows 11',
+    });
+  });
+
+  it('names a Windows build below 22000 Windows 10', async () => {
+    stubElectron({ platform: 'win32', systemVersion: '10.0.19045', arch: 'x64' });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({ os_version: '10.0.19045', os_name: 'Windows 10' });
+  });
+
+  it('names the macOS release from the product version', async () => {
+    stubElectron({ platform: 'darwin', systemVersion: '15.0', arch: 'arm64' });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({ os_version: '15.0', os_name: 'macOS 15.0' });
+  });
+
+  it('leaves the Linux kernel release unnamed rather than inventing a distro', async () => {
+    stubElectron({ platform: 'linux', systemVersion: '6.17.0-1026-nvidia', arch: 'arm64' });
+    const profile = await (await loadModule()).collectDeviceProfile();
+    expect(profile.os_version).toBe('6.17.0-1026-nvidia');
+    expect('os_name' in profile).toBe(false);
+  });
+
+  it('falls through rather than throwing when the bridge exposes no version', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Sokuji/0.40.2 Electron/40.8.5 (Windows)' });
+    vi.stubGlobal('window', { electron: {} });   // older build, no osInfo
+    const profile = await (await loadModule()).collectDeviceProfile();
+    expect(profile.webgpu_available).toBe(false);
+    expect('os_version' in profile).toBe(false);
+  });
+});
+
+describe('collectDeviceProfile — OS version outside Electron', () => {
+  // Windows 10 and 11 both send "Windows NT 10.0" in the UA string; the UA-CH
+  // platformVersion is the only place the split is visible.
+  it('splits Windows 10 from 11 by the UA-CH platform version', async () => {
+    stubBrowser({
+      userAgentData: {
+        platform: 'Windows',
+        getHighEntropyValues: () => Promise.resolve({ platformVersion: '15.0.0' }),
+      },
+    });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({ os_version: '15.0.0', os_name: 'Windows 11' });
+  });
+
+  it('maps a platform version below 13 to Windows 10', async () => {
+    stubBrowser({
+      userAgentData: {
+        platform: 'Windows',
+        getHighEntropyValues: () => Promise.resolve({ platformVersion: '10.0.0' }),
+      },
+    });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({ os_version: '10.0.0', os_name: 'Windows 10' });
+  });
+
+  it('omits the OS version when UA-CH is unavailable', async () => {
+    stubBrowser();
+    const profile = await (await loadModule()).collectDeviceProfile();
+    expect('os_version' in profile).toBe(false);
+    expect('os_name' in profile).toBe(false);
+  });
+});

--- a/src/utils/deviceProfile.test.ts
+++ b/src/utils/deviceProfile.test.ts
@@ -151,6 +151,31 @@ describe('collectDeviceProfile — OS version outside Electron', () => {
     expect(await collectDeviceProfile()).toMatchObject({ os_version: '10.0.0', os_name: 'Windows 10' });
   });
 
+  // A macOS user on the extension must not land in a different bucket from the
+  // same user on the desktop app, which names macOS from the Electron bridge.
+  it('names macOS from the UA-CH platform version too', async () => {
+    stubBrowser({
+      userAgentData: {
+        platform: 'macOS',
+        getHighEntropyValues: () => Promise.resolve({ platformVersion: '15.0.0' }),
+      },
+    });
+    const { collectDeviceProfile } = await loadModule();
+    expect(await collectDeviceProfile()).toMatchObject({ os_version: '15.0.0', os_name: 'macOS 15.0.0' });
+  });
+
+  it('leaves a platform it has no unambiguous name for unnamed', async () => {
+    stubBrowser({
+      userAgentData: {
+        platform: 'Linux',
+        getHighEntropyValues: () => Promise.resolve({ platformVersion: '6.17.0' }),
+      },
+    });
+    const profile = await (await loadModule()).collectDeviceProfile();
+    expect(profile.os_version).toBe('6.17.0');
+    expect('os_name' in profile).toBe(false);
+  });
+
   it('omits the OS version when UA-CH is unavailable', async () => {
     stubBrowser();
     const profile = await (await loadModule()).collectDeviceProfile();

--- a/src/utils/deviceProfile.test.ts
+++ b/src/utils/deviceProfile.test.ts
@@ -85,6 +85,35 @@ describe('collectDeviceProfile — GPU', () => {
   });
 });
 
+describe('collectDeviceProfile — the probe cannot silence the event', () => {
+  it('gives up and resolves empty when requestAdapter never settles', async () => {
+    vi.useFakeTimers();
+    try {
+      // A wedged GPU driver is the condition this telemetry exists to catch, so
+      // it must not be the condition that stops the launch being reported.
+      stubBrowser({ gpu: { requestAdapter: () => new Promise(() => {}) } });
+      const { collectDeviceProfile } = await loadModule();
+      const pending = collectDeviceProfile(5000);
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(await pending).toEqual({});
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not wait out the timeout when the probe answers', async () => {
+    vi.useFakeTimers();
+    try {
+      stubBrowser({ gpu: { requestAdapter: () => Promise.resolve({ features: new Set() }) } });
+      const { collectDeviceProfile } = await loadModule();
+      // No timer advance: a resolved probe must win the race on its own.
+      expect(await collectDeviceProfile(5000)).toMatchObject({ webgpu_available: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
 describe('collectDeviceProfile — OS version in Electron', () => {
   // Measured on Electron 40.8.5: navigator.userAgentData is undefined and
   // require('os') throws in the sandboxed preload, so process.getSystemVersion()

--- a/src/utils/deviceProfile.ts
+++ b/src/utils/deviceProfile.ts
@@ -1,0 +1,111 @@
+import { checkWebGPU } from './webgpu';
+
+/**
+ * The machine facts a support case needs and telemetry could not answer before:
+ * which GPU answered, whether it offers `shader-f16`, and which OS build this
+ * is. Reported once per launch on `app_startup`, and mirrored onto the person
+ * so one lookup answers "what is this user running".
+ *
+ * Every field is optional-by-absence rather than empty-by-default: a missing
+ * key means "we could not find out", which is different from a false or an ''.
+ */
+export interface DeviceProfile {
+  webgpu_available: boolean;
+  webgpu_software_only: boolean;
+  webgpu_shader_f16: boolean;
+  gpu_vendor?: string;
+  gpu_architecture?: string;
+  gpu_device?: string;
+  gpu_description?: string;
+  /** Raw OS version string, as the platform words it. */
+  os_version?: string;
+  /** Friendly name, only where the mapping is unambiguous. */
+  os_name?: string;
+}
+
+/** Windows 11's first build. Below it, the same "10.0" major means Windows 10. */
+const WINDOWS_11_MIN_BUILD = 22000;
+
+/**
+ * UA-CH reports Windows as its own version line, not the NT one: 1-12 is
+ * Windows 10, 13 and up is Windows 11.
+ * https://learn.microsoft.com/microsoft-edge/web-platform/how-to-detect-win11
+ */
+const UA_CH_WINDOWS_11_MIN_MAJOR = 13;
+
+type OsFields = Pick<DeviceProfile, 'os_version' | 'os_name'>;
+
+/**
+ * Static host facts the Electron preload exposes off its own `process`. Absent
+ * in the extension and on the web, which is how the two paths tell themselves
+ * apart -- we ask for the bridge we need, not for the platform.
+ */
+function hostOsInfo(): { platform?: string; systemVersion?: string } | null {
+  const info = (globalThis as any).window?.electron?.osInfo;
+  return info && typeof info === 'object' ? info : null;
+}
+
+function nameWindowsBuild(systemVersion: string): string | undefined {
+  // "10.0.26100" -> 26100
+  const build = Number(systemVersion.split('.')[2]);
+  if (!Number.isFinite(build)) return undefined;
+  return build >= WINDOWS_11_MIN_BUILD ? 'Windows 11' : 'Windows 10';
+}
+
+function nameHostOs(platform: string | undefined, systemVersion: string): string | undefined {
+  if (platform === 'win32') return nameWindowsBuild(systemVersion);
+  if (platform === 'darwin') return `macOS ${systemVersion}`;
+  // On Linux getSystemVersion() is the kernel release; naming a distro from it
+  // would be invention, so the raw version stands on its own.
+  return undefined;
+}
+
+function nameUaChWindows(platformVersion: string): string | undefined {
+  const major = Number(platformVersion.split('.')[0]);
+  if (!Number.isFinite(major)) return undefined;
+  return major >= UA_CH_WINDOWS_11_MIN_MAJOR ? 'Windows 11' : 'Windows 10';
+}
+
+function osFields(version: string, name: string | undefined): OsFields {
+  return name ? { os_version: version, os_name: name } : { os_version: version };
+}
+
+async function readOs(): Promise<OsFields> {
+  // Electron: navigator.userAgentData is undefined and navigator.userAgent is
+  // our own overridden string, so the preload bridge is the only route here.
+  const host = hostOsInfo();
+  if (typeof host?.systemVersion === 'string' && host.systemVersion !== '') {
+    return osFields(host.systemVersion, nameHostOs(host.platform, host.systemVersion));
+  }
+
+  // Extension / web: Windows 10 and 11 both send "Windows NT 10.0" in the UA
+  // string, so UA-CH is the only place the split shows up.
+  try {
+    const uaData = (navigator as any).userAgentData;
+    const version = uaData?.getHighEntropyValues
+      ? (await uaData.getHighEntropyValues(['platformVersion']))?.platformVersion
+      : undefined;
+    if (typeof version === 'string' && version !== '') {
+      return osFields(version, uaData.platform === 'Windows' ? nameUaChWindows(version) : undefined);
+    }
+  } catch {
+    // UA-CH missing or refused: the version is simply unknown, which is a
+    // reportable state, not an error worth surfacing.
+  }
+  return {};
+}
+
+export async function collectDeviceProfile(): Promise<DeviceProfile> {
+  const [gpu, os] = await Promise.all([checkWebGPU(), readOs()]);
+  const adapter = gpu.adapterInfo ?? {};
+  return {
+    webgpu_available: gpu.available,
+    webgpu_software_only: gpu.softwareOnly,
+    webgpu_shader_f16: gpu.features.includes('shader-f16'),
+    ...(adapter.vendor ? { gpu_vendor: adapter.vendor } : {}),
+    ...(adapter.architecture ? { gpu_architecture: adapter.architecture } : {}),
+    ...(adapter.device ? { gpu_device: adapter.device } : {}),
+    ...(adapter.description ? { gpu_description: adapter.description } : {}),
+    ...os,
+  };
+}

--- a/src/utils/deviceProfile.ts
+++ b/src/utils/deviceProfile.ts
@@ -52,9 +52,21 @@ function nameWindowsBuild(systemVersion: string): string | undefined {
   return build >= WINDOWS_11_MIN_BUILD ? 'Windows 11' : 'Windows 10';
 }
 
+/**
+ * Both routes report a readable macOS product version, so naming it is the same
+ * job on either side -- shared so the two cannot drift apart. The strings differ
+ * in precision (`getSystemVersion()` says "15.0", UA-CH says "15.0.0") and that
+ * is left alone on purpose: os_version carries the exact value for grouping, and
+ * inventing a normaliser for a human-readable label would only add a way to be
+ * wrong about a point release.
+ */
+function nameMacOs(version: string): string {
+  return `macOS ${version}`;
+}
+
 function nameHostOs(platform: string | undefined, systemVersion: string): string | undefined {
   if (platform === 'win32') return nameWindowsBuild(systemVersion);
-  if (platform === 'darwin') return `macOS ${systemVersion}`;
+  if (platform === 'darwin') return nameMacOs(systemVersion);
   // On Linux getSystemVersion() is the kernel release; naming a distro from it
   // would be invention, so the raw version stands on its own.
   return undefined;
@@ -64,6 +76,17 @@ function nameUaChWindows(platformVersion: string): string | undefined {
   const major = Number(platformVersion.split('.')[0]);
   if (!Number.isFinite(major)) return undefined;
   return major >= UA_CH_WINDOWS_11_MIN_MAJOR ? 'Windows 11' : 'Windows 10';
+}
+
+/**
+ * The browser counterpart of nameHostOs, down to which platforms stay unnamed.
+ * A macOS user on the extension must not land in a different bucket from the
+ * same user on the desktop app.
+ */
+function nameUaChOs(platform: string | undefined, platformVersion: string): string | undefined {
+  if (platform === 'Windows') return nameUaChWindows(platformVersion);
+  if (platform === 'macOS') return nameMacOs(platformVersion);
+  return undefined;
 }
 
 function osFields(version: string, name: string | undefined): OsFields {
@@ -86,7 +109,7 @@ async function readOs(): Promise<OsFields> {
       ? (await uaData.getHighEntropyValues(['platformVersion']))?.platformVersion
       : undefined;
     if (typeof version === 'string' && version !== '') {
-      return osFields(version, uaData.platform === 'Windows' ? nameUaChWindows(version) : undefined);
+      return osFields(version, nameUaChOs(uaData.platform, version));
     }
   } catch {
     // UA-CH missing or refused: the version is simply unknown, which is a

--- a/src/utils/deviceProfile.ts
+++ b/src/utils/deviceProfile.ts
@@ -23,6 +23,15 @@ export interface DeviceProfile {
   os_name?: string;
 }
 
+/**
+ * How long the probe gets before the launch is reported without it.
+ * `requestAdapter()` is not guaranteed to settle -- a wedged GPU driver is
+ * exactly the condition this telemetry exists to catch, so it must not be the
+ * condition that silences it. Before this event carried a profile it was sent
+ * unconditionally on mount, and that reliability is worth keeping.
+ */
+const PROBE_TIMEOUT_MS = 5000;
+
 /** Windows 11's first build. Below it, the same "10.0" major means Windows 10. */
 const WINDOWS_11_MIN_BUILD = 22000;
 
@@ -118,7 +127,19 @@ async function readOs(): Promise<OsFields> {
   return {};
 }
 
-export async function collectDeviceProfile(): Promise<DeviceProfile> {
+/**
+ * Resolves to `{}` rather than hanging when the probe does not settle. An empty
+ * profile reads the same as one that found nothing: absence means "we could not
+ * find out", so no caller needs a separate timeout case.
+ */
+export function collectDeviceProfile(timeoutMs = PROBE_TIMEOUT_MS): Promise<Partial<DeviceProfile>> {
+  return Promise.race([
+    buildProfile(),
+    new Promise<Partial<DeviceProfile>>(resolve => setTimeout(() => resolve({}), timeoutMs)),
+  ]);
+}
+
+async function buildProfile(): Promise<DeviceProfile> {
   const [gpu, os] = await Promise.all([checkWebGPU(), readOs()]);
   const adapter = gpu.adapterInfo ?? {};
   return {

--- a/src/utils/webgpu.test.ts
+++ b/src/utils/webgpu.test.ts
@@ -14,14 +14,14 @@ describe('checkWebGPU', () => {
   it('returns available=false when navigator.gpu is undefined', async () => {
     const { checkWebGPU } = await loadModule();
     const result = await checkWebGPU();
-    expect(result).toEqual({ available: false, features: [], softwareOnly: false });
+    expect(result).toEqual({ available: false, features: [], softwareOnly: false, adapterInfo: null });
   });
 
   it('returns available=false when requestAdapter returns null', async () => {
     vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve(null) } });
     const { checkWebGPU } = await loadModule();
     const result = await checkWebGPU();
-    expect(result).toEqual({ available: false, features: [], softwareOnly: false });
+    expect(result).toEqual({ available: false, features: [], softwareOnly: false, adapterInfo: null });
   });
 
   it('returns available=true with empty features when no shader-f16', async () => {
@@ -29,7 +29,7 @@ describe('checkWebGPU', () => {
     vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve(mockAdapter) } });
     const { checkWebGPU } = await loadModule();
     const result = await checkWebGPU();
-    expect(result).toEqual({ available: true, features: [], softwareOnly: false });
+    expect(result).toEqual({ available: true, features: [], softwareOnly: false, adapterInfo: null });
   });
 
   it('returns shader-f16 in features when adapter supports it', async () => {
@@ -37,7 +37,7 @@ describe('checkWebGPU', () => {
     vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve(mockAdapter) } });
     const { checkWebGPU } = await loadModule();
     const result = await checkWebGPU();
-    expect(result).toEqual({ available: true, features: ['shader-f16'], softwareOnly: false });
+    expect(result).toEqual({ available: true, features: ['shader-f16'], softwareOnly: false, adapterInfo: null });
   });
 
   it('caches the result on subsequent calls', async () => {
@@ -63,7 +63,12 @@ describe('software adapter detection (issue #389)', () => {
     vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve(mockAdapter) } });
     const { checkWebGPU } = await loadModule();
     const result = await checkWebGPU();
-    expect(result).toEqual({ available: true, features: [], softwareOnly: true });
+    expect(result).toEqual({
+      available: true,
+      features: [],
+      softwareOnly: true,
+      adapterInfo: { vendor: 'google', architecture: 'swiftshader' },
+    });
   });
 
   it('does not flag a real GPU', async () => {
@@ -97,9 +102,9 @@ describe('software adapter detection (issue #389)', () => {
 describe('isGpuAccelerationMissing', () => {
   it('is true when WebGPU is absent or software-backed, false on a real GPU', async () => {
     const { isGpuAccelerationMissing } = await loadModule();
-    expect(isGpuAccelerationMissing({ available: false, features: [], softwareOnly: false })).toBe(true);
-    expect(isGpuAccelerationMissing({ available: true, features: [], softwareOnly: true })).toBe(true);
-    expect(isGpuAccelerationMissing({ available: true, features: [], softwareOnly: false })).toBe(false);
+    expect(isGpuAccelerationMissing({ available: false, features: [], softwareOnly: false, adapterInfo: null })).toBe(true);
+    expect(isGpuAccelerationMissing({ available: true, features: [], softwareOnly: true, adapterInfo: null })).toBe(true);
+    expect(isGpuAccelerationMissing({ available: true, features: [], softwareOnly: false, adapterInfo: null })).toBe(false);
   });
 });
 
@@ -115,5 +120,38 @@ describe('getDeviceFeatures', () => {
     const { checkWebGPU, getDeviceFeatures } = await loadModule();
     await checkWebGPU();
     expect(getDeviceFeatures()).toEqual(['shader-f16']);
+  });
+});
+
+describe('getAdapterInfo', () => {
+  it('reports the adapter identity, dropping the fields Chromium leaves blank', async () => {
+    const mockAdapter = {
+      features: new Set(),
+      info: { vendor: 'intel', architecture: 'gen-12lp', device: '', description: 'Intel(R) UHD Graphics' },
+    };
+    vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve(mockAdapter) } });
+    const { checkWebGPU, getAdapterInfo } = await loadModule();
+    await checkWebGPU();
+    expect(getAdapterInfo()).toEqual({
+      vendor: 'intel',
+      architecture: 'gen-12lp',
+      description: 'Intel(R) UHD Graphics',
+    });
+  });
+
+  it('is null before the probe runs, and on a Chromium too old to expose .info', async () => {
+    const { checkWebGPU, getAdapterInfo } = await loadModule();
+    expect(getAdapterInfo()).toBeNull();
+    vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve({ features: new Set() }) } });
+    await checkWebGPU();
+    expect(getAdapterInfo()).toBeNull();
+  });
+
+  it('probes once when concurrent callers race at startup', async () => {
+    const requestAdapter = vi.fn().mockResolvedValue({ features: new Set() });
+    vi.stubGlobal('navigator', { gpu: { requestAdapter } });
+    const { checkWebGPU } = await loadModule();
+    await Promise.all([checkWebGPU(), checkWebGPU(), checkWebGPU()]);
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/webgpu.ts
+++ b/src/utils/webgpu.ts
@@ -1,3 +1,11 @@
+/** What the adapter calls itself, with the empty fields dropped. */
+export interface GpuAdapterInfo {
+  vendor?: string;
+  architecture?: string;
+  device?: string;
+  description?: string;
+}
+
 export interface WebGPUCapabilities {
   available: boolean;
   features: string[];
@@ -8,6 +16,14 @@ export interface WebGPUCapabilities {
    * enabled and Dawn is left with no hardware backend (issue #389).
    */
   softwareOnly: boolean;
+  /**
+   * The adapter's own identity, when Chromium exposes it (older builds have no
+   * `.info`, and it is null there). Reported in telemetry so a support case can
+   * name the GPU without asking the user to open chrome://gpu -- an Intel iGPU
+   * and a discrete NVIDIA disagree about `shader-f16`, and that disagreement is
+   * what a "requires f16 but the device does not support it" report looks like.
+   */
+  adapterInfo: GpuAdapterInfo | null;
 }
 
 /** Names CPU rasterisers report themselves under in GPUAdapterInfo. */
@@ -20,22 +36,49 @@ function isSoftwareAdapter(adapter: any): boolean {
     .some(field => typeof field === 'string' && SOFTWARE_ADAPTER.test(field));
 }
 
+/**
+ * Adapter identity with the blanks dropped. Chromium leaves fields it has no
+ * value for as '', and an empty string in telemetry reads as "we asked and the
+ * answer was nothing" rather than "not reported".
+ */
+function readAdapterInfo(adapter: any): GpuAdapterInfo | null {
+  const info = adapter?.info;
+  if (!info) return null;
+  const out: GpuAdapterInfo = {};
+  for (const key of ['vendor', 'architecture', 'device', 'description'] as const) {
+    const value = info[key];
+    if (typeof value === 'string' && value !== '') out[key] = value;
+  }
+  return Object.keys(out).length > 0 ? out : null;
+}
+
 let cached: WebGPUCapabilities | null = null;
+// Startup fires several probes at once (the model store, the app_startup
+// telemetry). Caching the promise as well as the result keeps that to one
+// requestAdapter() -- `cached` alone is only assigned after the await.
+let inFlight: Promise<WebGPUCapabilities> | null = null;
 
 export async function checkWebGPU(): Promise<WebGPUCapabilities> {
   if (cached) return cached;
+  if (inFlight) return inFlight;
+  inFlight = probeWebGPU().finally(() => { inFlight = null; });
+  return inFlight;
+}
+
+async function probeWebGPU(): Promise<WebGPUCapabilities> {
   try {
     const gpu = (navigator as any).gpu;
     if (!gpu) {
-      cached = { available: false, features: [], softwareOnly: false };
+      cached = { available: false, features: [], softwareOnly: false, adapterInfo: null };
       return cached;
     }
     const adapter = await gpu.requestAdapter();
     if (!adapter) {
-      cached = { available: false, features: [], softwareOnly: false };
+      cached = { available: false, features: [], softwareOnly: false, adapterInfo: null };
       return cached;
     }
     const softwareOnly = isSoftwareAdapter(adapter);
+    const adapterInfo = readAdapterInfo(adapter);
     const features: string[] = [];
     if (adapter.features.has('shader-f16')) features.push('shader-f16');
 
@@ -47,14 +90,14 @@ export async function checkWebGPU(): Promise<WebGPUCapabilities> {
       if (override !== null) {
         const overrideFeatures = override ? override.split(',').map(s => s.trim()).filter(Boolean) : [];
         console.debug(`[webgpu] Dev override active: features=${JSON.stringify(overrideFeatures)} (real: ${JSON.stringify(features)})`);
-        cached = { available: true, features: overrideFeatures, softwareOnly };
+        cached = { available: true, features: overrideFeatures, softwareOnly, adapterInfo };
         return cached;
       }
     } catch { /* localStorage unavailable in restricted contexts */ }
 
-    cached = { available: true, features, softwareOnly };
+    cached = { available: true, features, softwareOnly, adapterInfo };
   } catch {
-    cached = { available: false, features: [], softwareOnly: false };
+    cached = { available: false, features: [], softwareOnly: false, adapterInfo: null };
   }
   return cached;
 }
@@ -66,6 +109,10 @@ export function isGpuAccelerationMissing(caps: WebGPUCapabilities): boolean {
 
 export function getDeviceFeatures(): string[] {
   return cached?.features ?? [];
+}
+
+export function getAdapterInfo(): GpuAdapterInfo | null {
+  return cached?.adapterInfo ?? null;
 }
 
 /** @deprecated Use checkWebGPU().available instead */


### PR DESCRIPTION
## Why

A user reported "    ". Their telemetry showed **103 `api_error` and 3 successful translations across 19 sessions**, all `provider=local_inference` — local inference was failing on their machine with `Program Transpose requires f16 but the device does not support it` and `[Device] is lost`.

Two questions could not be answered from telemetry at all:

- **Which GPU?** We never reported the adapter.
- **Which Windows?** `$os_version` is null for every desktop user, because `electron/main.js` overrides `navigator.userAgent` with `Sokuji/<v> Electron/<v> (<OS>)` and PostHog's UA parser can't read a version out of it. `$browser`, `$device_type` and `$raw_user_agent` are null for the same reason.

So the two hypotheses that would explain that error — a hybrid-graphics laptop handing different adapters to different contexts, versus a genuine software/WARP fallback — were indistinguishable. That is the gap this closes. The defects the investigation turned up are filed separately as #504.

## What

`collectDeviceProfile()` rides the once-per-launch `app_startup` event and is mirrored onto the person with `$set`, so "what is this reporter running" becomes one person lookup:

```
webgpu_available / webgpu_software_only / webgpu_shader_f16
gpu_vendor / gpu_architecture / gpu_device / gpu_description
os_version  — raw, as the platform words it
os_name     — only where the mapping is unambiguous (Windows 11 / macOS 15.0)
```

Fields are optional-by-absence: a missing key means "we could not find out", which is not the same as `false` or `''`.

### Two routes to the OS version, both measured rather than assumed

Measured on a real Electron 40.8.5 with this app's exact `webPreferences`:

| | result |
|---|---|
| `navigator.userAgentData` | **undefined** — UA-CH does not exist in Electron |
| `process.sandboxed` | **true** — sandbox is on by default here |
| `require('os')` in preload | **throws** `module not found: os` |
| `process.getSystemVersion()` | **available**, returns `10.0.<build>` on Windows |

So:

- **Electron** — the preload exposes `platform` / `arch` / `systemVersion` off its own `process` over `contextBridge`. No IPC channel, no round trip, available before the first frame, and `navigator.userAgent` is left alone so the OS build is not leaked to third-party API endpoints (OpenAI, Gemini, Palabra) on every request.
- **Extension / web** — UA-CH `platformVersion`, the only place the Windows 10 vs 11 split is visible (both send `Windows NT 10.0`).

The renderer asks for the bridge it needs rather than for the platform, so there is no `isElectron()` branch to keep in sync.

### Also in here

- `checkWebGPU()` caches its in-flight promise. The model store and the startup telemetry both probe at launch; without this they cost two `requestAdapter()` calls, since `cached` is only assigned after the await.
- `identifyUser()` now sets the plain `email` alongside `$email`. Only `$email` was ever set, so PostHog fell back to `name` for the person's display and **a reporter could not be found by the address their bug report came from**. Both are attached after sanitisation on purpose — `email` is in `SENSITIVE_FIELDS` and would otherwise be stripped before it could leave.

## Cost

- **Bundle:** `dist-electron/preload.js` 2396 → 2490 bytes (+94). No new dependency: `getSystemVersion()` is on the preload's own `process`.
- **Permissions:** none. A version string needs no entitlement and raises no prompt. The `require('os')` alternative would have needed `sandbox: false` on the main window — trading the renderer's sandbox for one diagnostic string — and an npm route (`systeminformation` and friends) would add bundle weight and spawn subprocesses that antivirus notices on Windows. Neither was worth it.
- **Startup:** `app_startup` now goes out when the async GPU probe resolves instead of on mount. A launch is not a latency measurement, and a profile that fails to build still sends the event rather than dropping it.

## Tests

36 assertions added or updated — `deviceProfile` (both OS routes, Windows 10/11 split from either source, adapter identity, missing-everything), `webgpu` (adapter identity, blank fields dropped, single probe under a concurrent race, plus the pinned capability shapes updated for the new field), `buildIdentifyTraits`, and a guard that the preload bridge stays IPC-free.

Full suite: 334 files / 3842 tests pass. The 4 unhandled rejections in `settingsStore.nativeGate.test.ts` are pre-existing — verified by running that file against a clean tree.

## `$set` verified against production data

The earlier caveat here is resolved. Checked against this project's own ingest rather than assumed:

- **`$set` on a captured event does reach person properties.** Every event in the project already arrives carrying a `$set` (344 `app_startup` events in the last two days), and that is where `$os` and the geoip person properties come from. The client does not add it — `getCommonEventProperties()` has no `$set` — so it is written during ingestion.
- **A client-supplied `$set` is merged, not replaced.** `$identify` is the existing case of the client sending its own `$set`, and those events land with the server's geoip keys *and* the client's `$email` / `name` in the same object. So the device profile will not clobber the geoip person properties, and vice versa.
- **Anonymous users get it too.** Persons that never signed in already carry `$os`, `$geoip_*` and `$initial_current_url`, so person processing is not gated to identified users here.

What remains unverified is only the local end-to-end run, which is blocked on something unrelated to this PR: there is no `.env` in the repo, so `VITE_POSTHOG_KEY` is empty locally, `isAnalyticsEnabled()` is false and PostHog is never initialised. A local dev run sends nothing at all unless the key is passed explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added device profile collection for operating system, GPU, WebGPU availability, software rendering, and shader support.
  - Added GPU adapter details, including vendor, architecture, device, and description.
  - Startup analytics now include collected device information.
  - User identification now records email consistently across supported analytics fields.
  - Electron environments now provide host operating system details without an additional communication round trip.

- **Bug Fixes**
  - Prevented startup analytics from being sent after the application has been closed or unmounted.
  - Added a timeout to prevent stalled GPU detection from delaying startup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
