### PR TITLE
fix(export): make export reflect the Original/Translation/Both/Off to…

### DIFF
--- a/src/components/MainPanel/ExportButton.tsx
+++ b/src/components/MainPanel/ExportButton.tsx
@@ -35,7 +35,14 @@ import { ChildWindowPopover, useChildPopoverToggle } from '../Subtitle/ChildWind
 import './ExportButton.scss';
 
 interface ExportButtonProps {
-  /** Already-merged-and-sorted items from MainPanel's combinedItems memo. */
+  /**
+   * Already-merged-and-sorted conversation items to export. Callers must pass
+   * the display-mode-filtered list (MainPanel's `filteredItems` /
+   * SubtitleApp's equivalent, both built with `shouldShowItem`), not the raw
+   * combined list — the export should mirror what the speaker/participant
+   * "Original / Translation / Both / Off" toggles currently show on screen,
+   * not everything ever captured.
+   */
   combinedItems: Array<ConversationItem & {
     source?: string;
     sourceLanguage?: string;

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -4158,8 +4158,12 @@ const MainPanel: React.FC<MainPanelProps> = () => {
               {conversationCompactMode ? <ChevronsUpDown size={14} /> : <ChevronsDownUp size={14} />}
             </button>
             {/* Export */}
+            {/* filteredItems (not combinedItems): the export must reflect what the
+                speaker/participant display-mode toggles currently show — original
+                only, translation only, both, or hidden — not everything ever
+                captured. */}
             <ExportButton
-              combinedItems={combinedItems}
+              combinedItems={filteredItems}
               provider={provider}
               currentProviderSettings={currentSettings}
               localInferenceSettings={localInferenceSettings}

--- a/src/components/Subtitle/SubtitleApp.tsx
+++ b/src/components/Subtitle/SubtitleApp.tsx
@@ -7,6 +7,7 @@ import SubtitleIdle from './SubtitleIdle';
 import { deriveSubtitleIdleState } from './subtitleIdleState';
 import type { StartBlockReason, DeviceScope } from '../MainPanel/sessionStartGate';
 import { reasonToSettingsTarget } from '../MainPanel/sessionStartGate';
+import { shouldShowItem } from '../MainPanel/conversationFilter';
 import useSettingsStore, {
   useExitSubtitleMode,
   useProvider,
@@ -200,6 +201,14 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
     return all.sort((a, b) => (a.createdAt || 0) - (b.createdAt || 0));
   }, [items, participantItems, sourceLanguage, targetLanguage]);
 
+  // Export must mirror what the speaker/participant "Original / Translation /
+  // Both / Off" toggles currently show in the subtitle band, not everything
+  // ever captured — same filter SubtitleStream applies for on-screen display.
+  const exportItems = useMemo(
+    () => combinedItems.filter((item) => shouldShowItem(item, speakerMode, participantMode)),
+    [combinedItems, speakerMode, participantMode]
+  );
+
   // Session timer
   const [now, setNow] = useState(Date.now());
   useEffect(() => {
@@ -356,7 +365,7 @@ const SubtitleApp: React.FC<{ surface?: SubtitleSurfaceKind }> = ({ surface = 'e
         speakerActive={speakerActive}
         participantActive={participantActive}
         exportProps={{
-          combinedItems,
+          combinedItems: exportItems,
           provider,
           currentProviderSettings: providerSettings,
           localInferenceSettings,


### PR DESCRIPTION
This pull request improves the export functionality to ensure that only the conversation items currently visible (according to the user's display mode toggles) are exported, rather than all captured items. This makes the exported data accurately reflect what the user sees on screen.

Export functionality improvements:

* Updated the `ExportButton` component and its usage so that it receives only the filtered list of conversation items (`filteredItems` or `exportItems`), ensuring exports match the current display mode (e.g., original, translation, both, or off), not the full combined list. [[1]](diffhunk://#diff-043d718078a89d4c4bf022c3e97497e987390269da15093e42de9b15681bec1cL38-R45) [[2]](diffhunk://#diff-dc06108199335e73bca0d25e1218618a23c11ca956512a7c8ab53315e24a83a3R4161-R4166) [[3]](diffhunk://#diff-e33b793a62520ee4ddf3561c098087280ca912cf4efd041e165633ab32f3bae9L359-R368)
* Added logic in `SubtitleApp` to compute `exportItems` using the `shouldShowItem` filter, aligning exported content with the subtitle band's visible content. [[1]](diffhunk://#diff-e33b793a62520ee4ddf3561c098087280ca912cf4efd041e165633ab32f3bae9R204-R211) [[2]](diffhunk://#diff-e33b793a62520ee4ddf3561c098087280ca912cf4efd041e165633ab32f3bae9R10)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Exports now respect the active speaker and participant display filters, including Original, Translation, Both, and Off modes.
  - Subtitle exports include only conversation items currently eligible for display.
  - On-screen subtitle stream rendering remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->