### PR TITLE
fix(sidecar): render TranslateGemma's prompt the way its own template does

### DIFF
--- a/sidecar/sokuji_sidecar/translate_backend.py
+++ b/sidecar/sokuji_sidecar/translate_backend.py
@@ -147,20 +147,34 @@ def _hunyuan_prompt(tgt: str) -> str:
             "output the translated result without any additional explanation: ")
 
 
-# Full English language name -> BCP-47 code for TranslateGemma's chat-template
-# source_lang_code/target_lang_code fields. The engine passes full names; unknown
-# names (or values that are already codes) pass through unchanged.
-_GEMMA_LANG_CODE = {
-    "English": "en", "Chinese": "zh", "Japanese": "ja", "Korean": "ko",
-    "French": "fr", "German": "de", "Spanish": "es", "Portuguese": "pt",
-    "Italian": "it", "Russian": "ru", "Arabic": "ar", "Hindi": "hi",
-    "Dutch": "nl", "Vietnamese": "vi", "Thai": "th", "Indonesian": "id",
-    "Turkish": "tr", "Polish": "pl", "Ukrainian": "uk", "Greek": "el",
+# BCP-47 code -> English language name for TranslateGemma's prompt. Its upstream
+# chat template resolves the code this way and renders "Name (code)"; we render that
+# prompt by hand (the template crashes the legacy chat-template formatter), so the
+# table has to live here too. Names are verbatim from the template's own 581-entry
+# table, restricted to the codes the picker can send (LANGUAGE_OPTIONS in
+# src/utils/languages.ts — all 54 of them).
+#
+# The engine passes CODES, not names: localNative.sourceLanguage is 'ja'/'en' and
+# reaches the strategy untouched. The map that stood here until #525 was keyed on
+# English names, so it never hit once and every prompt read "en (en) to fr (fr)".
+_GEMMA_LANG_NAME = {
+    "af": "Afrikaans", "ar": "Arabic", "bg": "Bulgarian", "bn": "Bengali", "ca": "Catalan",
+    "cs": "Czech", "da": "Danish", "de": "German", "el": "Greek", "en": "English",
+    "es": "Spanish", "et": "Estonian", "fa": "Persian", "fi": "Finnish", "fr": "French",
+    "gu": "Gujarati", "he": "Hebrew", "hi": "Hindi", "hr": "Croatian", "hu": "Hungarian",
+    "id": "Indonesian", "is": "Icelandic", "it": "Italian", "ja": "Japanese",
+    "kn": "Kannada", "ko": "Korean", "lt": "Lithuanian", "lv": "Latvian", "ml": "Malayalam",
+    "mr": "Marathi", "mt": "Maltese", "nl": "Dutch", "no": "Norwegian", "pa": "Punjabi",
+    "pl": "Polish", "pt": "Portuguese", "ro": "Romanian", "ru": "Russian", "sk": "Slovak",
+    "sl": "Slovenian", "sr": "Serbian", "sv": "Swedish", "sw": "Swahili", "ta": "Tamil",
+    "te": "Telugu", "th": "Thai", "tl": "Tagalog", "tr": "Turkish", "uk": "Ukrainian",
+    "ur": "Urdu", "vi": "Vietnamese", "xh": "Xhosa", "zh": "Chinese", "zu": "Zulu",
 }
 
 
-def _gemma_code(name: str) -> str:
-    return _GEMMA_LANG_CODE.get(name, name)
+def _gemma_name(code: str) -> str:
+    """'en' -> 'English'. An unknown code passes through unchanged."""
+    return _GEMMA_LANG_NAME.get(code, code)
 
 
 class QwenStrategy:
@@ -190,25 +204,31 @@ class GemmaStrategy:
     max_tokens = 256
 
     def build(self, text, system_prompt, src, tgt, wrap, config):
-        return "complete", self._render_prompt(text, src, tgt, wrap), None
+        # `wrap` is deliberately NOT forwarded (#527). This strategy drops
+        # system_prompt because the upstream template refuses one — and that
+        # prompt (buildDefaultLocalPrompt) is the only text that ever told a model
+        # what <transcript> tags are. Wrapping without it leaves the model to treat
+        # them as content: on short input it translates the tag name into the
+        # target language, which _clean_output's literal regex cannot strip.
+        # Upstream never wraps either.
+        return "complete", self._render_prompt(text, src, tgt), None
 
-    def _render_prompt(self, text, src, tgt, wrap):
-        body = f"<transcript>{text}</transcript>" if wrap else text
-        s_name, s_code = src or "the source language", _gemma_code(src)
-        t_name, t_code = tgt or "the target language", _gemma_code(tgt)
-        # A falsy src/tgt has no real code — _gemma_code(name) on a falsy name
-        # just passes that same falsy value straight through the dict .get()
-        # fallback — so appending " (code)" unconditionally rendered a leaked
-        # empty parenthetical: "the source language ()". Only append it when
-        # there's both a real language name AND a real code for it.
-        s_label = f"{s_name} ({s_code})" if src and s_code else s_name
-        t_label = f"{t_name} ({t_code})" if tgt and t_code else t_name
+    def _render_prompt(self, text, src, tgt):
+        s_name = _gemma_name(src) if src else "the source language"
+        t_name = _gemma_name(tgt) if tgt else "the target language"
+        # Upstream renders "Name (code)". A falsy side has no code at all, and an
+        # unknown code resolves to itself — appending " (code)" would then either
+        # leak an empty parenthetical ("the source language ()") or repeat the code
+        # ("xx (xx)"). Append it only when a real name was actually resolved.
+        s_label = f"{s_name} ({src})" if src and s_name != src else s_name
+        t_label = f"{t_name} ({tgt})" if tgt and t_name != tgt else t_name
         return (f"<start_of_turn>user\nYou are a professional {s_label} to {t_label} "
                 f"translator. Your goal is to accurately convey the meaning and nuances of the original "
                 f"{s_name} text while adhering to {t_name} grammar, vocabulary, and cultural sensitivities.\n"
                 f"Produce only the {t_name} translation, without any additional explanations or commentary. "
                 f"Please translate the following {s_name} text into {t_name}:\n\n\n"
-                f"{body}<end_of_turn>\n<start_of_turn>model\n")
+                # Upstream renders `content["text"] | trim`.
+                f"{text.strip()}<end_of_turn>\n<start_of_turn>model\n")
 
 
 STRATEGIES = {"qwen": QwenStrategy(), "hunyuan": HunyuanStrategy(), "gemma": GemmaStrategy()}

