### PR TITLE
fix(asr): bound Voxtral idle audio pre-roll

### DIFF
--- a/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   boundedBatchEndSample,
+  promoteQueued,
   QueuedUtterance,
   StreamingAudioFeed,
   StreamingTextAccumulator,
@@ -117,11 +118,11 @@ describe('StreamingAudioFeed', () => {
     feed.append(f32(1));
     feed.requestFinish(0);
     feed.append(f32(2));
-    feed.sealStaged(1);
+    feed.sealStaged();
     feed.append(f32(3));
 
     feed.complete();
-    expect(Array.from(feed.audio)).toEqual([2, 0]);
+    expect(Array.from(feed.audio)).toEqual([2]);
     feed.requestFinish(0);
     feed.complete();
     expect(Array.from(feed.audio)).toEqual([3]);
@@ -170,6 +171,107 @@ describe('StreamingAudioFeed', () => {
     expect(feed.audio.length).toBe(0);
     feed.complete();
     expect(feed.audio.length).toBe(0);
+  });
+});
+
+describe('promoteQueued', () => {
+  /** Run 1 is draining its tail, so the worker queues every new utterance behind it. */
+  function draining() {
+    const feed = new StreamingAudioFeed();
+    const queue = new QueuedUtterance();
+    feed.append(f32(1));
+    feed.requestFinish(0);
+    return { feed, queue };
+  }
+
+  it('drops a queued misfire and promotes the utterance queued behind it', () => {
+    const { feed, queue } = draining();
+    queue.start();
+    feed.append(f32(2));
+    queue.stop();
+    feed.sealStaged();
+    queue.start();
+    feed.append(f32(3, 3));
+    queue.finish();
+    feed.sealStaged();
+
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBe('finish');
+    expect(Array.from(feed.audio)).toEqual([3, 3]);
+    expect(queue.pending).toBe(false);
+  });
+
+  it('keeps the audio after a lone queued misfire as the next pre-roll', () => {
+    const { feed, queue } = draining();
+    queue.start();
+    feed.append(f32(2));
+    queue.stop();
+    feed.sealStaged();
+    feed.append(f32(7, 7));
+
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBeNull();
+    expect(Array.from(feed.audio)).toEqual([7, 7]);
+    expect(queue.pending).toBe(false);
+  });
+
+  it('skips consecutive misfires', () => {
+    const { feed, queue } = draining();
+    for (const v of [2, 3]) {
+      queue.start();
+      feed.append(f32(v));
+      queue.stop();
+      feed.sealStaged();
+    }
+    queue.start();
+    feed.append(f32(4));
+
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBe('open');
+    expect(Array.from(feed.audio)).toEqual([4]);
+  });
+
+  it('promotes queued utterances one run at a time, in order', () => {
+    const { feed, queue } = draining();
+    queue.start();
+    feed.append(f32(2));
+    queue.finish();
+    feed.sealStaged();
+    queue.start();
+    feed.append(f32(3));
+
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBe('finish');
+    expect(Array.from(feed.audio)).toEqual([2]);
+
+    feed.requestFinish(0);
+    feed.append(f32(3)); // the next utterance keeps talking while this one drains
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBe('open');
+    expect(Array.from(feed.audio)).toEqual([3, 3]);
+    expect(queue.pending).toBe(false);
+  });
+
+  it('pads a queued finish once, when it is promoted', () => {
+    const { feed, queue } = draining();
+    queue.start();
+    feed.append(f32(2, 2));
+    queue.finish();
+    feed.sealStaged();
+
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBe('finish');
+    feed.requestFinish(3); // the worker pads here, as it does for a run that was never queued
+    expect(Array.from(feed.audio)).toEqual([2, 2, 0, 0, 0]);
+  });
+
+  it('leaves the feed alone when nothing is queued', () => {
+    const { feed, queue } = draining();
+    feed.append(f32(5));
+
+    feed.complete();
+    expect(promoteQueued(feed, queue)).toBeNull();
+    expect(Array.from(feed.audio)).toEqual([5]);
   });
 });
 

