### PR TITLE
fix(main-panel): clear speakerClientRef on teardown

### DIFF
--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1774,6 +1774,30 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           }
           setItems(client.getConversationItems());
           client.reset();
+          // Clear the ref, like the participant leg two blocks down has always
+          // done. Without this the object outlives its session, and the next
+          // session that builds NO speaker client — participant-only "Others"
+          // mode skips the whole `if (speakerWillStart)` block — reaches this
+          // same leg on Stop holding the previous session's dead client. Three
+          // things then happen, none of them wanted:
+          //
+          //  - `disconnect()` runs a second time, on a client whose handlers
+          //    are the PREVIOUS session's closures, re-emitting `session.closed`
+          //    (a spurious speaker-tagged row in the log panel) and, on the
+          //    managed-Soniox path, calling `detachLeg` on the old session.
+          //  - `setItems(client.getConversationItems())` becomes `setItems([])`,
+          //    because `reset()` already emptied it. In Others mode `items` is
+          //    NOT empty — it carries the participant-channel warning and the
+          //    descriptor's prepare notices — so those rows are silently wiped
+          //    at Stop. That one is user-visible, with no error and no log.
+          //  - LocalNativeClient.disconnect() disposes its ASR/translate/TTS
+          //    handles a second time, before the live participant leg is torn
+          //    down.
+          //
+          // It also retires the "a non-null ref here belongs to a previous
+          // session" reasoning that three comments in this file and
+          // sessionStartGate.ts were written around.
+          speakerClientRef.current = null;
         },
         participant: async () => {
           const participantClient = participantClientRef.current;
@@ -2571,10 +2595,12 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       //
       // Asks whether a channel WORKS, not whether a client object exists. The
       // refs cannot answer that: the participant catch is non-fatal by design
-      // and leaves `participantClientRef.current` set, and
-      // `speakerClientRef.current` is never assigned null anywhere in this file
-      // (not even on Stop), so the old ref-based condition also went permanently
-      // false after the first session that built a speaker client. See
+      // and leaves `participantClientRef.current` set. The speaker ref used to
+      // be worse still — it was never assigned null anywhere in this file, not
+      // even on Stop, so the old ref-based condition went permanently false
+      // after the first session that built a speaker client. Stop clears it
+      // now, but that only removes the stale-object hazard; a ref is still not
+      // evidence that a channel works, so this guard stays outcome-based. See
       // noChannelCameUp.
       if (noChannelCameUp({ speakerChannelStarted, participantChannelStarted })) {
         // A cancel that races client construction can surface here too: the
@@ -2599,9 +2625,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
         // the guard reads outcomes, so it fires for a leg that connected and
         // then failed to wire its recorder. There is never a speaker client to
         // take down — one that came up would have set speakerChannelStarted, and
-        // one that failed re-threw past this point — so a non-null
-        // speakerClientRef here belongs to a PREVIOUS session (this file never
-        // clears it) and must not be touched.
+        // one that failed re-threw past this point — so the speaker is left
+        // alone here. It used to matter more than it does: the ref was never
+        // cleared, so a non-null value here meant a PREVIOUS session's client
+        // that must not be touched. Stop clears it now, which leaves this leg
+        // correct for the simpler reason that this pass built nothing to undo.
         //
         // Ordered through teardownSessionLegs for its one invariant: every leg
         // is down before `session-end` is signalled. Releasing the lease while a
@@ -2707,6 +2735,11 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             }
             setItems(client.getConversationItems());
             client.reset();
+            // Same clear as disconnectConversation's leg. A cancelled start that
+            // got far enough to bring the speaker up must not leave its client
+            // behind either, or the next session inherits exactly the stale
+            // object this pass just tore down.
+            speakerClientRef.current = null;
           },
           participant: async () => {
             const client = participantClientRef.current;

--- a/src/components/MainPanel/MainPanel.tsx
+++ b/src/components/MainPanel/MainPanel.tsx
@@ -1666,6 +1666,17 @@ const MainPanel: React.FC<MainPanelProps> = () => {
     }
     disconnectInProgressRef.current = true;
 
+    // Capture the speaker client to tear down NOW, before any await. The
+    // `setIsSessionActive(false)` a few lines down runs synchronously and
+    // re-enables the Start button while this teardown is still in flight —
+    // nothing serializes a new Start behind an in-flight Stop — so by the time
+    // the speaker leg below runs, `speakerClientRef.current` may already hold
+    // the NEXT session's client. Reading the ref there would tear down the
+    // wrong one (disconnect/reset on a still-connecting client, then the null
+    // wiping its ref: a session that looks active and does nothing). The
+    // object this Stop owns is the one in the ref at this instant.
+    const speakerToTearDown = speakerClientRef.current;
+
     // Discard any in-flight Start: its prepare patches and its acquired
     // resources would target the session this teardown is ending.
     startAbortRef.current?.abort();
@@ -1742,7 +1753,9 @@ const MainPanel: React.FC<MainPanelProps> = () => {
       // SonioxClient, not the inert secondary port of the shared path.
       await teardownSessionLegs({
         speaker: async () => {
-          const client = speakerClientRef.current;
+          // Not `speakerClientRef.current` — see the capture at the top of
+          // this function. By now the ref may belong to the next session.
+          const client = speakerToTearDown;
           if (!client) return;
           // disconnect() emits final completion deltas via the throttle path,
           // which schedules a trailing setItems(client.getConversationItems())
@@ -1797,7 +1810,17 @@ const MainPanel: React.FC<MainPanelProps> = () => {
           // It also retires the "a non-null ref here belongs to a previous
           // session" reasoning that three comments in this file and
           // sessionStartGate.ts were written around.
-          speakerClientRef.current = null;
+          //
+          // Compare-and-clear, not a bare assignment: `await client.disconnect()`
+          // above is a real macrotask gap on providers whose disconnect hits
+          // the network (PalabraAI deletes its session and leaves the LiveKit
+          // room), and a Start clicked inside that gap has already put the
+          // NEXT session's client in the ref. Clearing unconditionally here
+          // would wipe it — a live session with a null ref, every audio frame
+          // dropped, nothing on screen. Only clear what this Stop owns.
+          if (speakerClientRef.current === client) {
+            speakerClientRef.current = null;
+          }
         },
         participant: async () => {
           const participantClient = participantClientRef.current;
@@ -2738,8 +2761,13 @@ const MainPanel: React.FC<MainPanelProps> = () => {
             // Same clear as disconnectConversation's leg. A cancelled start that
             // got far enough to bring the speaker up must not leave its client
             // behind either, or the next session inherits exactly the stale
-            // object this pass just tore down.
-            speakerClientRef.current = null;
+            // object this pass just tore down. Compare-and-clear for the same
+            // reason as there; here `client` is this pass's own and a second
+            // Start is blocked by connectInProgressRef, so the check is
+            // belt-and-braces rather than load-bearing.
+            if (speakerClientRef.current === client) {
+              speakerClientRef.current = null;
+            }
           },
           participant: async () => {
             const client = participantClientRef.current;

--- a/src/components/MainPanel/participantErrorOrdering.test.ts
+++ b/src/components/MainPanel/participantErrorOrdering.test.ts
@@ -82,3 +82,71 @@ describe('participant-connect error bubble vs. the post-init setItems overwrite'
     });
   });
 });
+
+/**
+ * The same overwrite hazard at the other end of the session.
+ *
+ * disconnectConversation's speaker leg ends with
+ * `setItems(client.getConversationItems()); client.reset();` — the plain-value
+ * overwrite again. It is correct for the session that owned the client: it
+ * captures the final transcript before reset empties it.
+ *
+ * It was wrong for the NEXT session, because `speakerClientRef.current` was
+ * never cleared. Participant-only ("Others") mode builds no speaker client at
+ * all, so its Stop reached this leg holding the previous session's object —
+ * already `reset()`, so `getConversationItems()` returns `[]`, so the overwrite
+ * is `setItems([])`. In Others mode `items` is not empty: it carries the
+ * participant-channel warning and the descriptor's prepare notices. Those rows
+ * vanished at Stop, silently.
+ *
+ * The fix is the null the participant leg always had. Modelled here the same
+ * way as above — the leg's `if (!client) return` is what the "fixed" case
+ * asserts, and there is still no React harness to mount MainPanel with.
+ */
+describe('stale speaker client vs. the teardown setItems overwrite', () => {
+  /** The tail of disconnectConversation's speaker leg. */
+  const teardownSpeakerLeg = (
+    setItems: (u: Updater) => void,
+    client: { getConversationItems: () => Item[] } | null,
+  ) => {
+    if (!client) return;
+    setItems(client.getConversationItems());
+  };
+
+  /** A client from an earlier session: disconnected and already reset, so empty. */
+  const staleClient = { getConversationItems: (): Item[] => [] };
+
+  const othersModeRows: Item[] = [
+    { id: 'warn-1', text: "Failed to start Other's audio channel." },
+    { id: 'notice-1', text: 'Prepare notice' },
+  ];
+
+  it('pre-fix: an Others-mode Stop wipes the warning and notice rows', () => {
+    const { setItems, getState } = makeStateContainer(othersModeRows);
+
+    // The ref still held the previous session's client, so the leg ran.
+    teardownSpeakerLeg(setItems, staleClient);
+
+    expect(getState()).toEqual([]); // both rows gone, no error, no log
+  });
+
+  it('cleared ref: the leg is skipped and the rows survive Stop', () => {
+    const { setItems, getState } = makeStateContainer(othersModeRows);
+
+    // Stop now nulls speakerClientRef, so a session that built no speaker
+    // client finds nothing to tear down.
+    teardownSpeakerLeg(setItems, null);
+
+    expect(getState()).toEqual(othersModeRows);
+  });
+
+  it('still captures the final transcript for the session that owned the client', () => {
+    const finalTranscript: Item[] = [{ id: 'speaker-1', text: 'hello' }];
+    const { setItems, getState } = makeStateContainer([{ id: 'stale', text: 'mid-stream' }]);
+
+    // The overwrite is not being removed — this is the case it exists for.
+    teardownSpeakerLeg(setItems, { getConversationItems: () => finalTranscript });
+
+    expect(getState()).toEqual(finalTranscript);
+  });
+});

--- a/src/components/MainPanel/participantErrorOrdering.test.ts
+++ b/src/components/MainPanel/participantErrorOrdering.test.ts
@@ -150,3 +150,79 @@ describe('stale speaker client vs. the teardown setItems overwrite', () => {
     expect(getState()).toEqual(finalTranscript);
   });
 });