--- a/sidecar/tests/test_translate_backend.py
+++ b/sidecar/tests/test_translate_backend.py
@@ -193,20 +193,58 @@ def test_gemma_uses_complete_with_rendered_prompt(native_env):
     gguf, log = native_env
     b = backends.make_backend("native_translate")
     b.load(gguf, "cpu", "q4_k_m", config=PlanConfig(prompt_family="gemma"))
-    b.translate("hello", "ignored-system-prompt", "English", "Japanese", False)
+    b.translate("hello", "ignored-system-prompt", "en", "ja", False)
     kind, prompt, max_tokens = log[-1]
     assert kind == "complete"
     assert "<start_of_turn>user" in prompt
-    assert "(en)" in prompt and "(ja)" in prompt
+    assert "professional English (en) to Japanese (ja) translator" in prompt
     assert max_tokens == 256
 
 
 def test_gemma_prompt_omits_empty_code_for_falsy_src():
     # Regression kept verbatim against the strategy's own prompt renderer.
-    prompt = tb.GemmaStrategy()._render_prompt("hello", "", "Japanese", False)
+    prompt = tb.GemmaStrategy()._render_prompt("hello", "", "ja")
     assert "()" not in prompt
     assert "the source language to Japanese (ja)" in prompt
     assert "(ja)" in prompt
