### PR TITLE
perf(local-inference): prefill Qwen3.5 one token at a time

### DIFF
--- a/src/lib/local-inference/workers/_shared/transformers-all.ts
+++ b/src/lib/local-inference/workers/_shared/transformers-all.ts
@@ -39,6 +39,8 @@ import * as T from '@huggingface/transformers';
   T.VoxtralForConditionalGeneration,
   T.VoxtralProcessor,
   T.Qwen3_5ForConditionalGeneration,
+  T.Tensor,
+  T.DynamicCache,
 ];
 
 export {
@@ -53,6 +55,10 @@ export {
   VoxtralForConditionalGeneration,
   VoxtralProcessor,
   Qwen3_5ForConditionalGeneration,
+  // Both are used only by qwen35-translation.worker.ts, to drive the model's
+  // forward pass directly for chunked prefill (#306).
+  Tensor,
+  DynamicCache,
 } from '@huggingface/transformers';
 
 export type {

--- a/src/lib/local-inference/workers/qwen35-translation.worker.ts
+++ b/src/lib/local-inference/workers/qwen35-translation.worker.ts
@@ -8,7 +8,9 @@
 
 import {
   AutoProcessor,
+  DynamicCache,
   Qwen3_5ForConditionalGeneration,
+  Tensor,
   TextStreamer,
   env,
 } from './_shared/transformers-all';
@@ -96,6 +98,88 @@ async function handleInit(msg: InitMessage) {
   }
 }
 
+// ─── Chunked prefill — Qwen3.5 only (#306) ─────────────────────────────────
+
+/**
+ * Feed the prompt one token at a time instead of in a single batched pass.
+ *
+ * Qwen3.5's ONNX export unrolls its recurrent layers along the sequence
+ * dimension, so one forward over M prompt tokens costs roughly 380ms + 136ms*M
+ * on a GB10 while a forward over a single token costs 47ms. Both shipped sizes
+ * spend the same ~16s on a 110-token prompt (0.8B 16,031ms vs 2B 16,228ms, at
+ * 2.5x the parameters) — a cost flat in FLOPs but linear in sequence length is
+ * per-position scheduling, not compute. Decode is unaffected and healthy at
+ * ~29 tok/s, which is why the symptom reads as "slow model" rather than "slow
+ * prompt".
+ *
+ * Measured end to end on a 110-token prompt: 16.7s -> 3.6s on a GB10, 16.2s ->
+ * 3.6s on an RTX 4070 SUPER, 2.8s -> 2.0s on an M4. Every chunk size was
+ * verified to select the same next token before this landed.
+ *
+ * Do not copy this into another worker. Every other model in the roster has a
+ * healthy batched path and pays only the per-dispatch floor, so the same loop
+ * makes Qwen3-0.6B 3.4x, Qwen2.5-0.5B 4.8x and HunyuanMT-1.8B 12.6x SLOWER.
+ * Chunk sizes between 2 and 32 lose even here — only a single token per pass
+ * escapes the bad path. `qwen35ChunkedPrefill.consistency.test.ts` pins that.
+ */
+async function prefillOneTokenAtATime(inputIds: any): Promise<any> {
+  // generate() needs at least one unprocessed token left to take its first
+  // step, and below a couple of tokens there is nothing to win.
+  const upTo = inputIds.dims[1] - 1;
+  if (upTo < 2) return null;
+
+  const ids = inputIds.data as BigInt64Array;
+  const mask: bigint[] = [];
+  let cache: any = null;
+
+  try {
+    for (let at = 0; at < upTo; at++) {
+      mask.push(1n);
+      const outputs = await model.forward({
+        input_ids: new Tensor('int64', [ids[at]], [1, 1]),
+        attention_mask: new Tensor('int64', [...mask], [1, mask.length]),
+        // Transformers.js derives position_ids from the full attention mask,
+        // which is the wrong length once the cache already covers part of it.
+        // Qwen3.5 takes 3D mrope positions; text-only means all three rows are
+        // the same 0-indexed run (its `_get_text_only_rope_index`).
+        position_ids: new Tensor('int64', [BigInt(at), BigInt(at), BigInt(at)], [3, 1, 1]),
+        past_key_values: cache,
+      });
+
+      // `getPastKeyValues` is not exported, so rename the `present*` outputs
+      // the way it does. Qwen3.5's cache is hybrid: conv and recurrent state
+      // sit beside the attention KV, and missing either name makes the next
+      // run fail with "Missing the following inputs: past_conv.0, ...".
+      const entries: Record<string, any> = {};
+      for (const name of Object.keys(outputs)) {
+        if (!name.startsWith('present')) continue;
+        entries[name
+          .replace('present_ssm', 'past_ssm')
+          .replace('present_conv', 'past_conv')
+          .replace('present_recurrent', 'past_recurrent')
+          .replace('present', 'past_key_values')] = outputs[name];
+      }
+      // update() disposes the GPU buffers it replaces; a plain object here
+      // would leak one cache per token.
+      if (cache) cache.update(entries);
+      else cache = new DynamicCache(entries);
+    }
+
+    const covered = cache.get_seq_length();
+    if (covered !== upTo) {
+      throw new Error(`chunked prefill covered ${covered} of ${upTo} tokens`);
+    }
+    return cache;
+  } catch {
+    // A transformers.js change that breaks any of the shapes above must not
+    // break translation, only slow it: fall back to the single batched pass
+    // this worker used before #306. `inferenceTimeMs` returning to ~16s is the
+    // signal that this happened.
+    await cache?.dispose().catch(() => {});
+    return null;
+  }
+}
+
 // ─── Translate handler ─────────────────────────────────────────────────────
 
 async function handleTranslate(msg: TranslateMessage) {
@@ -142,12 +226,23 @@ async function handleTranslate(msg: TranslateMessage) {
       },
     });
 
