### PR TITLE
ci(macos): sign from CSC_LINK again now that electron-builder ships the fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -315,18 +315,7 @@ jobs:
       # This is NOT notarization and buys nothing with Gatekeeper. Its only job is
       # to give the app a signing identity that stays the same between builds, which
       # is what Squirrel.Mac and TCC key on.
-      #
-      # The step also BUILDS the keychain electron-builder signs from, instead of
-      # letting electron-builder build one from CSC_LINK: app-builder-lib 26.x
-      # (through 26.16.0) creates that keychain with a random password and then
-      # runs `security set-key-partition-list -k <p12 password>` against it --
-      # electron-builder#10066, fixed by #10101 on master only. macOS <= 26.5
-      # tolerated the mismatch; the macos-26 runner image 20260831 (macOS 26.6.2)
-      # rejects it with "SecKeychainUnlock: The user name or passphrase you
-      # entered is not correct", which took every macos-arm64 build down on
-      # 2026-09-03 (both main pushes, #479, #480). Revert to plain CSC_LINK once
-      # electron-builder 26.x ships the #10101 backport.
-      - name: Trust the self-signed signing certificate and build the signing keychain (macOS)
+      - name: Trust the self-signed signing certificate (macOS)
         if: runner.os == 'macOS' && env.HAS_MAC_CERT == 'true'
         env:
           MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
@@ -343,33 +332,28 @@ jobs:
             -passin "pass:$MACOS_CSC_KEY_PASSWORD" -out "$RUNNER_TEMP/signing.pem"
           sudo security add-trusted-cert -d -r trustRoot -p codeSign \
             -k /Library/Keychains/System.keychain "$RUNNER_TEMP/signing.pem"
-          # Build the keychain electron-builder will sign from, the same way its
-          # own createKeychain() does -- except that set-key-partition-list gets
-          # the keychain's password, which is the whole fix. The password never
-          # leaves this step: no timeout and no lock-on-sleep are set, so nothing
-          # downstream needs to unlock it again. The keychain also joins the user
-          # search list, which is where productbuild (the pkg target) looks.
-          # Asking it for VALID identities doubles as the proof that the trust
-          # above actually took.
-          KEYCHAIN="$RUNNER_TEMP/signing.keychain"
-          KEYCHAIN_PASSWORD="$(openssl rand -hex 24)"
-          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
-          security set-keychain-settings "$KEYCHAIN"
-          security import "$RUNNER_TEMP/signing.p12" -k "$KEYCHAIN" \
-            -P "$MACOS_CSC_KEY_PASSWORD" -T /usr/bin/codesign -T /usr/bin/productbuild >/dev/null
+          # Prove the trust actually took, in the same shape electron-builder
+          # will see it: import into a scratch keychain and ask for VALID
+          # identities. Checking the default search list here would always say
+          # "0 valid identities found" -- nothing is imported into it, since
+          # electron-builder makes its own keychain from CSC_LINK at build time.
+          SCRATCH="$RUNNER_TEMP/trust-check.keychain"
+          security create-keychain -p check "$SCRATCH"
+          security unlock-keychain -p check "$SCRATCH"
+          security set-keychain-settings "$SCRATCH"
+          security import "$RUNNER_TEMP/signing.p12" -k "$SCRATCH" \
+            -P "$MACOS_CSC_KEY_PASSWORD" -T /usr/bin/codesign >/dev/null
           security set-key-partition-list -S apple-tool:,apple:,codesign: \
-            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
-          security list-keychains -d user -s "$KEYCHAIN" $(security list-keychains -d user | tr -d '"')
+            -s -k check "$SCRATCH" >/dev/null 2>&1
           echo "valid identities visible to electron-builder:"
-          security find-identity -v -p codesigning "$KEYCHAIN" | sed 's/^/  /'
-          if ! security find-identity -v -p codesigning "$KEYCHAIN" | grep -q "Sokuji Code Signing"; then
+          security find-identity -v -p codesigning "$SCRATCH" | sed 's/^/  /'
+          if ! security find-identity -v -p codesigning "$SCRATCH" | grep -q "Sokuji Code Signing"; then
             echo "FAIL: the certificate is still not a valid identity after trusting it." >&2
-            security delete-keychain "$KEYCHAIN" || true
+            security delete-keychain "$SCRATCH" || true
             exit 1
           fi
+          security delete-keychain "$SCRATCH"
           rm -f "$RUNNER_TEMP/signing.p12" "$RUNNER_TEMP/signing.pem"
