### PR TITLE
fix(sidecar): suppress known no-input hallucination

### DIFF
--- a/sidecar/sokuji_sidecar/translate_backend.py
+++ b/sidecar/sokuji_sidecar/translate_backend.py
@@ -115,6 +115,9 @@ from .catalog import split_artifact
 from .planner import PlanConfig
 
 _TRANSCRIPT_TAG = re.compile(r"</?transcript>", re.IGNORECASE)
+_KNOWN_NO_INPUT_HALLUCINATIONS = frozenset({
+    "Veuillez fournir le texte anglais à traduire.",
+})
 
 # I-1: the single shared budget unload() gives EVERY outstanding translate()
 # worker, combined, to self-report done before the model is freed regardless.
@@ -132,12 +135,14 @@ def _default_prompt(src: str, tgt: str) -> str:
 
 def _clean_output(text: str) -> str:
     """Clean a model's raw translation output: drop any <think>…</think> reasoning
-    block, then strip stray <transcript>/</transcript> tags. Small Qwen models echo
-    the wrapped input's framing (e.g. trailing '</transcript>') into the output."""
+    block, strip stray <transcript>/</transcript> tags, then suppress exact known
+    no-input hallucinations. Small Qwen models echo the wrapped input's framing
+    (e.g. trailing '</transcript>') into the output."""
     if "</think>" in text:
         text = text.split("</think>", 1)[1]
     text = _TRANSCRIPT_TAG.sub("", text)
-    return text.strip()
+    text = text.strip()
+    return "" if text in _KNOWN_NO_INPUT_HALLUCINATIONS else text
 
 
 def _hunyuan_prompt(tgt: str) -> str:

--- a/sidecar/sokuji_sidecar/translate_backend.py
+++ b/sidecar/sokuji_sidecar/translate_backend.py
@@ -115,8 +115,11 @@ from .catalog import split_artifact
 from .planner import PlanConfig
 
 _TRANSCRIPT_TAG = re.compile(r"</?transcript>", re.IGNORECASE)
-_KNOWN_NO_INPUT_HALLUCINATIONS = frozenset({
+_KNOWN_NON_TRANSLATION_RESPONSES = frozenset({
     "Veuillez fournir le texte anglais à traduire.",
+    'Il n\'y a pas de phrase complète à traduire. "ished" est une forme du passé. '
+    'Sans contexte, il est impossible de fournir une traduction précise. '
+    'Veuillez fournir la phrase complète.',
 })
 
 # I-1: the single shared budget unload() gives EVERY outstanding translate()
@@ -136,13 +139,13 @@ def _default_prompt(src: str, tgt: str) -> str:
 def _clean_output(text: str) -> str:
     """Clean a model's raw translation output: drop any <think>…</think> reasoning
     block, strip stray <transcript>/</transcript> tags, then suppress exact known
-    no-input hallucinations. Small Qwen models echo the wrapped input's framing
+    non-translation responses. Small Qwen models echo the wrapped input's framing
     (e.g. trailing '</transcript>') into the output."""
     if "</think>" in text:
         text = text.split("</think>", 1)[1]
     text = _TRANSCRIPT_TAG.sub("", text)
     text = text.strip()
-    return "" if text in _KNOWN_NO_INPUT_HALLUCINATIONS else text
+    return "" if text in _KNOWN_NON_TRANSLATION_RESPONSES else text
 
 
 def _hunyuan_prompt(tgt: str) -> str:

--- a/sidecar/sokuji_sidecar/translate_backend.py
+++ b/sidecar/sokuji_sidecar/translate_backend.py
@@ -121,6 +121,9 @@ _KNOWN_NON_TRANSLATION_RESPONSES = frozenset({
     'Sans contexte, il est impossible de fournir une traduction précise. '
     'Veuillez fournir la phrase complète.',
 })
+_KNOWN_TRANSLATION_PREAMBLES = (
+    "Voici la traduction en français :",
+)
 
 # I-1: the single shared budget unload() gives EVERY outstanding translate()
 # worker, combined, to self-report done before the model is freed regardless.
@@ -138,13 +141,17 @@ def _default_prompt(src: str, tgt: str) -> str:
 
 def _clean_output(text: str) -> str:
     """Clean a model's raw translation output: drop any <think>…</think> reasoning