-    await model.generate({
-      ...inputs,
-      max_new_tokens: 256,
-      do_sample: false,
-      streamer,
-    });
+    // generate() is handed the full input_ids alongside the cache; it computes
+    // positions over the whole prompt and then slices off the tokens the cache
+    // already covers, so only the final token is processed here.
+    const prefilled = await prefillOneTokenAtATime(inputs.input_ids);
+    try {
+      await model.generate({
+        ...inputs,
+        ...(prefilled ? { past_key_values: prefilled } : {}),
+        max_new_tokens: 256,
+        do_sample: false,
+        streamer,
+      });
+    } finally {
+      // A caller-supplied cache is deliberately kept alive by generate(), so
+      // releasing it is ours to do — once per utterance, not once per session.
+      await prefilled?.dispose();
+    }
 
     translatedText = translatedText.trim();
 

--- a/src/lib/local-inference/workers/qwen35ChunkedPrefill.consistency.test.ts
+++ b/src/lib/local-inference/workers/qwen35ChunkedPrefill.consistency.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Chunked prefill belongs to qwen35-translation.worker.ts and nowhere else.
+ *
+ * Qwen3.5's ONNX export unrolls its recurrent layers along the sequence
+ * dimension, so feeding its prompt one token at a time beats one batched pass
+ * by 6.3x on a GB10. Every other model in the roster has a healthy batched
+ * path and pays only the per-dispatch floor, so the same loop is a large
+ * regression there — measured on a GB10 against a 110-token prompt:
+ *
+ *   Qwen3-0.6B    3.4x slower      HunyuanMT-1.8B  12.6x slower
+ *   Qwen2.5-0.5B  4.8x slower      Qwen3.5-0.8B     5.5x FASTER
+ *
+ * The failure this guards against is someone reading the Qwen3.5 worker,
+ * seeing a 5x win, and lifting the loop into a second worker or a shared
+ * helper. See #306.
+ */
+
+// Captured at module scope: reading import.meta.url lazily from inside a
+// separately-declared function resolves to a truncated URL under this
+// Vite/Vitest version (same reason as harness-consolidation.test.ts).
+const here = import.meta.url;
+
+const WORKER_DIR = fileURLToPath(new URL('.', here));
+const OWNER = 'qwen35-translation.worker.ts';
+
+// Read the roster off disk so a worker added later is covered without anyone
+// remembering to list it here.
+const WORKERS = readdirSync(WORKER_DIR)
+  .filter((name) => name.endsWith('.worker.ts'))
+  .sort();
+
+const read = (name: string) => readFileSync(`${WORKER_DIR}${name}`, 'utf8');
+
+// The marks of driving the model's forward pass by hand and threading a cache
+// through it — what chunked prefill needs and nothing else here does.
+const PREFILL_MARKERS = ['DynamicCache', 'past_key_values', 'model.forward('];
+
+describe('chunked prefill is confined to Qwen3.5', () => {
+  it('finds the Qwen3.5 worker on disk', () => {
+    expect(WORKERS).toContain(OWNER);
+    expect(WORKERS.length).toBeGreaterThan(5);
+  });
+
+  it.each(PREFILL_MARKERS)('%s appears in the Qwen3.5 worker', (marker) => {
+    expect(read(OWNER)).toContain(marker);
+  });
+
+  it.each(WORKERS.filter((name) => name !== OWNER))(
+    '%s does not prefill in chunks',
+    (name) => {
+      const source = read(name);
+      for (const marker of PREFILL_MARKERS) {
+        expect(
+          source,
+          `${name} contains "${marker}". Chunked prefill is a 3.4-12.6x REGRESSION for ` +
+            `every model except Qwen3.5, whose ONNX export unrolls its recurrent layers ` +
+            `along the sequence dimension. See #306 before copying it here.`,
+        ).not.toContain(marker);
+      }
+    },
+  );
+
+  it('is actually wired into the translate path, not just defined', () => {
+    const source = read(OWNER);
+    expect(source).toContain('async function prefillOneTokenAtATime');
+    expect(source).toContain('await prefillOneTokenAtATime(');
+    // The cache reaches generate(), and is released afterwards: generate()
+    // deliberately keeps a caller-supplied cache alive.
+    expect(source).toContain('past_key_values: prefilled');
+    expect(source).toContain('prefilled?.dispose()');
+  });
+
+  it('feeds exactly one token per pass', () => {
+    const source = read(OWNER);
+    // Chunk sizes 2..32 were measured slower than a single batched pass even
+    // on Qwen3.5; only M=1 escapes the bad path. If this loop ever grows a
+    // chunk size, that measurement has to be redone first.
+    expect(source).toContain("new Tensor('int64', [ids[at]], [1, 1])");
+  });
+});


