### PR TITLE
i18n(provider): name the OpenAI Compatible provider for the protocol it speaks

### DIFF
--- a/src/locales/ar/translation.json
+++ b/src/locales/ar/translation.json
@@ -456,8 +456,8 @@
       "description": "تقنية الذكاء الاصطناعي من Google"
     },
     "openaiCompatible": {
-      "name": "واجهة برمجة التطبيقات المتوافقة مع OpenAI",
-      "description": "نقطة نهاية مخصصة متوافقة مع OpenAI",
+      "name": "متوافق مع OpenAI (Realtime القديم)",
+      "description": "نقطة نهاية من طرف ثالث تستخدم بروتوكول Realtime التجريبي القديم من OpenAI. ليست مخصصة لـ OpenAI نفسها.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/bn/translation.json
+++ b/src/locales/bn/translation.json
@@ -456,8 +456,8 @@
       "description": "Google এর AI প্রযুক্তি"
     },
     "openaiCompatible": {
-      "name": "OpenAI সামঞ্জস্যপূর্ণ API",
-      "description": "কাস্টম OpenAI-সামঞ্জস্যপূর্ণ এন্ডপয়েন্ট",
+      "name": "OpenAI সামঞ্জস্যপূর্ণ (লিগ্যাসি Realtime)",
+      "description": "OpenAI-এর পুরনো beta Realtime প্রোটোকল ব্যবহারকারী তৃতীয় পক্ষের এন্ডপয়েন্ট। OpenAI-এর নিজস্ব API-এর জন্য নয়।",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -456,8 +456,8 @@
       "description": "Googles AI-Technologie"
     },
     "openaiCompatible": {
-      "name": "OpenAI-kompatible API",
-      "description": "Benutzerdefinierter OpenAI-kompatibler Endpunkt",
+      "name": "OpenAI-kompatibel (Legacy Realtime)",
+      "description": "Drittanbieter-Endpunkt mit OpenAIs älterem Beta-Realtime-Protokoll. Nicht für OpenAI selbst.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -456,8 +456,8 @@
       "description": "Google's AI technology"
     },
     "openaiCompatible": {
-      "name": "OpenAI Compatible API",
-      "description": "Custom OpenAI-compatible endpoint",
+      "name": "OpenAI Compatible (Legacy Realtime)",
+      "description": "Third-party endpoint speaking OpenAI's older beta Realtime protocol. Not for OpenAI itself.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -456,8 +456,8 @@
       "description": "Tecnología AI de Google"
     },
     "openaiCompatible": {
-      "name": "API compatible con OpenAI",
-      "description": "Punto final compatible con OpenAI personalizado",
+      "name": "Compatible con OpenAI (Realtime heredado)",
+      "description": "Endpoint de terceros que usa el antiguo protocolo Realtime beta de OpenAI. No sirve para OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/fa/translation.json
+++ b/src/locales/fa/translation.json
@@ -456,8 +456,8 @@
       "description": "فناوری هوش مصنوعی Google"
     },
     "openaiCompatible": {
-      "name": "API سازگار با OpenAI",
-      "description": "نقطه پایانی سفارشی سازگار با OpenAI",
+      "name": "سازگار با OpenAI (Realtime قدیمی)",
+      "description": "نقطه پایانی شخص ثالث با پروتکل قدیمی Realtime بتای OpenAI. برای خود OpenAI نیست.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/fi/translation.json
+++ b/src/locales/fi/translation.json
@@ -456,8 +456,8 @@
       "description": "Googlen tekoälyteknologia"
     },
     "openaiCompatible": {
-      "name": "OpenAI-yhteensopiva API",
-      "description": "Mukautettu OpenAI-yhteensopiva päätepiste",
+      "name": "OpenAI-yhteensopiva (vanha Realtime)",
+      "description": "Kolmannen osapuolen päätepiste, joka käyttää OpenAI:n vanhaa beta-Realtime-protokollaa. Ei OpenAI:lle itselleen.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/fil/translation.json
+++ b/src/locales/fil/translation.json
@@ -456,8 +456,8 @@
       "description": "AI technology ng Google"
     },
     "openaiCompatible": {
-      "name": "OpenAI Compatible API",
-      "description": "Custom na OpenAI-compatible endpoint",
+      "name": "Tugma sa OpenAI (Legacy Realtime)",
+      "description": "Third-party endpoint na gumagamit ng lumang beta Realtime protocol ng OpenAI. Hindi para sa OpenAI mismo.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -456,8 +456,8 @@
       "description": "Technologie AI de Google"
     },
     "openaiCompatible": {
-      "name": "API compatible OpenAI",
-      "description": "Point de terminaison compatible OpenAI personnalisé",
+      "name": "Compatible OpenAI (Realtime hérité)",
+      "description": "Point de terminaison tiers utilisant l'ancien protocole Realtime bêta d'OpenAI. Pas pour OpenAI lui-même.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/he/translation.json
+++ b/src/locales/he/translation.json
@@ -456,8 +456,8 @@
       "description": "טכנולוגיית בינה מלאכותית של Google"
     },
     "openaiCompatible": {
-      "name": "API תואם OpenAI",
-      "description": "נקודת קצה מותאמת אישית תואמת OpenAI",
+      "name": "תואם OpenAI (Realtime ישן)",
+      "description": "נקודת קצה של צד שלישי המשתמשת בפרוטוקול Realtime בטא הישן של OpenAI. לא מיועד ל-OpenAI עצמה.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/hi/translation.json
+++ b/src/locales/hi/translation.json
@@ -456,8 +456,8 @@
       "description": "Google की AI तकनफ0940क"
     },
     "openaiCompatible": {
-      "name": "OpenAI संगत API",
-      "description": "कस्टम OpenAI-संगत एंडपॉइंट",
+      "name": "OpenAI संगत (लीगेसी Realtime)",
+      "description": "OpenAI के पुराने beta Realtime प्रोटोकॉल का उपयोग करने वाला थर्ड-पार्टी एंडपॉइंट। OpenAI के लिए नहीं।",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/id/translation.json
+++ b/src/locales/id/translation.json
@@ -456,8 +456,8 @@
       "description": "Teknologi AI Google"
     },
     "openaiCompatible": {
-      "name": "API Kompatibel OpenAI",
-      "description": "Endpoint kustom yang kompatibel dengan OpenAI",
+      "name": "Kompatibel OpenAI (Realtime lama)",
+      "description": "Endpoint pihak ketiga yang memakai protokol Realtime beta lama OpenAI. Bukan untuk OpenAI sendiri.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -456,8 +456,8 @@
       "description": "Tecnologia AI di Google"
     },
     "openaiCompatible": {
-      "name": "API compatibile con OpenAI",
-      "description": "Endpoint compatibile con OpenAI personalizzato",
+      "name": "Compatibile OpenAI (Realtime legacy)",
+      "description": "Endpoint di terze parti che usa il vecchio protocollo Realtime beta di OpenAI. Non per OpenAI stessa.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -456,8 +456,8 @@
       "description": "GoogleのAI技術"
     },
     "openaiCompatible": {
-      "name": "OpenAI 互換 API",
-      "description": "カスタム OpenAI 互換エンドポイント",
+      "name": "OpenAI 互換（旧 Realtime）",
+      "description": "OpenAI の旧 beta Realtime プロトコルを使うサードパーティ製エンドポイント。OpenAI 本体には非対応。",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -456,8 +456,8 @@
       "description": "구글의 AI 기술"
     },
     "openaiCompatible": {
-      "name": "OpenAI 호환 API",
-      "description": "사용자 정의 OpenAI 호환 엔드포인트",
+      "name": "OpenAI 호환 (레거시 Realtime)",
+      "description": "OpenAI의 구 beta Realtime 프로토콜을 사용하는 서드파티 엔드포인트. OpenAI 자체용이 아닙니다.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/ms/translation.json
+++ b/src/locales/ms/translation.json
@@ -456,8 +456,8 @@
       "description": "Teknologi AI Google"
     },
     "openaiCompatible": {
-      "name": "API Serasi OpenAI",
-      "description": "Titik akhir tersuai yang serasi dengan OpenAI",
+      "name": "Serasi OpenAI (Realtime lama)",
+      "description": "Titik akhir pihak ketiga yang menggunakan protokol Realtime beta lama OpenAI. Bukan untuk OpenAI sendiri.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/nl/translation.json
+++ b/src/locales/nl/translation.json
@@ -456,8 +456,8 @@
       "description": "Google's AI technologie"
     },
     "openaiCompatible": {
-      "name": "OpenAI Compatibele API",
-      "description": "Aangepast OpenAI-compatibel eindpunt",
+      "name": "OpenAI-compatibel (verouderde Realtime)",
+      "description": "Endpoint van derden met OpenAI's oudere beta-Realtime-protocol. Niet voor OpenAI zelf.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -456,8 +456,8 @@
       "description": "Technologia AI Google"
     },
     "openaiCompatible": {
-      "name": "API Kompatybilne z OpenAI",
-      "description": "Niestandardowy punkt końcowy kompatybilny z OpenAI",
+      "name": "Zgodny z OpenAI (starsze Realtime)",
+      "description": "Punkt końcowy innej firmy używający starszego protokołu Realtime beta OpenAI. Nie dla samego OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/pt_BR/translation.json
+++ b/src/locales/pt_BR/translation.json
@@ -456,8 +456,8 @@
       "description": "Tecnologia de IA do Google"
     },
     "openaiCompatible": {
-      "name": "API compatível com OpenAI",
-      "description": "Endpoint compatível com OpenAI personalizado",
+      "name": "Compatível com OpenAI (Realtime legado)",
+      "description": "Endpoint de terceiros que usa o antigo protocolo Realtime beta da OpenAI. Não serve para a OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/pt_PT/translation.json
+++ b/src/locales/pt_PT/translation.json
@@ -456,8 +456,8 @@
       "description": "Tecnologia AI da Google"
     },
     "openaiCompatible": {
-      "name": "API compatível com OpenAI",
-      "description": "Ponto final compatível com OpenAI personalizado",
+      "name": "Compatível com OpenAI (Realtime legado)",
+      "description": "Ponto final de terceiros que usa o antigo protocolo Realtime beta da OpenAI. Não serve para a OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/ru/translation.json
+++ b/src/locales/ru/translation.json
@@ -456,8 +456,8 @@
       "description": "AI-технология Google"
     },
     "openaiCompatible": {
-      "name": "API совместимый с OpenAI",
-      "description": "Пользовательская конечная точка совместимая с OpenAI",
+      "name": "Совместимый с OpenAI (устаревший Realtime)",
+      "description": "Сторонняя конечная точка со старым бета-протоколом Realtime от OpenAI. Не для самой OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/sv/translation.json
+++ b/src/locales/sv/translation.json
@@ -456,8 +456,8 @@
       "description": "Googles AI teknologi"
     },
     "openaiCompatible": {
-      "name": "OpenAI Kompatibel API",
-      "description": "Anpassad OpenAI-kompatibel slutpunkt",
+      "name": "OpenAI-kompatibel (äldre Realtime)",
+      "description": "Tredjepartsslutpunkt som använder OpenAI:s äldre beta-Realtime-protokoll. Inte för OpenAI själv.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/ta/translation.json
+++ b/src/locales/ta/translation.json
@@ -456,8 +456,8 @@
       "description": "Google-ன் AI தகவல்"
     },
     "openaiCompatible": {
-      "name": "OpenAI இணக்கமான API",
-      "description": "தனிப்பயன் OpenAI-இணக்கமான எண்ட்பாயிண்ட்",
+      "name": "OpenAI இணக்கமானது (பழைய Realtime)",
+      "description": "OpenAI-இன் பழைய beta Realtime நெறிமுறையைப் பயன்படுத்தும் மூன்றாம் தரப்பு எண்ட்பாயிண்ட். OpenAI-க்கு அல்ல.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/te/translation.json
+++ b/src/locales/te/translation.json
@@ -456,8 +456,8 @@
       "description": "Google AI టెక్నాలజీ"
     },
     "openaiCompatible": {
-      "name": "OpenAI అనుకూల API",
-      "description": "అనుకూల OpenAI-అనుకూల ఎండ్‌పాయింట్",
+      "name": "OpenAI అనుకూలం (లెగసీ Realtime)",
+      "description": "OpenAI యొక్క పాత beta Realtime ప్రోటోకాల్‌ను ఉపయోగించే థర్డ్-పార్టీ ఎండ్‌పాయింట్. OpenAI కోసం కాదు.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/th/translation.json
+++ b/src/locales/th/translation.json
@@ -456,8 +456,8 @@
       "description": "เทคโนโลยี AI ของ Google"
     },
     "openaiCompatible": {
-      "name": "OpenAI API ที่เข้ากันได้",
-      "description": "จุดปลายที่กำหนดเองที่เข้ากันได้กับ OpenAI",
+      "name": "เข้ากันได้กับ OpenAI (Realtime รุ่นเก่า)",
+      "description": "เอ็นด์พอยต์ของบุคคลที่สามที่ใช้โปรโตคอล Realtime เบต้ารุ่นเก่าของ OpenAI ไม่ใช่สำหรับ OpenAI เอง",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/tr/translation.json
+++ b/src/locales/tr/translation.json
@@ -456,8 +456,8 @@
       "description": "Google'un AI teknolojisi"
     },
     "openaiCompatible": {
-      "name": "OpenAI Uyumlu API",
-      "description": "Özel OpenAI uyumlu uç nokta",
+      "name": "OpenAI uyumlu (eski Realtime)",
+      "description": "OpenAI'nin eski beta Realtime protokolünü kullanan üçüncü taraf uç noktası. OpenAI'nin kendisi için değil.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/uk/translation.json
+++ b/src/locales/uk/translation.json
@@ -456,8 +456,8 @@
       "description": "Технологія AI від Google"
     },
     "openaiCompatible": {
-      "name": "API сумісний з OpenAI",
-      "description": "Користувацька кінцева точка сумісна з OpenAI",
+      "name": "Сумісний з OpenAI (застарілий Realtime)",
+      "description": "Стороння кінцева точка зі старим бета-протоколом Realtime від OpenAI. Не для самої OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/vi/translation.json
+++ b/src/locales/vi/translation.json
@@ -456,8 +456,8 @@
       "description": "Công nghệ AI của Google"
     },
     "openaiCompatible": {
-      "name": "API Tương Thích OpenAI",
-      "description": "Điểm cuối tùy chỉnh tương thích với OpenAI",
+      "name": "Tương thích OpenAI (Realtime cũ)",
+      "description": "Điểm cuối bên thứ ba dùng giao thức Realtime beta cũ của OpenAI. Không dành cho chính OpenAI.",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/zh_CN/translation.json
+++ b/src/locales/zh_CN/translation.json
@@ -456,8 +456,8 @@
       "description": "谷歌AI技术"
     },
     "openaiCompatible": {
-      "name": "OpenAI 兼容 API",
-      "description": "自定义 OpenAI 兼容端点",
+      "name": "OpenAI 兼容（旧版 Realtime）",
+      "description": "使用 OpenAI 旧版 beta Realtime 协议的第三方端点。不适用于 OpenAI 官方。",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/locales/zh_TW/translation.json
+++ b/src/locales/zh_TW/translation.json
@@ -456,8 +456,8 @@
       "description": "Google 的 AI 技術"
     },
     "openaiCompatible": {
-      "name": "OpenAI 相容 API",
-      "description": "自訂 OpenAI 相容端點",
+      "name": "OpenAI 相容（舊版 Realtime）",
+      "description": "使用 OpenAI 舊版 beta Realtime 協定的第三方端點。不適用於 OpenAI 官方。",
       "customEndpointPlaceholder": "https://your-api-endpoint.com"
     },
     "openai_translate": {

--- a/src/services/providers/OpenAICompatibleProviderConfig.ts
+++ b/src/services/providers/OpenAICompatibleProviderConfig.ts
@@ -76,7 +76,13 @@ export class OpenAICompatibleProviderConfig extends OpenAIProviderConfig {
     return {
       ...baseConfig,
       id: Provider.OPENAI_COMPATIBLE,
-      displayName: 'OpenAI Compatible API',
+      // "Legacy Realtime" is load-bearing, not decoration: this provider speaks
+      // the older beta Realtime protocol (createClient below builds the beta
+      // `openai-realtime-api` OpenAIClient, while the built-in OpenAI provider
+      // builds OpenAIGAClient against the current API). OpenAI has retired that
+      // beta, so "OpenAI Compatible" on its own now reads as a promise this
+      // provider cannot keep — pointing it at api.openai.com does not work.
+      displayName: 'OpenAI Compatible (Legacy Realtime)',
       apiKeyLabel: 'API Key',
       apiKeyPlaceholder: 'Enter your API key...',
       supportsCustomEndpoint: true,


### PR DESCRIPTION
## Why

**"OpenAI Compatible API" now reads as a promise the provider cannot keep.**

It speaks the *older beta* Realtime protocol — `OpenAICompatibleProviderConfig.createClient()` builds the beta `openai-realtime-api` `OpenAIClient`, while the built-in **OpenAI** provider builds `OpenAIGAClient` against the current API (only the WebRTC transport shares a client). OpenAI has since retired that beta.

So the name implies a route to OpenAI that does not exist: pointing this provider at `api.openai.com` does not work, and nothing in the UI said so. It also quietly misleads debugging — "just try it against OpenAI to isolate your endpoint" is a natural experiment to reach for, and it cannot work here.

## What changed

| | before | after |
|---|---|---|
| name | OpenAI Compatible API | **OpenAI Compatible (Legacy Realtime)** |
| description | Custom OpenAI-compatible endpoint | **Third-party endpoint speaking OpenAI's older beta Realtime protocol. Not for OpenAI itself.** |

Across all 30 locales, plus the `displayName` fallback in `OpenAICompatibleProviderConfig`, which carries the reasoning in a comment so the qualifier isn't mistaken for decoration and dropped later.

"OpenAI" stays in the name deliberately — it is the term users search for, and removing it would cost discoverability without buying accuracy the qualifier doesn't already provide.

## Implementation note

The locale edits are line-surgical rather than a JSON round-trip. Every `translation.json` is one key per line, and re-serialising would reflow `en`'s hand-formatted layout — which `scripts/sync-locale-keys.mjs` treats as read-only for exactly that reason. Each of the 30 files changes exactly two lines (60 insertions, 60 deletions), and each is re-parsed as JSON after writing.

## Test plan

- Full suite: 349 files / 4152 tests pass — the same count as `main`, so nothing pinned these strings and nothing broke. (The 4 unhandled rejections in `settingsStore.nativeGate.test.ts` are pre-existing on `main`.)
- `locales.consistency.test.ts` passes, so every registered descriptor still resolves its locale keys.
- Spot-checked rendering in en / zh_CN / zh_TW / ja / ko / de / ar / ru, including the RTL case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
