### PR TITLE
fix(electron): send a fixed origin instead of the install path

### DIFF
--- a/electron/better-auth-adapter.js
+++ b/electron/better-auth-adapter.js
@@ -1,6 +1,18 @@
 const { ipcMain, session } = require('electron');
 const { Conf } = require('electron-conf');
 
+/**
+ * The Origin/Referer main.js puts on backend requests from a packaged build.
+ *
+ * A fixed value, never the install path: on Windows that path runs through
+ * C:\Users\<username>\, so deriving it from __dirname sent the account name to
+ * the backend on every request and, when the name was non-ASCII, made the
+ * Workers runtime log a warning per header (#535). The backend trusts desktop
+ * requests on the `file://` prefix alone (better-auth matches non-http(s)
+ * origins with startsWith), so nothing after the scheme is load-bearing.
+ */
+const PACKAGED_ORIGIN = 'file://sokuji';
+
 const cookieJar = new Conf({
   name: '_better_auth',
   ext: ''
@@ -227,4 +239,4 @@ function betterAuthAdapter(opts) {
   console.log('[BetterAuth Adapter] Initialized successfully for:', backendDomain);
 }
 
-module.exports = { betterAuthAdapter };
+module.exports = { betterAuthAdapter, PACKAGED_ORIGIN };

--- a/electron/better-auth-adapter.test.js
+++ b/electron/better-auth-adapter.test.js
@@ -37,7 +37,12 @@ const BACKEND = 'https://sokuji.kizuna.ai';
 let userDataDir;
 let webRequestHandlers;
 
-function loadAdapter() {
+/**
+ * Require the adapter module against a fake 'electron'. Every load must go
+ * through here: a bare require would let electron-conf bind the real module
+ * (a path string under Node) and stay cached that way for the whole file.
+ */
+function loadModule() {
   webRequestHandlers = new Map();
   const fakeElectron = {
     app: { getPath: () => userDataDir },
@@ -62,8 +67,13 @@ function loadAdapter() {
     exports: fakeElectron,
   };
   delete nodeRequire.cache[modulePath]; // fresh jar per test
-  const { betterAuthAdapter } = nodeRequire(modulePath);
-  betterAuthAdapter({ backendUrl: BACKEND, origin: 'file:///opt/Sokuji/resources/app' });
+  return nodeRequire(modulePath);
+}
+
+function loadAdapter() {
+  const { betterAuthAdapter, PACKAGED_ORIGIN } = loadModule();
+  // Same call main.js makes in a packaged build.
+  betterAuthAdapter({ backendUrl: BACKEND, origin: PACKAGED_ORIGIN });
   return betterAuthAdapter;
 }
 
@@ -73,12 +83,59 @@ function receiveSetCookie(...cookieStrings) {
   onHeadersReceived({ responseHeaders: { 'set-cookie': cookieStrings } }, () => {});
 }
 
+/** Drive the real onHeadersReceived callback and return the headers it emits. */
+function receiveResponse(responseHeaders = {}) {
+  let emitted;
+  webRequestHandlers.get('headersReceived')({ responseHeaders }, (result) => {
+    emitted = result.responseHeaders;
+  });
+  return emitted;
+}
+
 beforeEach(() => {
   userDataDir = mkdtempSync(join(tmpdir(), 'sokuji-auth-'));
 });
 
 afterEach(() => {
   rmSync(userDataDir, { recursive: true, force: true });
+});
+
+// Issue #535. The packaged build used to send `file://${__dirname}` as Origin
+// and Referer on every backend request. On Windows that path sits under
+// C:\Users\<username>\AppData\Local\sokuji, so the account name left the
+// machine twice per request and landed verbatim in the Worker's logs, with a
+// runtime warning per header whenever the name was non-ASCII. The backend only
+// checks that the value starts with `file://` (better-auth matches non-http(s)
+// origins by prefix), so nothing depends on the path that followed.
+describe('packaged origin', () => {
+  it('is a fixed printable-ASCII value, so no header warning and no install path', () => {
+    const { PACKAGED_ORIGIN } = loadModule();
+
+    expect(PACKAGED_ORIGIN).toMatch(/^[\x21-\x7e]+$/);
+  });
+
+  it('keeps the file:// prefix the backend trusts desktop requests by', () => {
+    const { PACKAGED_ORIGIN } = loadModule();
+
+    expect(PACKAGED_ORIGIN.startsWith('file://')).toBe(true);
+  });
+
+  it('carries no path, so nothing from the local filesystem can ride along', () => {
+    const { PACKAGED_ORIGIN } = loadModule();
+    const rest = PACKAGED_ORIGIN.slice('file://'.length);
+
+    expect(rest).not.toMatch(/[\\/:]/);
+    expect(rest).not.toBe('');
+  });
+
+  it('is what the adapter echoes back as access-control-allow-origin', () => {
+    const adapter = loadAdapter();
+
+    const headers = receiveResponse();
+
+    expect(adapter._sendHeadersConfig.origin).toBe('file://sokuji');
+    expect(headers['access-control-allow-origin']).toEqual(['file://sokuji']);
+  });
 });
 
 describe('cookie capture', () => {

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,6 +1,6 @@
 const { app, BrowserWindow, ipcMain, Menu, dialog, shell, session, systemPreferences, desktopCapturer } = require('electron');
 const path = require('path');
-const { betterAuthAdapter } = require('./better-auth-adapter');
+const { betterAuthAdapter, PACKAGED_ORIGIN } = require('./better-auth-adapter');
 const { setupSubtitleHandlers } = require('./subtitle-window.js');
 const { setupCaptionDoubleClick } = require('./window-caption-dblclick.js');
 const { setupCaptionContextMenu } = require('./window-caption-menu.js');
@@ -466,7 +466,7 @@ app.whenReady().then(async () => {
   // Initialize Better Auth adapter
   try {
     const backendUrl = import.meta.env.VITE_BACKEND_URL || 'http://localhost:8787';
-    const origin = isDev ? 'http://localhost:5173' : `file://${__dirname}`;
+    const origin = isDev ? 'http://localhost:5173' : PACKAGED_ORIGIN;
 
     console.log(`[Sokuji] [Main] Initializing Better Auth adapter with backend: ${backendUrl}, origin: ${origin}`);
 


### PR DESCRIPTION
Closes #535

## What

The packaged Electron app now sends the fixed value `file://sokuji` as `Origin` and `Referer` on backend requests, instead of `file://${__dirname}`.

## Why

On Windows `__dirname` sits under `C:\Users\<username>\AppData\Local\sokuji\...`, so every backend request carried the user's Windows account name in two headers, and the Worker wrote it verbatim into its logs. When the name was non-ASCII, the Workers runtime also logged a warning per header per request (about 388 lines in 8.5 h from four users).

The backend trusts desktop requests on the `file://` prefix alone: better-auth matches non-http(s) origins with `startsWith`, and `sokuji-backend`'s `trustedOrigins` has a bare `"file://"` entry. Nothing after the scheme was ever load-bearing (on a Linux AppImage it was a random mount point per launch anyway). No backend change is needed.

## Changes

- `electron/better-auth-adapter.js`: new exported constant `PACKAGED_ORIGIN = 'file://sokuji'`, documented with the reason. It lives in a module `main.js` already requires, so the vite main-process entry map is untouched.
- `electron/main.js`: the packaged branch uses `PACKAGED_ORIGIN`; dev stays `http://localhost:5173`. The `access-control-allow-origin` echo in the adapter derives from the same value and follows automatically.
- `electron/better-auth-adapter.test.js`: pins the constant as printable ASCII, `file://`-prefixed and path-free, and asserts it is what the adapter echoes back. The shared loader now initialises the adapter the way `main.js` does in a packaged build, and every module load goes through the fake `electron`.

## Verification

- New tests failed first (constant missing), pass after the fix.
- `npx vitest run electron/`: 28 files, 418 tests passed.
- `npx vite build`: bundled `dist-electron/better-auth-adapter.js` exports `PACKAGED_ORIGIN: "file://sokuji"` and bundled `dist-electron/main.js` uses it for the packaged origin.
- Not done: a run on a real packaged Windows build, or a live sign-in against production. Backend acceptance of `file://sokuji` rests on the better-auth matching logic analysed in #535.

## Notes

- Users on 0.40.x keep sending the path until they update.
- The comment above the `"file://"` entry in `kizuna-ai-lab/sokuji-backend` `src/auth/index.ts` still says the client sends `file://${__dirname}`; it goes stale with this change and is not touched here.
- The `.toLowerCase()` applied to the origin in `main.js` is left in place; it is a no-op on the constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of authentication and backend requests in packaged app builds by using a consistent application origin.
  - Prevented installation-path differences from affecting origin handling or cross-origin response permissions.

- **Tests**
  - Added coverage to verify packaged origins remain stable, valid, and correctly applied to responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->