### PR DESCRIPTION
Refs #306.

Qwen3.5 translation spends essentially all of its wall time in prefill, and this feeds the prompt one token at a time to avoid it. On a GB10 that takes a real translation from **17.3 s to 3.3 s**; on an M4, from 3.5 s to 2.2 s.

## What is actually wrong

Qwen3.5's ONNX export unrolls its recurrent layers along the sequence dimension, so a single batched forward over M prompt tokens costs roughly `380 ms + 136 ms × M` on a GB10, while a forward over one token costs 47 ms. Feeding the prompt one token at a time and carrying the cache forward is therefore cheaper outright, even paying 113 separate dispatches.

The decisive evidence that this is per-position scheduling rather than compute: **Qwen3.5-0.8B and Qwen3.5-2B both spend ~16 s on the same 110-token prompt** (16,031 ms vs 16,228 ms) despite 2.5× the parameters, while decode *does* scale with size (34.4 → 38.5 ms/token) and is perfectly healthy at ~29 tok/s.

That healthy decode is also why #306 read the symptom as a decode collapse: dividing total time by output tokens folded a fixed 16 s prefill into a per-token rate and produced "~0.7 tok/s". Full measurements, including what this rules out (not CPU fallback, not the q4/q4f16 choice, not the VLM packaging or the text-only path), are in [this comment on #306](https://github.com/kizuna-ai-lab/sokuji/issues/306#issuecomment-5573169120).

