### PR TITLE
fix(settings): stop offering TranslateGemma a custom prompt it discards

### DIFF
--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -456,6 +456,23 @@ def test_resolve_tts_card_unknown_id_returns_none():
     assert catalog.resolve_tts_card("totally-unknown-xyz") is None
 
 
+def test_only_translategemma_uses_the_gemma_prompt_family():
+    """Pins the renderer's hardcoded copy of this family.
+
+    TranslateGemma's chat template assembles the whole instruction itself and
+    raises on a system role, so GemmaStrategy discards `system_prompt` and the
+    settings UI must not offer a custom-prompt box for it (#526). The renderer
+    cannot read `prompt_family` -- it is not on the wire -- so it pins the ids in
+    TEMPLATE_OWNS_PROMPT (src/lib/local-inference/native/nativeCatalog.ts).
+
+    If this fails because a new gemma-family card was added, update that set in
+    the same change, or the new card will silently offer a prompt box that gets
+    thrown away.
+    """
+    gemma = {m.id for m in catalog.TRANSLATE_MODELS if m.prompt_family == "gemma"}
+    assert gemma == {"translategemma-4b"}
+
+
 def test_llm_translate_rows_shape():
     m = catalog.translate_model("translategemma-4b")
     assert m is not None

--- a/src/components/Settings/sections/ProviderSpecificSettings.tsx
+++ b/src/components/Settings/sections/ProviderSpecificSettings.tsx
@@ -82,8 +82,8 @@ import {
 import { sonioxKeyField, sonioxVoiceField } from '../../../services/providers/SonioxProviderConfig';
 import { ManagedVoicesClient } from '../../../services/clients/ManagedVoicesClient';
 import { TtsSpeedControl, SpeechModeControl, VadControl, TranslationPromptControl, type SpeechMode } from './LocalSettingsControls';  // TranslationPromptControl shared by both local providers
-import { hasNativeTts } from '../../../lib/local-inference/native/nativeCatalog';
-import { useNativeCatalog } from '../../../stores/nativeModelStore';
+import { hasNativeTts, supportsCustomPrompt } from '../../../lib/local-inference/native/nativeCatalog';
+import { useNativeCatalog, useNativeModelStore } from '../../../stores/nativeModelStore';
 import { useAnalytics } from '../../../lib/analytics';
 import { useAuth } from '../../../lib/auth/hooks';
 
@@ -309,6 +309,22 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
     modelStatuses,
   ]);
   const selectedAsr = speakerResolved.asr?.modelId ?? '';
+
+  // LOCAL_NATIVE's resolved direction. The custom-prompt control needs to know
+  // which translation model would actually run, because not all of them accept
+  // one (#526) — the twin of speakerResolved above, which serves LOCAL_INFERENCE.
+  // Hoisted here because hooks must run unconditionally, even though only the
+  // LOCAL_NATIVE branch reads it.
+  const nativeResolved = useMemo(() => useNativeModelStore.getState().resolve(
+    localNativeSettings.sourceLanguage,
+    localNativeSettings.targetLanguage,
+    localNativeSettings.selections,
+  ), [
+    localNativeSettings.sourceLanguage,
+    localNativeSettings.targetLanguage,
+    localNativeSettings.selections,
+    nativeCatalog,
+  ]);
 
   // LOCAL_INFERENCE's EngineAdapter — hoisted above the return (hooks must
   // run unconditionally) even though it's only rendered in the