-          echo "CSC_KEYCHAIN=$KEYCHAIN" >> "$GITHUB_ENV"
 
       - name: Build macOS artifacts (electron-builder)
         if: runner.os == 'macOS'
@@ -385,20 +369,16 @@ jobs:
         # still looks green. The zip is what electron-updater actually installs.
         run: |
           set -euo pipefail
-          # CSC_LINK is deliberately NOT handed to electron-builder (see the trust
-          # step above): with it unset, macPackager takes the keychain from
-          # CSC_KEYCHAIN -- exported to GITHUB_ENV by that step -- and never runs
-          # its broken createKeychain(). CSC_NAME is what tells the afterPack hook
-          # (scripts/electron-builder-fuses.js) a real identity is configured, so
-          # it leaves the bundle for electron-builder to sign instead of ad-hoc
-          # signing it; electron-builder itself resolves the identity through
-          # build.mac.identity, which names the same certificate. Nothing here is
-          # declared under `env:` because an empty-but-defined CSC_LINK is not
-          # "unset" to electron-builder (loadCscLink("") dies on every fork PR,
-          # which gets no secrets at all -- #453); the same applies to the
-          # variables below, so they stay conditional on HAS_MAC_CERT.
+          # The signing pair is exported here instead of being declared in `env:`
+          # below, because an empty-but-defined CSC_LINK is not "unset" to
+          # electron-builder: getCscLink() keeps "" on purpose ("allow to specify
+          # as empty string"), macPackager guards only `cscLink == null`, and the
+          # pkg target forces the keychain open even when the .app itself skips
+          # signing. loadCscLink("") then resolves the empty path against the
+          # project dir and the build dies with "<projectDir> not a file" -- which
+          # is every fork PR, since GitHub passes it no secrets at all (#453).
           if [ "$HAS_MAC_CERT" = 'true' ]; then
-            export CSC_NAME="Sokuji Code Signing"
+            export CSC_LINK="$MACOS_CSC_LINK" CSC_KEY_PASSWORD="$MACOS_CSC_KEY_PASSWORD"
           fi
           npx electron-builder --mac pkg zip --${{ matrix.arch }} --publish never -c.directories.output=out/make-mac
         env:
@@ -408,6 +388,8 @@ jobs:
           # macOS auto-update stays off; scripts/electron-builder-fuses.js
           # ad-hoc signs in that case.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ secrets.MACOS_CSC_LINK != '' && 'true' || 'false' }}
+          MACOS_CSC_LINK: ${{ secrets.MACOS_CSC_LINK }}
+          MACOS_CSC_KEY_PASSWORD: ${{ secrets.MACOS_CSC_KEY_PASSWORD }}
           # electron-builder refuses to sign pull-request builds unless this is
           # set, so that untrusted forks cannot get at signing credentials. That
           # protection is redundant here -- GitHub does not pass secrets to fork
@@ -497,12 +479,6 @@ jobs:
             echo "FAIL: latest-mac.yml does not reference $(basename "$ZIP")." >&2; exit 1; }
           echo "OK: manifest references the zip."
 
-
-      # The keychain holds the signing key; the runner is ephemeral, but do not
-      # leave it behind on the search list for whatever runs after us.
-      - name: Remove the signing keychain (macOS)
-        if: always() && runner.os == 'macOS' && env.CSC_KEYCHAIN != ''
-        run: security delete-keychain "$CSC_KEYCHAIN" || true
       - name: Build Chrome Extension
         if: matrix.os == 'ubuntu-latest' && matrix.arch != 'arm64'
         run: |

--- a/docs/build/macos-auto-update.md
+++ b/docs/build/macos-auto-update.md
@@ -600,18 +600,17 @@ steps replaced by a certificate you issue yourself (§2.5). Concretely:
    `sudo security add-trusted-cert -d -r trustRoot -p codeSign -k /Library/Keychains/System.keychain cert.pem`
    — because electron-builder discovers identities with `find-identity -v`,
    which does not list an untrusted certificate (verified; §2.5e(a)).
-   *Workaround in force since 2026-09-04:* the workflow does not hand
-   `CSC_LINK` to electron-builder at all. app-builder-lib 26.x (through
-   26.16.0) builds its temporary keychain with a random password and then runs
+   This needs `electron-builder` >= 26.16.1, which is why `package.json` floors
+   it there. app-builder-lib 26.15.3 through 26.16.0 built its temporary signing
+   keychain with a random password and then ran
    `security set-key-partition-list -k <p12 password>` against it