+
+/**
+ * The clear must not wipe a session it does not own.
+ *
+ * disconnectConversation flips isSessionActive to false synchronously — which
+ * re-enables the Start button — and only then awaits (pauseRecording, a 100 ms
+ * settle, `client.disconnect()`). Nothing serializes a new Start behind that
+ * in-flight Stop, so a Stop→Start double-tap can put the NEXT session's client
+ * in `speakerClientRef` while the old teardown is still running. Two things
+ * then have to hold:
+ *
+ *  - the leg must tear down the client this Stop OWNED, not whatever the ref
+ *    holds by the time the leg runs — hence the capture at the top of
+ *    disconnectConversation, before any await;
+ *  - the clear must be compare-and-clear, so a ref that now points at the new
+ *    session's client is left alone.
+ *
+ * An unconditional `ref.current = null` there produced a live session with a
+ * null speaker ref: every audio frame dropped, nothing on screen, and the next
+ * Stop skipping the leg so the provider session was never closed.
+ */
+describe('teardown vs. a Start that lands mid-Stop', () => {
+  type Client = { getConversationItems: () => Item[] };
+
+  /** disconnectConversation's capture-then-tear-down shape, with the ref modelled. */
+  const runTeardown = (
+    ref: { current: Client | null },
+    captured: Client | null,
+    setItems: (u: Updater) => void,
+  ) => {
+    const client = captured;
+    if (!client) return;
+    setItems(client.getConversationItems());
+    if (ref.current === client) ref.current = null;
+  };
+
+  const oldClient: Client = { getConversationItems: () => [{ id: 'old-1', text: 'final line' }] };
+  const newClient: Client = { getConversationItems: () => [] };
+
+  it('a plain Stop clears the ref', () => {
+    const ref = { current: oldClient as Client | null };
+    const captured = ref.current; // top of disconnectConversation
+    const { setItems, getState } = makeStateContainer([]);
+
+    runTeardown(ref, captured, setItems);
+
+    expect(ref.current).toBeNull();
+    expect(getState()).toEqual([{ id: 'old-1', text: 'final line' }]);
+  });
+
+  it('a Start that lands during the old teardown keeps its client', () => {
+    const ref = { current: oldClient as Client | null };
+    const captured = ref.current; // top of disconnectConversation
+    const { setItems } = makeStateContainer([]);
+
+    // Start clicked inside the teardown's await window: the new session has
+    // already assigned its client before the old leg gets to run.
+    ref.current = newClient;
+
+    runTeardown(ref, captured, setItems);
+
+    // The old client was torn down (captured), and the new one is untouched.
+    expect(ref.current).toBe(newClient);
+  });
+
+  it('the pre-fix shape wiped the new session', () => {
+    // What an unconditional clear did in the same interleaving.
+    const ref = { current: oldClient as Client | null };
+    const captured = ref.current;
+    ref.current = newClient;
+
+    if (captured) ref.current = null; // the bare `= null` this test guards against
+
+    expect(ref.current).toBeNull(); // the live session just lost its client
+  });
+});