+
+
+def test_gemma_renders_language_names_from_the_iso_codes_the_renderer_sends():
+    # The renderer sends ISO codes, not English names: localNative.sourceLanguage
+    # defaults to 'ja'/'en' and reaches the strategy untouched. The upstream template
+    # resolves code -> name and emits "Name (code)"; feeding a translation-specific
+    # model "en (en)" is a malformed prompt. Asserted on the shape the caller sends.
+    prompt = tb.GemmaStrategy()._render_prompt("hello", "en", "fr")
+    assert "professional English (en) to French (fr) translator" in prompt
+    assert "en (en)" not in prompt
+    assert "following English text into French" in prompt
+
+
+def test_gemma_renders_names_for_languages_outside_the_original_twenty():
+    # The old map held 20 entries; the picker offers 54. Swedish/Czech/Danish were
+    # among those that silently rendered as "sv (sv)".
+    for code, name in (("sv", "Swedish"), ("cs", "Czech"), ("da", "Danish")):
+        prompt = tb.GemmaStrategy()._render_prompt("hello", code, "en")
+        assert f"professional {name} ({code}) to English (en) translator" in prompt
+
+
+def test_gemma_never_wraps_input_in_transcript_tags():
+    # Gemma discards system_prompt (its upstream template raises on one), and that
+    # prompt is the only text that ever explained <transcript> tags to a model.
+    # Wrapping without it makes the model treat the tags as content and translate
+    # the tag name, which _clean_output's literal regex cannot then strip.
+    _kind, prompt, _prefill = tb.GemmaStrategy().build(
+        "hello", "ignored-system-prompt", "en", "fr", True, PlanConfig(prompt_family="gemma"))
+    assert "<transcript>" not in prompt
+    assert "</transcript>" not in prompt
+    assert prompt.endswith("hello<end_of_turn>\n<start_of_turn>model\n")
+
+
+def test_gemma_trims_the_text_like_the_upstream_template():
+    # Upstream renders `content["text"] | trim`. ASR output is not guaranteed to
+    # arrive trimmed, and untrimmed text is a materially different prompt.
+    prompt = tb.GemmaStrategy()._render_prompt("  hello  ", "en", "fr")
+    assert prompt.endswith("hello<end_of_turn>\n<start_of_turn>model\n")
 
 
 def test_streaming_on_partial_gets_cumulative_cleaned_text(native_env):

--- a/sidecar/tests/test_translate_backend.py
+++ b/sidecar/tests/test_translate_backend.py
@@ -240,6 +240,33 @@ def test_gemma_never_wraps_input_in_transcript_tags():
     assert prompt.endswith("hello<end_of_turn>\n<start_of_turn>model\n")
 
 
+def test_gemma_prompt_is_verbatim_the_upstream_template():
+    """Whole-prompt parity, not fragments.
+
+    This strategy hand-renders what TranslateGemma's own chat template emits, so a
+    reworded instruction or a moved newline is a silent divergence -- and #525/#527
+    were both exactly that. Substring assertions cannot catch it; this one can.
+
+    The fixture is the text branch of `tokenizer.chat_template` as embedded in
+    mradermacher/translategemma-4b-it-GGUF, with source_lang_code='en' and
+    target_lang_code='fr'. To re-derive it after an upstream bump: read that KV out
+    of the GGUF (sidecar/sokuji_sidecar/gguf_header.py has a KV reader), render its
+    user branch for one language pair, and paste the result here.
+    """
+    expected = (
+        "<start_of_turn>user\n"
+        "You are a professional English (en) to French (fr) translator. Your goal is to "
+        "accurately convey the meaning and nuances of the original English text while "
+        "adhering to French grammar, vocabulary, and cultural sensitivities.\n"
+        "Produce only the French translation, without any additional explanations or "
+        "commentary. Please translate the following English text into French:\n"
+        "\n\n"
+        "hello world<end_of_turn>\n"
+        "<start_of_turn>model\n"
+    )
+    assert tb.GemmaStrategy()._render_prompt("hello world", "en", "fr") == expected
+
+
 def test_gemma_trims_the_text_like_the_upstream_template():
     # Upstream renders `content["text"] | trim`. ASR output is not guaranteed to
     # arrive trimmed, and untrimmed text is a materially different prompt.


### PR DESCRIPTION
Fixes #525
Fixes #527