@@ -2153,9 +2169,11 @@ const ProviderSpecificSettings: React.FC<ProviderSpecificSettingsProps> = ({
     // The speed slider is meaningful only when the target language has a native
     // voice (text-only is the common textOnly toggle, not a per-stage Off option).
     const ttsActive = hasNativeTts(localNativeSettings.targetLanguage, nativeCatalog);
-    // Every native translation model is an LLM (Qwen / TranslateGemma / Hunyuan-MT),
-    // so all of them honour the custom prompt.
-    const promptSupported = true;
+    // Not every native translation model accepts a custom prompt: TranslateGemma's
+    // own chat template assembles the whole instruction and refuses a system role,
+    // so the sidecar discards one. Offering the box and dropping what the user
+    // types is worse than not offering it (#526).
+    const promptSupported = supportsCustomPrompt(nativeResolved.translation?.modelId ?? '');
 
     return (
       <>

--- a/src/lib/local-inference/native/nativeCatalog.test.ts
+++ b/src/lib/local-inference/native/nativeCatalog.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { voiceCapability, requiresVoiceClip, resolveNativeTts, resolveNativeTranslation, requiredNativeModels, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps, estimateNativeMemoryByDevice, formatMemMb, actualNativeMemoryByDevice, resolvedTierState, statusReposFor, pinsFromSelections, defaultTtsVoice, curatedBuiltinVoices, infoToCard, frameworkLabel, accelApiLabel, buildBackendTooltipRows } from './nativeCatalog';
+import { voiceCapability, requiresVoiceClip, resolveNativeTts, resolveNativeTranslation, requiredNativeModels, nativeAsrCards, nativeTranslationCards, nativeTtsCards, supportsLanguage, compatibleNativeAsr, incompatibleNativeAsr, nativeAsrIncompatibleCards, nativeAsrForLanguage, tierLabel, hardwareGated, gpuTierAvailable, formatRtf, formatTps, estimateNativeMemoryByDevice, formatMemMb, actualNativeMemoryByDevice, resolvedTierState, statusReposFor, pinsFromSelections, defaultTtsVoice, curatedBuiltinVoices, infoToCard, frameworkLabel, accelApiLabel, buildBackendTooltipRows, supportsCustomPrompt } from './nativeCatalog';
 import type { NativeModelInfo, NativeVoiceInfo } from './nativeProtocol';
 
 const V = (name: string, language: string | undefined, curated: boolean, def = false): NativeVoiceInfo =>
@@ -566,5 +566,33 @@ describe('buildBackendTooltipRows', () => {
     expect(nativeTts.find((r) => r.key === 'repo')?.value).toBe('org/model');
     const onnx = buildBackendTooltipRows({ tier: 'cpu', backendId: 'moss_onnx', resolved: null, repo: 'org/onnx-assets' });
     expect(onnx.find((r) => r.key === 'repo')?.value).toBe('org/onnx-assets');
+  });
+});
+
+describe('supportsCustomPrompt', () => {
+  // #526: the UI offered an Advanced custom-prompt box for TranslateGemma and
+  // silently discarded what the user typed. Its upstream chat template raises on
+  // a system role and assembles the whole instruction from the language codes,
+  // so there is nowhere for user wording to go — GemmaStrategy is right to drop
+  // it, the UI was wrong to ask for it.
+  it('refuses TranslateGemma, whose own template assembles the whole prompt', () => {
+    expect(supportsCustomPrompt('translategemma-4b')).toBe(false);
+  });
+
+  it('allows the Qwen and Hunyuan families, which do honour a system prompt', () => {
+    expect(supportsCustomPrompt('qwen2.5-0.5b')).toBe(true);
+    expect(supportsCustomPrompt('qwen3-0.6b')).toBe(true);
+    expect(supportsCustomPrompt('qwen3.5-4b')).toBe(true);
+    expect(supportsCustomPrompt('hy-mt2-1.8b')).toBe(true);
+    expect(supportsCustomPrompt('hy-mt15-7b')).toBe(true);
+    expect(supportsCustomPrompt('eurollm-1.7b')).toBe(true);
+  });
+
+  it('allows an unresolved id rather than showing "unsupported" by default', () => {
+    // Before a direction resolves, the id is ''. Defaulting to false there would
+    // flash "this model does not support custom prompts" at a user who has not
+    // picked anything yet.
+    expect(supportsCustomPrompt('')).toBe(true);
+    expect(supportsCustomPrompt('some-future-model')).toBe(true);
   });
 });

--- a/src/lib/local-inference/native/nativeCatalog.ts
+++ b/src/lib/local-inference/native/nativeCatalog.ts
@@ -190,6 +190,32 @@ export function resolveNativeTranslation(choice: string): string | undefined {
 }
 
 /**
+ * Translation models whose prompt is assembled entirely by the model's own chat
+ * template, leaving nowhere for a user-supplied system prompt to go.
+ *
+ * TranslateGemma's upstream template raises on a system role and builds the whole
+ * instruction from the source/target language codes, so the sidecar's
+ * GemmaStrategy is right to discard `system_prompt` — the UI was wrong to ask for
+ * one and then drop it silently (#526).
+ *
+ * Pinned by id because the renderer cannot see the sidecar's `prompt_family`:
+ * that field is not on the wire. `sidecar/tests/test_catalog.py::
+ * test_only_translategemma_uses_the_gemma_prompt_family` fails if a second gemma
+ * card is added without updating this set.
+ */
+const TEMPLATE_OWNS_PROMPT: ReadonlySet<string> = new Set(['translategemma-4b']);
+
+/**
+ * Whether a translation model honours a user-supplied system prompt.
+ *
+ * An unknown or still-unresolved id answers true: the control's resting state is
+ * "available", not a claim that a model the user has not picked yet refuses it.
+ */
+export function supportsCustomPrompt(translationModelId: string): boolean {
+  return !TEMPLATE_OWNS_PROMPT.has(translationModelId);
+}
+
+/**
  * The native model ids a given config requires (for download/readiness). Always
  * an ASR model + a translation model, plus a TTS model when speech output is on.
  * No substitution: '' now means "resolution found nothing", and the Start gate


### PR DESCRIPTION
Fixes #526

Local Native showed the Advanced custom-prompt box for **TranslateGemma**, previewed what the user typed, saved it — and the sidecar threw it away.

The control was hardcoded open:

```tsx
// Every native translation model is an LLM (Qwen / TranslateGemma / Hunyuan-MT),
// so all of them honour the custom prompt.
const promptSupported = true;
```

The comment names the one model that doesn't. TranslateGemma's upstream chat template *raises* on a system role:

```jinja
{%- if (messages[0]['role'] != 'user') -%}
    {{ raise_exception("Conversations must start with a user prompt.") }}
```

and the user turn isn't free text either — `content` must be exactly one `mapping(type, source_lang_code, target_lang_code, text, image)`, with the whole instruction assembled by the template from those codes. There is nowhere for user wording to go. So `GemmaStrategy` dropping `system_prompt` is correct; the existing sidecar test has named that argument `"ignored-system-prompt"` all along. Only the UI was wrong.

Of the 11 native translation models this affects `translategemma-4b` alone — Qwen and Hunyuan both use `system_prompt or <default>`.

## The fix

A pure predicate in `nativeCatalog.ts`, wired into the settings panel:

```ts
const promptSupported = supportsCustomPrompt(nativeResolved.translation?.modelId ?? '');
```

`nativeResolved` is the twin of the existing `speakerResolved`, which already does this for LOCAL_INFERENCE.

Nothing else was needed on the UI side: the unsupported state already exists, is already translated in every locale, and the **WebGPU path has always gated this correctly** (`isQwenFamily`). Only the native path didn't.

An unresolved id (`''`, before a direction resolves) answers **supported**, so the control's resting state is not a claim about a model nobody has picked yet.

## Why pinned by id rather than a wire field

The renderer cannot see the sidecar's `prompt_family` — it isn't on the wire. Putting it there is the cleaner shape, but it would only reach users after a sidecar release, and today the family has exactly one card.

So `TEMPLATE_OWNS_PROMPT` pins the ids, and a new catalog test refuses to let that drift:

```python
gemma = {m.id for m in catalog.TRANSLATE_MODELS if m.prompt_family == "gemma"}
assert gemma == {"translategemma-4b"}
```

**Verified by mutation, not assumed** — temporarily marking `qwen2.5-0.5b` as gemma family turns it red. Its docstring points at the renderer constant, so whoever adds the second gemma card is told to update both.

## Verification

- CI's exact test scope: **647 passed / 1 skipped**
- `src/components/Settings/`: **476 passed** (see the note below)
- `sidecar/tests/test_catalog.py`: **65 passed / 5 skipped**
- No new tsc errors in either changed source file

## Three notes

**CI doesn't cover the wiring.** `test (diagnostics)` runs `src/lib/diagnostics`, `src/lib/local-inference` and a few others — **not `src/components/Settings`**. The predicate and the sidecar pin are covered; the one-line call site rests on tsc plus a local run.

**The copy is imprecise and I left it.** The existing string says "Switch to a **Qwen-family** model to enable", but on the native side Hunyuan and EuroLLM honour a custom prompt too. Fixing it means touching 29 locale files; that didn't belong in this change.

**One paragraph of #526 is now stale.** It claimed writing a custom prompt was *worse* than a no-op because it flipped `wrapTranscript` as a side effect. #527 (merged) made `GemmaStrategy` ignore `wrap` entirely, so that side effect is gone — #526 is now purely the UI-misleads-the-user half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom prompt settings for local translation models are now shown only when the selected model supports them.
  - TranslateGemma models no longer display the custom prompt option, while supported models continue to provide it.
  - Unrecognized or unresolved model IDs retain access to the custom prompt option for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->