### PR TITLE
feat(local-inference): bind the checked WebGPU adapter to the model runtime

### DIFF
--- a/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/cohere-transcribe-webgpu.worker.ts
@@ -31,7 +31,7 @@ import type {
   AsrDisposeMessage,
   StreamingAsrWorkerOutMessage,
 } from '../types';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -313,7 +313,7 @@ async function handleInit(msg: CohereTranscribeAsrInitMessage): Promise<void> {
     // 3. Load Cohere Transcribe pipeline
     post({ type: 'status', message: 'Loading Cohere Transcribe model (WebGPU)...' });
 
-    await assertShaderF16Supported(msg.dtype, 'Cohere Transcribe');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, msg.dtype, 'Cohere Transcribe');
 
     transcriber = (await pipeline('automatic-speech-recognition', msg.hfModelId, {
       dtype: msg.dtype as any,

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -30,7 +30,7 @@ import type {
   AsrDisposeMessage,
   AsrWorkerOutMessage,
 } from '../types';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -183,15 +183,14 @@ function buildPrompt(): string {
   return '<|audio|>Transcribe the speech to text';
 }
 
+/**
+ * Whether this worker can run on the GPU — and, in the same step, WHICH adapter
+ * it will run on. `acquireWebGpuAdapter` remembers it on the runtime env, so the
+ * f16 gate checks the adapter the model actually loads on instead of requesting
+ * a second one that could answer differently (#513).
+ */
 async function hasWebGPU(): Promise<boolean> {
-  try {
-    const gpu = (self as any).navigator?.gpu;
-    if (!gpu) return false;
-    const adapter = await gpu.requestAdapter();
-    return !!adapter;
-  } catch {
-    return false;
-  }
+  return !!(await acquireWebGpuAdapter(env.backends.onnx));
 }
 
 // ─── Speech Segment Processing ──────────────────────────────────────────────

--- a/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/granite-speech-webgpu.worker.ts
@@ -30,7 +30,7 @@ import type {
   AsrDisposeMessage,
   AsrWorkerOutMessage,
 } from '../types';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -398,7 +398,7 @@ async function handleInit(msg: GraniteSpeechInitMessage): Promise<void> {
     post({ type: 'status', message: 'Loading Granite Speech model (WebGPU)...' });
 
     processor = await AutoProcessor.from_pretrained(msg.hfModelId);
-    await assertShaderF16Supported(msg.dtype, 'Granite Speech');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, msg.dtype, 'Granite Speech');
     model = await GraniteSpeechForConditionalGeneration.from_pretrained(msg.hfModelId, {
       dtype: msg.dtype as any,
       device: 'webgpu',

--- a/src/lib/local-inference/workers/hy-mt-translation.worker.ts
+++ b/src/lib/local-inference/workers/hy-mt-translation.worker.ts
@@ -14,7 +14,7 @@
 
 import { pipeline, env } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── BCP-47 → English language names for the prompt template ────────────────
 // Mirrors manifest.languages one-for-one (36 entries).
@@ -73,7 +73,9 @@ async function handleInit(msg: InitMessage) {
       self.postMessage({ type: 'error', error: 'WebGPU not available. HY-MT translation requires WebGPU.' });
       return;
     }
-    const adapter = await gpu.requestAdapter();
+    // One acquisition, remembered on the runtime env: the gate below reuses
+    // this adapter rather than asking for a second one that could differ.
+    const adapter = await acquireWebGpuAdapter(env.backends.onnx);
     if (!adapter) {
       self.postMessage({ type: 'error', error: 'No WebGPU adapter found. HY-MT translation requires WebGPU.' });
       return;

--- a/src/lib/local-inference/workers/hy-mt-translation.worker.ts
+++ b/src/lib/local-inference/workers/hy-mt-translation.worker.ts
@@ -14,7 +14,7 @@
 
 import { pipeline, env } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── BCP-47 → English language names for the prompt template ────────────────
 // Mirrors manifest.languages one-for-one (36 entries).
@@ -83,7 +83,7 @@ async function handleInit(msg: InitMessage) {
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 
-    await assertShaderF16Supported(msg.dtype || 'q4', 'HY-MT translation');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, msg.dtype || 'q4', 'HY-MT translation');
 
     generator = await (pipeline as any)('text-generation', msg.hfModelId, {
       dtype: msg.dtype || 'q4',

--- a/src/lib/local-inference/workers/qwen-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen-translation.worker.ts
@@ -9,7 +9,7 @@
 import { pipeline, env } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
 import { buildDefaultLocalPrompt } from '../prompts';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -66,7 +66,7 @@ async function handleInit(msg: InitMessage) {
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 
-    await assertShaderF16Supported(msg.dtype || 'q4', 'the translation model');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, msg.dtype || 'q4', 'the translation model');
 
     generator = await (pipeline as any)('text-generation', msg.hfModelId, {
       dtype: msg.dtype || 'q4',

--- a/src/lib/local-inference/workers/qwen-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen-translation.worker.ts
@@ -9,7 +9,7 @@
 import { pipeline, env } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
 import { buildDefaultLocalPrompt } from '../prompts';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -55,7 +55,9 @@ async function handleInit(msg: InitMessage) {
       self.postMessage({ type: 'error', error: 'WebGPU not available. Qwen translation requires WebGPU.' });
       return;
     }
-    const adapter = await gpu.requestAdapter();
+    // One acquisition, remembered on the runtime env: the gate below reuses
+    // this adapter rather than asking for a second one that could differ.
+    const adapter = await acquireWebGpuAdapter(env.backends.onnx);
     if (!adapter) {
       self.postMessage({ type: 'error', error: 'No WebGPU adapter found. Qwen translation requires WebGPU.' });
       return;

--- a/src/lib/local-inference/workers/qwen3-asr-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/qwen3-asr-webgpu.worker.ts
@@ -43,7 +43,7 @@ import type {
   AsrDisposeMessage,
   AsrWorkerOutMessage,
 } from '../types';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -398,7 +398,7 @@ async function handleInit(msg: Qwen3AsrInitMessage): Promise<void> {
     // The resolved variant, not msg.dtype: an unknown dtype falls back to q4
     // above, and gating on the request rather than the fallback would refuse a
     // load that is about to run in q4 anyway.
-    await assertShaderF16Supported(variant, 'Qwen3-ASR');
+    await bindCheckedWebGpuAdapter(ortEnv, variant, 'Qwen3-ASR');
     const filters = JSON.parse(await text(cfg.mel?.filters_file ?? 'mel_filters.json')) as MelFilterbank;
     const decoder = createBpeDecoder(JSON.parse(await text('tokenizer.json')));
 

--- a/src/lib/local-inference/workers/qwen3-asr-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/qwen3-asr-webgpu.worker.ts
@@ -43,7 +43,7 @@ import type {
   AsrDisposeMessage,
   AsrWorkerOutMessage,
 } from '../types';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -180,15 +180,14 @@ let processingVad = false;
 /** The decode currently running or queued; decodes are serialized through it (see transcribe). */
 let currentDecodePromise: Promise<void> | null = null;
 
+/**
+ * Whether this worker can run on the GPU — and, in the same step, WHICH adapter
+ * it will run on. `acquireWebGpuAdapter` remembers it on the runtime env, so the
+ * f16 gate checks the adapter the model actually loads on instead of requesting
+ * a second one that could answer differently (#513).
+ */
 async function hasWebGPU(): Promise<boolean> {
-  try {
-    const gpu = (self as unknown as { navigator?: { gpu?: { requestAdapter(): Promise<unknown> } } }).navigator?.gpu;
-    if (!gpu) return false;
-    const adapter = await gpu.requestAdapter();
-    return !!adapter;
-  } catch {
-    return false;
-  }
+  return !!(await acquireWebGpuAdapter(ortEnv));
 }
 
 function inputTypesOf(session: InferenceSession): Record<string, string> {

--- a/src/lib/local-inference/workers/qwen35-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen35-translation.worker.ts
@@ -14,7 +14,7 @@ import {
 } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
 import { buildDefaultLocalPrompt } from '../prompts';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -80,7 +80,7 @@ async function handleInit(msg: InitMessage) {
       decoder_model_merged: 'q4' as const,
     };
 
-    await assertShaderF16Supported(dtype, 'Qwen3.5 translation');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, dtype, 'Qwen3.5 translation');
 
     model = await Qwen3_5ForConditionalGeneration.from_pretrained(msg.hfModelId, {
       dtype: dtype as any,

--- a/src/lib/local-inference/workers/qwen35-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen35-translation.worker.ts
@@ -14,7 +14,7 @@ import {
 } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
 import { buildDefaultLocalPrompt } from '../prompts';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -60,7 +60,9 @@ async function handleInit(msg: InitMessage) {
       self.postMessage({ type: 'error', error: 'WebGPU not available. Qwen3.5 translation requires WebGPU.' });
       return;
     }
-    const adapter = await gpu.requestAdapter();
+    // One acquisition, remembered on the runtime env: the gate below reuses
+    // this adapter rather than asking for a second one that could differ.
+    const adapter = await acquireWebGpuAdapter(env.backends.onnx);
     if (!adapter) {
       self.postMessage({ type: 'error', error: 'No WebGPU adapter found. Qwen3.5 translation requires WebGPU.' });
       return;

--- a/src/lib/local-inference/workers/shaderF16Gate.consistency.test.ts
+++ b/src/lib/local-inference/workers/shaderF16Gate.consistency.test.ts
@@ -140,6 +140,18 @@ describe('the shader-f16 gate covers every WebGPU worker', () => {
     expect(wrong).toEqual([]);
   });
 
+  // A worker that binds an adapter must not also ask for one itself: two
+  // answers to one question can differ, and the gate would then check an
+  // adapter the model does not run on. Acquisition goes through
+  // `acquireWebGpuAdapter`, which remembers it on the runtime env.
+  it('never requests a second adapter behind the gate', () => {
+    const offenders = workerSources()
+      .filter(w => w.source.includes('bindCheckedWebGpuAdapter('))
+      .filter(w => /\brequestAdapter\(/.test(w.source))
+      .map(w => w.name);
+    expect(offenders).toEqual([]);
+  });
+
   it('never puts the import inside another import block', () => {
     const broken = workerSources()
       .filter(w => /import type \{[^}]*\n\s*import \{ assertShaderF16Supported/.test(w.source))

--- a/src/lib/local-inference/workers/shaderF16Gate.consistency.test.ts
+++ b/src/lib/local-inference/workers/shaderF16Gate.consistency.test.ts
@@ -92,7 +92,7 @@ describe('the shader-f16 gate covers every WebGPU worker', () => {
   it('every WebGPU worker calls assertShaderF16Supported', () => {
     const missing = candidates()
       .filter(w => !(w.name in EXEMPT))
-      .filter(w => !w.source.includes('assertShaderF16Supported('))
+      .filter(w => !w.source.includes('bindCheckedWebGpuAdapter('))
       .map(w => w.name);
     expect(missing).toEqual([]);
   });
@@ -105,7 +105,7 @@ describe('the shader-f16 gate covers every WebGPU worker', () => {
       .map(([name, { reason, stillHolds }]) => {
         const worker = workerSources().find(w => w.name === name);
         if (!worker) return `${name}: exempted but no such worker`;
-        if (worker.source.includes('assertShaderF16Supported(')) return `${name}: calls the gate, exemption is stale`;
+        if (worker.source.includes('bindCheckedWebGpuAdapter(')) return `${name}: calls the gate, exemption is stale`;
         if (!stillHolds(worker.source)) return `${name}: no longer true that ${reason}`;
         return null;
       })
@@ -115,7 +115,7 @@ describe('the shader-f16 gate covers every WebGPU worker', () => {
 
   it('every worker that calls it also imports it', () => {
     const broken = workerSources()
-      .filter(w => w.source.includes('assertShaderF16Supported('))
+      .filter(w => w.source.includes('bindCheckedWebGpuAdapter('))
       .filter(w => !w.source.includes("from './shaderF16Gate'"))
       .map(w => w.name);
     expect(broken).toEqual([]);
@@ -123,6 +123,23 @@ describe('the shader-f16 gate covers every WebGPU worker', () => {
 
   // The import once landed inside a multi-line `import type { … }` block —
   // a syntax error the bundler catches, but only after a full build.
+  // The trap #513 names: six transformers.js workers ALSO import a raw ORT
+  // (`_shared/onnxruntime-all`) for their Silero VAD. Binding the adapter on
+  // THAT env would look right and configure nothing the model runs on.
+  it('binds the env of the runtime that loads the model, not the VAD\'s', () => {
+    const wrong = workerSources()
+      .filter(w => w.source.includes('bindCheckedWebGpuAdapter('))
+      .map(w => {
+        const call = w.source.match(/bindCheckedWebGpuAdapter\(\s*([A-Za-z0-9_.]+)/);
+        const handle = call?.[1];
+        const drivesOrtDirectly = w.source.includes("from './_shared/onnxruntime-webgpu'");
+        const expected = drivesOrtDirectly ? 'ortEnv' : 'env.backends.onnx';
+        return handle === expected ? null : `${w.name}: binds ${handle}, expected ${expected}`;
+      })
+      .filter(Boolean);
+    expect(wrong).toEqual([]);
+  });
+
   it('never puts the import inside another import block', () => {
     const broken = workerSources()
       .filter(w => /import type \{[^}]*\n\s*import \{ assertShaderF16Supported/.test(w.source))

--- a/src/lib/local-inference/workers/shaderF16Gate.test.ts
+++ b/src/lib/local-inference/workers/shaderF16Gate.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { needsShaderF16, assertShaderF16Supported } from './shaderF16Gate';
+import { describe, it, expect, vi } from 'vitest';
+import { needsShaderF16, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 const adapterWith = (...features: string[]) => ({
   requestAdapter: async () => ({ features: { has: (n: string) => features.includes(n) } }),
@@ -26,38 +26,114 @@ describe('needsShaderF16', () => {
 
 describe('assertShaderF16Supported', () => {
   it('refuses an f16 variant when this worker\'s adapter lacks the feature', async () => {
-    await expect(assertShaderF16Supported('q4f16', 'Cohere Transcribe', adapterWith()))
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4f16', 'Cohere Transcribe', adapterWith()))
       .rejects.toThrow(/does not support the WebGPU "shader-f16" feature/);
   });
 
   it('names the model, so the message is actionable without the stack', async () => {
-    await expect(assertShaderF16Supported('q4f16', 'Cohere Transcribe', adapterWith()))
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4f16', 'Cohere Transcribe', adapterWith()))
       .rejects.toThrow(/Cohere Transcribe/);
   });
 
   it('allows an f16 variant when the adapter offers the feature', async () => {
-    await expect(assertShaderF16Supported('q4f16', 'Voxtral', adapterWith('shader-f16')))
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4f16', 'Voxtral', adapterWith('shader-f16')))
       .resolves.toBeUndefined();
   });
 
   it('never blocks a non-f16 variant, whatever the adapter says', async () => {
-    await expect(assertShaderF16Supported('q4', 'Voxtral', adapterWith())).resolves.toBeUndefined();
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4', 'Voxtral', adapterWith())).resolves.toBeUndefined();
   });
 
   // The gate exists to make one specific failure legible. It must not become a
   // second, worse way to report "no GPU here" — that has its own path.
   it('stays out of the way when there is no WebGPU at all', async () => {
-    await expect(assertShaderF16Supported('q4f16', 'Voxtral', undefined)).resolves.toBeUndefined();
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4f16', 'Voxtral', undefined)).resolves.toBeUndefined();
   });
 
   it('stays out of the way when no adapter is returned', async () => {
-    await expect(assertShaderF16Supported('q4f16', 'Voxtral', { requestAdapter: async () => null }))
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4f16', 'Voxtral', { requestAdapter: async () => null }))
       .resolves.toBeUndefined();
   });
 
   it('stays out of the way when requesting an adapter throws', async () => {
-    await expect(assertShaderF16Supported('q4f16', 'Voxtral', {
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4f16', 'Voxtral', {
       requestAdapter: async () => { throw new Error('device lost'); },
     })).resolves.toBeUndefined();
+  });
+});
+
+describe('bindCheckedWebGpuAdapter — binding the runtime to the checked adapter', () => {
+  const gpuOf = (adapter: any) => ({ requestAdapter: vi.fn().mockResolvedValue(adapter) });
+  const withF16 = () => ({ id: 'A', features: { has: (n: string) => n === 'shader-f16' } });
+  const withoutF16 = () => ({ id: 'B', features: { has: () => false } });
+
+  it('hands the runtime the very adapter it checked', async () => {
+    const adapter = withF16();
+    const env: any = { webgpu: {} };
+    await bindCheckedWebGpuAdapter(env, 'q4f16', 'Voxtral', gpuOf(adapter));
+    // Identity, not equality: the whole point is that no second request can
+    // slip a different GPU between the check and the device.
+    expect(env.webgpu.adapter).toBe(adapter);
+  });
+
+  it('binds even when the dtype needs no f16, so the gate is sound next time', async () => {
+    const adapter = withoutF16();
+    const env: any = { webgpu: {} };
+    await bindCheckedWebGpuAdapter(env, 'q4', 'Voxtral', gpuOf(adapter));
+    expect(env.webgpu.adapter).toBe(adapter);
+  });
+
+  it('requests one adapter, not one per concern', async () => {
+    const gpu = gpuOf(withF16());
+    await bindCheckedWebGpuAdapter({ webgpu: {} } as any, 'q4f16', 'Voxtral', gpu);
+    expect(gpu.requestAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('reuses an adapter the runtime already holds instead of requesting another', async () => {
+    // Setting `adapter` only has effect before the first session, so once one
+    // is there it is what the runtime will use — check THAT, not a fresh one.
+    const bound = withoutF16();
+    const gpu = gpuOf(withF16());
+    const env: any = { webgpu: { adapter: bound } };
+    await expect(bindCheckedWebGpuAdapter(env, 'q4f16', 'Voxtral', gpu))
+      .rejects.toThrow(/shader-f16/);
+    expect(gpu.requestAdapter).not.toHaveBeenCalled();
+    expect(env.webgpu.adapter).toBe(bound);
+  });
+
+  it('still refuses an f16 variant when the bound adapter lacks the feature', async () => {
+    const env: any = { webgpu: {} };
+    await expect(bindCheckedWebGpuAdapter(env, 'q4f16', 'Cohere Transcribe', gpuOf(withoutF16())))
+      .rejects.toThrow(/Cohere Transcribe/);
+  });
+
+  it('survives a runtime env that exposes no webgpu section', async () => {
+    // transformers.js types `backends.onnx` as Partial<Env>, so `webgpu` can be
+    // absent. Degrade to checking without binding rather than throwing.
+    const adapter = withoutF16();
+    await expect(bindCheckedWebGpuAdapter({} as any, 'q4f16', 'Voxtral', gpuOf(adapter)))
+      .rejects.toThrow(/shader-f16/);
+    await expect(bindCheckedWebGpuAdapter(undefined, 'q4', 'Voxtral', gpuOf(adapter)))
+      .resolves.toBeUndefined();
+  });
+
+  it('binds nothing and throws nothing when there is no adapter to be had', async () => {
+    const env: any = { webgpu: {} };
+    await expect(bindCheckedWebGpuAdapter(env, 'q4f16', 'Voxtral', { requestAdapter: async () => null }))
+      .resolves.toBeUndefined();
+    expect(env.webgpu.adapter).toBeUndefined();
+
+    const env2: any = { webgpu: {} };
+    await expect(bindCheckedWebGpuAdapter(env2, 'q4f16', 'Voxtral', undefined))
+      .resolves.toBeUndefined();
+    expect(env2.webgpu.adapter).toBeUndefined();
+  });
+
+  it('binds nothing when requesting an adapter throws', async () => {
+    const env: any = { webgpu: {} };
+    await expect(bindCheckedWebGpuAdapter(env, 'q4f16', 'Voxtral', {
+      requestAdapter: async () => { throw new Error('device lost'); },
+    })).resolves.toBeUndefined();
+    expect(env.webgpu.adapter).toBeUndefined();
   });
 });

--- a/src/lib/local-inference/workers/shaderF16Gate.test.ts
+++ b/src/lib/local-inference/workers/shaderF16Gate.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { needsShaderF16, bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { needsShaderF16, bindCheckedWebGpuAdapter, acquireWebGpuAdapter } from './shaderF16Gate';
 
 const adapterWith = (...features: string[]) => ({
   requestAdapter: async () => ({ features: { has: (n: string) => features.includes(n) } }),
@@ -134,6 +134,55 @@ describe('bindCheckedWebGpuAdapter — binding the runtime to the checked adapte
     await expect(bindCheckedWebGpuAdapter(env, 'q4f16', 'Voxtral', {
       requestAdapter: async () => { throw new Error('device lost'); },
     })).resolves.toBeUndefined();
+    expect(env.webgpu.adapter).toBeUndefined();
+  });
+});
+
+describe('acquireWebGpuAdapter — one question, one answer', () => {
+  const gpuOf = (...answers: any[]) => {
+    const fn = vi.fn();
+    answers.forEach(a => (a instanceof Error ? fn.mockRejectedValueOnce(a) : fn.mockResolvedValueOnce(a)));
+    return { requestAdapter: fn };
+  };
+  const withF16 = () => ({ id: 'A', features: { has: (n: string) => n === 'shader-f16' } });
+
+  it('remembers the adapter on the runtime env', async () => {
+    const adapter = withF16();
+    const env: any = { webgpu: {} };
+    expect(await acquireWebGpuAdapter(env, gpuOf(adapter))).toBe(adapter);
+    expect(env.webgpu.adapter).toBe(adapter);
+  });
+
+  it('asks once however many times it is called', async () => {
+    const gpu = gpuOf(withF16(), withF16());
+    const env: any = { webgpu: {} };
+    const first = await acquireWebGpuAdapter(env, gpu);
+    const second = await acquireWebGpuAdapter(env, gpu);
+    expect(second).toBe(first);
+    expect(gpu.requestAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  // The regression this exists for: whisper decided `device = 'webgpu'` from
+  // its OWN adapter request, then the gate requested a second one. A second
+  // request coming back empty made the gate return silently while the model
+  // loaded on the GPU anyway, unchecked. Sharing the acquisition removes the
+  // second request, so the empty answer can no longer happen between them.
+  it('leaves no second request to fail between the availability check and the gate', async () => {
+    const gpu = gpuOf(withF16(), null);          // a second call would answer null
+    const env: any = { webgpu: {} };
+
+    const available = !!(await acquireWebGpuAdapter(env, gpu));
+    expect(available).toBe(true);
+
+    await bindCheckedWebGpuAdapter(env, 'q4f16', 'Whisper', gpu);
+    expect(gpu.requestAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports no GPU without remembering anything', async () => {
+    const env: any = { webgpu: {} };
+    expect(await acquireWebGpuAdapter(env, { requestAdapter: async () => null })).toBeNull();
+    expect(await acquireWebGpuAdapter(env, undefined)).toBeNull();
+    expect(await acquireWebGpuAdapter(env, { requestAdapter: async () => { throw new Error('lost'); } })).toBeNull();
     expect(env.webgpu.adapter).toBeUndefined();
   });
 });

--- a/src/lib/local-inference/workers/shaderF16Gate.ts
+++ b/src/lib/local-inference/workers/shaderF16Gate.ts
@@ -16,17 +16,21 @@
  * reaching this error at all proves the main thread believed `shader-f16` was
  * available, because otherwise the variant could not have been selected.
  *
- * SCOPE, precisely. This asks an adapter in the worker that is about to load
- * the model — the same global scope, moments before the load — not provably the
- * same `GPUAdapter` object the runtime ends up with. It cannot be: the
- * transformers.js workers load through the ORT that transformers.js carries
- * itself (see `_shared/onnxruntime-webgpu.ts`), which is a different instance
- * from the one this bundle imports, so there is no shared handle to read. What
- * it does buy is the failure mode that actually bites: in the mismatch case the
- * adapter the worker is handed is the one WITHOUT f16, which is precisely why
- * the load fails there, so the check fires. If the worker's adapter has f16 and
- * the runtime somehow got another, nothing is made worse — the same opaque
- * error appears as before. It fails safe in both directions.
+ * The check alone could still be unsound: asking one adapter and letting the
+ * runtime request its own leaves room for a false PASS — check adapter A, run
+ * on adapter B. So the adapter is requested once and handed to the runtime
+ * (`env.webgpu.adapter`, honoured only before the first session is created),
+ * which makes the verdict binding: if this passes, the device the runtime
+ * builds has the feature, because it is built from this adapter (#513).
+ *
+ * SCOPE, precisely. This binds the CHECK to the RUNTIME. It does not bind
+ * either to variant SELECTION, which happens on the main thread and cannot:
+ * a `GPUAdapter` is not structured-cloneable, so it cannot cross into a
+ * worker. A machine whose main thread sees f16 and whose workers do not will
+ * therefore still select an f16 variant — and this will now refuse it with a
+ * message naming the model, every time, instead of refusing it only when two
+ * unrelated adapter requests happened to agree. Making selection itself
+ * correct is the remaining half, and is not this.
  */
 
 const SHADER_F16 = 'shader-f16';
@@ -62,32 +66,45 @@ interface AdapterLike { features: { has(name: string): boolean } }
 interface GpuLike { requestAdapter(): Promise<AdapterLike | null> }
 
 /**
- * Throws when an f16 variant was requested and this worker's adapter does not
- * offer `shader-f16`. A non-f16 dtype is never blocked, and neither is a
- * context with no WebGPU at all — a model that needs a GPU fails on its own
- * terms, and this gate must not become a second, worse way to say that.
+ * The slice of an ONNX Runtime `env` this needs. Optional throughout because
+ * transformers.js types its `backends.onnx` as `Partial<Env>`, so `webgpu` can
+ * legitimately be absent.
  */
-export async function assertShaderF16Supported(
+export interface RuntimeEnvLike {
+  webgpu?: { adapter?: unknown };
+}
+
+/**
+ * Gives the runtime an adapter this function has checked, and refuses an f16
+ * variant that adapter cannot run.
+ *
+ * `runtimeEnv` must be the env of the runtime that will LOAD THE MODEL:
+ * `env.backends.onnx` for a transformers.js worker, the `env` exported by
+ * `_shared/onnxruntime-webgpu` for a worker driving ORT directly. Passing the
+ * `_shared/onnxruntime-all` env of a worker's Silero VAD would look right and
+ * bind nothing that matters — see the consistency test, which enforces this.
+ *
+ * Never throws for a missing GPU: no `navigator.gpu`, no adapter, or a
+ * `requestAdapter()` that rejects all return quietly. A model that needs a GPU
+ * fails on its own terms, and this must not become a second, worse way to say
+ * so.
+ */
+export async function bindCheckedWebGpuAdapter(
+  runtimeEnv: RuntimeEnvLike | undefined,
   dtype: unknown,
   modelLabel: string,
   gpu: GpuLike | undefined = (globalThis as any).navigator?.gpu,
 ): Promise<void> {
-  if (!needsShaderF16(dtype)) return;
-  if (!gpu) return;
-
-  let adapter: AdapterLike | null = null;
-  try {
-    adapter = await gpu.requestAdapter();
-  } catch {
-    // An adapter request that throws is not evidence about f16; let the real
-    // load report whatever is actually wrong with the GPU.
-    return;
-  }
+  const adapter = await acquireAdapter(runtimeEnv, gpu);
   if (!adapter) return;
 
-  if (!adapter.features.has(SHADER_F16)) {
+  // Bind before checking: a refusal creates no session, so an env carrying the
+  // adapter it was refused on is both harmless and easier to reason about.
+  if (runtimeEnv?.webgpu) runtimeEnv.webgpu.adapter = adapter;
+
+  if (needsShaderF16(dtype) && !adapter.features.has(SHADER_F16)) {
     // Deliberately does NOT suggest re-downloading. `downloadModel()` re-runs
-    // `selectVariant(entry, getDeviceFeatures())` against the main thread's
+    // `selectVariant(entry, getDeviceFeatures())` against the MAIN THREAD's
     // cache, which in this very scenario still reports shader-f16 — so it would
     // pick the same f16 variant again and charge the user another multi-gigabyte
     // download for no change.
@@ -97,5 +114,28 @@ export async function assertShaderF16Supported(
       + `did support it, so this device is handing different adapters to different contexts `
       + `(hybrid graphics, or a software fallback). Choose a model that does not need f16.`,
     );
+  }
+}
+
+/**
+ * The adapter the runtime will use: the one it already holds if a session has
+ * been prepared, otherwise a fresh one. Requested bare, with no
+ * `powerPreference`, because that is exactly how ORT requests it when nothing
+ * sets `env.webgpu.powerPreference` — as nothing in this repo does — so binding
+ * hands over the adapter the runtime would have chosen anyway.
+ */
+async function acquireAdapter(
+  runtimeEnv: RuntimeEnvLike | undefined,
+  gpu: GpuLike | undefined,
+): Promise<AdapterLike | null> {
+  const alreadyBound = runtimeEnv?.webgpu?.adapter as AdapterLike | undefined;
+  if (alreadyBound) return alreadyBound;
+  if (!gpu) return null;
+  try {
+    return await gpu.requestAdapter();
+  } catch {
+    // An adapter request that throws is not evidence about f16; let the real
+    // load report whatever is actually wrong with the GPU.
+    return null;
   }
 }

--- a/src/lib/local-inference/workers/shaderF16Gate.ts
+++ b/src/lib/local-inference/workers/shaderF16Gate.ts
@@ -75,6 +75,39 @@ export interface RuntimeEnvLike {
 }
 
 /**
+ * The one adapter this worker will use, remembered on the runtime env.
+ *
+ * Call this wherever a worker needs to know whether WebGPU is available at
+ * all — it answers that question (null means no) AND makes the answer the
+ * runtime's, in one request. A worker that asks `navigator.gpu` for an adapter
+ * itself and then lets the gate ask again has two answers to one question, and
+ * they can differ: the second request coming back empty made the gate return
+ * silently while the worker, having decided on WebGPU from the first, loaded
+ * the model anyway with nothing checked. Acquiring once removes that state.
+ */
+export async function acquireWebGpuAdapter(
+  runtimeEnv: RuntimeEnvLike | undefined,
+  gpu: GpuLike | undefined = (globalThis as any).navigator?.gpu,
+): Promise<AdapterLike | null> {
+  const alreadyBound = runtimeEnv?.webgpu?.adapter as AdapterLike | undefined;
+  if (alreadyBound) return alreadyBound;
+  if (!gpu) return null;
+
+  let adapter: AdapterLike | null = null;
+  try {
+    adapter = await gpu.requestAdapter();
+  } catch {
+    // An adapter request that throws is not evidence about f16; let the real
+    // load report whatever is actually wrong with the GPU.
+    return null;
+  }
+  if (!adapter) return null;
+
+  if (runtimeEnv?.webgpu) runtimeEnv.webgpu.adapter = adapter;
+  return adapter;
+}
+
+/**
  * Gives the runtime an adapter this function has checked, and refuses an f16
  * variant that adapter cannot run.
  *
@@ -95,12 +128,8 @@ export async function bindCheckedWebGpuAdapter(
   modelLabel: string,
   gpu: GpuLike | undefined = (globalThis as any).navigator?.gpu,
 ): Promise<void> {
-  const adapter = await acquireAdapter(runtimeEnv, gpu);
+  const adapter = await acquireWebGpuAdapter(runtimeEnv, gpu);
   if (!adapter) return;
-
-  // Bind before checking: a refusal creates no session, so an env carrying the
-  // adapter it was refused on is both harmless and easier to reason about.
-  if (runtimeEnv?.webgpu) runtimeEnv.webgpu.adapter = adapter;
 
   if (needsShaderF16(dtype) && !adapter.features.has(SHADER_F16)) {
     // Deliberately does NOT suggest re-downloading. `downloadModel()` re-runs
@@ -117,25 +146,3 @@ export async function bindCheckedWebGpuAdapter(
   }
 }
 
-/**
- * The adapter the runtime will use: the one it already holds if a session has
- * been prepared, otherwise a fresh one. Requested bare, with no
- * `powerPreference`, because that is exactly how ORT requests it when nothing
- * sets `env.webgpu.powerPreference` — as nothing in this repo does — so binding
- * hands over the adapter the runtime would have chosen anyway.
- */
-async function acquireAdapter(
-  runtimeEnv: RuntimeEnvLike | undefined,
-  gpu: GpuLike | undefined,
-): Promise<AdapterLike | null> {
-  const alreadyBound = runtimeEnv?.webgpu?.adapter as AdapterLike | undefined;
-  if (alreadyBound) return alreadyBound;
-  if (!gpu) return null;
-  try {
-    return await gpu.requestAdapter();
-  } catch {
-    // An adapter request that throws is not evidence about f16; let the real
-    // load report whatever is actually wrong with the GPU.
-    return null;
-  }
-}

--- a/src/lib/local-inference/workers/translategemma-translation.worker.ts
+++ b/src/lib/local-inference/workers/translategemma-translation.worker.ts
@@ -12,7 +12,7 @@
 
 import { pipeline, env } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -55,7 +55,9 @@ async function handleInit(msg: InitMessage) {
       self.postMessage({ type: 'error', error: 'WebGPU not available. TranslateGemma requires WebGPU.' });
       return;
     }
-    const adapter = await gpu.requestAdapter();
+    // One acquisition, remembered on the runtime env: the gate below reuses
+    // this adapter rather than asking for a second one that could differ.
+    const adapter = await acquireWebGpuAdapter(env.backends.onnx);
     if (!adapter) {
       self.postMessage({ type: 'error', error: 'No WebGPU adapter found. TranslateGemma requires WebGPU.' });
       return;

--- a/src/lib/local-inference/workers/translategemma-translation.worker.ts
+++ b/src/lib/local-inference/workers/translategemma-translation.worker.ts
@@ -12,7 +12,7 @@
 
 import { pipeline, env } from './_shared/transformers-all';
 import { initTransformersEnv } from './_shared/transformers-env';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── Message types ─────────────────────────────────────────────────────────
 
@@ -66,7 +66,7 @@ async function handleInit(msg: InitMessage) {
 
     self.postMessage({ type: 'status', status: 'loading', modelId: msg.hfModelId, device: 'webgpu' });
 
-    await assertShaderF16Supported(msg.dtype || 'q4', 'TranslateGemma');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, msg.dtype || 'q4', 'TranslateGemma');
 
     generator = await (pipeline as any)('text-generation', msg.hfModelId, {
       dtype: msg.dtype || 'q4',

--- a/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-3b-webgpu.worker.ts
@@ -36,7 +36,7 @@ import type {
   AsrDisposeMessage,
   StreamingAsrWorkerOutMessage,
 } from '../types';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -351,7 +351,7 @@ async function handleInit(msg: Voxtral3BAsrInitMessage): Promise<void> {
 
     // 4. Load model (WebGPU)
     post({ type: 'status', message: 'Loading Voxtral 3B model (WebGPU)...' });
-    await assertShaderF16Supported(msg.dtype, 'Voxtral 3B');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, msg.dtype, 'Voxtral 3B');
     model = await VoxtralForConditionalGeneration.from_pretrained(msg.hfModelId, {
       dtype: msg.dtype as any,
       device: 'webgpu',

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -33,7 +33,7 @@ import type {
   AsrDisposeMessage,
   StreamingAsrWorkerOutMessage,
 } from '../types';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -434,7 +434,7 @@ async function handleInit(msg: VoxtralAsrInitMessage): Promise<void> {
       ? { audio_encoder: msg.dtype, embed_tokens: msg.dtype, decoder_model_merged: msg.dtype }
       : msg.dtype;
 
-    await assertShaderF16Supported(dtype, 'Voxtral');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, dtype, 'Voxtral');
 
     voxtralModel = await VoxtralRealtimeForConditionalGeneration.from_pretrained(
       msg.hfModelId,

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -29,7 +29,7 @@ import type {
   AsrDisposeMessage,
   AsrWorkerOutMessage,
 } from '../types';
-import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
+import { acquireWebGpuAdapter, bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -249,15 +249,14 @@ async function patchWhisperConfigs(
 }
 
 /** Detect WebGPU availability in this worker context */
+/**
+ * Whether this worker can run on the GPU — and, in the same step, WHICH adapter
+ * it will run on. `acquireWebGpuAdapter` remembers it on the runtime env, so the
+ * f16 gate checks the adapter the model actually loads on instead of requesting
+ * a second one that could answer differently (#513).
+ */
 async function hasWebGPU(): Promise<boolean> {
-  try {
-    const gpu = (self as any).navigator?.gpu;
-    if (!gpu) return false;
-    const adapter = await gpu.requestAdapter();
-    return !!adapter;
-  } catch {
-    return false;
-  }
+  return !!(await acquireWebGpuAdapter(env.backends.onnx));
 }
 
 // ─── Speech Segment Processing ──────────────────────────────────────────────

--- a/src/lib/local-inference/workers/whisper-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/whisper-webgpu.worker.ts
@@ -29,7 +29,7 @@ import type {
   AsrDisposeMessage,
   AsrWorkerOutMessage,
 } from '../types';
-import { assertShaderF16Supported } from './shaderF16Gate';
+import { bindCheckedWebGpuAdapter } from './shaderF16Gate';
 
 // ─── ORT / Transformers.js env setup ─────────────────────────────────────────
 
@@ -456,7 +456,7 @@ async function handleInit(msg: WhisperAsrInitMessage): Promise<void> {
       decoder_model_merged: webgpuAvailable ? 'q4' : 'q8',
     };
 
-    await assertShaderF16Supported(dtype, 'Whisper');
+    await bindCheckedWebGpuAdapter(env.backends.onnx, dtype, 'Whisper');
 
     transcriber = (await pipeline('automatic-speech-recognition', msg.hfModelId, {
       device,


### PR DESCRIPTION
Closes #513.

## Why

#506 re-checked `shader-f16` inside the worker before loading an f16 variant, which made the failure legible. It asked its own adapter, though, and let the runtime request another — so the verdict was advisory: **check adapter A, run on adapter B**. A pass proved nothing.

## What

The adapter is requested **once** and handed to the runtime via `env.webgpu.adapter`, which ORT honours before the first session is created. A pass now binds: the device the runtime builds carries the feature, because it is built from the adapter that was checked.

Two handles, because the workers do not share one runtime:

| workers | model loads through | handle |
|---|---|---|
| the nine transformers.js workers | the ORT bundled inside `@huggingface/transformers` | `env.backends.onnx` |
| `qwen3-asr-webgpu` | `onnxruntime-web/webgpu` | the imported `env` |

**The trap this had to avoid.** Six of those transformers.js workers *also* import a raw ORT via `_shared/onnxruntime-all` — the wasm-only instance their Silero VAD runs on. Binding the adapter there would look entirely correct and configure nothing the model runs on. The consistency test now derives the expected handle from whether a worker imports `_shared/onnxruntime-webgpu`, and fails on a mismatch. Mutation-checked by pointing `cohere-transcribe` at the VAD env: *"binds ortEnv, expected env.backends.onnx"*.

Two details that keep this from changing behaviour on healthy machines:

- The adapter is requested **bare**, with no `powerPreference` — exactly how ORT requests it when nothing sets `env.webgpu.powerPreference`, and nothing in this repo does. So we hand over the adapter the runtime would have chosen anyway.
- An adapter the env **already holds** is reused, never replaced. Setting it after the first session has no effect, so the held one is what will actually run — checking a fresh one instead would reintroduce the very unsoundness this fixes.

Missing GPU stays quiet throughout: no `navigator.gpu`, no adapter, or a rejecting `requestAdapter()` all return without binding and without throwing. A model that needs a GPU fails on its own terms.

## Scope — stated plainly, because the issue overclaimed it

This binds the **check** to the **runtime**. It does *not* bind either to variant **selection**, and cannot: selection runs on the main thread, and a `GPUAdapter` is not structured-cloneable, so it never crosses into a worker.

So a machine whose main thread sees `shader-f16` and whose workers do not will **still select an f16 variant**. The difference is that it is now refused *every time*, with the model named, instead of only when two unrelated adapter requests happened to disagree. It does not make the model usable.

Making selection itself correct — the worker reporting its real feature set back so `webgpu.ts`'s cache stops lying to `selectVariant()` / `isModelReady()` — is the remaining half of #504 case 1, written up on #513. That half is also what would make "re-download the model" valid advice again; #506 removed that suggestion because it currently cannot work.

I corrected #513's title and body to match, rather than leave the wrong claim standing.

## Tests

9 added on the gate (binds the checked adapter by identity; binds even for non-f16 dtypes so the next check is sound; one request, not one per concern; reuses an already-bound adapter without requesting another; still refuses; survives an env with no `webgpu` section; binds nothing and throws nothing for null/absent/throwing adapters) plus the handle guard on the consistency test.

Full suite: **340 files / 3901 tests pass**. `npm run build` succeeds and all ten worker bundles carry the adapter assignment. The 4 unhandled rejections in `settingsStore.nativeGate.test.ts` are pre-existing.

## Not verified

No hardware here can produce two disagreeing adapters — the fleet is single-GPU (GB10, M4, RTX 4070 SUPER). The binding's *correctness* is covered by unit tests; its end-to-end benefit is only observable on a machine that exhibits the split. #513's acceptance criteria keep that open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved WebGPU initialization for local speech recognition and translation models by validating and reusing the adapter associated with the active runtime.
  - Added safer handling for unavailable GPUs, missing adapters, and adapter request failures without throwing errors.
  - Ensured models use the correct runtime adapter before loading, reducing inconsistent capability checks across supported models.

- **Tests**
  - Expanded coverage for adapter binding, reuse, failure handling, and runtime consistency across supported models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->