`GemmaStrategy` renders TranslateGemma's prompt by hand — the upstream jinja template crashes the legacy chat-template formatter — and that copy had drifted from the original in two ways, both of which reached the model on the default configuration.

## #525 — the language map never hit

`_GEMMA_LANG_CODE` was keyed on English names (`'English'`) while the engine passes ISO codes: `localNative.sourceLanguage` is `'ja'`/`'en'` and travels to the strategy untouched (`LocalNativeClient` → wire `sourceLang` → `TranslateEngine.init` → `backend.translate` → `_render_prompt`). So `.get('en')` missed every single time and the model read:

```
You are a professional en (en) to fr (fr) translator. ...
Please translate the following en text into fr:
```

Every language pair, since the strategy landed. Replaced with a code → name map covering all 54 codes the picker can send (`LANGUAGE_OPTIONS` in `src/utils/languages.ts`), names taken verbatim from the template's own 581-entry table.

**Why it stayed green:** the existing test passed full names — the one input shape where the old map did hit. Both existing tests now assert on the shape the caller actually sends.

## #527 — a wrapper the model was never told about

The strategy correctly drops `system_prompt` (the upstream template *raises* on a system role) but still wrapped the input in `<transcript>` tags — and that discarded prompt (`buildDefaultLocalPrompt`, "Translate the speech transcript inside `<transcript>` tags") is the only text that ever explained those tags to a model. Upstream never wraps. So the model treated them as content and, on short input, translated the tag name into the target language, at which point `_clean_output`'s literal `r"</?transcript>"` could no longer strip it:

```
en->ja  'uh'       -> <トランスクリプト>う</トランスクリプト>
en->de  'ublished' -> <Überschrift>veröffentlicht</Überschrift>
```

Simple mode is the default (`useTemplateMode: true` → `wrap=True`), so this shipped on the default configuration. Qwen and Hunyuan are unaffected — their system prompt explains the tags.

`build()` no longer forwards `wrap`, with a comment on why that is deliberate rather than an omission.

Also trims the text, matching the template's `| trim` — a third, smaller divergence found while checking the first two.

## Verification

- **Byte-identical to upstream.** The rendered prompt now matches what the template emits, across six language pairs, compared against the template read out of the GGUF itself (`tokenizer.chat_template` in `mradermacher/translategemma-4b-it-GGUF`) — not a third-party transcription.
- **End-to-end on the real model.** TranslateGemma 4B q4_k_m, GB10/Vulkan, greedy (determinism verified), 8 inputs × 5 target languages through the full production path `build(wrap=True)` → `complete()` → `_clean_output()`: **20/40 outputs leaked angle brackets before, 0/40 after.**
- `sidecar/tests/test_translate_backend.py`: 27 passed. The wider sidecar suite: 406 passed — the remaining failures are `huggingface_hub`/`soxr`/`websockets` missing from the bare interpreter used here, unrelated to this change.

## Tests

Four new tests, each watched failing first:

| test | covers |
|---|---|
| `..._renders_language_names_from_the_iso_codes_the_renderer_sends` | #525, on the caller's real input shape |
| `..._renders_names_for_languages_outside_the_original_twenty` | sv/cs/da — among the 34 codes the old 20-entry map never had |
| `..._never_wraps_input_in_transcript_tags` | #527, asserted on `build()`, the seam a caller reaches |
| `..._trims_the_text_like_the_upstream_template` | the `\| trim` divergence |

## Note on the fix shape

`_TRANSCRIPT_TAG` is deliberately **not** widened to also match `<transcription>`/`<転写>`/`<转录>`/`<transkript>`. Six languages produced eight spellings and the upstream table has 581 language codes; a literal denylist cannot cover content the model will translate. Fixing it at the source removes the need. (Same reasoning that made #522 the wrong shape.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Gemma translation language handling for ISO language codes.
  * Added support for identifying additional languages, including Swedish, Czech, and Danish.
  * Prevented malformed language labels from appearing in translation prompts.
  * Improved prompt formatting by trimming unnecessary whitespace and removing unwanted transcript tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->