--- a/src/components/MainPanel/sessionStartGate.test.ts
+++ b/src/components/MainPanel/sessionStartGate.test.ts
@@ -570,9 +570,11 @@ describe('noChannelCameUp — the post-init guard reads outcomes, not refs', () 
    *    `participantClientRef.current`. A participant leg whose connect() or
    *    startSystemAudioRecording() rejected therefore left the ref set and the
    *    guard silent.
-   *  - `speakerClientRef.current` is never assigned null anywhere in MainPanel,
-   *    not even in disconnectConversation. After the first session that builds a
-   *    speaker client, the left-hand operand is false forever.
+   *  - `speakerClientRef.current` was never assigned null anywhere in MainPanel
+   *    at the time, not even in disconnectConversation, so after the first
+   *    session that built a speaker client the left-hand operand was false
+   *    forever. Stop clears it now; the guard stays outcome-based regardless,
+   *    since a ref set mid-start still proves nothing about the leg.
    *
    * Together those make the participant-only session the real hazard: no
    * microphone, the participant leg fails, and the session is nonetheless marked

--- a/src/components/MainPanel/sessionStartGate.ts
+++ b/src/components/MainPanel/sessionStartGate.ts
@@ -277,10 +277,12 @@ export function computeStartGate(input: StartGateInput): StartGate {
  *  - The participant catch block is non-fatal by design and does NOT clear
  *    `participantClientRef.current`, so a leg whose connect() or
  *    startSystemAudioRecording() rejected still left the ref set.
- *  - `speakerClientRef.current` is never assigned null anywhere in MainPanel,
- *    not even on Stop — so after the first session that builds a speaker client
- *    the speaker half of the old condition was false for the rest of the
- *    process's life, and the guard could not fire at all.
+ *  - `speakerClientRef.current` used to be worse still: it was never assigned
+ *    null anywhere in MainPanel, not even on Stop, so after the first session
+ *    that built a speaker client the speaker half of the old condition was
+ *    false for the rest of the process's life and the guard could not fire at
+ *    all. Stop clears it now, but that only retires the stale-object hazard —
+ *    a ref set mid-start still says nothing about whether the leg came up.
  *
  * The case that makes this matter is the participant-only session: no
  * microphone, the participant leg fails, and the session is marked active with


### PR DESCRIPTION
Follow-up to #549, which deferred this. Two lines of behaviour change; the rest is comments and tests.

## The defect

`speakerClientRef` was **never assigned null** — not on Stop, not on a cancelled start — while `participantClientRef` has always been cleared at both. So after any session that built a speaker client, the object outlived its session, with that session's event handlers still bound to it.

## Why it matters

Participant-only ("Others") mode builds no speaker client — it skips the whole `if (speakerWillStart)` block. So its Stop reached `disconnectConversation`'s speaker leg holding **the previous session's dead client**, and:

- ran `disconnect()` a second time, on handlers belonging to a session that had already ended — re-emitting `session.closed` (a spurious speaker-tagged row in the log panel) and, on the managed-Soniox path, calling `detachLeg` on the old session;
- turned `setItems(client.getConversationItems())` into **`setItems([])`**, because `reset()` had already emptied it. In Others mode `items` is *not* empty — it carries the participant-channel warning and the descriptor's prepare notices — so **those rows were wiped at Stop, with no error and no log.** This one is user-visible;
- had `LocalNativeClient.disconnect()` dispose its ASR/translate/TTS handles a second time, *before* the live participant leg was torn down.

## The fix

The null the participant leg already had, at both teardown sites (`disconnectConversation`'s leg and the cancelled-start leg).

## The audit behind it

All 22 remaining reads of the ref were checked. **No second hazard**: they are gated on `speakerChannelStarted`, `speakerChannelActive`, `isUsingWebRTC`, or a local assigned in the same pass.

Worth recording, though: several were safe only *by accident* — the guard that saved them lives in another module rather than at the read site.

| site | what actually saved it |
|---|---|
| `:2436` participant slot resolution (a live participant leg grafted onto a dead speaker socket) | `speakerWillStart` inside `resolveParticipantSlot`, in `managedSonioxSplit.ts`, guarding a different stated invariant |
| `:3600` waveform rAF loop, ~60 Hz, ungated on session state | `WebRTCAudioBridge.getLocalFrequencies`'s null-analyser check |
| `:2296`–`:2326` recorder callbacks | `ModernBrowserAudioService.stopRecording()` nulling its callback |
| `:2793` post-init `setItems(...getConversationItems() \|\| [])` | every client's `reset()` emptying its item list — one missing `reset()` from being a real transcript leak |

Clearing the ref makes all of those safe by construction instead.

## Comments

Three comments asserting "never assigned null" (here and in `sessionStartGate.ts` / its test) are **updated rather than deleted**. `noChannelCameUp` still takes outcomes rather than refs, and still should: a ref set mid-start proves nothing about whether the leg came up. Only the stale-object half of its rationale is retired.

## Test plan

New cases in `participantErrorOrdering.test.ts`, which already models this exact `setItems` overwrite hazard at session **start** with the same no-React-harness approach — this is the same shape at **stop**. Three cases: the pre-fix wipe, the cleared-ref survival, and the one that keeps the overwrite honest (the session that owns the client still captures its final transcript).

- Full suite: 349 files / 4156 tests pass. (The 4 unhandled rejections in `settingsStore.nativeGate.test.ts` are pre-existing on `main`.)
- `tsc --noEmit`: 541 errors, 11 of them in the files touched here — both identical to `main`. No new type errors.

## Caveat

The `LocalNativeClient` double-dispose was identified but not chased to the bottom — whether a second `dispose()` can disturb the live participant leg depends on whether the sidecar's native backend handles are per-client or shared (its singleton is documented as "last `load()` wins"). Clearing the ref means the second dispose no longer happens, so the question is now moot on this path rather than answered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved participant warnings and notices when stopping a conversation.
  - Preserved final speaker transcripts during conversation cleanup.
  - Prevented stale speaker session data from affecting subsequent conversations.
  - Improved handling when conversations cannot start due to sign-in or managed access requirements, including directing users to the appropriate provider settings.

- **Tests**
  - Added coverage for session cleanup, transcript preservation, and conversation-start access checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->