-    block, strip stray <transcript>/</transcript> tags, then suppress exact known
-    non-translation responses. Small Qwen models echo the wrapped input's framing
-    (e.g. trailing '</transcript>') into the output."""
+    block, strip stray <transcript>/</transcript> tags and known preambles, then
+    suppress exact known non-translation responses. Small Qwen models echo the
+    wrapped input's framing (e.g. trailing '</transcript>') into the output."""
     if "</think>" in text:
         text = text.split("</think>", 1)[1]
     text = _TRANSCRIPT_TAG.sub("", text)
     text = text.strip()
+    for preamble in _KNOWN_TRANSLATION_PREAMBLES:
+        if text.startswith(preamble):
+            text = text.removeprefix(preamble).lstrip()
+            break
     return "" if text in _KNOWN_NON_TRANSLATION_RESPONSES else text
 
 

--- a/sidecar/tests/test_translate_backend.py
+++ b/sidecar/tests/test_translate_backend.py
@@ -27,6 +27,11 @@ def test_clean_output_strips_transcript_tags():
     assert tb._clean_output("<think>x</think> Hello</transcript>") == "Hello"
 
 
+def test_clean_output_drops_known_no_input_hallucination():
+    assert tb._clean_output("Veuillez fournir le texte anglais à traduire.") == ""
+    assert tb._clean_output("  Veuillez fournir le texte anglais à traduire.\n") == ""
+
+
 class _FakeTranslator:
     def __init__(self, log):
         self.log = log

--- a/sidecar/tests/test_translate_backend.py
+++ b/sidecar/tests/test_translate_backend.py
@@ -27,9 +27,14 @@ def test_clean_output_strips_transcript_tags():
     assert tb._clean_output("<think>x</think> Hello</transcript>") == "Hello"
 
 
-def test_clean_output_drops_known_no_input_hallucination():
+def test_clean_output_drops_known_non_translation_responses():
     assert tb._clean_output("Veuillez fournir le texte anglais à traduire.") == ""
     assert tb._clean_output("  Veuillez fournir le texte anglais à traduire.\n") == ""
+    assert tb._clean_output(
+        'Il n\'y a pas de phrase complète à traduire. "ished" est une forme du passé. '
+        'Sans contexte, il est impossible de fournir une traduction précise. '
+        'Veuillez fournir la phrase complète.'
+    ) == ""
 
 
 class _FakeTranslator:

--- a/sidecar/tests/test_translate_backend.py
+++ b/sidecar/tests/test_translate_backend.py
@@ -37,6 +37,19 @@ def test_clean_output_drops_known_non_translation_responses():
     ) == ""
 
 
+def test_clean_output_strips_known_translation_preamble():
+    assert tb._clean_output(
+        "Voici la traduction en français : Et, veuillez excuser, indiquer les "
+        "différences de fréquences entre ces trois décalages."
+    ) == (
+        "Et, veuillez excuser, indiquer les différences de fréquences entre ces "
+        "trois décalages."
+    )
+    assert tb._clean_output(
+        "Le locuteur dit : Voici la traduction en français : exemple."
+    ) == "Le locuteur dit : Voici la traduction en français : exemple."
+
+
 class _FakeTranslator:
     def __init__(self, log):
         self.log = log


### PR DESCRIPTION
## Summary

- suppress two exact known non-translation responses produced by local models:
  - `Veuillez fournir le texte anglais à traduire.`
  - the incomplete-input commentary beginning `Il n'y a pas de phrase complète à traduire…`
- strip the known `Voici la traduction en français :` preamble while preserving the translation that follows
- apply the checks after existing `<think>` and `<transcript>` cleanup so wrapped or whitespace-padded output is also handled
- add focused regression coverage for all three responses

## Why

The local native translation backend already cleans model drift such as reasoning blocks and echoed transcript tags, but known no-input boilerplate and incomplete-input commentary were still returned as translation text. An exact-match denylist keeps the fix narrow and avoids dropping legitimate translations that merely contain similar wording.

## Testing

- [x] each regression test was observed failing before its corresponding fix
- [x] `PYTHONPATH=sidecar .venv-test/bin/python -m pytest sidecar/tests/test_translate_backend.py -q` — 25 passed
- [x] `PYTHONPATH=sidecar .venv-test/bin/python -m pytest sidecar/tests -q` — 780 passed, 19 skipped
- [x] `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removes a recognized French translation preamble from the beginning of translated output.
  * Continues suppressing known non-translation responses and preserving existing cleanup of transcript tags and surrounding whitespace.
  * Leaves the same phrase unchanged when it appears within the translated text rather than at the beginning.

* **Tests**
  * Added coverage for leading French preamble removal and mid-text preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->