-   (electron-builder#10066; fix #10101 is on master only). macOS ≤ 26.5
-   tolerated the mismatch, the `macos-26` runner image 20260831 (macOS 26.6.2)
-   rejects it with `SecKeychainUnlock: The user name or passphrase you entered
-   is not correct`. So the trust step also imports the `.p12` into a keychain
-   it builds itself and passes to electron-builder as `CSC_KEYCHAIN`, with
-   `CSC_NAME` set so `scripts/electron-builder-fuses.js` still takes the
-   real-identity branch. Revert to plain `CSC_LINK` once electron-builder 26.x
-   ships the #10101 backport.
+   (electron-builder#10066). macOS <= 26.5 tolerated the mismatch; the `macos-26`
+   runner image 20260831 (macOS 26.6.2) rejects it with `SecKeychainUnlock: The
+   user name or passphrase you entered is not correct`, which took every
+   `macos-arm64` build down on 2026-09-03. From 2026-09-04 to 2026-09-08 the
+   workflow worked around it by building the keychain itself and passing
+   `CSC_KEYCHAIN` (#483); 26.16.1 carries the v26 backport (#10172), so the
+   workaround is gone and `CSC_LINK` is handed to electron-builder again (#484).
 3. **Signing**: replace the ad-hoc `codesign --force --deep --sign -` in
    `scripts/electron-builder-fuses.js` with electron-builder's normal
    inside-out signing. Pin the DR with `codesign -r` using a requirement dumped

--- a/package-lock.json
+++ b/package-lock.json
@@ -49,7 +49,7 @@
         "concurrently": "^8.2.2",
         "cross-env": "^7.0.3",
         "electron": "40.8.5",
-        "electron-builder": "^26.15.3",
+        "electron-builder": "^26.16.1",
         "fake-indexeddb": "^6.2.5",
         "i18next": "^25.2.1",
         "i18next-browser-languagedetector": "^8.1.0",
@@ -3398,15 +3398,18 @@
       }
     },
     "node_modules/@peculiar/asn1-schema": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.8.0.tgz",
-      "integrity": "sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==",
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@peculiar/asn1-schema/-/asn1-schema-2.9.4.tgz",
+      "integrity": "sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@peculiar/utils": "^2.0.2",
         "asn1js": "^3.0.10",
         "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@peculiar/json-schema": {
@@ -4768,9 +4771,9 @@
       }
     },
     "node_modules/app-builder-lib": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.15.3.tgz",
-      "integrity": "sha512-2VnyWkqsP5v5XbBhL3tD5Syx8iNPBYsoU7kY4S2fz7wg8Rj/nztWKCUzGKaFRTv0Xwf3/H058CR1Kvtd/3lRow==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-26.16.1.tgz",
+      "integrity": "sha512-FhaO6YOup01ZfQW0Z6gt3AyukJjv1gW4uFK47jTgwcHZKqyN/fSlK2LqPf9tAeZYLP2bRJLDzeOkRImsw2X4Pg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4782,13 +4785,13 @@
         "@electron/rebuild": "^4.0.4",
         "@electron/universal": "2.0.3",
         "@malept/flatpak-bundler": "^0.4.0",
-        "@noble/hashes": "^2.2.0",
+        "@noble/hashes": "^1.8.0",
         "@peculiar/webcrypto": "^1.7.1",
         "@types/fs-extra": "9.0.13",
         "ajv": "^8.18.0",
         "asn1js": "^3.0.10",
         "async-exit-hook": "^2.0.1",
-        "builder-util": "26.15.3",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chromium-pickle-js": "^0.2.0",
         "ci-info": "4.3.1",
@@ -4796,7 +4799,7 @@
         "dotenv": "^16.4.5",
         "dotenv-expand": "^11.0.6",
         "ejs": "^3.1.8",
-        "electron-publish": "26.15.3",
+        "electron-publish": "26.16.0",
         "fs-extra": "^10.1.0",
         "hosted-git-info": "^4.1.0",
         "isbinaryfile": "^5.0.0",
@@ -4820,8 +4823,8 @@
         "node": ">=14.0.0"
       },
       "peerDependencies": {
-        "dmg-builder": "26.15.3",
-        "electron-builder-squirrel-windows": "26.15.3"
+        "dmg-builder": "26.16.1",
+        "electron-builder-squirrel-windows": "26.16.1"
       }
     },
     "node_modules/app-builder-lib/node_modules/@electron/fuses": {
@@ -4855,10 +4858,23 @@
         "node": ">=10"
       }
     },
