### PR TITLE
fix: three unbounded retentions in the renderer (#531)

### DIFF
--- a/src/components/LogsPanel/LogsPanel.test.tsx
+++ b/src/components/LogsPanel/LogsPanel.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, fireEvent, act } from '@testing-library/react';
 import LogsPanel from './LogsPanel';
-import useLogStore from '../../stores/logStore';
+import useLogStore, { MAX_EVENTS_PER_GROUP } from '../../stores/logStore';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -120,6 +120,25 @@ describe('LogsPanel', () => {
       const { container } = render(<LogsPanel toggleLogs={() => {}} />);
       expect(container.querySelector('.event-entry.error')).toBeNull();
       expect(container.querySelector('.event-entry.warning')).toBeNull();
+    });
+  });
+
+  describe('grouped rows', () => {
+    // A silent session's mic appends all land in one row. The store keeps only
+    // the newest MAX_EVENTS_PER_GROUP of them (#531), so the row's count has to
+    // come from groupCount, not from how many events it still holds.
+    it('shows the true event count once a group passes the cap', () => {
+      const total = MAX_EVENTS_PER_GROUP + 5;
+      write(() => {
+        for (let i = 0; i < total; i++) {
+          useLogStore.getState().addRealtimeEvent(
+            { type: 'input_audio_buffer.append', audio: `chunk-${i}` } as never,
+            'client', 'input_audio_buffer.append', 'speaker'
+          );
+        }
+      });
+      const { container } = render(<LogsPanel toggleLogs={() => {}} />);
+      expect(container.querySelector('.event-count')?.textContent).toBe(`(${total})`);
     });
   });
 

--- a/src/components/LogsPanel/LogsPanel.test.tsx
+++ b/src/components/LogsPanel/LogsPanel.test.tsx
@@ -140,6 +140,35 @@ describe('LogsPanel', () => {
       const { container } = render(<LogsPanel toggleLogs={() => {}} />);
       expect(container.querySelector('.event-count')?.textContent).toBe(`(${total})`);
     });
