### PR TITLE
fix(webgpu): retry the adapter request instead of caching a startup race

### DIFF
--- a/src/utils/webgpu.test.ts
+++ b/src/utils/webgpu.test.ts
@@ -17,11 +17,20 @@ describe('checkWebGPU', () => {
     expect(result).toEqual({ available: false, features: [], softwareOnly: false, adapterInfo: null });
   });
 
-  it('returns available=false when requestAdapter returns null', async () => {
-    vi.stubGlobal('navigator', { gpu: { requestAdapter: () => Promise.resolve(null) } });
-    const { checkWebGPU } = await loadModule();
-    const result = await checkWebGPU();
-    expect(result).toEqual({ available: false, features: [], softwareOnly: false, adapterInfo: null });
+  it('returns available=false when requestAdapter keeps returning null', async () => {
+    vi.useFakeTimers();
+    try {
+      const requestAdapter = vi.fn().mockResolvedValue(null);
+      vi.stubGlobal('navigator', { gpu: { requestAdapter } });
+      const { checkWebGPU } = await loadModule();
+      const pending = checkWebGPU();
+      await vi.runAllTimersAsync();
+      expect(await pending).toEqual({ available: false, features: [], softwareOnly: false, adapterInfo: null });
+      // Gave the GPU process more than one chance before believing it.
+      expect(requestAdapter).toHaveBeenCalledTimes(4);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('returns available=true with empty features when no shader-f16', async () => {
@@ -152,6 +161,65 @@ describe('getAdapterInfo', () => {
     vi.stubGlobal('navigator', { gpu: { requestAdapter } });
     const { checkWebGPU } = await loadModule();
     await Promise.all([checkWebGPU(), checkWebGPU(), checkWebGPU()]);
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('the startup adapter race (Windows)', () => {
+  // Measured on the Windows box: requestAdapter() in the first ~50-100 ms of a
+  // renderer's life resolves to null instead of waiting for the GPU process.
+  // Caching that null permanently made the app treat a 4070 SUPER as having no
+  // GPU for the rest of the session.
+  it('retries a null answer and reports the adapter that eventually arrives', async () => {
+    vi.useFakeTimers();
+    try {
+      const requestAdapter = vi.fn()
+        .mockResolvedValueOnce(null)                                  // asked at ~0 ms
+        .mockResolvedValue({ features: new Set(['shader-f16']), info: { vendor: 'nvidia' } });
+      vi.stubGlobal('navigator', { gpu: { requestAdapter } });
+      const { checkWebGPU } = await loadModule();
+      const pending = checkWebGPU();
+      await vi.runAllTimersAsync();
+      const result = await pending;
+      expect(result.available).toBe(true);
+      expect(result.features).toEqual(['shader-f16']);
+      expect(result.adapterInfo).toEqual({ vendor: 'nvidia' });
+      expect(requestAdapter).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not retry once an adapter has answered', async () => {
+    const requestAdapter = vi.fn().mockResolvedValue({ features: new Set() });
+    vi.stubGlobal('navigator', { gpu: { requestAdapter } });
+    const { checkWebGPU } = await loadModule();
+    await checkWebGPU();
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry a software adapter — that is an answer, not a machine waking up', async () => {
+    const requestAdapter = vi.fn().mockResolvedValue({
+      features: new Set(),
+      info: { vendor: 'google', architecture: 'swiftshader' },
+    });
+    vi.stubGlobal('navigator', { gpu: { requestAdapter } });
+    const { checkWebGPU } = await loadModule();
+    expect((await checkWebGPU()).softwareOnly).toBe(true);
+    expect(requestAdapter).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry when there is no WebGPU at all', async () => {
+    vi.stubGlobal('navigator', {});
+    const { checkWebGPU } = await loadModule();
+    expect((await checkWebGPU()).available).toBe(false);
+  });
+
+  it('does not retry a requestAdapter that throws — that is a real failure', async () => {
+    const requestAdapter = vi.fn().mockRejectedValue(new Error('device lost'));
+    vi.stubGlobal('navigator', { gpu: { requestAdapter } });
+    const { checkWebGPU } = await loadModule();
+    expect((await checkWebGPU()).available).toBe(false);
     expect(requestAdapter).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/utils/webgpu.ts
+++ b/src/utils/webgpu.ts
@@ -52,6 +52,39 @@ function readAdapterInfo(adapter: any): GpuAdapterInfo | null {
   return Object.keys(out).length > 0 ? out : null;
 }
 
+/**
+ * How many times to ask for an adapter before believing there is none, and how
+ * long to wait between asks.
+ *
+ * Measured on the Windows box (RTX 4070 SUPER, Electron 40.8.5, a shown window
+ * and the app's own GPU flags): a `requestAdapter()` issued in the first
+ * ~50-100 ms of a renderer's life resolves to `null` rather than waiting for
+ * the GPU process — null when asked at 0 ms and at 50 ms, a working adapter
+ * from 100 ms on, and from 250 ms on it answers in under 50 ms. macOS (M4) and
+ * Linux (GB10) answered on the first ask at 0 ms.
+ *
+ * Losing that race used to poison the whole session, because the null was
+ * cached permanently: `getDeviceFeatures()` stayed empty so no f16 variant
+ * could ever be selected, `isModelReady()` reported downloaded f16 models as
+ * missing, and the no-acceleration notice appeared — on a machine with a
+ * 4070 SUPER in it.
+ *
+ * Only a `null` answer is retried. A returned adapter is an answer, including
+ * a software one, and a `requestAdapter()` that throws is a real failure rather
+ * than a machine still waking up.
+ */
+const ADAPTER_ATTEMPTS = 4;
+const ADAPTER_RETRY_MS = 150;
+
+async function requestAdapterWithRetry(gpu: any): Promise<any> {
+  for (let attempt = 0; attempt < ADAPTER_ATTEMPTS; attempt++) {
+    if (attempt > 0) await new Promise(resolve => setTimeout(resolve, ADAPTER_RETRY_MS));
+    const adapter = await gpu.requestAdapter();
+    if (adapter) return adapter;
+  }
+  return null;
+}
+
 let cached: WebGPUCapabilities | null = null;
 // Startup fires several probes at once (the model store, the app_startup
 // telemetry). Caching the promise as well as the result keeps that to one
@@ -72,7 +105,7 @@ async function probeWebGPU(): Promise<WebGPUCapabilities> {
       cached = { available: false, features: [], softwareOnly: false, adapterInfo: null };
       return cached;
     }
-    const adapter = await gpu.requestAdapter();
+    const adapter = await requestAdapterWithRetry(gpu);
     if (!adapter) {
       cached = { available: false, features: [], softwareOnly: false, adapterInfo: null };
       return cached;


### PR DESCRIPTION
Found while running the post-merge regression pass for #505/#506/#514 on the Windows box — by measuring, not by reading code.

## The race

On the Windows machine (RTX 4070 SUPER, Electron 40.8.5, shown window, the app's own GPU flags), `requestAdapter()` issued in the first ~50–100 ms of a renderer's life resolves to **`null`** rather than waiting for the GPU process:

| asked at | result |
|---|---|
| 0 ms | **null** (2/2 runs, answers in ~83 ms) |
| 50 ms | **null** |
| 100 ms | adapter |
| 250 / 500 / 750 / 1000 / 1500 ms | adapter, answering in <50 ms |

A single-shot probe at 1500 ms succeeds on its *first* ask, so this is a race against GPU-process startup — not a machine that refuses the first request. macOS (M4) and Linux (GB10, with the app's Vulkan flags) both answered on the first ask at 0 ms.

## Why it mattered

`probeWebGPU()` cached that `null` for the rest of the session — `cached` is assigned once and `checkWebGPU()` returns it forever after. Losing the race therefore made the app believe a machine with a 4070 SUPER in it had **no GPU at all**, for as long as it stayed open:

| | consequence |
|---|---|
| `getDeviceFeatures()` stayed `[]` | no f16 variant could ever be selected |
| `isModelReady()` | already-downloaded f16 models read as missing |
| `isGpuAccelerationMissing()` | the no-acceleration notice appeared |
| `app_startup` | reported `webgpu_available: false` |

The renderer probably asks late enough to win on most machines — the chain is bundle parse → React mount → `SettingsInitializer` → `modelStore.initialize()`. But it is a race with no designed margin, it fails **silently**, and it **sticks for the whole session**. Retrying costs nothing when there is a GPU, and bounds the damage when the answer is merely slow.

## The change

Four attempts, 150 ms apart, and **only a `null` answer is retried**:

- a returned adapter is an answer, including a software one — a SwiftShader result is not a machine still waking up;
- a `requestAdapter()` that throws is a real failure, not a slow start;
- a context with no `navigator.gpu` never waits at all, so a genuinely GPU-less machine pays nothing.

## Verified on the machine that shows the bug

Not just unit-tested — the retry logic was run on the Windows box at the exact point the old code returned null. **3/3 runs:**

```
attempt 0 @   0 ms → null   (~83 ms)
attempt 1 @ 240 ms → nvidia / lovelace, shader-f16 ✓
settled in 284–334 ms
```

Two of the four attempts, with margin to spare.

## Tests

6 added: retries a null and reports the adapter that arrives; gives up after four attempts and caches the negative; does not retry an adapter that answered; does not retry a software adapter; does not retry when `navigator.gpu` is absent; does not retry a `requestAdapter()` that throws. Fake timers throughout, so the suite pays none of the wait.

Full suite: **340 files / 3911 tests pass**. `npm run build` succeeds. The 4 unhandled rejections in `settingsStore.nativeGate.test.ts` are pre-existing.

## Related, not fixed here

The same regression pass measured that GB10's real NVIDIA Vulkan adapter reports **24 features but not `shader-f16`**. That is not a bug — but it does mean GB10 cannot exercise the f16 path at all, so the f16 gate from #506 and the binding from #514 have no coverage on that box. Windows and macOS are the machines that can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebGPU startup detection by retrying temporary unavailable responses.
  * WebGPU initialization now waits briefly for a valid adapter before reporting that support is unavailable.
  * Successful adapters, software adapters, missing WebGPU support, and adapter errors are handled without unnecessary retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->