## Why this is confined to Qwen3.5

Every other model in the roster has a healthy batched path and pays only the per-dispatch floor, so the identical loop is a large regression for them. Measured on a GB10 against the same prompt:

| chunk = 1 vs one batched pass | Qwen2.5-0.5B | Qwen3-0.6B | HunyuanMT-1.8B | Qwen3.5-0.8B |
|---|---|---|---|---|
| | 4.8× slower | 3.4× slower | 12.6× slower | **5.5× faster** |

Chunk sizes between 2 and 32 lose even on Qwen3.5 — only a single token per pass escapes the bad path. `qwen35ChunkedPrefill.consistency.test.ts` pins both facts: the loop is present and wired into the translate path in this worker, and absent from every other worker (the roster is read off disk, so a worker added later is covered without anyone remembering to list it).

## Verification

Run against the path it replaces on three machines, alternating modes twice each to rule out warm-up, comparing **the translation** and not just the clock:

| | batched | chunked | |
|---|---|---|---|
| GB10 (Vulkan, arm64, no `shader-f16`) | 17.3 s | **3.3 s** | 5.2× |
| RTX 4070 SUPER (D3D12, `shader-f16`) | 17.3 / 14.4 s | **3.57 / 3.59 s** | ~4.4× |
| Apple M4 (Metal, `shader-f16`) | 3.5 s | **2.2 s** | 1.6× |

Twelve runs across three backends produced **one byte-identical translation**, and the fallback never fired.

Chunked prefill is also far more *predictable*, which for live translation matters more than the mean: on the 4070 SUPER the batched path took 16,367 ms and 13,743 ms on its two runs (19 % apart) while the chunked path took 3,023 ms and 3,015 ms (0.3 % apart). The same pattern holds on the GB10.

The new consistency test was mutation-checked: deleting the call site, copying the loop into `hy-mt-translation.worker.ts`, and widening the chunk from 1 to 8 each fail it.

## Notes for review

- **The cache must be a `DynamicCache`, not a plain object.** Its `update()` disposes the GPU buffers it replaces; a plain record leaks one cache per prompt token.
- **Qwen3.5's cache is hybrid** — `past_conv.*` and `past_recurrent.*` sit beside the attention KV, and omitting either rename makes the next call fail with `Missing the following inputs: past_conv.0, ...`.
- **position_ids are built by hand** because transformers.js derives them from the full attention mask, which is the wrong length once the cache covers part of it.
- **`logits` is CPU-resident, so the loop leaks nothing.** transformers.js sets `preferredOutputLocation: 'gpu-buffer'` only for the `present*` cache names (`models/session.js:110-123`). Measured on a real prefill forward: `logits` comes back at `location: 'cpu'` (993 KB), and all 48 GPU-backed outputs are `present*` tensors — every one of them owned by the `DynamicCache`, which disposes each generation as `update()` replaces it.
- **Failure degrades, it does not break.** A `get_seq_length()` mismatch — the shape a future transformers.js change would disturb — falls back to the single batched pass rather than translating from a wrong state. `inferenceTimeMs` returning to ~16 s is the signal that happened.
- `Tensor` and `DynamicCache` are added to the `transformers-all` shim per the rule in its header comment (pin array *and* export block), so worker chunk dedup is preserved.

Separately worth knowing when picking defaults: HunyuanMT-1.5 1.8B answers the same prompt in ~0.5 s end to end. Neither Qwen3.5 card is `recommended`, so `pickBestModel` never selects one automatically — this change matters for users who choose it by hand or need a language pair outside HY-MT's 36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011Py3CqUzoUtMdooC7ZihmU