--- a/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
@@ -46,6 +46,15 @@ describe('QueuedUtterance', () => {
     expect(queued.finish()).toBe(false);
     expect(queued.take()).toBeNull();
   });
+
+  it('keeps consecutive queued utterances and their endpoints distinct', () => {
+    const queued = new QueuedUtterance();
+    queued.start();
+    queued.finish();
+    queued.start();
+    expect(queued.take()).toBe('finish');
+    expect(queued.take()).toBe('open');
+  });
 });
 
 describe('StreamingAudioFeed', () => {
@@ -71,6 +80,13 @@ describe('StreamingAudioFeed', () => {
     expect(Array.from(feed.audio)).toEqual([1, 2]);
   });
 
+  it('uses a safe finite bound for invalid history limits', () => {
+    const feed = new StreamingAudioFeed();
+    feed.append(f32(1, 2, 3));
+    feed.retainLatest(Number.POSITIVE_INFINITY);
+    expect(feed.audio.length).toBe(0);
+  });
+
   it('pads the buffer with silence on finish so the model can decode its tail', () => {
     const feed = new StreamingAudioFeed();
     feed.append(f32(1, 2, 3));
@@ -94,6 +110,21 @@ describe('StreamingAudioFeed', () => {
     feed.complete();
     expect(Array.from(feed.audio)).toEqual([9, 9]);
     expect(feed.finishing).toBe(false);
+  });
+
+  it('keeps staged utterance boundaries distinct while an old run drains', () => {
+    const feed = new StreamingAudioFeed();
+    feed.append(f32(1));
+    feed.requestFinish(0);
+    feed.append(f32(2));
+    feed.sealStaged(1);
+    feed.append(f32(3));
+
+    feed.complete();
+    expect(Array.from(feed.audio)).toEqual([2, 0]);
+    feed.requestFinish(0);
+    feed.complete();
+    expect(Array.from(feed.audio)).toEqual([3]);
   });
 
   it('keeps consuming whole chunks after a finish until the padded audio runs out', () => {

--- a/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
@@ -24,6 +24,21 @@ describe('StreamingAudioFeed', () => {
     expect(Array.from(feed.audio)).toEqual([1, 2, 3]);
   });
 
+  it('keeps only bounded recent audio while waiting for speech', () => {
+    const feed = new StreamingAudioFeed();
+    feed.append(f32(1, 2, 3));
+    feed.append(f32(4, 5));
+    feed.retainLatest(3);
+    expect(Array.from(feed.audio)).toEqual([3, 4, 5]);
+  });
+
+  it('does not pad a short pre-roll up to its history limit', () => {
+    const feed = new StreamingAudioFeed();
+    feed.append(f32(1, 2));
+    feed.retainLatest(4);
+    expect(Array.from(feed.audio)).toEqual([1, 2]);
+  });
+
   it('pads the buffer with silence on finish so the model can decode its tail', () => {
     const feed = new StreamingAudioFeed();
     feed.append(f32(1, 2, 3));

--- a/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'vitest';
-import { StreamingAudioFeed, StreamingTextAccumulator, tailPadSamples } from './streaming-generation';
+import {
+  boundedBatchEndSample,
+  QueuedUtterance,
+  StreamingAudioFeed,
+  StreamingTextAccumulator,
+  tailPadSamples,
+} from './streaming-generation';
 
 const f32 = (...values: number[]) => Float32Array.from(values);
 
@@ -13,6 +19,32 @@ describe('tailPadSamples', () => {
 
   it('has nothing to pad when the token length is unknown', () => {
     expect(tailPadSamples(0)).toBe(0);
+  });
+});
+
+describe('boundedBatchEndSample', () => {
+  it('consumes aligned backlog without exceeding the per-call token cap', () => {
+    expect(boundedBatchEndSample(1_000, 100_000, 1_280, 4)).toBe(4_840);
+  });
+
+  it('never extends past the available aligned samples', () => {
+    expect(boundedBatchEndSample(1_000, 3_700, 1_280, 32)).toBe(3_560);
+  });
+});
+
+describe('QueuedUtterance', () => {
+  it('preserves an endpoint observed while the previous run is finishing', () => {
+    const queued = new QueuedUtterance();
+    queued.start();
+    expect(queued.finish()).toBe(true);
+    expect(queued.take()).toBe('finish');
+    expect(queued.pending).toBe(false);
+  });
+
+  it('does not consume an endpoint when no utterance is queued', () => {
+    const queued = new QueuedUtterance();
+    expect(queued.finish()).toBe(false);
+    expect(queued.take()).toBeNull();
   });
 });
 

--- a/src/lib/local-inference/workers/_shared/streaming-generation.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.ts
@@ -19,9 +19,71 @@
  */
 export const TAIL_PAD_TOKENS = 7;
 
+/** Keep individual audio-encoder calls small even when a backlog accumulated. */
+export const MAX_AUDIO_TOKENS_PER_ENCODER_CALL = 32;
+
 /** Samples of silence to append at an utterance end. */
 export function tailPadSamples(rawAudioLengthPerTok: number): number {
   return TAIL_PAD_TOKENS * rawAudioLengthPerTok;
+}
+
+/**
+ * Extend a required encoder chunk by whole audio-token steps, up to a hard cap.
+ *
+ * The streaming worker used to extend a chunk to all currently buffered audio.
+ * A lifecycle delay could therefore turn one ORT call into a minutes-long input.
+ */
+export function boundedBatchEndSample(
+  endNeeded: number,
+  availableSamples: number,
+  samplesPerTok: number,
+  maxTokens = MAX_AUDIO_TOKENS_PER_ENCODER_CALL,
+): number {
+  if (!Number.isFinite(samplesPerTok) || samplesPerTok <= 0) return endNeeded;
+  const extraAvailable = Math.max(0, Math.floor((availableSamples - endNeeded) / samplesPerTok));
+  const extraAllowed = Math.max(0, Math.floor(maxTokens) - 1);
+  return endNeeded + Math.min(extraAvailable, extraAllowed) * samplesPerTok;
+}
+
+export type QueuedUtteranceState = 'open' | 'finish' | 'stop';
+
+/** Endpoint state for an utterance staged while the preceding run drains. */
+export class QueuedUtterance {
+  private queued = false;
+  private endpoint: Exclude<QueuedUtteranceState, 'open'> | null = null;
+
+  get pending(): boolean {
+    return this.queued;
+  }
+
+  start(): void {
+    this.queued = true;
+    this.endpoint = null;
+  }
+
+  finish(): boolean {
+    if (!this.queued) return false;
+    this.endpoint = 'finish';
+    return true;
+  }
+
+  stop(): boolean {
+    if (!this.queued) return false;
+    this.endpoint = 'stop';
+    return true;
+  }
+
+  take(): QueuedUtteranceState | null {
+    if (!this.queued) return null;
+    const state = this.endpoint ?? 'open';
+    this.clear();
+    return state;
+  }
+
+  clear(): void {
+    this.queued = false;
+    this.endpoint = null;
+  }
 }
 
 function concat(a: Float32Array, b: Float32Array): Float32Array {

--- a/src/lib/local-inference/workers/_shared/streaming-generation.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.ts
@@ -77,6 +77,20 @@ export class StreamingAudioFeed {
     }
   }
 
+  /**
+   * Bound audio retained before a generate run starts.
+   *
+   * The worker continuously receives silence while VAD is idle. Keeping that
+   * entire history makes the next utterance feed an arbitrarily large first
+   * backlog into ORT. Preserve only the recent pre-roll needed for speech onset.
+   */
+  retainLatest(maxSamples: number): void {
+    if (this._finishing || this._stopped) return;
+    const limit = Math.max(0, Math.floor(maxSamples));
+    if (this.active.length <= limit) return;
+    this.active = this.active.slice(this.active.length - limit);
+  }
+
   /** End the run gracefully, padding with `padSamples` of silence first. */
   requestFinish(padSamples: number): void {
     if (this._finishing) return;

--- a/src/lib/local-inference/workers/_shared/streaming-generation.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.ts
@@ -49,40 +49,40 @@ export type QueuedUtteranceState = 'open' | 'finish' | 'stop';
 
 /** Endpoint state for an utterance staged while the preceding run drains. */
 export class QueuedUtterance {
-  private queued = false;
-  private endpoint: Exclude<QueuedUtteranceState, 'open'> | null = null;
+  private queue: QueuedUtteranceState[] = [];
 
   get pending(): boolean {
-    return this.queued;
+    return this.queue.length > 0;
   }
 
   start(): void {
-    this.queued = true;
-    this.endpoint = null;
+    this.queue.push('open');
   }
 
   finish(): boolean {
-    if (!this.queued) return false;
-    this.endpoint = 'finish';
-    return true;
+    return this.setLatestOpenEndpoint('finish');
   }
 
   stop(): boolean {
-    if (!this.queued) return false;
-    this.endpoint = 'stop';
-    return true;
+    return this.setLatestOpenEndpoint('stop');
   }
 
   take(): QueuedUtteranceState | null {
-    if (!this.queued) return null;
-    const state = this.endpoint ?? 'open';
-    this.clear();
-    return state;
+    return this.queue.shift() ?? null;
   }
 
   clear(): void {
-    this.queued = false;
-    this.endpoint = null;
+    this.queue = [];
+  }
+
+  private setLatestOpenEndpoint(endpoint: Exclude<QueuedUtteranceState, 'open'>): boolean {
+    for (let i = this.queue.length - 1; i >= 0; i--) {
+      if (this.queue[i] === 'open') {
+        this.queue[i] = endpoint;
+        return true;
+      }
+    }
+    return false;
   }
 }
 
@@ -110,6 +110,7 @@ function concat(a: Float32Array, b: Float32Array): Float32Array {
 export class StreamingAudioFeed {
   private active: Float32Array = new Float32Array(0);
   private staged: Float32Array = new Float32Array(0);
+  private stagedSegments: Float32Array[] = [];
   private _finishing = false;
   private _stopped = false;
 
@@ -148,9 +149,17 @@ export class StreamingAudioFeed {
    */
   retainLatest(maxSamples: number): void {
     if (this._finishing || this._stopped) return;
-    const limit = Math.max(0, Math.floor(maxSamples));
+    const limit = Number.isFinite(maxSamples) ? Math.max(0, Math.floor(maxSamples)) : 0;
     if (this.active.length <= limit) return;
     this.active = this.active.slice(this.active.length - limit);
+  }
+
+  /** Seal the staged utterance at its VAD endpoint while the active run drains. */
+  sealStaged(padSamples: number): void {
+    const padding = Number.isFinite(padSamples) ? Math.max(0, Math.floor(padSamples)) : 0;
+    if (padding > 0) this.staged = concat(this.staged, new Float32Array(padding));
+    this.stagedSegments.push(this.staged);
+    this.staged = new Float32Array(0);
   }
 
   /** End the run gracefully, padding with `padSamples` of silence first. */
@@ -179,8 +188,12 @@ export class StreamingAudioFeed {
 
   /** The run is over: staged audio becomes the next run's starting buffer. */
   complete(): void {
-    this.active = this.staged;
-    this.staged = new Float32Array(0);
+    if (this.stagedSegments.length > 0) {
+      this.active = this.stagedSegments.shift()!;
+    } else {
+      this.active = this.staged;
+      this.staged = new Float32Array(0);
+    }
     this._finishing = false;
     this._stopped = false;
   }
@@ -188,6 +201,7 @@ export class StreamingAudioFeed {
   clear(): void {
     this.active = new Float32Array(0);
     this.staged = new Float32Array(0);
+    this.stagedSegments = [];
     this._finishing = false;
     this._stopped = false;
   }

--- a/src/lib/local-inference/workers/_shared/streaming-generation.ts
+++ b/src/lib/local-inference/workers/_shared/streaming-generation.ts
@@ -154,10 +154,13 @@ export class StreamingAudioFeed {
     this.active = this.active.slice(this.active.length - limit);
   }
 
-  /** Seal the staged utterance at its VAD endpoint while the active run drains. */
-  sealStaged(padSamples: number): void {
-    const padding = Number.isFinite(padSamples) ? Math.max(0, Math.floor(padSamples)) : 0;
-    if (padding > 0) this.staged = concat(this.staged, new Float32Array(padding));
+  /**
+   * Seal the staged utterance at its VAD endpoint while the active run drains.
+   *
+   * No padding here: the tail pad is added once, by `requestFinish()`, when the
+   * sealed segment is promoted to a run of its own.
+   */
+  sealStaged(): void {
     this.stagedSegments.push(this.staged);
     this.staged = new Float32Array(0);
   }
@@ -205,6 +208,29 @@ export class StreamingAudioFeed {
     this._finishing = false;
     this._stopped = false;
   }
+}
+
+/**
+ * Hand the feed to the next queued utterance, after a run's `complete()`.
+ *
+ * `QueuedUtterance` and the feed's sealed segments are two FIFOs kept in
+ * lockstep: each sealed entry ('finish' or 'stop') owns one segment, and a
+ * trailing 'open' entry owns the staged audio not yet sealed. A queued misfire
+ * is dropped here and the utterance behind it promoted in the same call, so no
+ * entry is left waiting for a run that will never start.
+ *
+ * Returns how the utterance now in `feed.audio` ends, or null when nothing is
+ * queued — the feed then holds the audio after the last endpoint, as pre-roll.
+ */
+export function promoteQueued(
+  feed: StreamingAudioFeed,
+  queue: QueuedUtterance,
+): Exclude<QueuedUtteranceState, 'stop'> | null {
+  for (let state = queue.take(); state !== null; state = queue.take()) {
+    if (state !== 'stop') return state;
+    feed.complete();
+  }
+  return null;
 }
 
 /** Sentence terminators that finalize a result without waiting for VAD silence. */

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -117,6 +117,8 @@ async function initVad(vadConfig?: VoxtralAsrInitMessage['vadConfig'], vadModelU
 
   maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
   preSpeechPadSamples = Math.ceil((preSpeechPadMs / 1000) * VAD_SAMPLE_RATE);
+  // NaN would survive the idle trim's Math.max() and discard the first chunk too.
+  if (!Number.isFinite(preSpeechPadSamples) || preSpeechPadSamples < 0) preSpeechPadSamples = 0;
 
   frameProcessor = new FrameProcessor(
     vadInfer,
@@ -429,7 +431,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
     // Keep enough pre-roll for the VAD onset and Voxtral's first chunk, but do
     // not hand an unbounded backlog to ORT when speech eventually starts.
     if (!frameProcessor.speaking && !isGenerating && !queuedUtterance.pending) {
-      audioFeed.retainLatest(Math.max(preSpeechPadSamples, voxtralProcessor.num_samples_first_audio_chunk));
+      audioFeed.retainLatest(Math.max(preSpeechPadSamples, voxtralProcessor?.num_samples_first_audio_chunk ?? 0));
     }
   } finally {
     processingVad = false;

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -27,6 +27,7 @@ import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processo
 import { resolveVadThresholds } from './_shared/vad-thresholds';
 import {
   boundedBatchEndSample,
+  promoteQueued,
   QueuedUtterance,
   StreamingAudioFeed,
   StreamingTextAccumulator,
@@ -310,16 +311,17 @@ async function runVoxtralGenerate(): Promise<void> {
     isGenerating = false;
     // Audio staged during the finish belongs to the next utterance.
     audioFeed.complete();
-    const queuedState = queuedUtterance.take();
-    if (queuedState && !disposing) {
-      if (queuedState === 'stop') {
-        audioFeed.clear();
-      } else {
-        void runVoxtralGenerate();
-        // SpeechEnd may have arrived while the old run was still draining. Apply
-        // that endpoint to the newly promoted run instead of losing it.
-        if (queuedState === 'finish') audioFeed.requestFinish(utterancePadSamples());
-      }
+    const next = disposing ? null : promoteQueued(audioFeed, queuedUtterance);
+    if (next && (!voxtralModel || !voxtralProcessor)) {
+      // No run can start, so nothing would ever drain the queue: drop it rather
+      // than hold the idle trim off indefinitely.
+      audioFeed.clear();
+      queuedUtterance.clear();
+    } else if (next) {
+      void runVoxtralGenerate();
+      // SpeechEnd arrived while the old run was still draining. Its segment was
+      // sealed at that endpoint, so the promoted run finishes right away.
+      if (next === 'finish') audioFeed.requestFinish(utterancePadSamples());
     }
   }
 }
@@ -330,7 +332,7 @@ async function runVoxtralGenerate(): Promise<void> {
  */
 function finishGenerate() {
   if (queuedUtterance.finish()) {
-    audioFeed.sealStaged(utterancePadSamples());
+    audioFeed.sealStaged();
     return;
   }
   if (!isGenerating) {
@@ -343,7 +345,7 @@ function finishGenerate() {
 /** Abandon the current utterance without decoding its tail. */
 function abortGenerate() {
   if (queuedUtterance.stop()) {
-    audioFeed.sealStaged(0);
+    audioFeed.sealStaged();
     return;
   }
   audioFeed.requestStop();

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -25,7 +25,13 @@ import { initTransformersEnv } from './_shared/transformers-env';
 import { FrameProcessor, Message } from '@ricky0123/vad-web';
 import type { FrameProcessorEvent } from '@ricky0123/vad-web/dist/frame-processor';
 import { resolveVadThresholds } from './_shared/vad-thresholds';
-import { StreamingAudioFeed, StreamingTextAccumulator, tailPadSamples } from './_shared/streaming-generation';
+import {
+  boundedBatchEndSample,
+  QueuedUtterance,
+  StreamingAudioFeed,
+  StreamingTextAccumulator,
+  tailPadSamples,
+} from './_shared/streaming-generation';
 
 import type {
   VoxtralAsrInitMessage,
@@ -159,8 +165,8 @@ let voxtralProcessor: any = null;
 const PUNCTUATION_ENDPOINT_ENABLED = true;
 
 let isGenerating = false;
-/** A SpeechStart that arrived while the previous run was still draining its tail. */
-let pendingStart = false;
+/** An utterance that arrived while the previous run was still draining its tail. */
+const queuedUtterance = new QueuedUtterance();
 /** Teardown in progress — un-emitted tokens are dropped instead of flushed. */
 let disposing = false;
 
@@ -235,11 +241,7 @@ async function runVoxtralGenerate(): Promise<void> {
         // drained, then let generate() end so the streamer flushes its last tokens.
         if (!audioFeed.hasSamples(endNeeded)) break;
 
-        const availableSamples = audio().length;
-        let batchEndSample = endNeeded;
-        while (batchEndSample + samplesPerTok <= availableSamples) {
-          batchEndSample += samplesPerTok;
-        }
+        const batchEndSample = boundedBatchEndSample(endNeeded, audio().length, samplesPerTok);
 
         const chunkInputs = await voxtralProcessor(
           audio().slice(startIdx, batchEndSample),
@@ -308,9 +310,16 @@ async function runVoxtralGenerate(): Promise<void> {
     isGenerating = false;
     // Audio staged during the finish belongs to the next utterance.
     audioFeed.complete();
-    if (pendingStart && !disposing) {
-      pendingStart = false;
-      runVoxtralGenerate();
+    const queuedState = queuedUtterance.take();
+    if (queuedState && !disposing) {
+      if (queuedState === 'stop') {
+        audioFeed.clear();
+      } else {
+        void runVoxtralGenerate();
+        // SpeechEnd may have arrived while the old run was still draining. Apply
+        // that endpoint to the newly promoted run instead of losing it.
+        if (queuedState === 'finish') audioFeed.requestFinish(utterancePadSamples());
+      }
     }
   }
 }
@@ -320,6 +329,7 @@ async function runVoxtralGenerate(): Promise<void> {
  * decodes the words it is still holding, then let generate() finish on its own.
  */
 function finishGenerate() {
+  if (queuedUtterance.finish()) return;
   if (!isGenerating) {
     audioFeed.clear();
     return;
@@ -329,6 +339,7 @@ function finishGenerate() {
 
 /** Abandon the current utterance without decoding its tail. */
 function abortGenerate() {
+  if (queuedUtterance.stop()) return;
   audioFeed.requestStop();
   if (!isGenerating) audioFeed.clear();
 }
@@ -369,7 +380,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
             if (isGenerating) {
               // The previous utterance is still draining its padded tail; its
               // run picks this one up when it completes.
-              pendingStart = true;
+              queuedUtterance.start();
             } else {
               // Start Voxtral generate loop (non-blocking)
               runVoxtralGenerate();
@@ -409,7 +420,7 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
     // Audio arrives continuously, including potentially hours of idle silence.
     // Keep enough pre-roll for the VAD onset and Voxtral's first chunk, but do
     // not hand an unbounded backlog to ORT when speech eventually starts.
-    if (!frameProcessor.speaking && !isGenerating && !pendingStart) {
+    if (!frameProcessor.speaking && !isGenerating && !queuedUtterance.pending) {
       audioFeed.retainLatest(Math.max(preSpeechPadSamples, voxtralProcessor.num_samples_first_audio_chunk));
     }
   } finally {
@@ -466,7 +477,7 @@ async function handleInit(msg: VoxtralAsrInitMessage): Promise<void> {
     // Reset buffers
     vadAudioBuffer = new Float32Array(0);
     audioFeed.clear();
-    pendingStart = false;
+    queuedUtterance.clear();
     disposing = false;
 
     const loadTimeMs = Math.round(performance.now() - startTime);
@@ -509,7 +520,7 @@ async function handleDispose(): Promise<void> {
 
   vadAudioBuffer = new Float32Array(0);
   audioFeed.clear();
-  pendingStart = false;
+  queuedUtterance.clear();
   processingVad = false;
   isGenerating = false;
 

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -329,7 +329,10 @@ async function runVoxtralGenerate(): Promise<void> {
  * decodes the words it is still holding, then let generate() finish on its own.
  */
 function finishGenerate() {
-  if (queuedUtterance.finish()) return;
+  if (queuedUtterance.finish()) {
+    audioFeed.sealStaged(utterancePadSamples());
+    return;
+  }
   if (!isGenerating) {
     audioFeed.clear();
     return;
@@ -339,7 +342,10 @@ function finishGenerate() {
 
 /** Abandon the current utterance without decoding its tail. */
 function abortGenerate() {
-  if (queuedUtterance.stop()) return;
+  if (queuedUtterance.stop()) {
+    audioFeed.sealStaged(0);
+    return;
+  }
   audioFeed.requestStop();
   if (!isGenerating) audioFeed.clear();
 }

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -506,6 +506,9 @@ function handleFlush(): void {
 
 async function handleDispose(): Promise<void> {
   disposing = true;
+  // Drop queued utterances first: with one queued, abortGenerate() would only
+  // seal it and leave the run that is still draining untouched.
+  queuedUtterance.clear();
   abortGenerate();
 
   // Wait briefly for generate to stop

--- a/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
+++ b/src/lib/local-inference/workers/voxtral-webgpu.worker.ts
@@ -76,6 +76,7 @@ let vadSession: VadSession | null = null;
 let frameProcessor: FrameProcessor | null = null;
 let maxSpeechFrames = 625; // ~20s at 32ms/frame
 let speechFramesSinceStart = 0;
+let preSpeechPadSamples = Math.ceil(0.8 * VAD_SAMPLE_RATE);
 
 async function vadInfer(frame: Float32Array): Promise<{ isSpeech: number; notSpeech: number }> {
   if (!vadSession) return { isSpeech: 0, notSpeech: 1 };
@@ -108,6 +109,7 @@ async function initVad(vadConfig?: VoxtralAsrInitMessage['vadConfig'], vadModelU
   const maxSpeechDurationMs = (vadConfig?.maxSpeechDuration ?? 20) * 1000;
 
   maxSpeechFrames = Math.ceil(maxSpeechDurationMs / VAD_FRAME_MS);
+  preSpeechPadSamples = Math.ceil((preSpeechPadMs / 1000) * VAD_SAMPLE_RATE);
 
   frameProcessor = new FrameProcessor(
     vadInfer,
@@ -402,6 +404,13 @@ async function feedAudio(samples: Int16Array, sampleRate: number): Promise<void>
       } else {
         speechFramesSinceStart = 0;
       }
+    }
+
+    // Audio arrives continuously, including potentially hours of idle silence.
+    // Keep enough pre-roll for the VAD onset and Voxtral's first chunk, but do
+    // not hand an unbounded backlog to ORT when speech eventually starts.
+    if (!frameProcessor.speaking && !isGenerating && !pendingStart) {
+      audioFeed.retainLatest(Math.max(preSpeechPadSamples, voxtralProcessor.num_samples_first_audio_chunk));
     }
   } finally {
     processingVad = false;


### PR DESCRIPTION
## Summary

- bound the Voxtral Realtime pre-speech audio history instead of retaining every idle sample since worker initialization
- retain enough recent audio for both the configured VAD pre-roll and Voxtral's required first streaming chunk
- cap each subsequent audio-encoder call to a token-aligned batch instead of consuming the entire backlog at once
- preserve FIFO utterance boundaries and `SpeechEnd`/misfire state while a previous run drains
- add regression coverage for idle trimming, encoder-batch bounds, and queued endpoints

## Root cause

`voxtral-webgpu.worker.ts` appended every incoming audio frame to `StreamingAudioFeed` before VAD classification. While VAD was idle, nothing consumed or cleared that buffer. After a long quiet period, the next `SpeechStart` therefore handed the entire idle history to the streaming generator. Its catch-up loop could turn that backlog into a very large mel chunk and encoder attention/cache shapes, eventually making ONNX Runtime fail `OrtRun()` in `SafeIntOnOverflow`.

There was also a handoff edge case: if both `SpeechStart` and `SpeechEnd` occurred while the previous run was draining its tail, the endpoint was applied to the old feed and lost. The promoted run could then remain open and continue consuming silence.

The idle buffer is now capped when no generation/handoff is active, every encoder invocation has an independent hard batch ceiling, and an endpoint observed for a queued utterance is applied as soon as that utterance is promoted.

## Verification

- `npm run test -- src/lib/local-inference/workers/_shared/streaming-generation.test.ts --run` — 28 passed
- CI-equivalent local-inference/diagnostics command — 657 passed
- `npm run build` — passed
- `git diff --check` — passed

The repository-wide Vitest command was also exercised locally under Node 26; it reached 3,969 passing tests but retained 67 unrelated environment-sensitive failures around unavailable `localStorage` and an incomplete Electron install. The PR's Node 20 CI scope passes locally.

A full hardware reproduction with the multi-gigabyte Voxtral model was not available in this environment. The diagnosis is based on tracing the exact unbounded idle-audio path into the oversized encoder chunk and ORT shapes reported by the failure; the regression tests cover the invariants that prevent that path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Limited audio processed during each streaming generation step for more consistent performance.
  - Preserved queued utterances and their finish or stop states while earlier generation completes.
  - Retained a bounded amount of recent pre-speech audio without unnecessary padding.
- **Bug Fixes**
  - Preserved distinct audio boundaries across consecutive utterances.
  - Improved handling of queued audio, including misfires, backlog limits, and consecutive utterances.
  - Prevented stale queued state from persisting after audio generation is disposed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->