+    "node_modules/app-builder-lib/node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/app-builder-lib/node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
-      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4876,9 +4892,9 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4928,13 +4944,13 @@
       }
     },
     "node_modules/app-builder-lib/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -5547,9 +5563,9 @@
       "license": "MIT"
     },
     "node_modules/builder-util": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.15.3.tgz",
-      "integrity": "sha512-q2hn7Mbo2nFNkVekPiHFx6Nfo3hURmES3tfBn+k5Pqxl2RkmP3QGqZUhH/q9Pch/4G05NRhPjDlVj1O8q4Txvw==",
+      "version": "26.16.0",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-26.16.0.tgz",
+      "integrity": "sha512-RLyJhB7Si3YkzKR9ubQslWuXW3Vhs3CGe1i+SeixBZ0qTd1mk3XBmssvY22TlB6CS5blyko8Gu1JzpYk8UkYAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6336,14 +6352,14 @@
       }
     },
     "node_modules/dmg-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.15.3.tgz",
-      "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-26.16.1.tgz",
+      "integrity": "sha512-pnI/3Qb24Uk+rMTgIUrsVUKosVgwmBUdF8Zeb8TexOSbpq8MWc7v6l+n+FrEqVkjNZwzBN+XpDS9ENgZ/rkWAw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "fs-extra": "^10.1.0",
         "js-yaml": "^4.1.0"
       }
@@ -6484,18 +6500,18 @@
       }
     },
     "node_modules/electron-builder": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.15.3.tgz",
-      "integrity": "sha512-a1KM5heqS3gQCZzizXEI8RjJy3QVogULPdeSknt76uLDpBIW/HDGsMg/XgP0riP6PI9COsRvFITKKGDqA8fJxA==",
+      "version": "26.16.1",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-26.16.1.tgz",
+      "integrity": "sha512-LrLK65QX5PUYYODXqp23FKrV7CILTtVY7mrJckNknO9jLNSMiqFkKbSMiDRw4CjOADMPVDdWLxY4mezOZWswxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "app-builder-lib": "26.15.3",
-        "builder-util": "26.15.3",
+        "app-builder-lib": "26.16.1",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "ci-info": "^4.2.0",
-        "dmg-builder": "26.15.3",
+        "dmg-builder": "26.16.1",
         "fs-extra": "^10.1.0",
         "lazy-val": "^1.0.5",
         "simple-update-notifier": "2.0.0",
@@ -6769,15 +6785,15 @@
       "optional": true
     },
     "node_modules/electron-publish": {
-      "version": "26.15.3",
-      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.15.3.tgz",
-      "integrity": "sha512-g/2bn8YTavY4cuS5F+jOS7zmZbXXBV8KZ8yHKfJjFPoKtzBqrpCdNPxBd3tqdBwP7BVd0lGzf7Bk2s0KesWZ4Q==",
+      "version": "26.16.0",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-26.16.0.tgz",
+      "integrity": "sha512-Vt3KzQIiw9BImvNOYtndg9Mjki+tl4+1sQiC/+G5j8khWaENOJFWodiB+sUl6yyHwtd37avehskdtPw7f8y/+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/fs-extra": "^9.0.11",
         "aws4": "^1.13.2",
-        "builder-util": "26.15.3",
+        "builder-util": "26.16.0",
         "builder-util-runtime": "9.7.0",
         "chalk": "^4.1.2",
         "form-data": "^4.0.5",
@@ -11424,9 +11440,9 @@
       }
     },
     "node_modules/pvutils": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.1.5.tgz",
-      "integrity": "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pvutils/-/pvutils-1.2.0.tgz",
+      "integrity": "sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -171,7 +171,7 @@
     "concurrently": "^8.2.2",
     "cross-env": "^7.0.3",
     "electron": "40.8.5",
-    "electron-builder": "^26.15.3",
+    "electron-builder": "^26.16.1",
     "fake-indexeddb": "^6.2.5",
     "i18next": "^25.2.1",
     "i18next-browser-languagedetector": "^8.1.0",


### PR DESCRIPTION
Reverts the `CSC_KEYCHAIN` signing workaround from #483 now that upstream has shipped the fix. Closes #484.

## The fix is published

`electron-builder@26.16.1` / `app-builder-lib@26.16.1`, published **2026-09-07 18:26:37Z**.

Verified by unpacking the published tarball, not by reading the changelog — 26.16.0 was published *after* #10101 merged and still did not carry it (#10167). In `app-builder-lib@26.16.1`, `out/codeSign/macCodeSign.js`:

```js
164:  const password = keyPasswords[i] ?? "";
165:  exec("/usr/bin/security", ["import", paths[i], "-k", keychainFile, ..., "-P", password]);
      // `-k` expects the keychain's own unlock password (as used by create-keychain/unlock-keychain above),
      // not the imported item's password used by `security import -P`.
170:  exec("/usr/bin/security", ["set-key-partition-list", "-S", "apple-tool:,apple:", "-s", "-k", keychainPassword, keychainFile]);
```

Line 170 now passes `keychainPassword` (the temporary keychain's own unlock password). 26.16.0 passed `password` from line 164 — the per-certificate `.p12` import password — which macOS 26.6.2 rejects with `SecKeychainUnlock: The user name or passphrase you entered is not correct`.

Upstream trail: report [#10066](https://github.com/electron-userland/electron-builder/issues/10066) (deadsoftie, 2026-08-07) → fix [#10101](https://github.com/electron-userland/electron-builder/pull/10101) (merged to `master` 2026-08-27, v27 alpha only) → missing-from-26.16.0 report [#10167](https://github.com/electron-userland/electron-builder/issues/10167) (GitKraken) → v26 backport [#10172](https://github.com/electron-userland/electron-builder/pull/10172) (merged to `release/v26` 2026-09-03) → released in 26.16.1.

## What changed

**`package.json`** — `electron-builder` floored at `^26.16.1` instead of `^26.15.3`. The floor is what guarantees the fix; npm's `latest` dist-tag for this package still points at 26.15.3 (only the `v26` tag tracks 26.16.1), so the old range said nothing useful about which version you get. Not pinned exactly, because there is no livekit-style server-side cap here — the floor is the whole requirement.

**`package-lock.json`** — `electron-builder`, `app-builder-lib`, `dmg-builder` → 26.16.1; `builder-util`, `electron-publish` → 26.16.0 (26.16.1 was a patch release that did not move them); plus `@peculiar/asn1-schema`, `pvutils`, and three packages nested under `app-builder-lib` (`@noble/hashes`, `@xmldom/xmldom`, `brace-expansion`, `minimatch`). I traced every one of them: each reaches the tree only through the `electron-builder` devDependency, so nothing unrelated rode along.

**`.github/workflows/build.yml`** — restored to its exact pre-#483 shape: `CSC_LINK` / `CSC_KEY_PASSWORD` are exported to the electron-builder step again, the trust step goes back to a scratch keychain it deletes itself, and `CSC_KEYCHAIN`, `CSC_NAME` and the `always()` cleanup step are gone.

`CSC_NAME` is deliberately **not** kept. `scripts/electron-builder-fuses.js:59` keys the real-vs-adhoc branch on `Boolean(process.env.CSC_NAME || process.env.CSC_LINK)`, so `CSC_LINK` alone still selects the real-identity branch — which is how it worked for months before #483.

**`docs/build/macos-auto-update.md`** — the #483 workaround note is replaced by a short history of the bug, so the `>= 26.16.1` floor in `package.json` does not read as an arbitrary version number to whoever touches signing next.

## Verification

- `app-builder-lib@26.16.1` tarball unpacked and grepped (output above).
- Lockfile resolves `app-builder-lib` to 26.16.1, so `npm ci` in CI installs the fixed code.
- Every changed lockfile entry traced to the `electron-builder` subtree.
- `build.yml` parses as YAML; the `build` job still has its 23 steps.
- `src/utils/featureGateForwarding.consistency.test.ts` passes (4/4) — it parses `build.yml`'s `env:` blocks and is the one test that reads this file.

## What still needs a human

**Run `build (macos-arm64)` twice.** The macos-26 image rollout is gradual, so a single green run may have landed on an old (26.5.x) image and proves nothing. At least one attempt must land on macOS 26.6+ and show, in the log: the identity found, electron-builder signing with `Sokuji Code Signing`, and the DR pinned to `92E86A47…`.

One deliberate non-change worth a reviewer's eye: the restored trust step silences the partition-list command with `>/dev/null 2>&1`, which #483 had removed. `set -euo pipefail` still aborts the step on failure, so this only hides the reason, not the failure. Kept as-is to make this a clean revert; happy to drop the `2>&1` in a follow-up if you'd rather see the message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS code-signing reliability during builds.
  * Updated signing configuration to support the latest electron-builder fixes.

* **Documentation**
  * Updated macOS auto-update guidance to reflect the current signing workflow and affected versions.

* **Chores**
  * Updated the electron-builder development dependency to version 26.16.1 or later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->