+
+    // An expanded row caches its events as JSON. Once the group is capped,
+    // every new event drops the oldest one, so the cache has to follow the
+    // events; otherwise the numbering (from groupCount) and the content (from
+    // the cache) drift apart.
+    it('keeps an expanded capped group in step with its events', async () => {
+      const total = MAX_EVENTS_PER_GROUP + 5;
+      const append = (i: number) =>
+        useLogStore.getState().addRealtimeEvent(
+          { type: 'input_audio_buffer.append', audio: `chunk-${i}` } as never,
+          'client', 'input_audio_buffer.append', 'speaker'
+        );
+      // The row builds its JSON on a zero-delay timer.
+      const settle = () => act(async () => { await new Promise(r => setTimeout(r, 10)); });
+
+      write(() => { for (let i = 0; i < total; i++) append(i); });
+      const { container } = render(<LogsPanel toggleLogs={() => {}} />);
+      fireEvent.click(container.querySelector('.event-header')!);
+      await settle();
+      expect(container.querySelectorAll('.grouped-event pre')).toHaveLength(MAX_EVENTS_PER_GROUP);
+
+      write(() => append(total));
+      await settle();
+
+      const rows = container.querySelectorAll('.grouped-event');
+      const last = rows[rows.length - 1];
+      expect(last.querySelector('.grouped-event-index')?.textContent).toContain(`${total + 1}`);
+      expect(last.querySelector('pre')?.textContent).toContain(`chunk-${total}`);
+    });
   });
 
   describe('row identity', () => {

--- a/src/components/LogsPanel/LogsPanel.tsx
+++ b/src/components/LogsPanel/LogsPanel.tsx
@@ -30,6 +30,13 @@ const Event: React.FC<{ logEntry: LogEntry }> = memo(({ logEntry }) => {
   // Get the latest event for display in collapsed view
   const latestEvent = events[events.length - 1];
   
+  // The cached JSON describes the events it was built from. A capped group
+  // swaps its oldest event for every new one, so drop the cache whenever the
+  // events change and let the effect below rebuild it while expanded.
+  useEffect(() => {
+    setJsonString(null);
+  }, [events]);
+
   // Lazy load JSON string only when expanded
   useEffect(() => {
     if (isExpanded && !jsonString) {

--- a/src/components/LogsPanel/LogsPanel.tsx
+++ b/src/components/LogsPanel/LogsPanel.tsx
@@ -23,6 +23,9 @@ const Event: React.FC<{ logEntry: LogEntry }> = memo(({ logEntry }) => {
   const isClient = source === 'client';
   const eventTypeDisplay = eventType || t('logsPanel.unknown');
   const hasMultipleEvents = events.length > 1;
+  // A grouped row keeps only its newest events (logStore's MAX_EVENTS_PER_GROUP);
+  // groupCount is how many it has seen.
+  const total = logEntry.groupCount ?? events.length;
   
   // Get the latest event for display in collapsed view
   const latestEvent = events[events.length - 1];
@@ -62,7 +65,7 @@ const Event: React.FC<{ logEntry: LogEntry }> = memo(({ logEntry }) => {
           <span className="source-label">{isClient ? t('logsPanel.client') : t('logsPanel.server')}:</span>
           <span className="event-type">{eventTypeDisplay}</span>
           {hasMultipleEvents && (
-            <span className="event-count">({events.length})</span>
+            <span className="event-count">({total})</span>
           )}
         </div>
       </div>
@@ -74,7 +77,7 @@ const Event: React.FC<{ logEntry: LogEntry }> = memo(({ logEntry }) => {
                 jsonString.split('\n---\n').map((eventStr, index) => (
                   <div key={index} className="grouped-event">
                     <div className="grouped-event-header">
-                      <span className="grouped-event-index">{t('logsPanel.event')} {index + 1} {t('logsPanel.of')} {events.length}</span>
+                      <span className="grouped-event-index">{t('logsPanel.event')} {index + 1 + total - events.length} {t('logsPanel.of')} {total}</span>
                     </div>
                     <pre>{eventStr}</pre>
                   </div>
@@ -101,7 +104,9 @@ const Event: React.FC<{ logEntry: LogEntry }> = memo(({ logEntry }) => {
     prevProps.logEntry.timestamp === nextProps.logEntry.timestamp &&
     prevProps.logEntry.eventType === nextProps.logEntry.eventType &&
     prevProps.logEntry.source === nextProps.logEntry.source &&
-    prevProps.logEntry.events?.length === nextProps.logEntry.events?.length
+    prevProps.logEntry.events?.length === nextProps.logEntry.events?.length &&
+    // Capped groups stop growing `events`; the count still moves.
+    prevProps.logEntry.groupCount === nextProps.logEntry.groupCount
   );
 });
 

--- a/src/lib/modern-audio/ModernAudioRecorder.test.ts
+++ b/src/lib/modern-audio/ModernAudioRecorder.test.ts
@@ -78,3 +78,55 @@ describe('ModernAudioRecorder.begin — a capture that fails is an error, not `f
     await expect(rec.begin('mic-1')).rejects.toThrow(/microphone access is blocked/i);
   });
 });
+
+// The MediaRecorder runs for the whole session and hands us one encoded chunk
+// every 100ms, but nothing in the app ever reads them: all five
+// `recorder.end()` call sites discard the return value, and save() was only
+// ever reached from end() itself. The chunks were pushed onto an array that
+// lived as long as the session, so a heap snapshot of a 40-minute session
+// showed 19,937 Blob objects still alive -- ~86MB of native memory, which
+// survived the end of the session too, since only the next record() cleared
+// the array. Issue #531.
+describe('ModernAudioRecorder — the MediaRecorder output is not retained (#531)', () => {
+  const fakeMediaRecorder = () => ({
+    state: 'recording',
+    ondataavailable: null as ((event: { data: unknown }) => void) | null,
+    onstart: null as (() => void) | null,
+    onstop: null as (() => void) | null,
+    onerror: null as ((event: unknown) => void) | null,
+  });
+
+  const armed = () => {
+    const rec = new ModernAudioRecorder() as any;
+    rec.mediaRecorder = fakeMediaRecorder();
+    rec.setupMediaRecorderEvents();
+    return rec;
+  };
+
+  it('holds on to none of the chunks it is handed', () => {
+    const rec = armed();
+
+    const delivered: unknown[] = [];
+    for (let i = 0; i < 600; i++) {  // 600 chunks == one minute at a 100ms timeslice
+      const data = { size: 1600, seq: i };
+      delivered.push(data);
+      rec.mediaRecorder.ondataavailable({ data });
+    }
+
+    // Deliberately not "audioChunks is empty": the property that matters is
+    // that no field of the recorder still points at a delivered chunk.
+    const retaining = Object.entries(rec)
+      .filter(([, value]) => Array.isArray(value) && value.some((x) => delivered.includes(x)))
+      .map(([name]) => name);
+    expect(retaining).toEqual([]);
+  });
+
+  it('still wires the lifecycle handlers', () => {
+    const rec = armed();
+
+    expect(typeof rec.mediaRecorder.ondataavailable).toBe('function');
+    expect(typeof rec.mediaRecorder.onstart).toBe('function');
+    expect(typeof rec.mediaRecorder.onstop).toBe('function');
+    expect(typeof rec.mediaRecorder.onerror).toBe('function');
+  });
+});

--- a/src/lib/modern-audio/ModernAudioRecorder.ts
+++ b/src/lib/modern-audio/ModernAudioRecorder.ts
@@ -39,9 +39,16 @@ interface AudioDataWithMeta {
  * - Performance mode configuration
  */
 export class ModernAudioRecorder extends BaseAudioRecorder {
-  // MediaRecorder
+  /**
+   * Kept for its lifecycle state, not for its output.
+   *
+   * Every method here gates on it ("Session ended: please call .begin() first")
+   * and pause() drives it, but the encoded chunks it produces have no consumer:
+   * all five `recorder.end()` call sites in ModernBrowserAudioService discard
+   * the returned blob. They used to be accumulated for the whole session -- see
+   * setupMediaRecorderEvents, and #531.
+   */
   private mediaRecorder: MediaRecorder | null = null;
-  private audioChunks: Blob[] = [];
 
   // Frequency analysis
   private analyser: AnalyserNode | null = null;
@@ -390,8 +397,6 @@ export class ModernAudioRecorder extends BaseAudioRecorder {
         passthroughVolume: this._passthroughVolume
       });
     };
-    this.audioChunks = [];
-
     console.info(`${this.getLogPrefix()} Recording started`);
 
     if (this._isFirstRecording && this.useAudioWorklet) {
@@ -450,15 +455,6 @@ export class ModernAudioRecorder extends BaseAudioRecorder {
       await this.pause();
     }
 
-    let savedAudio: { blob: Blob; url: string } | null = null;
-    try {
-      if (this.audioChunks.length > 0) {
-        savedAudio = await this.save(true);
-      }
-    } catch {
-      savedAudio = { blob: new Blob([], { type: 'audio/webm' }), url: '' };
-    }
-
     // Cleanup RNNoise node
     if (this.rnnoiseNode) {
       this.rnnoiseNode.disconnect();
@@ -481,7 +477,9 @@ export class ModernAudioRecorder extends BaseAudioRecorder {
 
     this.mediaRecorder = null;
 
-    return savedAudio || { blob: new Blob([], { type: 'audio/webm' }), url: '' };
+    // Always empty: nothing accumulates the session's audio any more, and no
+    // caller reads this. The shape is kept so the five call sites don't churn.
+    return { blob: new Blob([], { type: 'audio/webm' }), url: '' };
   }
 
   /**
@@ -501,43 +499,22 @@ export class ModernAudioRecorder extends BaseAudioRecorder {
   private setupMediaRecorderEvents(): void {
     if (!this.mediaRecorder) return;
 
-    this.mediaRecorder.ondataavailable = (event) => {
-      if (event.data.size > 0) {
-        this.audioChunks.push(event.data);
-      }
-    };
+    // Handled and dropped. This used to push every chunk onto a session-long
+    // array, which nothing ever read: a 40-minute session left 19,937 Blob
+    // objects alive (~86MB, in native memory rather than the JS heap, which is
+    // why it showed up as renderer private bytes and not as heap growth), and
+    // they outlived the session because only the next record() cleared the
+    // array. The handler stays so the chunk is released here, explicitly,
+    // rather than looking like an oversight. See #531.
+    this.mediaRecorder.ondataavailable = () => {};
     this.mediaRecorder.onstart = () => console.debug(`${this.getLogPrefix()} MediaRecorder started`);
     this.mediaRecorder.onstop = () => console.debug(`${this.getLogPrefix()} MediaRecorder stopped`);
     this.mediaRecorder.onerror = (event) => console.error(`${this.getLogPrefix()} MediaRecorder error:`, event);
   }
 
-  async clear(): Promise<boolean> {
-    if (!this.mediaRecorder) {
-      throw new Error('Session ended: please call .begin() first');
-    }
-    this.audioChunks = [];
-    return true;
-  }
-
   async read(): Promise<{ meanValues: Float32Array; channels: Float32Array[] }> {
     console.warn(`${this.getLogPrefix()} Read operation not supported`);
     return { meanValues: new Float32Array(0), channels: [] };
-  }
-
-  async save(force = false): Promise<{ blob: Blob; url: string }> {
-    if (!this.mediaRecorder) {
-      throw new Error('Session ended: please call .begin() first');
-    }
-    if (!force && this.recording) {
-      throw new Error('Currently recording: please call .pause() first');
-    }
-    if (this.audioChunks.length === 0) {
-      throw new Error('No audio data to save');
-    }
-
-    const mimeType = this.getSupportedMimeType();
-    const blob = new Blob(this.audioChunks, { type: mimeType });
-    return { blob, url: URL.createObjectURL(blob) };
   }
 
   // ==================== Frequency Analysis (Unique) ====================

--- a/src/services/clients/OpenAIClient.test.ts
+++ b/src/services/clients/OpenAIClient.test.ts
@@ -26,11 +26,28 @@ vi.mock('openai-realtime-api', () => {
       merged.set(chunk, this.inputAudioBuffer.length);
       this.inputAudioBuffer = merged;
     });
-    handlers: Record<string, (payload: any) => void> = {};
+    // Mirrors the SDK's RealtimeEventHandler contract: an array of handlers per
+    // event, `on` appends, `off(event, cb)` removes only that callback.
+    // OpenAIClient registers two 'realtime.event' handlers - the forwarder and
+    // waitForSessionWithErrorHandling's temporary errorHandler - so a single
+    // slot would silently drop one. (The SDK throws when `cb` is missing; that
+    // is its own defect, and deliberately not modelled here.)
+    handlers: Record<string, Array<(payload: any) => void>> = {};
     constructor(_opts: unknown) {}
-    on(event: string, handler: (payload: any) => void) { this.handlers[event] = handler; }
-    off() {}
-    emit(event: string, payload: any) { this.handlers[event]?.(payload); }
+    on(event: string, handler: (payload: any) => void) {
+      if (!this.handlers[event]) this.handlers[event] = [];
+      this.handlers[event].push(handler);
+    }
+    off(event: string, handler?: (payload: any) => void) {
+      if (!handler) { delete this.handlers[event]; return; }
+      const list = this.handlers[event];
+      if (!list) return;
+      const i = list.indexOf(handler);
+      if (i >= 0) list.splice(i, 1);
+    }
+    emit(event: string, payload: any) {
+      for (const h of [...(this.handlers[event] || [])]) h(payload);
+    }
     getTurnDetectionType() { return this.turnDetectionType; }
   }
   return { RealtimeClient, arrayBufferToBase64: () => 'BASE64' };

--- a/src/services/clients/OpenAIClient.test.ts
+++ b/src/services/clients/OpenAIClient.test.ts
@@ -26,9 +26,11 @@ vi.mock('openai-realtime-api', () => {
       merged.set(chunk, this.inputAudioBuffer.length);
       this.inputAudioBuffer = merged;
     });
+    handlers: Record<string, (payload: any) => void> = {};
     constructor(_opts: unknown) {}
-    on() {}
+    on(event: string, handler: (payload: any) => void) { this.handlers[event] = handler; }
     off() {}
+    emit(event: string, payload: any) { this.handlers[event]?.(payload); }
     getTurnDetectionType() { return this.turnDetectionType; }
   }
   return { RealtimeClient, arrayBufferToBase64: () => 'BASE64' };
@@ -298,5 +300,79 @@ describe('OpenAIClient — realtime send failure handling', () => {
 
     expect(() => client.appendInputAudio(chunk())).not.toThrow();
     expect(reportedOps()).toEqual(['input_audio_buffer.append']);
+  });
+});
+
+// The mirror image of #406, on the output side. The SDK's RealtimeConversation
+// keeps every item for the whole session -- `items` and `itemLookup` are only
+// emptied by clear(), which we call at teardown -- and its
+// "response.audio.delta" handler merges each chunk of translated speech onto
+// `item.formatted.audio` (dist/index.js:640). convertToConversationItem already
+// drops that field from the copy handed to the UI, but the SDK's own copy stayed
+// reachable, so an hours-long session retained every second of audio it had ever
+// played. Issue #531.
+describe('OpenAIClient — output audio retention in the SDK conversation (#531)', () => {
+  let client: any;
+  let sdk: any;
+
+  beforeEach(() => {
+    client = new OpenAIClient('test-api-key');
+    sdk = client.client;
+    client.setEventHandlers({ onConversationUpdated: () => {} });
+  });
+
+  /** An SDK item shaped like the one `conversation.updated` carries. */
+  const sdkItem = (samples = 24000) => ({
+    id: 'item_1',
+    role: 'assistant',
+    type: 'message',
+    status: 'in_progress',
+    formatted: { text: '', transcript: 'hello', audio: new Int16Array(samples) },
+    content: [],
+  });
+
+  it('releases the SDK copy of the audio when keepReplayAudio is off', () => {
+    client.keepReplayAudio = false;
+    const item = sdkItem();
+
+    sdk.emit('conversation.updated', { item, delta: { audio: new Int16Array(480) } });
+
+    // Empty, not undefined: the SDK merges the next delta onto this field via
+    // mergeInt16Arrays (which throws on anything but an Int16Array) and
+    // "conversation.item.truncated" slices it.
+    expect(item.formatted.audio).toBeInstanceOf(Int16Array);
+    expect(item.formatted.audio.length).toBe(0);
+  });
+
+  it('does not retain audio across a run of deltas', () => {
+    client.keepReplayAudio = false;
+    const item = sdkItem(0);
+
+    // Stand in for the SDK's own delta handler: merge, then hand us the item.
+    for (let i = 0; i < 100; i++) {
+      const merged = new Int16Array(item.formatted.audio.length + 480);
+      merged.set(item.formatted.audio, 0);
+      item.formatted.audio = merged;
+      sdk.emit('conversation.updated', { item, delta: { audio: new Int16Array(480) } });
+    }
+
+    // Without the fix this is 48000 samples and still climbing.
+    expect(item.formatted.audio.length).toBe(0);
+  });
+
+  it('leaves the audio alone when the user opted into replay', () => {
+    client.keepReplayAudio = true;
+    const item = sdkItem();
+
+    sdk.emit('conversation.updated', { item, delta: { audio: new Int16Array(480) } });
+
+    expect(item.formatted.audio.length).toBe(24000);
+  });
+
+  it('tolerates an item with no formatted block', () => {
+    client.keepReplayAudio = false;
+    const item: any = { id: 'item_2', role: 'user', type: 'message', content: [] };
+
+    expect(() => sdk.emit('conversation.updated', { item, delta: undefined })).not.toThrow();
   });
 });

--- a/src/services/clients/OpenAIClient.ts
+++ b/src/services/clients/OpenAIClient.ts
@@ -394,8 +394,41 @@ export class OpenAIClient implements IClient {
       }
       
       const conversationItem = this.convertToConversationItem(item);
+      this.releaseRetainedItemAudio(item);
       this.eventHandlers.onConversationUpdated?.({ item: conversationItem, delta });
     });
+  }
+
+  /**
+   * Drop the SDK's own copy of an item's output PCM, once the UI copy has been
+   * built from it.
+   *
+   * The mirror image of the input-side fix in #406. `RealtimeConversation` keeps
+   * every item for the whole session -- `items` and `itemLookup` are only
+   * emptied by `clear()`, which we reach at session teardown -- and its
+   * `response.audio.delta` handler merges each chunk of translated speech onto
+   * `item.formatted.audio`. `convertToConversationItem` already drops that field
+   * from the object we hand the UI when `keepReplayAudio` is off, but the SDK's
+   * copy stayed reachable behind it, so an hours-long session retained every
+   * second of audio it had ever played (~2.8MB/min at 24kHz) and each delta
+   * re-copied the item's audio so far. Playback reads `delta.audio`, never this
+   * field, so on the default path nothing downstream loses anything. See #531.
+   *
+   * Left untouched when the user opted into replay audio -- retaining it is
+   * exactly what that setting is for.
+   */
+  private releaseRetainedItemAudio(item: Realtime.Item | FormattedItem): void {
+    if (this.keepReplayAudio) return;
+
+    const formatted = ('formatted' in item ? item.formatted : undefined) as
+      | { audio?: Int16Array }
+      | undefined;
+    if (!formatted?.audio?.length) return;
+
+    // Emptied, not deleted: the SDK merges the next delta onto this field with
+    // mergeInt16Arrays, which throws on anything that is not an Int16Array, and
+    // `conversation.item.truncated` slices it.
+    formatted.audio = new Int16Array(0);
   }
 
   private convertToConversationItem(item: Realtime.Item | FormattedItem): ConversationItem {

--- a/src/stores/logStore.test.ts
+++ b/src/stores/logStore.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import useLogStore from './logStore';
+import useLogStore, { MAX_EVENTS_PER_GROUP } from './logStore';
 
 // These tests assert what reaches the log store, which records nothing unless
 // diagnostic logs are switched on (they are off by default in the app).
@@ -44,6 +44,24 @@ describe('logStore — per-client event grouping', () => {
     expect(speaker).toHaveLength(1);
     expect(speaker[0].events).toHaveLength(3);
     expect(speaker[0].groupingKey).toBe('input_audio_buffer');
+  });
+
+  // A session nobody speaks in sends nothing but mic appends, and they all
+  // share one groupingKey, so they land in ONE entry for as long as the silence
+  // lasts. Uncapped, that entry grew for the whole session and every append
+  // copied its entire history (#531).
+  it('caps the events one group keeps and still counts all of them', () => {
+    const total = MAX_EVENTS_PER_GROUP + 50;
+    for (let i = 0; i < total; i++) append('speaker', i);
+
+    const speaker = entriesFor('speaker');
+    expect(speaker).toHaveLength(1);
+    const events = speaker[0].events!;
+    expect(events).toHaveLength(MAX_EVENTS_PER_GROUP);
+    expect(speaker[0].groupCount).toBe(total);
+    // The newest are kept; the oldest are the ones dropped.
+    expect((events[events.length - 1] as any).audio).toBe(`chunk-${total - 1}`);
+    expect((events[0] as any).audio).toBe('chunk-50');
   });
 
   it('keeps interleaved clients in separate groups', () => {

--- a/src/stores/logStore.ts
+++ b/src/stores/logStore.ts
@@ -180,6 +180,11 @@ export interface LogEntry {
   eventType?: string; // The type of the event (e.g., 'session.created', 'response.text.delta')
   groupingKey?: string; // Custom grouping key for specific event types
   /**
+   * How many events this entry has grouped in total. `events` keeps only the
+   * newest MAX_EVENTS_PER_GROUP of them, so this is the count to show.
+   */
+  groupCount?: number;
+  /**
    * Which session leg produced this, or undefined for an app-scope failure
    * (settings, auth, devices, models). LogsPanel shows undefined under BOTH
    * tabs; it is not a synonym for 'speaker'.
@@ -216,6 +221,17 @@ const BATCH_DELAY_MS = 150; // Batch updates every 150ms for better performance
  * trimming cannot orphan one.
  */
 const MAX_LOG_ENTRIES = 2000;
+
+/**
+ * How many events one grouped entry keeps; `groupCount` still counts them all.
+ *
+ * MAX_LOG_ENTRIES bounds entries, not the events inside one. A session nobody
+ * speaks in sends nothing but mic appends (~12/s), which all share one
+ * groupingKey, so they land in a single entry for as long as the silence
+ * lasts: uncapped, it grew for the whole session and every append copied the
+ * entry's entire history (#531).
+ */
+export const MAX_EVENTS_PER_GROUP = 100;
 
 let nextLogId = 0;
 const takeLogId = (): number => ++nextLogId;
@@ -492,10 +508,17 @@ const useLogStore = create<LogStore>(
           groupingKey !== undefined
         ) {
           // Update the log with new event
+          // Keep only the newest MAX_EVENTS_PER_GROUP events, so each append
+          // copies a bounded array instead of the group's whole history;
+          // groupCount keeps the true total for the panel.
+          const kept = lastLogForClient.events || [];
           const updatedLog = {
             ...lastLogForClient,
             timestamp, // Update timestamp to the latest
-            events: [...(lastLogForClient.events || []), sanitizedEvent]
+            events: kept.length >= MAX_EVENTS_PER_GROUP
+              ? [...kept.slice(kept.length - MAX_EVENTS_PER_GROUP + 1), sanitizedEvent]
+              : [...kept, sanitizedEvent],
+            groupCount: (lastLogForClient.groupCount ?? kept.length) + 1,
           };
 
           const timer = scheduleFlush(state, () => get().flushPendingLogs());
@@ -535,6 +558,7 @@ const useLogStore = create<LogStore>(
           message,
           type: severityForEventType(eventType),
           events: [sanitizedEvent], // Initialize events array with the sanitized event
+          groupCount: 1,
           source,
           eventType,
           groupingKey,


### PR DESCRIPTION
Three independent retention bugs found while investigating #531 (renderer private bytes growing ~1.6 GB/hour over 7.7 hours). One commit each, plus a test-only commit that makes the client test's mock honest — happy to split if preferred.

## How this was found

Reproduced on Windows 11 build 26200 / 64 GB running the same 0.40.3 desktop build, driving the renderer over the DevTools protocol: per-process private bytes sampled from Windows alongside CDP heap snapshots and exact `Runtime.getHeapUsage`.

| Scenario | Sample | Slope |
|---|---|---|
| App open, no session | 16.6 min | **0** — no trend |
| Session connected, nobody speaking | 25 min, n=130 | **0.041 GB/h** |
| Session connected, active conversation, official OpenAI provider | — | ~0.15 GB/h retained |
| Session connected, active conversation, **the reporter's exact stack** | n=14 | **3.03 GB/h** |

The growth is native memory, not the JS heap: total heap self-size was 39–49 MB with the V8 used size flat at ~11 MB. That matches the reporter's "renderer subprocess only, handles stable" observation.

## 1. `fix(audio)` — the MediaRecorder's output was retained for the whole session

The snapshot diff had exactly one dominant term: `native | Blob`, **+17,771 objects in 35 minutes** — one per 100 ms, which is the timeslice `record()` starts the MediaRecorder with. Walking the retaining edges showed all 18,848 of them held as elements of a single JS `Array`: `ModernAudioRecorder.audioChunks`.

Nothing ever read that array. All five `recorder.end()` call sites in `ModernBrowserAudioService` discard the returned blob, and `save()` was only ever reached from `end()` itself. It also outlived the session, since only the *next* `record()` cleared it — after stopping the session and forcing a GC, 19,937 Blobs were still alive. And `end()` concatenated the whole array into one Blob on teardown, which for a multi-hour session is a multi-GB allocation that is then thrown away.

The fix drops the chunk in the handler, and deletes `save()` and `clear()`, which existed only to serve that array and have no callers anywhere in the repo. The `MediaRecorder` itself stays — a dozen methods gate on it for lifecycle state and `pause()` drives it.

Blob payloads live in native memory rather than the JS heap, which is why this presented as private-bytes growth against a flat heap.

## 2. `fix(openai)` — the beta SDK conversation retained every item's output audio

The reporter used the **OpenAI Compatible** provider, which builds an `OpenAIClient` (the `openai-realtime-api` beta SDK) rather than the GA client. That SDK's `RealtimeConversation` keeps every item for the whole session — `items` and `itemLookup` are only emptied by `clear()`, which we reach at teardown — and its `response.audio.delta` handler merges each chunk of translated speech onto `item.formatted.audio`.

`convertToConversationItem` already dropped that field from the copy handed to the UI when `keepReplayAudio` is off, but the SDK's own copy stayed reachable behind it. So an hours-long session retained every second of audio it had ever played, and each delta re-copied the item's audio so far.

**This is restoring parity, not inventing a policy.** `OpenAIGAClient` already documents and implements exactly this behaviour for the official client: *"When false, audio chunks are not pushed into `audioChunks` and never merged into `item.formatted.audio`, so ... no per-item PCM memory is retained."* The beta client never got that gate.

The fix releases the field once the UI copy has been built, on the default path only. Playback reads `delta.audio` and never this field. It is emptied rather than deleted because the SDK merges the next delta onto it with `mergeInt16Arrays`, which throws on anything that is not an `Int16Array`, and `conversation.item.truncated` slices it. The mirror image of the input-side fix in #406.

The follow-up `test(openai)` commit makes the test's mock SDK keep every handler registered for an event, as the real `RealtimeEventHandler` does — `OpenAIClient` registers `realtime.event` twice, and the old single-slot mock let the second registration silently replace the first.

## 3. `fix(logs)` — one log group grew for as long as nobody spoke

`MAX_LOG_ENTRIES` bounds the number of log entries, not the events grouped inside one. A session nobody speaks in sends nothing but mic appends (~12/s in a real session), and they all share the groupingKey `input_audio_buffer`, so every one of them lands in a **single** entry for as long as the silence lasts. That entry's `events` array grew for the whole session, and every append copied its entire history into a new array.

Measured in the renderer: 20,000 appends built one group of 20,000 events that held **3.7 MB (~184 bytes each)** until the logs were cleared, and the cost of 1,000 appends rose from **23 ms to 272 ms** as the group grew. A 5-minute silent session through the real UI built a group of 3,696. Small next to #531's rate, but unbounded and quadratic.

Since #538 the log store records nothing unless diagnostic logs are switched on in Help, which they are not by default. So this now only bites a user who turned them on to report a bug, and for that user it is still unbounded.

The fix keeps only the newest `MAX_EVENTS_PER_GROUP` (100) events per group and counts the rest in `groupCount`. LogsPanel shows that count, numbers expanded events by their real position ("Event 12,246 of 12,345") with the existing locale strings, and compares it in the row memo, since a capped `events.length` stops changing.

## Verification

Every fix got a failing test first. The recorder test asserts that **no field of the recorder still points at a delivered chunk** rather than that `audioChunks` is empty, so it stays honest if the implementation moves; before the fix it failed with `["audioChunks"]`, naming the culprit. The client test drives 100 deltas through the SDK's own merge pattern; before the fix it failed with `expected 48000 to be 0`. The log store test failed with `expected [ Array(150) ] to have a length of 100`, and the LogsPanel test then pinned the row count to the true total (`expected '(100)' to be '(105)'` until the panel read `groupCount`).

Full suite, rebased onto main after #538: **4060 passed / 2 skipped, 349 files passed (1 skipped)**. The run also reports 4 unhandled errors, all originating in `settingsStore.nativeGate.test.ts` (`settingsStore.validateApiKey`) and present before this branch.

Fixes 1 and 2 were measured **A/B in the running app** — real Electron, the real `MediaRecorder` on a real microphone, and the real SDK event emitter — by importing the pre-fix file and the fixed file side by side in the same session:

| | before | after |
|---|---|---|
| Recorder, 60 s of live capture | **500 Blobs / 0.93 MB** retained (8.3/s) | **0** — and 0 `Blob` nodes in a heap snapshot |
| Client, 1200 `response.audio.delta` (24 s of 24 kHz speech, merged as the SDK does) | **576,000 samples / 1,125 KB** on one item | **0** |

**Both signatures were confirmed live on the reporter's exact stack** — OpenAI Compatible pointed at a third-party OpenAI-compatible endpoint, `gpt-realtime` over WebSocket, `keepReplayAudio` off, stock 0.40.3 on Windows. A ~5-minute session grew at **3.03 GB/h while speaking** and was flat while silent. A heap snapshot taken during it found 36 `formatted.audio` Int16Arrays (6.84 MB, retainer chain `Int16Array.buffer <- Object.audio <- Object.formatted <- Object.item_<id>`) — fix 2's target — and 2,248 `Blob` objects at 8/s — fix 1's target.

### With the fixes: the production bundle, a speaking session, through the real UI

To see what is left, the fixed app was run as a **production bundle** (`vite build` + `vite preview`) in Electron, holding speaking sessions through its own UI against a local fake OpenAI-compatible endpoint that streams `response.audio.delta` at 10 Hz with a new utterance every 8 s — zero API cost. Two back-to-back 5-minute sessions, each judged after stopping with a forced GC ×3 **plus a critical memory-pressure notification**:

| | RSS (anon) | JS heap |
|---|---|---|
| Baseline | 50.7 MB | 7.8 MB |
| Session A, while speaking | rises, then **flat at ~150 MB from minute 3** | — |
| After session A | 82.0 MB (+31.3, one-time) | 9.8 MB |
| Session B, while speaking | **flat at ~150–155 MB** again | — |
| After session B | **87.3 MB (+5.3)** | 10.0 MB |

No speech-proportional growth remains: memory plateaus while speech keeps streaming, and the second session adds a sixth of the first. A heap snapshot after session B holds no audio at all — the only ArrayBuffer backing stores alive are the two players' fixed 24 MB of SharedArrayBuffers.

Two measurement traps worth recording for whoever picks this up:

- **Do not judge leaks on the vite dev server.** React 19.2's development build writes a retained `PerformanceMeasure` for every component render. A 5-minute speaking session wrote **72,902** of them (mostly `ConversationRow` / `ConversationBubble`), and clearing only those freed **173 MB** — on the dev server this looks like ~2 GB/h, the same shape as #531, and none of it exists in a production build.
- **Plain GC overstates what survives.** Freed pages the allocator has not returned yet stay in RSS; without the memory-pressure purge, ~10 MB of that reads as a leak.

## What is still open

- These runs used a local fake endpoint on Linux, not the reporter's Windows machine and provider. Whether the reporter's growth is gone needs a build with these fixes on their stack, so #531 stays open until then.
- `openai-realtime-api`'s `RealtimeAPI._log` runs `structuredClone(event)` + `JSON.stringify(event, null, 2)` on **every** sent and received frame *before* checking its `debug` flag, then discards the result. Measured at 2–3 µs and ~6 KB of garbage per event — real waste, collectible, not fixed here.
- Replacing the beta client with the GA client is **not** a way out: the compatible endpoint tested accepts a GA *handshake* but rejects the GA session schema (`Unknown parameter: 'session.type'`) and emits **beta** event names on the wire, so `OpenAIGAClient` would connect, report "connected", and stay silent. The beta path has to be fixed, not bypassed.

Refs #531

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced memory usage during audio recording by discarding processed audio data.
  * Prevented retained replay audio from accumulating when replay audio is disabled.
  * Limited grouped log entries to the newest 100 events while preserving accurate total counts.
  * Corrected grouped log count badges, event numbering, and expanded event details after older entries are trimmed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
