### PR TITLE
fix(qwen3.5): make the thinking switch real, and stop paying for /no_think

### DIFF
--- a/src/lib/local-inference/workers/qwen35-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen35-translation.worker.ts
@@ -110,8 +110,12 @@ async function handleTranslate(msg: TranslateMessage) {
     const resolvedPrompt = msg.systemPrompt && msg.systemPrompt.trim()
       ? msg.systemPrompt
       : buildDefaultLocalPrompt(msg.sourceLang, msg.targetLang);
-    // Qwen3.5 supports /no_think (it's a Qwen3 family model)
-    const systemPrompt = `${resolvedPrompt} /no_think`;
+    // No `/no_think`: that is Qwen3's soft switch, trained into the model. The
+    // Qwen3.5 chat template does not contain the string at all, so appending it
+    // only spends prompt tokens — four of them, and prefill is this model's
+    // whole cost (measured: ~125-140 ms per prompt token on Vulkan/D3D12,
+    // ~29 ms on Metal), so it is not free.
+    const systemPrompt = resolvedPrompt;
 
     const userContent = msg.wrapTranscript
       ? `<transcript>${msg.text}</transcript>`
@@ -123,10 +127,17 @@ async function handleTranslate(msg: TranslateMessage) {
       { role: 'user', content: userContent },
     ];
 
-    // Apply chat template with thinking disabled
+    // `enable_thinking` must sit at the TOP LEVEL to reach the chat template.
+    // transformers.js destructures `tokenizer_kwargs` out of the options and
+    // forwards it to the tokenizer call; only the remaining `...kwargs` become
+    // Jinja variables. Nested, it was inert.
+    //
+    // Thinking is off either way for this model — the template's else branch
+    // pre-fills a closed `<think>\n\n</think>` when `enable_thinking` is
+    // undefined — but code that looks like a switch should be one.
     const text = processor.apply_chat_template(messages, {
       add_generation_prompt: true,
-      tokenizer_kwargs: { enable_thinking: false },
+      enable_thinking: false,
     });
 
     // Process text-only input (no images)

--- a/src/lib/local-inference/workers/thinkingSuppression.consistency.test.ts
+++ b/src/lib/local-inference/workers/thinkingSuppression.consistency.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * How a worker asks a chat template to disable thinking.
+ *
+ * `apply_chat_template` destructures `tokenizer_kwargs` out of its options and
+ * forwards it to the TOKENIZER; only the remaining `...kwargs` are spread into
+ * the Jinja render context. So `{ tokenizer_kwargs: { enable_thinking: false } }`
+ * never reaches the template — it is inert, and silently so: no error, no
+ * warning, and for Qwen3.5 no visible difference either, because that template
+ * already suppresses thinking when the variable is undefined.
+ *
+ * A source scan rather than a unit test, because the mistake is in the SHAPE of
+ * a call into a third-party API. There is nothing to extract and no worker
+ * harness in this repo; what can be checked is that no worker writes the
+ * ineffective form again.
+ */
+
+const WORKERS_DIR = join(__dirname);
+const QWEN35 = join(WORKERS_DIR, 'qwen35-translation.worker.ts');
+
+describe('disabling thinking reaches the chat template', () => {
+  it('never nests enable_thinking under tokenizer_kwargs', () => {
+    const source = readFileSync(QWEN35, 'utf8');
+    expect(source).not.toMatch(/tokenizer_kwargs:\s*\{[^}]*enable_thinking/);
+  });
+
+  it('passes enable_thinking at the top level of apply_chat_template', () => {
+    const source = readFileSync(QWEN35, 'utf8');
+    const call = source.match(/apply_chat_template\([\s\S]*?\n    \}\);/);
+    expect(call).not.toBeNull();
+    expect(call![0]).toMatch(/^\s*enable_thinking:\s*false,\s*$/m);
+  });
+
+  // `/no_think` is Qwen3's soft switch, trained into the model. The Qwen3.5
+  // chat template does not contain the string, so appending it only spends
+  // prompt tokens — and prefill is where this model's time goes.
+  it('does not append /no_think for Qwen3.5', () => {
+    expect(readFileSync(QWEN35, 'utf8')).not.toMatch(/`\$\{[\w.]+\} \/no_think`/);
+  });
+
+  it('still appends /no_think for the plain Qwen3 worker, which does understand it', () => {
+    const source = readFileSync(join(WORKERS_DIR, 'qwen-translation.worker.ts'), 'utf8');
+    expect(source).toMatch(/\/no_think/);
+  });
+});


### PR DESCRIPTION
Found while measuring why `qwen3.5-0.8b-translation` takes ~16 s per translation. **It is not thinking** — but both things the code does to suppress thinking were wrong, in opposite ways.

## `enable_thinking` was inert

It sat under `tokenizer_kwargs`. transformers.js destructures that key out of the options and forwards it to the **tokenizer**; only the remaining `...kwargs` are spread into the Jinja render context:

```js
let { …, tokenizer_kwargs = {}, ...kwargs } = options;
compiledTemplate.render({ messages, add_generation_prompt, …, ...kwargs });   // ← template sees only kwargs
if (tokenize) this._call(rendered, { …, ...tokenizer_kwargs });               // ← tokenizer_kwargs go here
```

So the flag never reached the template. It happened not to matter — which is why nobody noticed — because the Qwen3.5 template suppresses thinking when the variable is **undefined**:

```jinja
{%- if enable_thinking is defined and enable_thinking is true %}
    {{- '<think>\n' }}
{%- else %}
    {{- '<think>\n\n</think>\n\n' }}
{%- endif %}
```

The else branch pre-fills a closed block, so the model never thinks. Confirmed by measurement: three runs, **17 generated tokens each**, `<think>` absent from the raw output, nowhere near the 256 cap.

Code that looks like a switch should be one, so it now sits at the top level where the template can see it.

## `/no_think` does nothing *and* costs

That is Qwen3's soft switch, trained into the model. The string does not appear anywhere in the Qwen3.5 chat template — zero occurrences. It only adds four prompt tokens.

Four tokens is not free here, because **prefill is where this model's entire latency lives**. Measured per prompt token:

| machine | backend | ms per prompt token |
|---|---|---|
| GB10 | Vulkan | ~140 ms |
| RTX 4070 SUPER | D3D12 | ~125 ms |
| Apple M4 | Metal | ~29 ms |

So roughly half a second on two of the three machines, for a string the model does not read.

## What this is *not*

It is not a fix for the ~16 s. That is prefill scaling **linearly** with prompt length — 114 tokens vs 55 tokens measured at the same ms/token on every machine — which means the ~95-token system prompt is re-processed from scratch on every translation. Shortening it and caching the prefix KV are the levers, and are separate work.

For scale: 114 → 55 prompt tokens took GB10 from 16.5 s to 8.4 s and Windows from 14.2 s to 7.3 s.

## Tests

A source scan, because the defect is the **shape of a call into a third-party API**: there is nothing to extract, and this repo has no worker harness. It fails if `enable_thinking` is nested again, or if `/no_think` returns for Qwen3.5, while asserting the plain Qwen3 worker keeps it (that model does understand it). Mutation-checked — restoring the nested form turns 2 of the 4 assertions red.

Full suite: 341 files / 3910 tests pass. `npm run build` succeeds. The one tsc warning on this file (line 72, `initTransformersEnv`) is pre-existing and shared by every transformers worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Qwen3.5 translation behavior by preserving configured system prompts exactly as written.
  - Corrected translation generation settings so unnecessary internal reasoning is properly disabled, producing more consistent translation results.
  - Preserved the existing prompt handling behavior for the standard Qwen3 translation model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->